### PR TITLE
feat: Add selection-to-chat functionality via context menu and a floa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Privacy-first Ollama Chrome extension to chat with local AI models like LLaMA, Mistral, Gemma — fully offline.",
   "author": "Shishir Chaurasiya",
   "keywords": [
@@ -149,7 +149,8 @@
       "storage",
       "sidePanel",
       "tabs",
-      "declarativeNetRequest"
+      "declarativeNetRequest",
+      "contextMenus"
     ],
     "browser_specific_settings": {
       "gecko": {

--- a/src/background/handlers/handle-context-menu.ts
+++ b/src/background/handlers/handle-context-menu.ts
@@ -1,0 +1,51 @@
+import { browser } from "@/lib/browser-api"
+import { DEFAULT_CONTEXT_MENU_ID, MESSAGE_KEYS } from "@/lib/constants"
+import type { ChromeSidePanel } from "@/types"
+
+export const initializeContextMenu = () => {
+  browser.contextMenus.create(
+    {
+      id: DEFAULT_CONTEXT_MENU_ID,
+      title: "Ask Ollama Client",
+      contexts: ["selection"]
+    },
+    () => {
+      if (browser.runtime.lastError) {
+        console.log(
+          "Context menu item already exists or error:",
+          browser.runtime.lastError.message
+        )
+      }
+    }
+  )
+
+  browser.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === DEFAULT_CONTEXT_MENU_ID && info.selectionText) {
+      // Open sidepanel if possible (Chrome specific)
+      if ("sidePanel" in browser) {
+        const sidePanel = (browser as unknown as { sidePanel: ChromeSidePanel })
+          .sidePanel
+        if (sidePanel.open && tab?.windowId) {
+          sidePanel
+            .open({ windowId: tab.windowId })
+            .catch((err: unknown) =>
+              console.error(
+                "Failed to open sidepanel:",
+                err instanceof Error ? err.message : String(err)
+              )
+            )
+        }
+      }
+
+      browser.runtime
+        .sendMessage({
+          type: MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT,
+          payload: info.selectionText,
+          fromBackground: true
+        })
+        .catch((err) => {
+          console.log("Could not send selection to chat:", err)
+        })
+    }
+  })
+}

--- a/src/contents/selection-button.tsx
+++ b/src/contents/selection-button.tsx
@@ -1,0 +1,110 @@
+import cssText from "data-text:~globals.css"
+import { useStorage } from "@plasmohq/storage/hook"
+import type { PlasmoCSConfig, PlasmoGetStyle } from "plasmo"
+import { useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { Quote } from "@/lib/lucide-icon"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+
+export const config: PlasmoCSConfig = {
+  matches: ["<all_urls>"],
+  all_frames: true
+}
+
+export const getStyle: PlasmoGetStyle = () => {
+  const style = document.createElement("style")
+  style.textContent = cssText
+  // Fix for :root variables in Shadow DOM
+  // Replace :root with :host to ensure variables apply within the shadow tree
+  style.textContent = style.textContent.replace(/:root/g, ":host")
+  return style
+}
+
+const SelectionButton = () => {
+  const [showButton, setShowButton] = useState(false)
+  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const [selectionText, setSelectionText] = useState("")
+
+  const [isEnabled] = useStorage<boolean>(
+    {
+      key: STORAGE_KEYS.BROWSER.SHOW_SELECTION_BUTTON,
+      instance: plasmoGlobalStorage
+    },
+    true
+  )
+
+  useEffect(() => {
+    if (!isEnabled) {
+      setShowButton(false)
+      return
+    }
+
+    const handleSelectionChange = () => {
+      const selection = window.getSelection()
+      const text = selection?.toString().trim()
+
+      if (text && text.length > 0) {
+        const range = selection?.getRangeAt(0)
+        const rect = range?.getBoundingClientRect()
+
+        if (rect) {
+          setPosition({
+            top: rect.bottom + window.scrollY + 10,
+            left: rect.right + window.scrollX - 30
+          })
+          setSelectionText(text)
+          setShowButton(true)
+        }
+      } else {
+        setShowButton(false)
+      }
+    }
+
+    document.addEventListener("mouseup", handleSelectionChange)
+    document.addEventListener("keyup", handleSelectionChange)
+
+    return () => {
+      document.removeEventListener("mouseup", handleSelectionChange)
+      document.removeEventListener("keyup", handleSelectionChange)
+    }
+  }, [isEnabled])
+
+  const handleClick = async () => {
+    try {
+      await chrome.runtime.sendMessage({
+        type: MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT,
+        payload: selectionText
+      })
+
+      setShowButton(false)
+      window.getSelection()?.removeAllRanges()
+    } catch (error) {
+      console.error("Failed to send selection:", error)
+    }
+  }
+
+  if (!showButton || !isEnabled) return null
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: position.top,
+        left: position.left,
+        zIndex: 2147483647
+      }}>
+      <Button
+        onClick={handleClick}
+        variant="secondary"
+        className="h-8 gap-2 rounded-lg px-3 shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-xl"
+        title="Add to Ollama Client">
+        <Quote className="size-3.5" />
+        <span className="text-xs font-medium">Ask Ollama client</span>
+      </Button>
+    </div>
+  )
+}
+
+export default SelectionButton

