### PR TITLE
refactor: OG image typography with Geist font, black bg, cleaner layout

### DIFF
--- a/docs-src/src/components/starlight/Head.astro
+++ b/docs-src/src/components/starlight/Head.astro
@@ -1,12 +1,12 @@
 ---
-import { SITE_URL } from "@/seo/constants.mjs"
+import { SITE_URL, OG_IMAGE_VERSION } from "@/seo/constants.mjs"
 
 const { head, id: slug, entry, siteTitle, lastUpdated, lang } =
   Astro.locals.starlightRoute
 
 const base = Astro.site?.toString() ?? SITE_URL
 const site = base.replace(/\/$/, "")
-const ogUrl = `${site}/og/${slug}.png`
+const ogUrl = `${site}/og/${slug}.png?${OG_IMAGE_VERSION}`
 const pageUrl = `${site}/${slug}/`
 
 const jsonLd = {

--- a/docs-src/src/layouts/BaseLayout.astro
+++ b/docs-src/src/layouts/BaseLayout.astro
@@ -10,7 +10,7 @@
 import "@fontsource-variable/geist"
 import "@fontsource-variable/geist-mono"
 import "@/styles/globals.css"
-import { KEYWORDS, SITE_URL, SITE_TITLE } from "@/seo/constants.mjs"
+import { KEYWORDS, SITE_URL, SITE_TITLE, OG_IMAGE_VERSION } from "@/seo/constants.mjs"
 
 interface Props {
   title: string
@@ -25,7 +25,7 @@ const ogPath =
   Astro.url.pathname === "/"
     ? "/og/index.png"
     : `/og${Astro.url.pathname.replace(/\/$/, "")}.png`
-const ogUrl = new URL(ogPath, site)
+const ogUrl = new URL(`${ogPath}?${OG_IMAGE_VERSION}`, site)
 ---
 
 <!doctype html>

--- a/docs-src/src/pages/og/[...route].ts
+++ b/docs-src/src/pages/og/[...route].ts
@@ -1,6 +1,13 @@
 import { OGImageRoute } from "astro-og-canvas"
 import { LANDING_TITLE, LANDING_DESCRIPTION } from "@/seo/constants.mjs"
 
+const keySlugs = new Set([
+  "concepts/architecture",
+  "concepts/provider-matrix",
+  "guides/provider-setup",
+  "legal/privacy-policy",
+])
+
 type MarkdownModule = {
   frontmatter: { title?: string; description?: string }
 }
@@ -10,45 +17,55 @@ const docFiles = import.meta.glob(
   { eager: true },
 ) as Record<string, MarkdownModule>
 
-const pages = Object.fromEntries(
-  Object.entries(docFiles).map(([path, mod]) => {
-    const slug = path
-      .replace("/src/content/docs/", "")
-      .replace(/\/index\.mdx?$/, "")
-      .replace(/\.mdx?$/, "")
-    const { title, description } = mod.frontmatter
-    return [slug, { title, description: description ?? "" }]
-  }),
-)
+const pages: Record<string, { title: string; description: string }> = {
+  index: { title: LANDING_TITLE, description: LANDING_DESCRIPTION },
+}
 
-pages.index = {
-  title: LANDING_TITLE,
-  description: LANDING_DESCRIPTION,
+for (const [path, mod] of Object.entries(docFiles)) {
+  const slug = path
+    .replace("/src/content/docs/", "")
+    .replace(/\/index\.mdx?$/, "")
+    .replace(/\.mdx?$/, "")
+  if (keySlugs.has(slug)) {
+    const { title, description } = mod.frontmatter
+    pages[slug] = { title, description: description ?? "" }
+  }
+}
+
+const logo = {
+  path: "./public/assets/favicon-32x32.png",
+  size: [32] as [width?: number, height?: number],
+}
+
+const imageOptions = {
+  bgGradient: [[0, 0, 0], [8, 8, 10]] as [number, number, number][],
+  fonts: [
+    "https://api.fontsource.org/v1/fonts/geist/latin-700-normal.ttf",
+    "https://api.fontsource.org/v1/fonts/geist/latin-400-normal.ttf",
+  ],
+  font: {
+    title: {
+      color: [255, 255, 255] as [number, number, number],
+      size: 64,
+      weight: "Bold" as const,
+      lineHeight: 1.15,
+    },
+    description: {
+      color: [200, 200, 205] as [number, number, number],
+      size: 28,
+      lineHeight: 1.4,
+    },
+  },
+  padding: 64,
 }
 
 export const { getStaticPaths, GET } = await OGImageRoute({
   param: "route",
   pages,
   getImageOptions: (_path, page) => ({
+    logo,
+    ...imageOptions,
     title: page.title,
     description: page.description,
-    bgGradient: [[10, 10, 11], [23, 23, 27]],
-    border: {
-      color: [63, 63, 70],
-      width: 3,
-      side: "inline-start",
-    },
-    font: {
-      title: {
-        color: [250, 250, 250],
-        size: 64,
-        weight: "Bold",
-      },
-      description: {
-        color: [161, 161, 170],
-        size: 32,
-      },
-    },
-    padding: 60,
   }),
 })

--- a/docs-src/src/seo/constants.mjs
+++ b/docs-src/src/seo/constants.mjs
@@ -9,5 +9,7 @@ export const LANDING_TITLE = "Ollama Client — Local AI chat in your browser"
 
 export const LANDING_DESCRIPTION = `${SITE_DESCRIPTION} Local-first by design.`
 
+export const OG_IMAGE_VERSION = "v1"
+
 export const KEYWORDS =
   "ollama, local llm, browser extension, chrome extension, firefox extension, side panel, rag, embeddings, local-first, privacy, lm studio, llama.cpp, openai compatible, open source"


### PR DESCRIPTION
- Switch from Noto Sans to Geist (Bold 700 + Regular 400)
- Pure black background gradient
- Remove left accent border from all OG images
- Restore dynamic frontmatter-driven text via import.meta.glob
- Sharper typography with explicit bold font loading
- Add OG_IMAGE_VERSION for Twitter cache busting
- Add og:image:alt and twitter:image:alt tags

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors OG image generation to use Geist fonts (fetched from `api.fontsource.org` at build time), switches to a pure-black background gradient, removes the left accent border, and adds `OG_IMAGE_VERSION` for Twitter cache-busting plus `og:image:alt` / `twitter:image:alt` meta tags.

- **`[...route].ts`**: Introduces a `keySlugs` whitelist limiting static OG image generation to 5 pages; extracts `imageOptions` into a shared constant and adds a favicon logo overlay.
- **`Head.astro` / `BaseLayout.astro`**: Consistently appends `?${OG_IMAGE_VERSION}` to all OG image URLs and adds `alt` attributes to both `og:image` and `twitter:image` meta tags.
- **`constants.mjs`**: Exports `OG_IMAGE_VERSION = "v1"` as the single source of truth for the cache-bust token.

<h3>Confidence Score: 4/5</h3>

The OG image refactor is mostly self-contained, but open questions about the font-loading strategy in [...route].ts flagged in prior review rounds remain unresolved and could cause silent font fallback or build failures.

The cache-busting, alt-tag additions, and imageOptions refactor in Head.astro, BaseLayout.astro, and constants.mjs are straightforward and low-risk. The concern sits entirely in [...route].ts: build-time font fetching from an external API and potential mismatched package paths were raised in earlier rounds without a confirmed fix, so OG images may silently render without the intended Geist typeface or fail the build under adverse network conditions.

docs-src/src/pages/og/[...route].ts — font loading strategy and frontmatter title nullability warrant a closer look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs-src/src/pages/og/[...route].ts | Major refactor: introduces keySlugs whitelist (intentional per developer), moves font loading to network URLs at build time, extracts imageOptions object, switches to pure-black gradient — unresolved font-loading and title-type issues from prior threads remain open. |
| docs-src/src/components/starlight/Head.astro | Appends OG_IMAGE_VERSION query param to ogUrl for Twitter cache-busting; adds og:image:alt and twitter:image:alt meta tags using entry.data.title. |
| docs-src/src/layouts/BaseLayout.astro | Appends OG_IMAGE_VERSION query param to the landing-page ogUrl; adds og:image:alt and twitter:image:alt meta tags using the required title prop. |
| docs-src/src/seo/constants.mjs | Adds OG_IMAGE_VERSION = "v1" constant used as a query-string cache-busting token across OG image meta tags. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build starts] --> B[import.meta.glob collects all md/mdx files]
    B --> C{slug in keySlugs?}
    C -- Yes --> D[Extract frontmatter title and description]
    C -- No --> E[Skip - no OG image generated]
    D --> F[pages Record: slug to title/description]
    G[index entry: LANDING_TITLE/DESC] --> F
    F --> H[OGImageRoute: getStaticPaths + GET]
    H --> I[Fetch Geist fonts from api.fontsource.org]
    I --> J[Render PNG 1200x630 black bg]
    J --> K[Static file at /og/slug.png]
    K --> L[Head.astro: og:image with OG_IMAGE_VERSION]
    K --> M[BaseLayout.astro: og:image with OG_IMAGE_VERSION]
```

<sub>Reviews (3): Last reviewed commit: ["refactor: OG image typography with Geist..."](https://github.com/shishir435/ollama-client/commit/6df2d9ab1dd850d7c77faa3fd418a6360b408b0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33604053)</sub>

<!-- /greptile_comment -->