### PR TITLE
feat: add dark-mode support

### DIFF
--- a/components/chat-input-box.tsx
+++ b/components/chat-input-box.tsx
@@ -1,11 +1,12 @@
 import { Textarea } from "@/components/ui/textarea"
 import { useAutoResizeTextarea } from "@/hooks/use-auto-resize-textarea"
-import { useRef } from "react"
+import { useEffect, useRef } from "react"
 
 import BugReportIcon from "./bug-report-icon"
 import ModelMenu from "./model-menu"
 import SendOrStopButton from "./send-or-stop-button"
 import SettingsButton from "./settings-button"
+import ThemeToggle from "./theme-toggle"
 
 export default function ChatInputBox({
   input,
@@ -33,6 +34,7 @@ export default function ChatInputBox({
   return (
     <div className="relative h-auto">
       <Textarea
+        id="chat-input-textarea"
         ref={textareaRef}
         placeholder="Type your message..."
         value={input}
@@ -41,10 +43,11 @@ export default function ChatInputBox({
         className="max-h-[300px] min-h-[80px] w-full resize-none overflow-hidden rounded-b-2xl pb-10"
         autoFocus
       />
-      <div className="absolute bottom-0 left-2 flex items-center gap-2">
+      <div className="absolute bottom-0 left-2 flex items-center gap-1">
         <ModelMenu tooltipTextContent="Switch model" />
         <SettingsButton />
         <BugReportIcon />
+        <ThemeToggle />
       </div>
       <SendOrStopButton
         isLoading={isLoading}

--- a/components/chat-message-bubble.tsx
+++ b/components/chat-message-bubble.tsx
@@ -25,15 +25,15 @@ export default function ChatMessageBubble({
       )}>
       <div
         className={cn(
-          "max-w-2xl rounded-xl px-3 py-2 text-sm shadow transition-colors",
+          "max-w-2xl rounded-xl p-2 text-sm shadow transition-colors",
           isUser
-            ? "max-w-[80%] bg-blue-400 text-white dark:bg-blue-500"
-            : "bg-gray-100 text-gray-900 dark:bg-[#1e1e1e] dark:text-gray-100"
+            ? "bg-gray-200 text-gray-900 dark:bg-gray-900 dark:text-gray-100"
+            : "bg-gray-100 text-gray-900 dark:bg-zinc-900 dark:text-zinc-100"
         )}>
         <MarkdownRenderer content={msg.content} />
 
         {msg.role === "assistant" && msg.model && !isLoading && (
-          <div className="mt-2 flex items-center gap-1 text-xs text-foreground">
+          <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground dark:text-zinc-400">
             <CopyButton text={msg.content} />
             <RegenerateButton
               model={msg.model}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,9 +1,11 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useChat } from "@/hooks/use-chat"
+import { STORAGE_KEYS } from "@/lib/constant"
 
 import ChatInputBox from "./chat-input-box"
 import ChatMessageBubble from "./chat-message-bubble"
+import { ThemeProvider } from "./them-provider"
 import WelcomeScreen from "./welcome-screen"
 
 export default function Chat() {
@@ -25,47 +27,49 @@ export default function Chat() {
   }
 
   return (
-    <TooltipProvider>
-      <div className="flex h-screen flex-col rounded-md p-1">
-        {messages.length === 0 ? (
-          <WelcomeScreen />
-        ) : (
-          <ScrollArea className="flex-1 px-2 scrollbar-none">
-            {messages.map((msg, idx) => (
-              <div key={idx} className={getMessageMargin(idx)}>
-                <ChatMessageBubble
-                  msg={msg}
-                  isLoading={
-                    isLoading &&
-                    msg.role === "assistant" &&
-                    idx === messages.length - 1
-                  }
-                  onRegenerate={
-                    msg.role === "assistant"
-                      ? (model) => {
-                          const prevUser = [...messages.slice(0, idx)]
-                            .reverse()
-                            .find((m) => m.role === "user")
-                          if (prevUser) sendMessage(prevUser.content, model)
-                        }
-                      : undefined
-                  }
-                />
-              </div>
-            ))}
-            <div ref={scrollRef} />
-          </ScrollArea>
-        )}
-        <div className="sticky bottom-0 z-10 w-full bg-background pt-2">
-          <ChatInputBox
-            input={input}
-            setInput={setInput}
-            isLoading={isLoading}
-            onSend={sendMessage}
-            stopGeneration={stopGeneration}
-          />
+    <ThemeProvider storageKey={STORAGE_KEYS.THEME.PREFERENCE}>
+      <TooltipProvider>
+        <div className="flex h-screen flex-col rounded-md p-1">
+          {messages.length === 0 ? (
+            <WelcomeScreen />
+          ) : (
+            <ScrollArea className="flex-1 px-2 scrollbar-none">
+              {messages.map((msg, idx) => (
+                <div key={idx} className={getMessageMargin(idx)}>
+                  <ChatMessageBubble
+                    msg={msg}
+                    isLoading={
+                      isLoading &&
+                      msg.role === "assistant" &&
+                      idx === messages.length - 1
+                    }
+                    onRegenerate={
+                      msg.role === "assistant"
+                        ? (model) => {
+                            const prevUser = [...messages.slice(0, idx)]
+                              .reverse()
+                              .find((m) => m.role === "user")
+                            if (prevUser) sendMessage(prevUser.content, model)
+                          }
+                        : undefined
+                    }
+                  />
+                </div>
+              ))}
+              <div ref={scrollRef} />
+            </ScrollArea>
+          )}
+          <div className="sticky bottom-0 z-10 w-full bg-background pt-2">
+            <ChatInputBox
+              input={input}
+              setInput={setInput}
+              isLoading={isLoading}
+              onSend={sendMessage}
+              stopGeneration={stopGeneration}
+            />
+          </div>
         </div>
-      </div>
-    </TooltipProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   )
 }

--- a/components/markdown-renderer.tsx
+++ b/components/markdown-renderer.tsx
@@ -5,7 +5,7 @@ export function MarkdownRenderer({ content }: { content: string }) {
 
   return (
     <div
-      className="prose prose-sm max-w-none break-words px-2 py-1 [&_code]:whitespace-pre-wrap [&_code]:text-black [&_p]:my-1 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-gray-100 [&_pre]:p-2 [&_pre]:text-xs [&_pre]:text-black [&_table]:block [&_table]:overflow-x-auto"
+      className="prose prose-sm max-w-none break-words px-2 py-1 dark:prose-invert [&_code]:whitespace-pre-wrap [&_code]:text-black dark:[&_code]:text-white [&_p]:my-1 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-gray-100 [&_pre]:p-2 [&_pre]:text-xs [&_pre]:text-black dark:[&_pre]:bg-gray-900 dark:[&_pre]:text-white [&_table]:block [&_table]:overflow-x-auto"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   )

--- a/components/them-provider.tsx
+++ b/components/them-provider.tsx
@@ -1,0 +1,70 @@
+import { STORAGE_KEYS } from "@/lib/constant"
+import { createContext, useContext, useEffect } from "react"
+
+import { Storage } from "@plasmohq/storage"
+import { useStorage } from "@plasmohq/storage/hook"
+
+type Theme = "dark" | "light" | "system"
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+const storage = new Storage()
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = STORAGE_KEYS.THEME.PREFERENCE
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useStorage<Theme>(
+    {
+      key: storageKey,
+      instance: storage
+    },
+    defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    root.classList.remove("light", "dark")
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light"
+      root.classList.add(systemTheme)
+    } else {
+      root.classList.add(theme)
+    }
+  }, [theme])
+
+  return (
+    <ThemeProviderContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return context
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,50 @@
+import { useTheme } from "@/components/them-provider"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@/components/ui/tooltip"
+import { Moon, Sun } from "lucide-react"
+
+export default function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Toggle theme"
+              autoFocus={false}>
+              <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+              <span className="sr-only">Toggle theme</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">Toggle Theme</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,195 @@
+import { cn } from "@/lib/utils"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}>
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "origin-[--radix-dropdown-menu-content-transform-origin] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}>
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}>
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/components/welcome-screen.tsx
+++ b/components/welcome-screen.tsx
@@ -11,9 +11,9 @@ export default function WelcomeScreen() {
   if (!show) return null
 
   return (
-    <div className="flex h-screen w-full flex-col items-center justify-center rounded-full px-4 text-center scrollbar-none">
+    <div className="flex h-screen w-full flex-col items-center justify-center rounded-b-lg rounded-t-2xl bg-white px-4 text-center text-gray-900 scrollbar-none dark:bg-gray-900 dark:text-gray-100">
       <h1 className="mb-2 text-2xl font-semibold">Welcome to Ollama Chat</h1>
-      <p className="mb-6 max-w-md text-sm text-muted-foreground">
+      <p className="dark:text-muted-foreground-dark mb-6 max-w-md text-sm text-muted-foreground">
         Start chatting with your local models using Ollama. Type a message below
         to get started.
       </p>
@@ -34,7 +34,7 @@ export default function WelcomeScreen() {
 
       <Button
         variant="ghost"
-        className="mt-2 text-xs text-muted-foreground hover:text-foreground"
+        className="dark:text-muted-foreground-dark mt-2 text-xs text-muted-foreground hover:text-foreground dark:hover:text-gray-200"
         onClick={() => setShow(false)}>
         <PanelTopClose className="mr-1 h-4 w-4" />
         Hide Welcome

--- a/hooks/use-markdown-parser.tsx
+++ b/hooks/use-markdown-parser.tsx
@@ -8,7 +8,7 @@ import highlightjs from "markdown-it-highlightjs"
 import taskLists from "markdown-it-task-lists"
 import { useEffect, useState } from "react"
 
-import "highlight.js/styles/github.css"
+import "highlight.js/styles/github-dark.css"
 
 const md = new MarkdownIt({
   html: true,

--- a/lib/constant.ts
+++ b/lib/constant.ts
@@ -14,6 +14,9 @@ export const STORAGE_KEYS = {
   OLLAMA: {
     BASE_URL: "ollama-base-url",
     SELECTED_MODEL: "selected-ollama-model"
+  },
+  THEME: {
+    PREFERENCE: "light-dark-theme"
   }
 }
 

--- a/options/index.tsx
+++ b/options/index.tsx
@@ -7,6 +7,8 @@ import "../globals.css"
 import ModelMenu from "@/components/model-menu"
 import OllamaSetupInstructions from "@/components/ollama-setup-instructions"
 import SocialHandles from "@/components/social-handles"
+import { ThemeProvider } from "@/components/them-provider"
+import ThemeToggle from "@/components/theme-toggle"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -34,62 +36,65 @@ function OptionsIndex() {
   }
 
   return (
-    <TooltipProvider>
-      <div className="space-y-6 p-4 text-sm text-gray-900">
-        <div className="fex-col flex flex-wrap items-center justify-center gap-8">
-          <Card className="w-3/4">
-            <CardHeader>
-              <CardTitle>Ollama Client Options</CardTitle>
-              <CardDescription>
-                Set your local Ollama server URL and review selected model.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <Label htmlFor="ollama-url">Ollama Local URL</Label>
-                <div className="mt-2 flex gap-2">
-                  <Input
-                    id="ollama-url"
-                    type="text"
-                    value={ollamaUrl}
-                    onChange={(e) => setOllamaUrl(e.target.value)}
-                    placeholder="http://localhost:11434"
-                    className="w-full"
-                  />
-                  <Button onClick={handleSave}>Save</Button>
-                </div>
-                {saved && (
-                  <div className="mt-2 flex items-center gap-1 text-sm text-green-600">
-                    <CheckCircle2 size={16} /> <span>Saved!</span>
+    <ThemeProvider storageKey={STORAGE_KEYS.THEME.PREFERENCE}>
+      <TooltipProvider>
+        <div className="space-y-6 p-4 text-sm text-gray-900">
+          <div className="fex-col flex flex-wrap items-center justify-center gap-8">
+            <Card className="w-3/4">
+              <CardHeader>
+                <CardTitle>Ollama Client Options</CardTitle>
+                <CardDescription>
+                  Set your local Ollama server URL and review selected model.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <Label htmlFor="ollama-url">Ollama Local URL</Label>
+                  <div className="mt-2 flex gap-2">
+                    <Input
+                      id="ollama-url"
+                      type="text"
+                      value={ollamaUrl}
+                      onChange={(e) => setOllamaUrl(e.target.value)}
+                      placeholder="http://localhost:11434"
+                      className="w-full"
+                    />
+                    <Button onClick={handleSave}>Save</Button>
                   </div>
-                )}
-              </div>
+                  {saved && (
+                    <div className="mt-2 flex items-center gap-1 text-sm text-green-600">
+                      <CheckCircle2 size={16} /> <span>Saved!</span>
+                    </div>
+                  )}
+                </div>
 
-              <div className="flex items-center gap-4">
-                <Label>Selected Model</Label>
-                <ModelMenu tooltipTextContent="Switch model" />
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="w-3/4">
-            <CardHeader>
-              <CardTitle>Configuration Guide</CardTitle>
-              <CardDescription>
-                Follow these steps to prevent CORS issues when using this
-                extension with Ollama.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <OllamaSetupInstructions />
-            </CardContent>
-          </Card>
-        </div>
+                <div className="flex items-center gap-4">
+                  <Label>Selected Model</Label>
+                  <ModelMenu tooltipTextContent="Switch model" />
+                  <ThemeToggle />
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="w-3/4">
+              <CardHeader>
+                <CardTitle>Configuration Guide</CardTitle>
+                <CardDescription>
+                  Follow these steps to prevent CORS issues when using this
+                  extension with Ollama.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <OllamaSetupInstructions />
+              </CardContent>
+            </Card>
+          </div>
 
-        <div className="mt-8 flex justify-center">
-          <SocialHandles />
+          <div className="mt-8 flex justify-center">
+            <SocialHandles />
+          </div>
         </div>
-      </div>
-    </TooltipProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama client",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Chat with your local Ollama LLMs directly in your browser. Lightweight, fast, and privacy-focused.",
   "author": "shishir.chaurasiya",
   "scripts": {
@@ -16,6 +16,7 @@
     "@plasmohq/storage": "^1.15.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "2.1.2",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.15
+        version: 2.1.15(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-label':
         specifier: 2.1.2
         version: 2.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1501,6 +1504,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.15':
+    resolution: {integrity: sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
     peerDependencies:
@@ -1534,6 +1550,19 @@ packages:
 
   '@radix-ui/react-label@2.1.2':
     resolution: {integrity: sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.15':
+    resolution: {integrity: sha512-tVlmA3Vb9n8SZSd+YSbuFR66l87Wiy4du+YE+0hzKQEANA+7cWKH1WgqcEX4pXqxUFQKrWQGHdvEfw00TjFiew==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1612,6 +1641,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.10':
+    resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5641,6 +5683,21 @@ snapshots:
       '@types/react': 18.2.48
       '@types/react-dom': 18.2.18
 
+  '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-menu': 2.1.15(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.48)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
   '@radix-ui/react-focus-guards@1.1.2(@types/react@18.2.48)(react@18.2.0)':
     dependencies:
       react: 18.2.0
@@ -5670,6 +5727,32 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
+  '@radix-ui/react-menu@2.1.15(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      aria-hidden: 1.2.6
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.7.0(@types/react@18.2.48)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.2.48
       '@types/react-dom': 18.2.18
@@ -5747,6 +5830,23 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@18.2.48)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
+  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.48)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     optionalDependencies:


### PR DESCRIPTION
#### ✨ Changes made:

* Unified chat message bubble styling across light and dark modes:

  * User messages now use a subtle variant of the assistant response background in light mode for visual consistency.
* Improved dark mode support for `WelcomeScreen` and `ChatMessageBubble` components.
* Enhanced `ThemeToggle` with a tooltip using `shadcn/ui`'s `Tooltip` component.
* Suppressed default focus styles (outline/ring) on `<Textarea>` for a cleaner chat input UX.

#### 🧪 Tested:

* Manually verified light/dark mode switches.
* Checked auto-resizing and Enter-key handling in chat input.
* Verified tooltips and interaction on settings/models/actions.