--- a/src/features/chat/stores/chat-input-store.ts
+++ b/src/features/chat/stores/chat-input-store.ts
@@ -5,14 +5,16 @@ import type { ChatInput } from "@/types"
 
 export const chatInputStore = create<ChatInput>((set) => ({
   input: "",
-  setInput: (text) => set({ input: text })
+  setInput: (text) => set({ input: text }),
+  appendInput: (text) => set((state) => ({ input: state.input + text }))
 }))
 
 export const useChatInput = () => {
   return chatInputStore(
     useShallow((s) => ({
       input: s.input,
-      setInput: s.setInput
+      setInput: s.setInput,
+      appendInput: s.appendInput
     }))
   )
 }

--- a/src/features/model/components/global-settings.tsx
+++ b/src/features/model/components/global-settings.tsx
@@ -18,6 +18,7 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
+import { SelectionButtonToggle } from "@/features/model/components/selection-button-toggle"
 import {
   CONTENT_SCRAPER_OPTIONS,
   SCROLL_STRATEGY_DESCRIPTIONS,
@@ -250,6 +251,21 @@ export const GlobalSettings = ({ config, onUpdate }: GlobalSettingsProps) => {
             checked={config.enabled}
             onCheckedChange={(checked) => onUpdate({ enabled: checked })}
           />
+        </div>
+
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between space-x-2">
+            <Label
+              htmlFor="show-selection-button"
+              className="flex flex-col space-y-1">
+              <span>Show "Ask ollama client" button on selection</span>
+              <span className="font-normal text-muted-foreground text-xs">
+                Show a floating button when selecting text to quickly add it to
+                chat
+              </span>
+            </Label>
+            <SelectionButtonToggle />
+          </div>
         </div>
 
         <Separator />

--- a/src/features/model/components/selection-button-toggle.tsx
+++ b/src/features/model/components/selection-button-toggle.tsx
@@ -1,0 +1,22 @@
+import { useStorage } from "@plasmohq/storage/hook"
+import { Switch } from "@/components/ui/switch"
+import { STORAGE_KEYS } from "@/lib/constants"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+
+export const SelectionButtonToggle = () => {
+  const [showButton, setShowButton] = useStorage<boolean>(
+    {
+      key: STORAGE_KEYS.BROWSER.SHOW_SELECTION_BUTTON,
+      instance: plasmoGlobalStorage
+    },
+    true
+  )
+
+  return (
+    <Switch
+      id="show-selection-button"
+      checked={showButton}
+      onCheckedChange={setShowButton}
+    />
+  )
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -25,7 +25,8 @@ export const MESSAGE_KEYS = {
   },
   BROWSER: {
     OPEN_TAB: "open-tab",
-    GET_PAGE_CONTENT: "get-page-content"
+    GET_PAGE_CONTENT: "get-page-content",
+    ADD_SELECTION_TO_CHAT: "add-selection-to-chat"
   }
 }
 
@@ -42,7 +43,8 @@ export const STORAGE_KEYS = {
   BROWSER: {
     TABS_ACCESS: "browser-tab-access",
     EXCLUDE_URL_PATTERNS: "exclude-url-pattern",
-    CONTENT_EXTRACTION_CONFIG: "content-extraction-config"
+    CONTENT_EXTRACTION_CONFIG: "content-extraction-config",
+    SHOW_SELECTION_BUTTON: "show-selection-button"
   },
   TTS: {
     RATE: "tts-rate",
@@ -63,6 +65,8 @@ export const STORAGE_KEYS = {
 
 // Default embedding model - use `mxbai-embed-large` for improved semantics
 export const DEFAULT_EMBEDDING_MODEL = "mxbai-embed-large"
+
+export const DEFAULT_CONTEXT_MENU_ID = "add-to-ollama-client"
 
 export type ChunkingStrategy = "fixed" | "semantic" | "hybrid"
 

--- a/src/lib/lucide-icon.ts
+++ b/src/lib/lucide-icon.ts
@@ -48,6 +48,7 @@ import Notebook from "lucide-react/dist/esm/icons/notebook"
 import Package from "lucide-react/dist/esm/icons/package"
 import Paperclip from "lucide-react/dist/esm/icons/paperclip"
 import Plus from "lucide-react/dist/esm/icons/plus"
+import Quote from "lucide-react/dist/esm/icons/quote"
 import RefreshCcw from "lucide-react/dist/esm/icons/refresh-ccw"
 import RefreshCw from "lucide-react/dist/esm/icons/refresh-cw"
 import RotateCcw from "lucide-react/dist/esm/icons/rotate-ccw"
@@ -155,5 +156,6 @@ export {
   Trash2,
   type LucideIcon,
   Bot,
-  User
+  User,
+  Quote
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,14 @@ export interface ChromeMessage {
   query?: string
   name?: string
   cancel?: boolean
+  fromBackground?: boolean
+}
+
+export interface ChromeSidePanel {
+  open: (options: { windowId: number; tabId?: number }) => Promise<void>
+  setPanelBehavior: (options: {
+    openPanelOnActionClick: boolean
+  }) => Promise<void>
 }
 
 export interface ChromeResponse {
@@ -342,7 +350,8 @@ export interface LoadStreamState {
 
 export interface ChatInput {
   input: string
-  setInput: (value: string) => void
+  setInput: (text: string) => void
+  appendInput: (text: string) => void
 }
 
 // Re-export embedding config types from constants


### PR DESCRIPTION
## Description
Closes #35

This PR implements the **"Selection as Context"** feature, enabling users to seamlessly bring text from any webpage into the Ollama Client chat.

## Key Features

- **Context Menu Integration**: Added a right-click option **"Ask Ollama Client"** that appends selected text to the chat.
- **Floating Action Button**: Introduced a configurable floating button labeled **"Ask Ollama client"** that appears near the cursor upon text selection.
  - Toggle available in **Settings -> Extraction**.
- **Smart Input Handling**: Selected text is **appended** to the existing chat input instead of overwriting it.
- **Auto-Open Sidepanel**: Automatically opens the extension sidepanel if it is closed when triggering the feature.

## Technical Changes

- Added `contextMenus` permission to `manifest.json`.
- Implemented `selection-button.tsx` as a Plasmo Content Script UI.
- Refactored `chat-input-store.ts` to support `appendInput`.