### PR TITLE
fix(docs): add vercel.json for correct output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "cd docs-src && pnpm install --frozen-lockfile && pnpm run build",
+  "outputDirectory": "docs",
+  "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
# Fix vercel deployment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `vercel.json` to configure Vercel deployments for the Astro-based docs site, pointing Vercel at the correct output directory (`docs/`) produced by building inside `docs-src/`.

- `outputDirectory: "docs"` correctly matches `outDir: "../docs"` in `docs-src/astro.config.mjs`, so Vercel will serve the right build output.
- `installCommand` runs `pnpm install --frozen-lockfile` at the repo root (which already installs all workspace packages, including `docs-src`), and then `buildCommand` runs `pnpm install` again inside `docs-src/` — the second install is redundant since the workspace root lockfile covers both packages.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — output directory and build command are correct, and the docs site will deploy as intended.

The only issue is a redundant pnpm install step inside buildCommand that wastes build time on every Vercel deployment, but it does not break anything. The outputDirectory matches what Astro actually emits, and the workspace lockfile is handled correctly.

No files require special attention beyond the minor inefficiency in vercel.json.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vercel.json | Adds Vercel deployment config pointing to docs-src build output; the installCommand causes a redundant pnpm install since buildCommand already installs inside docs-src |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant V as Vercel
    participant R as Repo Root
    participant D as docs-src/
    participant O as docs/ (output)

    V->>R: installCommand: pnpm install --frozen-lockfile
    Note over R: Installs all workspace deps<br/>(extension + docs-src)
    V->>D: buildCommand: cd docs-src
    D->>D: pnpm install --frozen-lockfile (redundant)
    D->>D: pnpm run build (astro build)
    D->>O: outDir: ../docs
    V->>O: serve outputDirectory: docs
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avercel.json%3A2%0ARedundant%20install%20step%3A%20the%20root%20%60pnpm%20install%20--frozen-lockfile%60%20%28run%20by%20%60installCommand%60%29%20already%20installs%20all%20workspace%20packages%2C%20including%20%60docs-src%60%2C%20because%20%60pnpm-workspace.yaml%60%20lists%20%60%22docs-src%22%60%20as%20a%20workspace%20member%20with%20a%20shared%20lockfile.%20Running%20%60pnpm%20install%60%20a%20second%20time%20inside%20%60docs-src%2F%60%20adds%20unnecessary%20time%20to%20every%20Vercel%20build.%20Dropping%20the%20inner%20install%20and%20keeping%20only%20%60pnpm%20run%20build%60%20is%20sufficient.%0A%0A%60%60%60suggestion%0A%20%20%22buildCommand%22%3A%20%22cd%20docs-src%20%26%26%20pnpm%20run%20build%22%2C%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=77&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22docs%2Frefactor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Frefactor%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avercel.json%3A2%0ARedundant%20install%20step%3A%20the%20root%20%60pnpm%20install%20--frozen-lockfile%60%20%28run%20by%20%60installCommand%60%29%20already%20installs%20all%20workspace%20packages%2C%20including%20%60docs-src%60%2C%20because%20%60pnpm-workspace.yaml%60%20lists%20%60%22docs-src%22%60%20as%20a%20workspace%20member%20with%20a%20shared%20lockfile.%20Running%20%60pnpm%20install%60%20a%20second%20time%20inside%20%60docs-src%2F%60%20adds%20unnecessary%20time%20to%20every%20Vercel%20build.%20Dropping%20the%20inner%20install%20and%20keeping%20only%20%60pnpm%20run%20build%60%20is%20sufficient.%0A%0A%60%60%60suggestion%0A%20%20%22buildCommand%22%3A%20%22cd%20docs-src%20%26%26%20pnpm%20run%20build%22%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): add vercel.json for correct o..."](https://github.com/shishir435/ollama-client/commit/b9c52dd0bfcd8d714d732ec4377573c9c835e18e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33487091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->