### PR TITLE
Refactor/zod and logger

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -8,7 +8,6 @@
       ]
     }
   },
-
   "lsp": {
     "tailwindcss-language-server": {
       "settings": {
@@ -19,5 +18,17 @@
         }
       }
     }
-  }
+  },
+  "file_scan_exclusions": [
+    "**/.svn",
+    "**/.hg",
+    "**/.jj",
+    "**/CVS",
+    "**/.DS_Store",
+    "**/Thumbs.db",
+    "**/.classpath",
+    "**/.settings"
+  ],
+  "formatter": "auto",
+  "format_on_save": "on"
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,7 +5,31 @@
         "tailwindcss-intellisense-css",
         "!vscode-css-language-server",
         "tailwindcss-language-server"
-      ]
+      ],
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JSON": { "formatter": { "language_server": { "name": "biome" } } },
+    "JSONC": { "formatter": { "language_server": { "name": "biome" } } },
+    "JavaScript": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TypeScript": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TSX": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
     }
   },
   "lsp": {
@@ -29,6 +53,5 @@
     "**/.classpath",
     "**/.settings"
   ],
-  "formatter": "auto",
   "format_on_save": "on"
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "turndown": "^7.2.4",
     "vectra": "^0.11.1",
     "webextension-polyfill": "^0.12.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, and llama.cpp, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,10 +148,13 @@ importers:
         version: 7.2.4
       vectra:
         specifier: ^0.11.1
-        version: 0.11.1(ws@8.21.0)(zod@3.25.76)
+        version: 0.11.1(ws@8.21.0)(zod@4.4.3)
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.0.0)(immer@11.1.8)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -6637,9 +6640,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -6790,7 +6790,7 @@ snapshots:
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@astrojs/starlight@0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
@@ -11676,7 +11676,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@8.21.0)(zod@3.25.76):
+  openai@4.104.0(ws@8.21.0)(zod@4.4.3):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -11687,7 +11687,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.21.0
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - encoding
 
@@ -13115,14 +13115,14 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vectra@0.11.1(ws@8.21.0)(zod@3.25.76):
+  vectra@0.11.1(ws@8.21.0)(zod@4.4.3):
     dependencies:
       axios: 1.16.1
       cheerio: 1.2.0
       dotenv: 16.6.1
       gpt-3-encoder: 1.1.4
       json-colorizer: 3.0.1
-      openai: 4.104.0(ws@8.21.0)(zod@3.25.76)
+      openai: 4.104.0(ws@8.21.0)(zod@4.4.3)
       turndown: 7.2.4
       uuid: 11.1.1
       wink-bm25-text-search: 3.1.2
@@ -13536,8 +13536,6 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}
 

--- a/src/background/handlers/__tests__/handle-embedding-download.test.ts
+++ b/src/background/handlers/__tests__/handle-embedding-download.test.ts
@@ -5,6 +5,7 @@ import {
   checkEmbeddingModelExists,
   downloadEmbeddingModelSilently
 } from "../handle-embedding-download"
+import { createMockResponse } from "./test-utils"
 
 // Mock dependencies
 vi.mock("@/background/lib/utils", () => ({
@@ -53,46 +54,42 @@ describe("Handle Embedding Download", () => {
 
   describe("checkEmbeddingModelExists", () => {
     it("should return true if model exists", async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({
           models: [{ name: "nomic-embed-text:latest" }]
         })
-      } as any)
+      )
 
       const result = await checkEmbeddingModelExists("nomic-embed-text")
       expect(result.exists).toBe(true)
     })
 
     it("should return true if model exists with tag match", async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({
           models: [{ name: "nomic-embed-text:latest" }]
         })
-      } as any)
+      )
 
       const result = await checkEmbeddingModelExists("nomic-embed-text:latest")
       expect(result.exists).toBe(true)
     })
 
     it("should return false if model not found", async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({
           models: [{ name: "llama2:latest" }]
         })
-      } as any)
+      )
 
       const result = await checkEmbeddingModelExists("nomic-embed-text")
       expect(result.exists).toBe(false)
     })
 
     it("should return false on API error", async () => {
-      vi.mocked(fetch).mockResolvedValue({
-        ok: false,
-        statusText: "Server Error"
-      } as any)
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse(null, { ok: false, statusText: "Server Error" })
+      )
 
       const result = await checkEmbeddingModelExists("nomic-embed-text")
       expect(result.exists).toBe(false)
@@ -109,12 +106,11 @@ describe("Handle Embedding Download", () => {
   describe("downloadEmbeddingModelSilently", () => {
     it("should skip download if model exists", async () => {
       // Mock checkEmbeddingModelExists behavior by mocking fetch response
-      vi.mocked(fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({
           models: [{ name: "nomic-embed-text:latest" }]
         })
-      } as any)
+      )
 
       const result = await downloadEmbeddingModelSilently("nomic-embed-text")
 
@@ -131,13 +127,8 @@ describe("Handle Embedding Download", () => {
       // First call (check): not found
       // Second call (pull): success
       vi.mocked(fetch)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ models: [] })
-        } as any)
-        .mockResolvedValueOnce({
-          ok: true
-        } as any)
+        .mockResolvedValueOnce(createMockResponse({ models: [] }))
+        .mockResolvedValueOnce(createMockResponse(null))
 
       const result = await downloadEmbeddingModelSilently("nomic-embed-text")
 
@@ -162,16 +153,14 @@ describe("Handle Embedding Download", () => {
 
     it("should handle download failure", async () => {
       vi.mocked(fetch)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ models: [] })
-        } as any)
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: "Internal Server Error",
-          text: async () => "Error details"
-        } as any)
+        .mockResolvedValueOnce(createMockResponse({ models: [] }))
+        .mockResolvedValueOnce(
+          createMockResponse("Error details", {
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error"
+          })
+        )
 
       const result = await downloadEmbeddingModelSilently("nomic-embed-text")
 
@@ -181,10 +170,7 @@ describe("Handle Embedding Download", () => {
 
     it("should handle network error during download", async () => {
       vi.mocked(fetch)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ models: [] })
-        } as any)
+        .mockResolvedValueOnce(createMockResponse({ models: [] }))
         .mockRejectedValueOnce(new Error("Network Error"))
 
       const result = await downloadEmbeddingModelSilently("nomic-embed-text")

--- a/src/background/handlers/__tests__/handle-get-loaded-model.test.ts
+++ b/src/background/handlers/__tests__/handle-get-loaded-model.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { handleGetLoadedModels } from "../handle-get-loaded-model"
+import { createMockResponse } from "./test-utils"
 
 vi.mock("@/background/lib/utils", () => ({
   getBaseUrl: vi.fn(),
@@ -32,10 +33,7 @@ describe("handleGetLoadedModels", () => {
       models: [{ name: "llama2:latest", size: 3825819519 }]
     }
 
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue(mockData)
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse(mockData))
 
     const sendResponse = vi.fn()
     await handleGetLoadedModels(undefined, sendResponse)
@@ -49,10 +47,7 @@ describe("handleGetLoadedModels", () => {
 
   it("should use custom base URL", async () => {
     vi.mocked(getBaseUrl).mockResolvedValue("http://custom:8080")
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({})
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse({}))
 
     const sendResponse = vi.fn()
     await handleGetLoadedModels(undefined, sendResponse)
@@ -61,11 +56,13 @@ describe("handleGetLoadedModels", () => {
   })
 
   it("should handle API errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error"
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse(null, {
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error"
+      })
+    )
 
     const sendResponse = vi.fn()
     await handleGetLoadedModels(undefined, sendResponse)
@@ -89,10 +86,9 @@ describe("handleGetLoadedModels", () => {
   })
 
   it("should handle JSON parsing errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockRejectedValue(new Error("Invalid JSON"))
-    } as any)
+    const mockResp = createMockResponse(null)
+    vi.mocked(mockResp.json).mockRejectedValue(new Error("Invalid JSON"))
+    vi.mocked(fetch).mockResolvedValue(mockResp)
 
     const sendResponse = vi.fn()
     await handleGetLoadedModels(undefined, sendResponse)

--- a/src/background/handlers/__tests__/handle-get-provider-version.test.ts
+++ b/src/background/handlers/__tests__/handle-get-provider-version.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import { handleGetProviderVersion } from "../handle-get-provider-version"
+import { createMockResponse } from "./test-utils"
 
 vi.mock("@/background/lib/utils", () => ({
   getBaseUrl: vi.fn(),
@@ -18,10 +19,7 @@ describe("handleGetProviderVersion", () => {
   it("should get provider version successfully", async () => {
     const mockData = { version: "0.1.17" }
 
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue(mockData)
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse(mockData))
 
     const sendResponse = vi.fn()
     await handleGetProviderVersion(sendResponse)
@@ -35,10 +33,9 @@ describe("handleGetProviderVersion", () => {
 
   it("should use custom base URL", async () => {
     vi.mocked(getBaseUrl).mockResolvedValue("http://custom:8080")
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "0.1.17" })
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse({ version: "0.1.17" })
+    )
 
     const sendResponse = vi.fn()
     await handleGetProviderVersion(sendResponse)
@@ -47,11 +44,13 @@ describe("handleGetProviderVersion", () => {
   })
 
   it("should handle API errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found"
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse(null, {
+        ok: false,
+        status: 404,
+        statusText: "Not Found"
+      })
+    )
 
     const sendResponse = vi.fn()
     await handleGetProviderVersion(sendResponse)

--- a/src/background/handlers/__tests__/handle-model-pull.test.ts
+++ b/src/background/handlers/__tests__/handle-model-pull.test.ts
@@ -6,7 +6,13 @@ import {
 } from "@/background/lib/abort-controller-registry"
 import { safePostMessage } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
+import type { ModelPullMessage } from "@/types"
 import { handleModelPull } from "../handle-model-pull"
+import {
+  createMockPort,
+  createMockResponse,
+  createMockStreamResponse
+} from "./test-utils"
 
 // Mock dependencies
 vi.mock("@/background/handlers/handle-pull-stream", () => ({
@@ -33,7 +39,7 @@ vi.mock("@/lib/providers/factory", () => ({
 global.fetch = vi.fn()
 
 describe("Handle Model Pull", () => {
-  const mockPort = { name: "test-port" } as any
+  const mockPort = createMockPort()
   const isPortClosed = vi.fn().mockReturnValue(false)
 
   beforeEach(() => {
@@ -50,12 +56,11 @@ describe("Handle Model Pull", () => {
   })
 
   it("should initiate pull successfully", async () => {
-    const msg = { payload: "llama2" } as any
+    const msg = { payload: "llama2" } satisfies ModelPullMessage
 
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      body: "stream"
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockStreamResponse(["stream-data"])
+    )
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
@@ -71,7 +76,7 @@ describe("Handle Model Pull", () => {
   })
 
   it("should handle cancellation", async () => {
-    const msg = { payload: "llama2", cancel: true } as any
+    const msg = { payload: "llama2", cancel: true } satisfies ModelPullMessage
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
@@ -80,13 +85,15 @@ describe("Handle Model Pull", () => {
   })
 
   it("should handle fetch errors", async () => {
-    const msg = { payload: "llama2" } as any
+    const msg = { payload: "llama2" } satisfies ModelPullMessage
 
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found"
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse(null, {
+        ok: false,
+        status: 404,
+        statusText: "Not Found"
+      })
+    )
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
@@ -97,12 +104,9 @@ describe("Handle Model Pull", () => {
   })
 
   it("should handle missing body", async () => {
-    const msg = { payload: "llama2" } as any
+    const msg = { payload: "llama2" } satisfies ModelPullMessage
 
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      body: null
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse(null, { ok: true }))
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
@@ -112,7 +116,7 @@ describe("Handle Model Pull", () => {
   })
 
   it("should handle network errors", async () => {
-    const msg = { payload: "llama2" } as any
+    const msg = { payload: "llama2" } satisfies ModelPullMessage
 
     vi.mocked(fetch).mockRejectedValue(new Error("Network Error"))
 
@@ -124,7 +128,7 @@ describe("Handle Model Pull", () => {
   })
 
   it("should handle abort errors specially", async () => {
-    const msg = { payload: "llama2" } as any
+    const msg = { payload: "llama2" } satisfies ModelPullMessage
     const abortError = new Error("Aborted")
     abortError.name = "AbortError"
 

--- a/src/background/handlers/__tests__/handle-scrape-model-variants.test.ts
+++ b/src/background/handlers/__tests__/handle-scrape-model-variants.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { safeSendResponse } from "@/background/lib/utils"
 import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import { handleScrapeModelVariants } from "../handle-scrape-model-variants"
+import { createMockResponse } from "./test-utils"
 
 vi.mock("@/background/lib/utils", () => ({
   safeSendResponse: vi.fn()
@@ -16,9 +17,7 @@ describe("handleScrapeModelVariants", () => {
 
   it("should scrape model variants successfully", async () => {
     const mockHtml = "<html>Model variants page</html>"
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockResolvedValue(mockHtml)
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse(mockHtml))
 
     const sendResponse = vi.fn()
     await handleScrapeModelVariants("llama2", sendResponse)
@@ -33,9 +32,7 @@ describe("handleScrapeModelVariants", () => {
   })
 
   it("should encode model name", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockResolvedValue("<html></html>")
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse("<html></html>"))
 
     const sendResponse = vi.fn()
     await handleScrapeModelVariants("llama 2", sendResponse)
@@ -58,9 +55,9 @@ describe("handleScrapeModelVariants", () => {
   })
 
   it("should handle text parsing errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockRejectedValue(new Error("Parse error"))
-    } as any)
+    const mockResp = createMockResponse(null)
+    vi.mocked(mockResp.text).mockRejectedValue(new Error("Parse error"))
+    vi.mocked(fetch).mockResolvedValue(mockResp)
 
     const sendResponse = vi.fn()
     await handleScrapeModelVariants("llama2", sendResponse)

--- a/src/background/handlers/__tests__/handle-scrape-model.test.ts
+++ b/src/background/handlers/__tests__/handle-scrape-model.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { safeSendResponse } from "@/background/lib/utils"
 import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import { handleScrapeModel } from "../handle-scrape-model"
+import { createMockResponse } from "./test-utils"
 
 vi.mock("@/background/lib/utils", () => ({
   safeSendResponse: vi.fn()
@@ -16,9 +17,7 @@ describe("handleScrapeModel", () => {
 
   it("should scrape model search results successfully", async () => {
     const mockHtml = "<html>Model search results</html>"
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockResolvedValue(mockHtml)
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse(mockHtml))
 
     const sendResponse = vi.fn()
     await handleScrapeModel("llama", sendResponse)
@@ -33,9 +32,7 @@ describe("handleScrapeModel", () => {
   })
 
   it("should encode query parameters", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockResolvedValue("<html></html>")
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(createMockResponse("<html></html>"))
 
     const sendResponse = vi.fn()
     await handleScrapeModel("llama 2 chat", sendResponse)
@@ -58,9 +55,9 @@ describe("handleScrapeModel", () => {
   })
 
   it("should handle text parsing errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      text: vi.fn().mockRejectedValue(new Error("Parse error"))
-    } as any)
+    const mockResp = createMockResponse(null)
+    vi.mocked(mockResp.text).mockRejectedValue(new Error("Parse error"))
+    vi.mocked(fetch).mockResolvedValue(mockResp)
 
     const sendResponse = vi.fn()
     await handleScrapeModel("llama", sendResponse)

--- a/src/background/handlers/__tests__/handle-unload-model.test.ts
+++ b/src/background/handlers/__tests__/handle-unload-model.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { safeSendResponse } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { handleUnloadModel } from "../handle-unload-model"
+import { createMockResponse } from "./test-utils"
 
 // Mock dependencies
 vi.mock("@/background/lib/utils", () => ({
@@ -30,10 +31,9 @@ describe("Handle Unload Model", () => {
   })
 
   it("should successfully unload a model", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({ done_reason: "unload" })
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse({ done_reason: "unload" })
+    )
 
     await handleUnloadModel("llama2", mockSendResponse)
 
@@ -56,11 +56,13 @@ describe("Handle Unload Model", () => {
   })
 
   it("should handle API errors", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error"
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse(null, {
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error"
+      })
+    )
 
     await handleUnloadModel("llama2", mockSendResponse)
 
@@ -82,10 +84,9 @@ describe("Handle Unload Model", () => {
   })
 
   it("should handle non-unload done reasons", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({ done_reason: "stop" })
-    } as any)
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse({ done_reason: "stop" })
+    )
 
     await handleUnloadModel("llama2", mockSendResponse)
 

--- a/src/background/handlers/__tests__/test-utils.ts
+++ b/src/background/handlers/__tests__/test-utils.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest"
-import type { ChromePort, SendResponseFunction } from "@/types"
+import type { ChromeMessage, ChromePort, SendResponseFunction } from "@/types"
 
 /**
  * Create a mock Ollama API response
@@ -96,6 +96,92 @@ export const mockModelDetailsResponse = {
     parameter_size: "8B",
     quantization_level: "Q4_0"
   }
+}
+
+/**
+ * Create a mock Response object
+ */
+export const createMockResponse = (
+  data: unknown,
+  options?: { ok?: boolean; status?: number; statusText?: string }
+): Response => {
+  const ok = options?.ok ?? true
+  return {
+    ok,
+    status: options?.status ?? (ok ? 200 : 500),
+    statusText: options?.statusText ?? (ok ? "OK" : "Internal Server Error"),
+    json: vi.fn().mockResolvedValue(data),
+    text: vi
+      .fn()
+      .mockResolvedValue(
+        typeof data === "string" ? data : JSON.stringify(data)
+      ),
+    headers: new Headers(),
+    redirected: false,
+    type: "basic",
+    url: "",
+    clone: vi.fn(),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    bytes: () => Promise.resolve(new Uint8Array(0))
+  } as Response
+}
+
+/**
+ * Create a mock ChromeMessage
+ */
+export const createMockMessage = (
+  overrides?: Partial<ChromeMessage>
+): ChromeMessage => ({
+  type: "TEST_MESSAGE",
+  ...overrides
+})
+
+/**
+ * Create a mock streaming Response with body.getReader()
+ */
+export const createMockStreamResponse = (
+  chunks: string[],
+  options?: { ok?: boolean }
+): Response => {
+  const ok = options?.ok ?? true
+  let index = 0
+  const encoder = new TextEncoder()
+  const reader = {
+    read: vi.fn().mockImplementation(() => {
+      if (index < chunks.length) {
+        return Promise.resolve({
+          done: false,
+          value: encoder.encode(chunks[index++])
+        })
+      }
+      return Promise.resolve({ done: true, value: undefined })
+    }),
+    cancel: vi.fn(),
+    releaseLock: vi.fn(),
+    closed: Promise.resolve(undefined)
+  }
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? "OK" : "Internal Server Error",
+    body: { getReader: () => reader } as unknown as ReadableStream<Uint8Array>,
+    headers: new Headers(),
+    redirected: false,
+    type: "basic",
+    url: "",
+    clone: vi.fn(),
+    bodyUsed: false,
+    json: vi.fn(),
+    text: vi.fn(),
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    bytes: () => Promise.resolve(new Uint8Array(0))
+  } as Response
 }
 
 /**

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -145,7 +145,7 @@ export const handleChatWithModel = withErrorContext(
         if (isPortClosed()) return
 
         if (process.env.NODE_ENV === "development") {
-          console.log("[ChatStream] chunk", {
+          logger.debug("Chat stream chunk", "ChatStream", {
             hasDelta: typeof chunk.delta === "string" && chunk.delta.length > 0,
             deltaPreview:
               typeof chunk.delta === "string"

--- a/src/background/handlers/handle-embed-chunks.ts
+++ b/src/background/handlers/handle-embed-chunks.ts
@@ -29,8 +29,12 @@ export const handleEmbedFileChunks = async (
         success: false,
         error: { status: 0, message: "Invalid payload" }
       })
-    } catch (_) {
-      /* ignore */
+    } catch (e) {
+      logger.warn(
+        "Port closed before error response sent",
+        "handleEmbedFileChunks",
+        { error: e }
+      )
     }
     return
   }
@@ -72,8 +76,12 @@ export const handleEmbedFileChunks = async (
         success: true,
         data: { embedded: results.length }
       })
-    } catch (_) {
-      /* ignore if port disconnected */
+    } catch (e) {
+      logger.warn(
+        "Port closed before success response sent",
+        "handleEmbedFileChunks",
+        { error: e }
+      )
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
@@ -82,8 +90,12 @@ export const handleEmbedFileChunks = async (
         success: false,
         error: { status: 500, message: errorMessage }
       })
-    } catch (_) {
-      /* ignore */
+    } catch (e) {
+      logger.warn(
+        "Port closed before error response sent",
+        "handleEmbedFileChunks",
+        { error: e }
+      )
     }
   }
 }
@@ -105,7 +117,12 @@ export const handleEmbedFileChunksPort = (port: ChromePort) => {
     try {
       port.postMessage(message as unknown as ChromeMessage)
       return true
-    } catch (_) {
+    } catch (e) {
+      logger.warn(
+        "Port disconnected during postMessage",
+        "handleEmbedFileChunksPort",
+        { error: e }
+      )
       cancelled = true
       closed = true
       return false
@@ -117,7 +134,13 @@ export const handleEmbedFileChunksPort = (port: ChromePort) => {
     closed = true
     try {
       port.disconnect()
-    } catch (_) {}
+    } catch (e) {
+      logger.warn(
+        "Port already closed during disconnect",
+        "handleEmbedFileChunksPort",
+        { error: e }
+      )
+    }
   }
 
   port.onMessage.addListener(async (message) => {

--- a/src/background/handlers/handle-embedding-download.ts
+++ b/src/background/handlers/handle-embedding-download.ts
@@ -187,9 +187,10 @@ export const checkEmbeddingModelExists = async (
           return ""
         })
         .filter((name) => name.length > 0)
-      console.log(
-        `[checkEmbeddingModelExists] Checking '${normalizedModelName}' against provider models:`,
-        modelNames
+      logger.debug(
+        `Checking '${normalizedModelName}' against provider models`,
+        "checkEmbeddingModelExists",
+        { modelNames }
       )
 
       // Normalize model names for comparison (remove tags)
@@ -205,8 +206,9 @@ export const checkEmbeddingModelExists = async (
           m.startsWith(`${normalizedModelName}:`) ||
           m.startsWith(`${normalizedSearchName}:`)
         if (isMatch) {
-          console.log(
-            `[checkEmbeddingModelExists] Found match: '${m}' matches '${normalizedModelName}'`
+          logger.debug(
+            `Found match: '${m}' matches '${normalizedModelName}'`,
+            "checkEmbeddingModelExists"
           )
         }
         return isMatch
@@ -238,14 +240,16 @@ export const checkEmbeddingModelExists = async (
         models: modelNames,
         method: "provider-failed-not-found"
       }
-      console.warn(
-        `[checkEmbeddingModelExists] Model '${normalizedModelName}' NOT found in provider models.`
+      logger.warn(
+        `Model '${normalizedModelName}' NOT found in provider models`,
+        "checkEmbeddingModelExists"
       )
     }
   } catch (error) {
-    console.warn(
-      "[checkEmbeddingModelExists] Provider check failed, trying fallback",
-      error
+    logger.warn(
+      "Provider check failed, trying fallback",
+      "checkEmbeddingModelExists",
+      { error }
     )
     providerDebug = { error, method: "provider-error" }
   }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -261,12 +261,29 @@ browser.runtime.onMessage.addListener(
       }
 
       case MESSAGE_KEYS.BROWSER.OPEN_TAB: {
-        browser.tabs.query({}).then((tabs) => {
-          logger.debug("Queried browser tabs", "BackgroundSW", {
-            tabCount: tabs.length
+        browser.tabs
+          .query({})
+          .then((tabs) => {
+            logger.debug("Queried browser tabs", "BackgroundSW", {
+              tabCount: tabs.length
+            })
+            safeSendResponse(sendResponse, { success: true, tabs })
           })
-          safeSendResponse(sendResponse, { success: true, tabs })
-        })
+          .catch((error: unknown) => {
+            logger.error("Failed to query browser tabs", "BackgroundSW", {
+              error
+            })
+            safeSendResponse(sendResponse, {
+              success: false,
+              error: {
+                status: 0,
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to query tabs"
+              }
+            })
+          })
         return true
       }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -223,7 +223,13 @@ browser.runtime.onConnect.addListener((port: ChromePort) => {
           status: "error",
           message: err instanceof Error ? err.message : String(err)
         } as unknown as ChromeMessage)
-      } catch (_) {}
+      } catch (e) {
+        logger.warn(
+          "Port already closed during error response",
+          "BackgroundSW",
+          { error: e }
+        )
+      }
       port.disconnect()
     }
   }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -264,7 +264,7 @@ browser.runtime.onMessage.addListener(
         browser.tabs
           .query({})
           .then((tabs) => {
-            logger.debug("Queried browser tabs", "BackgroundSW", {
+            logger.info("Queried browser tabs", "BackgroundSW", {
               tabCount: tabs.length
             })
             safeSendResponse(sendResponse, { success: true, tabs })

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -36,6 +36,7 @@ import {
   MESSAGE_KEYS,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { runEmbeddingDimensionMigration } from "@/lib/migration/embedding-dimension-migration"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { migrateLegacyProviderStorage } from "@/lib/storage/provider-migration"
@@ -76,7 +77,9 @@ if (isChromiumBased() && "sidePanel" in browser) {
 
   sidePanel
     .setPanelBehavior({ openPanelOnActionClick: true })
-    .catch((error: Error) => console.error("SidePanel error:", error))
+    .catch((error: Error) =>
+      logger.error("SidePanel error", "BackgroundSW", { error })
+    )
 
   // Explicit action handler to avoid browser/version quirks where panel behavior
   // is not applied consistently.
@@ -94,9 +97,10 @@ if (isChromiumBased() && "sidePanel" in browser) {
           tabId: tab.id
         })
         .catch((error) => {
-          console.warn(
-            "Failed to open side panel, falling back to popup:",
-            error
+          logger.warn(
+            "Failed to open side panel, falling back to popup",
+            "BackgroundSW",
+            { error }
           )
           openClientWindow()
         })
@@ -111,7 +115,10 @@ if (isChromiumBased() && "sidePanel" in browser) {
 }
 
 if (!isChromiumBased()) {
-  console.warn("DNR not available: skipping CORS workaround (likely Firefox)")
+  logger.warn(
+    "DNR not available: skipping CORS workaround (likely Firefox)",
+    "BackgroundSW"
+  )
 }
 
 if (isChromiumBased()) {
@@ -120,7 +127,10 @@ if (isChromiumBased()) {
 
     // Auto-download embedding model on first install
     if (details.reason === "install") {
-      console.log("Extension installed - downloading embedding model...")
+      logger.info(
+        "Extension installed - downloading embedding model",
+        "BackgroundSW"
+      )
 
       // Check if already downloaded
       const alreadyDownloaded = await plasmoGlobalStorage.get<boolean>(
@@ -132,17 +142,23 @@ if (isChromiumBased()) {
         downloadEmbeddingModelSilently(DEFAULT_EMBEDDING_MODEL)
           .then((result) => {
             if (result.success) {
-              console.log(
-                `✅ Successfully downloaded embedding model: ${DEFAULT_EMBEDDING_MODEL}`
+              logger.info(
+                `Successfully downloaded embedding model: ${DEFAULT_EMBEDDING_MODEL}`,
+                "BackgroundSW"
               )
             } else {
-              console.warn(
-                `⚠️ Failed to auto-download embedding model: ${result.error}`
+              logger.warn(
+                `Failed to auto-download embedding model: ${result.error}`,
+                "BackgroundSW"
               )
             }
           })
           .catch((error) => {
-            console.error("Error during embedding model download:", error)
+            logger.error(
+              "Error during embedding model download",
+              "BackgroundSW",
+              { error }
+            )
           })
       }
     }
@@ -178,7 +194,7 @@ browser.runtime.onConnect.addListener((port: ChromePort) => {
     }
 
     if (msg.type === MESSAGE_KEYS.PROVIDER.STOP_GENERATION) {
-      console.log("Stop generation requested")
+      logger.info("Stop generation requested", "BackgroundSW")
       abortAndClearController(port.name) // Reset the controller
     }
   })
@@ -197,7 +213,11 @@ browser.runtime.onConnect.addListener((port: ChromePort) => {
     try {
       handleEmbedFileChunksPort(port)
     } catch (err) {
-      console.error("Error attaching embed chunks port handler:", err)
+      logger.error(
+        "Error attaching embed chunks port handler",
+        "BackgroundSW",
+        { error: err }
+      )
       try {
         port.postMessage({
           status: "error",
@@ -236,7 +256,9 @@ browser.runtime.onMessage.addListener(
 
       case MESSAGE_KEYS.BROWSER.OPEN_TAB: {
         browser.tabs.query({}).then((tabs) => {
-          console.log(tabs)
+          logger.debug("Queried browser tabs", "BackgroundSW", {
+            tabCount: tabs.length
+          })
           safeSendResponse(sendResponse, { success: true, tabs })
         })
         return true
@@ -402,10 +424,9 @@ browser.runtime.onMessage.addListener(
           const tabId = _sender.tab?.id
           if (windowId && sidePanel.open) {
             sidePanel.open({ windowId, tabId }).catch((err: unknown) => {
-              console.error(
-                "Failed to open sidepanel:",
-                err instanceof Error ? err.message : String(err)
-              )
+              logger.error("Failed to open sidepanel", "BackgroundSW", {
+                error: err instanceof Error ? err.message : String(err)
+              })
             })
           }
         }
@@ -424,9 +445,10 @@ browser.runtime.onMessage.addListener(
                   fromBackground: true
                 })
                 .catch((err) => {
-                  console.log(
-                    "Could not forward selection to chat (sidepanel might be closed):",
-                    err
+                  logger.debug(
+                    "Could not forward selection to chat (sidepanel might be closed)",
+                    "BackgroundSW",
+                    { error: err }
                   )
                 })
             }, 500)

--- a/src/background/lib/__tests__/process-stream-chunk.test.ts
+++ b/src/background/lib/__tests__/process-stream-chunk.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { createMockPort } from "@/background/handlers/__tests__/test-utils"
 import {
   processRemainingMetricsBuffer,
   processStreamChunk
@@ -17,7 +18,7 @@ describe("Process Stream Chunk", () => {
   describe("processStreamChunk", () => {
     it("should process complete JSON line", () => {
       const chunk = encoder.encode('{"message":{"content":"Hello"}}\n')
-      const port = {} as any
+      const port = createMockPort()
 
       const result = processStreamChunk(chunk, decoder, "", "", port)
 
@@ -29,7 +30,7 @@ describe("Process Stream Chunk", () => {
 
     it("should buffer incomplete line", () => {
       const chunk = encoder.encode('{"message":{"content":"Hel')
-      const port = {} as any
+      const port = createMockPort()
 
       const result = processStreamChunk(chunk, decoder, "", "", port)
 
@@ -41,7 +42,7 @@ describe("Process Stream Chunk", () => {
     it("should process buffered content + new chunk", () => {
       const chunk = encoder.encode('lo"}}\n')
       const buffer = '{"message":{"content":"Hel'
-      const port = {} as any
+      const port = createMockPort()
 
       const result = processStreamChunk(
         chunk,
@@ -60,7 +61,7 @@ describe("Process Stream Chunk", () => {
       const chunk = encoder.encode(
         '{"message":{"content":"A"}}\n{"message":{"content":"B"}}\n'
       )
-      const port = {} as any
+      const port = createMockPort()
 
       const result = processStreamChunk(chunk, decoder, "", "", port)
 
@@ -72,7 +73,7 @@ describe("Process Stream Chunk", () => {
 
     it("should handle done signal", () => {
       const chunk = encoder.encode('{"done":true,"total_duration":100}\n')
-      const port = {} as any
+      const port = createMockPort()
 
       const result = processStreamChunk(chunk, decoder, "", "Final Text", port)
 
@@ -86,7 +87,7 @@ describe("Process Stream Chunk", () => {
 
     it("should ignore invalid JSON", () => {
       const chunk = encoder.encode("Invalid JSON\n")
-      const port = {} as any
+      const port = createMockPort()
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
       const result = processStreamChunk(chunk, decoder, "", "", port)
@@ -100,7 +101,7 @@ describe("Process Stream Chunk", () => {
   describe("processRemainingMetricsBuffer", () => {
     it("should process valid metrics in buffer", () => {
       const buffer = '{"done":true,"total_duration":100}'
-      const port = {} as any
+      const port = createMockPort()
 
       processRemainingMetricsBuffer(buffer, "Final", port)
 
@@ -113,7 +114,7 @@ describe("Process Stream Chunk", () => {
 
     it("should ignore incomplete/invalid buffer", () => {
       const buffer = '{"done":true'
-      const port = {} as any
+      const port = createMockPort()
 
       processRemainingMetricsBuffer(buffer, "Final", port)
 

--- a/src/background/lib/__tests__/utils.test.ts
+++ b/src/background/lib/__tests__/utils.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createMockPort } from "@/background/handlers/__tests__/test-utils"
 import { browser } from "@/lib/browser-api"
 import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import type { ChatStreamMessage } from "@/types"
 import {
   getBaseUrl,
   getPullAbortControllerKey,
@@ -43,8 +45,8 @@ describe("Background Utils", () => {
 
   describe("safePostMessage", () => {
     it("should post message to port", () => {
-      const port = { postMessage: vi.fn() } as any
-      const message = { delta: "test" } as any
+      const port = createMockPort()
+      const message: ChatStreamMessage = { delta: "test" }
 
       safePostMessage(port, message)
 
@@ -52,14 +54,13 @@ describe("Background Utils", () => {
     })
 
     it("should handle port disconnect (runtime.lastError)", () => {
-      const port = {
-        postMessage: vi.fn().mockImplementation(() => {
-          throw new Error("Port disconnected")
-        })
-      } as any
+      const port = createMockPort()
+      vi.mocked(port.postMessage).mockImplementation(() => {
+        throw new Error("Port disconnected")
+      })
       ;(browser.runtime as any).lastError = { message: "Port disconnected" }
 
-      safePostMessage(port, { delta: "test" } as any)
+      safePostMessage(port, { delta: "test" })
 
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining("channel may be closed"),
@@ -70,13 +71,12 @@ describe("Background Utils", () => {
 
     it("should handle other errors", () => {
       const error = new Error("Random error")
-      const port = {
-        postMessage: vi.fn().mockImplementation(() => {
-          throw error
-        })
-      } as any
+      const port = createMockPort()
+      vi.mocked(port.postMessage).mockImplementation(() => {
+        throw error
+      })
 
-      safePostMessage(port, { delta: "test" } as any)
+      safePostMessage(port, { delta: "test" })
 
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining("Could not send message"),

--- a/src/background/lib/__tests__/utils.test.ts
+++ b/src/background/lib/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { browser } from "@/lib/browser-api"
 import { STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import {
   getBaseUrl,
@@ -15,6 +16,15 @@ vi.mock("@/lib/browser-api", () => ({
     runtime: {
       lastError: null
     }
+  }
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
   }
 }))
 
@@ -48,13 +58,13 @@ describe("Background Utils", () => {
         })
       } as any
       ;(browser.runtime as any).lastError = { message: "Port disconnected" }
-      const consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {})
 
       safePostMessage(port, { delta: "test" } as any)
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining("channel may be closed"),
-        "Port disconnected"
+        "BackgroundUtils",
+        { error: "Port disconnected" }
       )
     })
 
@@ -65,13 +75,13 @@ describe("Background Utils", () => {
           throw error
         })
       } as any
-      const consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {})
 
       safePostMessage(port, { delta: "test" } as any)
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining("Could not send message"),
-        error
+        "BackgroundUtils",
+        { error }
       )
     })
   })
@@ -91,13 +101,13 @@ describe("Background Utils", () => {
         throw new Error("Channel closed")
       })
       ;(browser.runtime as any).lastError = { message: "Channel closed" }
-      const consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {})
 
       safeSendResponse(sendResponse, { success: true })
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining("channel may be closed"),
-        "Channel closed"
+        "BackgroundUtils",
+        { error: "Channel closed" }
       )
     })
   })

--- a/src/background/lib/dnr.ts
+++ b/src/background/lib/dnr.ts
@@ -1,11 +1,13 @@
 import { isChromiumBased } from "@/lib/browser-api"
 import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
 export const updateDNRRules = async (): Promise<void> => {
   if (!isChromiumBased()) {
-    console.warn(
-      "DNR not available: Firefox requires local provider origin configuration"
+    logger.warn(
+      "DNR not available: Firefox requires local provider origin configuration",
+      "DNR"
     )
     return
   }
@@ -49,6 +51,6 @@ export const updateDNRRules = async (): Promise<void> => {
     })
   } catch (error) {
     // Don't throw - allow extension to continue without DNR
-    console.error("Failed to update DNR rules:", error)
+    logger.error("Failed to update DNR rules", "DNR", { error })
   }
 }

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import type { ChromePort, NetworkError, PortStatusFunction } from "@/types"
 import { clearAbortController } from "./abort-controller-registry"
 import { safePostMessage } from "./utils"
@@ -44,8 +45,9 @@ export const withErrorContext = <T>(
       }
 
       // 4. Handle generic errors with enhanced logging
-      console.error(
-        `[${context.handler}] Error during ${context.operation || "operation"}:`,
+      logger.error(
+        `Error during ${context.operation || "operation"}`,
+        context.handler,
         {
           message: error.message,
           model: context.modelId,

--- a/src/background/lib/selection-bridge.ts
+++ b/src/background/lib/selection-bridge.ts
@@ -1,4 +1,5 @@
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import type { ChromePort } from "@/types"
 
 const selectionBridgePorts = new Set<ChromePort>()
@@ -23,9 +24,10 @@ export const postSelectionToSidePanels = (selectionText: string) => {
         fromBackground: true
       })
     } catch (error) {
-      console.warn(
-        "Failed to post selection to side panel port:",
-        error instanceof Error ? error.message : String(error)
+      logger.warn(
+        "Failed to post selection to side panel port",
+        "SelectionBridge",
+        { error: error instanceof Error ? error.message : String(error) }
       )
       selectionBridgePorts.delete(port)
     }

--- a/src/background/lib/utils.ts
+++ b/src/background/lib/utils.ts
@@ -1,5 +1,6 @@
 import { browser } from "@/lib/browser-api"
 import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type {
   ChatStreamMessage,
@@ -27,12 +28,15 @@ export const safePostMessage = (
     // Port closed or disconnected (e.g., tab in back/forward cache)
     // This is expected and not an error condition
     if (browser.runtime.lastError) {
-      console.debug(
-        "Could not send message to port, channel may be closed:",
-        browser.runtime.lastError.message
+      logger.debug(
+        "Could not send message to port, channel may be closed",
+        "BackgroundUtils",
+        { error: browser.runtime.lastError.message }
       )
     } else {
-      console.debug("Could not send message to port:", error)
+      logger.debug("Could not send message to port", "BackgroundUtils", {
+        error
+      })
     }
   }
 }
@@ -51,12 +55,13 @@ export const safeSendResponse = (
     // Message channel closed (e.g., tab in back/forward cache)
     // This is expected and not an error condition
     if (browser.runtime.lastError) {
-      console.debug(
-        "Could not send response, channel may be closed:",
-        browser.runtime.lastError.message
+      logger.debug(
+        "Could not send response, channel may be closed",
+        "BackgroundUtils",
+        { error: browser.runtime.lastError.message }
       )
     } else {
-      console.debug("Could not send response:", error)
+      logger.debug("Could not send response", "BackgroundUtils", { error })
     }
   }
 }

--- a/src/contents/content-extraction.ts
+++ b/src/contents/content-extraction.ts
@@ -1,6 +1,7 @@
 import { Readability } from "@mozilla/readability"
 import Defuddle from "defuddle"
 
+import { logger } from "@/lib/logger"
 import { normalizeWhitespaceForLLM } from "@/lib/text-utils"
 import type { ContentExtractionConfig } from "@/types"
 
@@ -40,7 +41,7 @@ const tryDefuddle = (doc: Document): ReadableContent | null => {
         : "defuddle-html"
     }
   } catch (error) {
-    console.warn("[Content Script] Defuddle failed:", error)
+    logger.warn("Defuddle failed", "ContentExtraction", { error })
     return null
   }
 }
@@ -62,7 +63,7 @@ const tryReadability = (
       selectedReason: forced ? "forced-readability" : "auto-readability-better"
     }
   } catch (error) {
-    console.error("[Content Script] Readability failed:", error)
+    logger.error("Readability failed", "ContentExtraction", { error })
     return null
   }
 }

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -8,6 +8,7 @@ import {
   extractContentWithLoading,
   getEffectiveConfig
 } from "@/lib/content-extractor"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { getTranscript } from "@/lib/transcript-extractor"
 import type { ChromeMessage, ContentExtractionConfig } from "@/types"
@@ -143,9 +144,10 @@ const handleGetPageContent = async (
         )
       ])
     } catch (error) {
-      console.warn(
-        "[Content Script] Enhanced extraction failed, falling back to basic extraction:",
-        error
+      logger.warn(
+        "Enhanced extraction failed, falling back to basic extraction",
+        "ContentScript",
+        { error }
       )
     }
   }
@@ -172,8 +174,9 @@ const handleGetPageContent = async (
     readable.readableText
 
   if (!finalContent || finalContent.trim().length < 50) {
-    console.error(
-      `[Content Script] Extraction failed: Only ${finalContent?.length || 0} chars extracted`
+    logger.error(
+      `Extraction failed: Only ${finalContent?.length || 0} chars extracted`,
+      "ContentScript"
     )
     throw new Error(
       `Failed to extract meaningful content (only ${finalContent?.length || 0} chars). URL: ${currentUrl}`
@@ -229,9 +232,11 @@ browser.runtime.onMessage.addListener(
 
     contentDebugLog("[Content Script] Starting GET_PAGE_CONTENT handler")
     handleGetPageContent(sendResponse).catch((err) => {
-      console.error("[Content Script] Error in content script:", err)
       const errorMessage = err instanceof Error ? err.message : String(err)
-      console.error("[Content Script] Error details:", errorMessage)
+      logger.error("Error in content script", "ContentScript", {
+        error: err,
+        errorMessage
+      })
       safeSendResponse(sendResponse, {
         html: `Failed to parse content. Error: ${errorMessage}`,
         title: document.title || "Untitled"

--- a/src/entrypoints/selection-button.content.tsx
+++ b/src/entrypoints/selection-button.content.tsx
@@ -5,6 +5,7 @@ import {
   MESSAGE_KEYS,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ContentExtractionConfig } from "@/types"
 
@@ -198,7 +199,7 @@ export default defineContentScript({
           hideButton()
           window.getSelection()?.removeAllRanges()
         } catch (error) {
-          console.error("Failed to send selection:", error)
+          logger.error("Failed to send selection", "SelectionButton", { error })
         }
       }
 

--- a/src/features/chat/components/chat-backfill-panel.tsx
+++ b/src/features/chat/components/chat-backfill-panel.tsx
@@ -8,6 +8,7 @@ import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messa
 import { getEmbeddableMessagesBySession } from "@/features/chat/utils/embedding-backfill"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { AlertCircle, Loader2, Sparkles } from "@/lib/lucide-icon"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
@@ -54,7 +55,7 @@ export const ChatBackfillPanel = () => {
       const errorMessage =
         err instanceof Error ? err.message : "Backfill failed"
       setError(errorMessage)
-      console.error("Backfill error:", err)
+      logger.error("Backfill error", "ChatBackfillPanel", { error: err })
     } finally {
       setIsRunning(false)
     }

--- a/src/features/chat/components/chat-input-box.tsx
+++ b/src/features/chat/components/chat-input-box.tsx
@@ -25,6 +25,7 @@ import { useToast } from "@/hooks/use-toast"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import type { ProcessedFile } from "@/lib/file-processors/types"
 
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { cn } from "@/lib/utils"
 import type { ChatMessage, ChromeMessage } from "@/types"
@@ -67,7 +68,7 @@ export const ChatInputBox = ({
     clearAllProcessingStates
   } = useFileUpload({
     onError: (error) => {
-      console.error("File processing error:", error)
+      logger.error("File processing error", "ChatInputBox", { error })
       toast({
         variant: "destructive",
         title: "File Upload Failed",

--- a/src/features/chat/components/copy-button.tsx
+++ b/src/features/chat/components/copy-button.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@/components/ui/tooltip"
+import { logger } from "@/lib/logger"
 import { Check, Copy } from "@/lib/lucide-icon"
 
 export const CopyButton = ({ text }: { text: string }) => {
@@ -14,7 +15,11 @@ export const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(text).catch((err) => console.error(err))
+    navigator.clipboard
+      .writeText(text)
+      .catch((err) =>
+        logger.error("Clipboard write failed", "CopyButton", { error: err })
+      )
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }

--- a/src/features/chat/components/feedback-buttons.tsx
+++ b/src/features/chat/components/feedback-buttons.tsx
@@ -9,6 +9,7 @@ import {
   TooltipTrigger
 } from "@/components/ui/tooltip"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
+import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 
 export interface FeedbackButtonsProps {
@@ -47,7 +48,7 @@ export const FeedbackButtons = ({
 
       await Promise.all(promises)
     } catch (e) {
-      console.error("Failed to record feedback", e)
+      logger.error("Failed to record feedback", "FeedbackButtons", { error: e })
       // Revert on error? Or just log
     }
   }

--- a/src/features/chat/components/file-attachment-display.tsx
+++ b/src/features/chat/components/file-attachment-display.tsx
@@ -90,7 +90,7 @@ function FileViewerDialog({ file }: FileViewerDialogProps) {
           />
         }>
         {getFileIcon(file.fileType)}
-        <span className="max-w-[120px] truncate">{file.fileName}</span>
+        <span className="max-w-30 truncate">{file.fileName}</span>
         <span className="text-[10px] text-muted-foreground">
           {formatFileSize(file.fileSize)}
         </span>

--- a/src/features/chat/components/file-attachment-display.tsx
+++ b/src/features/chat/components/file-attachment-display.tsx
@@ -11,6 +11,7 @@ import {
   DialogTrigger
 } from "@/components/ui/dialog"
 import { getAllDocuments } from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
 import type { FileAttachment } from "@/types"
 
 export interface FileAttachmentDisplayProps {
@@ -63,7 +64,9 @@ function FileViewerDialog({ file }: FileViewerDialogProps) {
           setFullText(file.textPreview || "No content available")
         }
       } catch (error) {
-        console.error("Failed to fetch file content:", error)
+        logger.error("Failed to fetch file content", "FileAttachmentDisplay", {
+          error
+        })
         setFullText(
           file.textPreview || "Error loading content. Please try again."
         )

--- a/src/features/chat/components/semantic-chat-search-dialog.tsx
+++ b/src/features/chat/components/semantic-chat-search-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/features/chat/hooks/use-semantic-chat-search"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { useDebounce } from "@/hooks/use-debounce"
+import { logger } from "@/lib/logger"
 import { Loader2 } from "@/lib/lucide-icon"
 
 import { SearchEmptyState } from "./search/search-empty-state"
@@ -115,7 +116,7 @@ export const SemanticChatSearchDialog = ({
       .catch((err) => {
         // Only log error if this is still the current search
         if (currentSearchRef.current === searchPromise) {
-          console.error("Search error:", err)
+          logger.error("Search error", "SemanticSearch", { error: err })
         }
       })
 

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { browser } from "@/lib/browser-api"
 import { PROVIDER_MESSAGE_KEYS } from "@/lib/constants/keys"
+import { logger } from "@/lib/logger"
 import type { UseChatStreamProps } from "../use-chat-stream"
 import { useChatStream } from "../use-chat-stream"
 
@@ -11,6 +12,15 @@ vi.mock("@/lib/browser-api", () => ({
     runtime: {
       connect: vi.fn()
     }
+  }
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
   }
 }))
 
@@ -205,19 +215,16 @@ describe("useChatStream", () => {
       })
     )
 
-    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
-
     act(() => {
       result.current.stopStream()
     })
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Stop requested but port not created yet"
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Stop requested but port not created yet",
+      "useChatStream"
     )
     expect(setIsLoading).toHaveBeenCalledWith(false)
     expect(setIsStreaming).toHaveBeenCalledWith(false)
-
-    consoleSpy.mockRestore()
   })
 
   it("should handle stop message failure", () => {
@@ -240,17 +247,13 @@ describe("useChatStream", () => {
       throw new Error("Port disconnected")
     })
 
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-
     act(() => {
       result.current.stopStream()
     })
 
-    expect(consoleSpy).toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalled()
     expect(setIsLoading).toHaveBeenCalledWith(false)
     expect(setIsStreaming).toHaveBeenCalledWith(false)
-
-    consoleSpy.mockRestore()
   })
 
   it("should handle aborted stream", () => {

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -4,6 +4,7 @@ import { useToast } from "@/hooks/use-toast"
 
 import { browser } from "@/lib/browser-api"
 import { ERROR_MESSAGES, MESSAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import type { ChatMessage } from "@/types"
 
 interface StreamOptions {
@@ -181,7 +182,7 @@ export const useChatStream = ({
 
     const listener = (msg: StreamMessage) => {
       if (DEBUG_THINKING_STREAM) {
-        console.debug("[Stream] msg", {
+        logger.debug("Stream msg", "useChatStream", {
           type: msg.type,
           hasDelta: typeof msg.delta === "string" && msg.delta.length > 0,
           deltaPreview:
@@ -196,7 +197,7 @@ export const useChatStream = ({
           done: msg.done,
           error: msg.error
         })
-        console.log("MSG", JSON.stringify(msg, null, 3))
+        logger.debug("MSG", "useChatStream", JSON.stringify(msg, null, 3))
       }
       if (firstChunk) {
         setIsStreaming(true)
@@ -216,7 +217,9 @@ export const useChatStream = ({
 
       if (msg.thinkingDelta) {
         if (DEBUG_THINKING_STREAM) {
-          console.debug("[ThinkingStream] delta", msg.thinkingDelta)
+          logger.debug("ThinkingStream delta", "useChatStream", {
+            delta: msg.thinkingDelta
+          })
         }
         assistantMessage.thinking = `${assistantMessage.thinking || ""}${msg.thinkingDelta}`
         didUpdate = true
@@ -230,7 +233,7 @@ export const useChatStream = ({
 
         if (thinking) {
           if (DEBUG_THINKING_STREAM) {
-            console.debug("[ThinkingStream] parsed", thinking)
+            logger.debug("ThinkingStream parsed", "useChatStream", { thinking })
           }
           assistantMessage.thinking = `${assistantMessage.thinking || ""}${thinking}`
           didUpdate = true
@@ -304,10 +307,9 @@ export const useChatStream = ({
 
     port.onDisconnect.addListener(() => {
       if (browser.runtime.lastError) {
-        console.debug(
-          "[ChatStream] Port disconnected unexpectedly:",
-          browser.runtime.lastError.message
-        )
+        logger.debug("Port disconnected unexpectedly", "useChatStream", {
+          error: browser.runtime.lastError.message
+        })
       }
       if (!assistantMessage.done) {
         setIsLoading(false)
@@ -337,7 +339,7 @@ export const useChatStream = ({
   const stopStream = () => {
     // Handle case where port hasn't been created yet
     if (!portRef.current) {
-      console.warn("Stop requested but port not created yet")
+      logger.warn("Stop requested but port not created yet", "useChatStream")
       setIsLoading(false)
       setIsStreaming(false)
       return
@@ -348,7 +350,7 @@ export const useChatStream = ({
         type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION
       })
     } catch (error) {
-      console.error("Failed to send stop message:", error)
+      logger.error("Failed to send stop message", "useChatStream", { error })
     } finally {
       // Always reset state, even if message fails
       setIsLoading(false)

--- a/src/features/context/components/context-settings.tsx
+++ b/src/features/context/components/context-settings.tsx
@@ -41,6 +41,7 @@ import {
   getStorageStats,
   removeDuplicateVectors
 } from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
 import {
   AlertTriangle,
   BookOpen,
@@ -137,7 +138,7 @@ export const ContextSettings = () => {
       }
       setCacheStats(cacheStatsValue)
     } catch (error) {
-      console.error("Failed to load stats:", error)
+      logger.error("Failed to load stats", "ContextSettings", { error })
     } finally {
       isLoadingRef.current = false
     }
@@ -167,7 +168,7 @@ export const ContextSettings = () => {
       })
       await loadStats()
     } catch (error) {
-      console.error("Failed to remove duplicates:", error)
+      logger.error("Failed to remove duplicates", "ContextSettings", { error })
       toast({
         title: t(
           "model.embedding_config.database_management.remove_duplicates_error"
@@ -193,7 +194,7 @@ export const ContextSettings = () => {
       })
       await loadStats()
     } catch (error) {
-      console.error("Failed to clear chat vectors:", error)
+      logger.error("Failed to clear chat vectors", "ContextSettings", { error })
       toast({
         title: t("model.embedding_config.database_management.clear_chat_error"),
         variant: "destructive"
@@ -212,7 +213,7 @@ export const ContextSettings = () => {
       })
       await loadStats()
     } catch (error) {
-      console.error("Failed to clear all vectors:", error)
+      logger.error("Failed to clear all vectors", "ContextSettings", { error })
       toast({
         title: t("model.embedding_config.database_management.clear_all_error"),
         variant: "destructive"
@@ -244,7 +245,7 @@ export const ContextSettings = () => {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to rebuild embeddings"
-      console.error("Failed to rebuild embeddings:", error)
+      logger.error("Failed to rebuild embeddings", "ContextSettings", { error })
       setRebuildError(message)
     } finally {
       setIsRebuilding(false)

--- a/src/features/file-upload/components/file-upload-area.tsx
+++ b/src/features/file-upload/components/file-upload-area.tsx
@@ -8,6 +8,7 @@ import type {
   FileProcessingState,
   ProcessedFile
 } from "@/lib/file-processors/types"
+import { logger } from "@/lib/logger"
 
 export interface FileUploadAreaProps {
   onFilesProcessed: (files: ProcessedFile[]) => void
@@ -41,7 +42,7 @@ export const FileUploadArea = ({
     useFileUpload({
       onFileProcessed: handleFileProcessed,
       onError: (error) => {
-        console.error("File processing error:", error)
+        logger.error("File processing error", "FileUploadArea", { error })
       }
     })
 

--- a/src/features/file-upload/hooks/use-file-upload.ts
+++ b/src/features/file-upload/hooks/use-file-upload.ts
@@ -316,10 +316,22 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
                     }
                     try {
                       port.postMessage({ type: "done" })
-                    } catch (_) {}
+                    } catch (e) {
+                      logger.warn(
+                        "Port closed before done signal",
+                        "useFileUpload",
+                        { error: e }
+                      )
+                    }
                     try {
                       port.disconnect()
-                    } catch (_) {}
+                    } catch (e) {
+                      logger.warn(
+                        "Port already disconnected",
+                        "useFileUpload",
+                        { error: e }
+                      )
+                    }
                   } else if (m?.status === "error") {
                     logger.warn("Background embedding error", "useFileUpload", {
                       error: m?.message
@@ -338,7 +350,13 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
                     }
                     try {
                       port.disconnect()
-                    } catch (_) {}
+                    } catch (e) {
+                      logger.warn(
+                        "Port already disconnected on error",
+                        "useFileUpload",
+                        { error: e }
+                      )
+                    }
                   }
                 } catch (e) {
                   logger.warn("Error handling port message", "useFileUpload", {
@@ -368,7 +386,13 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
                   )
                   try {
                     port.disconnect()
-                  } catch (_) {}
+                  } catch (e) {
+                    logger.warn(
+                      "Port already disconnected on batch fail",
+                      "useFileUpload",
+                      { error: e }
+                    )
+                  }
                   break
                 }
               }

--- a/src/features/knowledge/components/data-migration-settings.tsx
+++ b/src/features/knowledge/components/data-migration-settings.tsx
@@ -21,6 +21,7 @@ import { useToast } from "@/hooks/use-toast"
 import { backupService, type ImportResult } from "@/lib/backup-service"
 import { MESSAGE_KEYS } from "@/lib/constants/keys"
 import { formatBackupFilenameTimestamp } from "@/lib/format-utils"
+import { logger } from "@/lib/logger"
 import {
   CheckCircle,
   Download,
@@ -64,7 +65,7 @@ export const DataMigrationSettings = () => {
         description: errorMessage,
         variant: "destructive"
       })
-      console.error("Export failed:", error)
+      logger.error("Export failed", "DataMigrationSettings", { error })
     } finally {
       setIsExporting(false)
     }
@@ -92,7 +93,7 @@ export const DataMigrationSettings = () => {
       setImportResult(result)
       setResultDialogOpen(true)
     } catch (error: unknown) {
-      console.error("Import failed:", error)
+      logger.error("Import failed", "DataMigrationSettings", { error })
       setImportResult({
         syncStorage: {
           ok: false,

--- a/src/features/memory/components/memory-settings.tsx
+++ b/src/features/memory/components/memory-settings.tsx
@@ -13,6 +13,7 @@ import { useConfirmAction } from "@/hooks/use-confirm-action"
 import { useToast } from "@/hooks/use-toast"
 import { STORAGE_KEYS } from "@/lib/constants"
 import { clearAllVectors, getStorageStats } from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
 import { Brain, Trash2 } from "@/lib/lucide-icon"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
@@ -45,7 +46,7 @@ export const MemorySettings = () => {
       // Refresh stats
       loadStats()
     } catch (error) {
-      console.error("Failed to clear memory:", error)
+      logger.error("Failed to clear memory", "MemorySettings", { error })
       toast({
         title: t("settings.memory.clear.error"),
         variant: "destructive"
@@ -60,7 +61,7 @@ export const MemorySettings = () => {
       const s = await getStorageStats()
       setStats(s)
     } catch (error) {
-      console.error("Failed to load stats:", error)
+      logger.error("Failed to load stats", "MemorySettings", { error })
     }
   }, [])
 

--- a/src/features/model/components/embedding-index-controls.tsx
+++ b/src/features/model/components/embedding-index-controls.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { SettingsCard } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { buildKeywordIndexFromExisting } from "@/lib/embeddings/auto-index"
+import { logger } from "@/lib/logger"
 import { Database, Loader2 } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
@@ -40,7 +41,9 @@ export const EmbeddingIndexControls = () => {
 
       setRebuildResult(`✅ ${t("settings.embeddings.rebuild_index.success")}`)
     } catch (error) {
-      console.error("Failed to rebuild index:", error)
+      logger.error("Failed to rebuild index", "EmbeddingIndexControls", {
+        error
+      })
       setRebuildResult(`❌ ${t("settings.embeddings.rebuild_index.error")}`)
     } finally {
       setIsRebuildingIndex(false)

--- a/src/features/model/components/embedding-status-indicator.tsx
+++ b/src/features/model/components/embedding-status-indicator.tsx
@@ -247,7 +247,7 @@ export const EmbeddingStatusIndicator = () => {
         }>
         {icon}
       </TooltipTrigger>
-      <TooltipContent side="left" className="max-w-[250px]">
+      <TooltipContent side="left" className="max-w-62.5">
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2 text-sm font-medium">
             <span className={statusColor}>{statusText}</span>

--- a/src/features/model/components/embedding-status-indicator.tsx
+++ b/src/features/model/components/embedding-status-indicator.tsx
@@ -20,6 +20,7 @@ import {
   normalizeEmbeddingModelName,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import {
   AlertTriangle,
   Database,
@@ -74,7 +75,7 @@ export const EmbeddingStatusIndicator = () => {
     setIsChecking(true)
     setError(null)
     try {
-      console.info("[EmbeddingStatus] Checking model", {
+      logger.info("Checking model", "EmbeddingStatusIndicator", {
         model: modelName,
         providerId
       })
@@ -92,7 +93,7 @@ export const EmbeddingStatusIndicator = () => {
         )
       ])) as ModelCheckResponse
 
-      console.info("[EmbeddingStatus] Check response", {
+      logger.debug("Check response", "EmbeddingStatusIndicator", {
         model: modelName,
         providerId,
         success: resp?.success,
@@ -110,7 +111,7 @@ export const EmbeddingStatusIndicator = () => {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      console.warn("[EmbeddingStatus] Check failed", {
+      logger.warn("Check failed", "EmbeddingStatusIndicator", {
         model: modelName,
         providerId,
         error: message
@@ -154,7 +155,7 @@ export const EmbeddingStatusIndicator = () => {
     e?.stopPropagation()
     setError(null)
     setRetryCount(0)
-    console.info("[EmbeddingStatus] Manual retry", {
+    logger.info("Manual retry", "EmbeddingStatusIndicator", {
       model: modelName,
       providerId
     })

--- a/src/features/model/components/loaded-models-info.tsx
+++ b/src/features/model/components/loaded-models-info.tsx
@@ -17,6 +17,7 @@ import {
 import { useProviderModels } from "@/features/model/hooks/use-provider-models"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import {
   Brain,
   ChevronDown,
@@ -82,11 +83,15 @@ export const LoadedModelsInfo = () => {
         if (res?.success && res.data?.models) {
           setModels(res.data.models)
         } else {
-          console.error(res?.error)
+          logger.error("Failed to fetch loaded models", "LoadedModelsInfo", {
+            error: res?.error
+          })
           setModels([])
         }
       } catch (error) {
-        console.error("Failed to fetch loaded models:", error)
+        logger.error("Failed to fetch loaded models", "LoadedModelsInfo", {
+          error
+        })
         setModels([])
       } finally {
         setLoading(false)
@@ -109,10 +114,10 @@ export const LoadedModelsInfo = () => {
       if (res?.success) {
         setModels((prev) => prev.filter((m) => m.name !== modelName))
       } else {
-        console.error("Unload error", res?.error)
+        logger.error("Unload error", "LoadedModelsInfo", { error: res?.error })
       }
     } catch (error) {
-      console.error("Failed to unload model:", error)
+      logger.error("Failed to unload model", "LoadedModelsInfo", { error })
     } finally {
       setUnloading(null)
     }

--- a/src/features/model/components/model-menu.tsx
+++ b/src/features/model/components/model-menu.tsx
@@ -25,6 +25,7 @@ import {
 import { useProviderModels } from "@/features/model/hooks/use-provider-models"
 import { browser } from "@/lib/browser-api"
 import { DEFAULT_PROVIDER_ID, MESSAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { Check, ChevronDown, RotateCcw } from "@/lib/lucide-icon"
 import { getProviderDisplayName } from "@/lib/providers/registry"
 import { cn } from "@/lib/utils"
@@ -90,7 +91,7 @@ export const ModelMenu = ({
           }
         })
         .catch((error) => {
-          console.warn("Failed to trigger model warmup", error)
+          logger.warn("Failed to trigger model warmup", "ModelMenu", { error })
         })
     }
   }

--- a/src/features/model/components/provider-base-url-settings.tsx
+++ b/src/features/model/components/provider-base-url-settings.tsx
@@ -156,7 +156,7 @@ export const ProviderBaseUrlSettings = () => {
                 onClick={handleSubmit}
                 disabled={!urlIsValid || isLoading || saved}
                 className={cn(
-                  "min-w-[80px] transition-all",
+                  "min-w-20 transition-all",
                   saved &&
                     "bg-status-success text-status-success-foreground hover:bg-status-success/90"
                 )}>

--- a/src/features/model/components/provider-base-url-settings.tsx
+++ b/src/features/model/components/provider-base-url-settings.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input"
 import { useProviderModels } from "@/features/model/hooks/use-provider-models"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { Check, ExternalLink, Loader2, Server } from "@/lib/lucide-icon"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { cn } from "@/lib/utils"
@@ -46,9 +47,14 @@ export const ProviderBaseUrlSettings = () => {
       })
       setSaved(true)
       refresh()
-      console.log("Base URL updated and DNR rule applied")
+      logger.info(
+        "Base URL updated and DNR rule applied",
+        "ProviderBaseUrlSettings"
+      )
     } catch (err) {
-      console.error("Failed to update base URL:", err)
+      logger.error("Failed to update base URL", "ProviderBaseUrlSettings", {
+        error: err
+      })
     } finally {
       setIsLoading(false)
       setTimeout(() => setSaved(false), 1500)

--- a/src/features/model/components/provider-settings.tsx
+++ b/src/features/model/components/provider-settings.tsx
@@ -37,6 +37,7 @@ import { ProviderGrid } from "@/features/model/components/provider-grid"
 import { useProviderHealth } from "@/features/model/hooks/use-provider-health"
 import { toast } from "@/hooks/use-toast"
 import { DEFAULT_PROVIDER_ID } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { DEFAULT_PROVIDERS, ProviderManager } from "@/lib/providers/manager"
 import { isBetaProvider } from "@/lib/providers/registry"
@@ -81,7 +82,7 @@ export const ProviderSettings = () => {
       const data = await ProviderManager.getProviders()
       setProviders(data)
     } catch (e) {
-      console.error(e)
+      logger.error("Failed to load providers", "ProviderSettings", { error: e })
     } finally {
       setLoading(false)
     }
@@ -115,7 +116,7 @@ export const ProviderSettings = () => {
   const handleTestConnection = async () => {
     if (!activeConfig) return
 
-    console.log("[ProviderSettings] Testing connection with config:", {
+    logger.info("Testing connection with config", "ProviderSettings", {
       id: activeConfig.id,
       name: activeConfig.name,
       baseUrl: activeConfig.baseUrl,
@@ -146,14 +147,14 @@ export const ProviderSettings = () => {
 
     try {
       const provider = await ProviderFactory.getProviderWithConfig(activeConfig)
-      console.log(
-        "[ProviderSettings] Provider instance created, calling getModels()"
+      logger.debug(
+        "Provider instance created, calling getModels()",
+        "ProviderSettings"
       )
       const models = await provider.getModels()
-      console.log(
-        "[ProviderSettings] getModels() succeeded, found models:",
-        models.length
-      )
+      logger.debug("getModels() succeeded", "ProviderSettings", {
+        count: models.length
+      })
 
       // Treat 0 models as a connection failure: the URL may be wrong, the
       // service may be offline, auth may have failed, or no models are loaded.
@@ -197,7 +198,7 @@ export const ProviderSettings = () => {
         variant: "default"
       })
     } catch (error: unknown) {
-      console.error("[ProviderSettings] Connection test failed:", error)
+      logger.error("Connection test failed", "ProviderSettings", { error })
       const errorMessage =
         error instanceof Error ? error.message : "Failed to connect"
       const shouldShowCspHint =
@@ -275,12 +276,12 @@ export const ProviderSettings = () => {
           activeConfig
         )
         setHasUnsavedChanges(false)
-        console.log(
-          "[ProviderSettings] Auto-saved configuration for",
-          activeConfig.name
+        logger.debug(
+          `Auto-saved configuration for ${activeConfig.name}`,
+          "ProviderSettings"
         )
       } catch (e) {
-        console.error("[ProviderSettings] Auto-save failed", e)
+        logger.error("Auto-save failed", "ProviderSettings", { error: e })
       }
     }, 2000)
 
@@ -402,7 +403,11 @@ export const ProviderSettings = () => {
                         { enabled: checked }
                       )
                     } catch (e) {
-                      console.error("Failed to auto-save toggle", e)
+                      logger.error(
+                        "Failed to auto-save toggle",
+                        "ProviderSettings",
+                        { error: e }
+                      )
                     }
                   }}
                 />

--- a/src/features/model/hooks/use-embedding-dimension-stats.ts
+++ b/src/features/model/hooks/use-embedding-dimension-stats.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { getEmbeddingDimensionStats } from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
 
 export interface EmbeddingDimensionStats {
   totalVectors: number
@@ -32,7 +33,11 @@ export const useEmbeddingDimensionStats =
         const next = await getEmbeddingDimensionStats()
         setStats(next)
       } catch (error) {
-        console.error("Failed to load embedding dimension stats:", error)
+        logger.error(
+          "Failed to load embedding dimension stats",
+          "useEmbeddingDimensionStats",
+          { error }
+        )
       }
     }, [])
 

--- a/src/features/model/hooks/use-embedding-model-check.ts
+++ b/src/features/model/hooks/use-embedding-model-check.ts
@@ -10,6 +10,7 @@ import {
   isLikelyEmbeddingModelName,
   recommendedEmbeddingBaseSet
 } from "@/lib/embeddings/model-name-filter"
+import { logger } from "@/lib/logger"
 import type { ChromeResponse, ProviderModel } from "@/types"
 
 const POLL_INTERVAL_MS = 5_000
@@ -81,8 +82,9 @@ export const useEmbeddingModelCheck = ({
         }
 
         if (response?.data?.debug) {
-          console.log(
-            `[useEmbeddingModelCheck] check debug for ${currentModel}:`,
+          logger.debug(
+            `Check debug for ${currentModel}`,
+            "useEmbeddingModelCheck",
             response.data.debug
           )
         }
@@ -118,9 +120,10 @@ export const useEmbeddingModelCheck = ({
           applyModelChange(nextModel, resolveProviderForModel(nextModel))
         }
       } catch (error) {
-        console.error(
-          "Error checking embedding model in useEmbeddingModelCheck:",
-          error
+        logger.error(
+          "Error checking embedding model",
+          "useEmbeddingModelCheck",
+          { error }
         )
         setModelExists(false)
       }

--- a/src/features/model/hooks/use-embedding-rebuild.ts
+++ b/src/features/model/hooks/use-embedding-rebuild.ts
@@ -5,6 +5,7 @@ import { getEmbeddableMessagesBySession } from "@/features/chat/utils/embedding-
 import { rebuildEmbeddings } from "@/features/context/lib/embedding-rebuild"
 import { clearEmbeddingCache } from "@/lib/embeddings/embedding-client"
 import { clearAllVectors } from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
 
 export interface RebuildProgress {
   current: number
@@ -74,7 +75,9 @@ export const useEmbeddingRebuild = ({
     } catch (e) {
       const message =
         e instanceof Error ? e.message : "Failed to rebuild embeddings"
-      console.error("Failed to rebuild embeddings:", e)
+      logger.error("Failed to rebuild embeddings", "useEmbeddingRebuild", {
+        error: e
+      })
       setError(message)
     } finally {
       setIsRebuilding(false)

--- a/src/features/model/hooks/use-provider-models.ts
+++ b/src/features/model/hooks/use-provider-models.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 
 import { DEFAULT_PROVIDER_ID, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderManager } from "@/lib/providers/manager"
@@ -25,17 +26,16 @@ import { isEmbeddingModel } from "../lib/model-utils"
 const fetchAllProviderModels = async (): Promise<ProviderModel[]> => {
   const providers = await ProviderManager.getProviders()
   const enabledProviders = providers.filter((p) => p.enabled)
-  console.log(
-    "[useProviderModels] Enabled providers:",
-    enabledProviders.map((p) => p.id)
-  )
+  logger.info("Enabled providers", "useProviderModels", {
+    providers: enabledProviders.map((p) => p.id)
+  })
 
   const allModels: ProviderModel[] = []
 
   await Promise.all(
     enabledProviders.map(async (config) => {
       try {
-        console.log(`[useProviderModels] Fetching for ${config.id}...`)
+        logger.debug(`Fetching for ${config.id}`, "useProviderModels")
         const provider = await ProviderFactory.getProvider(config.id)
         const providerModels = await provider.getModels()
         const customs = config.customModels || []
@@ -73,7 +73,11 @@ const fetchAllProviderModels = async (): Promise<ProviderModel[]> => {
           allModels.push(model)
         })
       } catch (e) {
-        console.error(`Failed to fetch models for ${config.id}`, e)
+        logger.error(
+          `Failed to fetch models for ${config.id}`,
+          "useProviderModels",
+          { error: e }
+        )
       }
     })
   )
@@ -84,8 +88,9 @@ const fetchAllProviderModels = async (): Promise<ProviderModel[]> => {
   allModels.forEach((m) => {
     if (m.providerId && m.providerId !== DEFAULT_PROVIDER_ID) {
       if (mappings[m.name]) {
-        console.warn(
-          `[useProviderModels] Model name collision: "${m.name}" is served by both "${mappings[m.name]}" and "${m.providerId}". Keeping first mapping.`
+        logger.warn(
+          `Model name collision: "${m.name}" is served by both "${mappings[m.name]}" and "${m.providerId}". Keeping first mapping.`,
+          "useProviderModels"
         )
       } else {
         mappings[m.name] = m.providerId
@@ -244,7 +249,11 @@ export const useProviderModels = () => {
       }
     }
     runMigration().catch((error) => {
-      console.error("Failed to migrate selected model reference", error)
+      logger.error(
+        "Failed to migrate selected model reference",
+        "useProviderModels",
+        { error }
+      )
     })
   }, [
     isStorageLoading,
@@ -308,7 +317,7 @@ export const useProviderModels = () => {
       })
     },
     onError: (err) => {
-      console.error("Error deleting model:", err)
+      logger.error("Error deleting model", "useProviderModels", { error: err })
     }
   })
 

--- a/src/features/prompt/components/prompt-selector-dialog.tsx
+++ b/src/features/prompt/components/prompt-selector-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { usePromptTemplates } from "@/features/prompt/hooks/use-prompt-templates"
+import { logger } from "@/lib/logger"
 import {
   Clock,
   Copy,
@@ -101,7 +102,9 @@ export const PromptSelectorDialog = ({
     try {
       await navigator.clipboard.writeText(text)
     } catch (err) {
-      console.error("Failed to copy text: ", err)
+      logger.error("Failed to copy text", "PromptSelectorDialog", {
+        error: err
+      })
     }
   }
 

--- a/src/features/prompt/components/prompt-template-actions.tsx
+++ b/src/features/prompt/components/prompt-template-actions.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react"
 import { useTranslation } from "react-i18next"
+import { z } from "zod"
 import { ConfirmActionDialog } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import {
@@ -10,8 +11,11 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { logger } from "@/lib/logger"
 import { Download, MoreHorizontal, RotateCcw, Upload } from "@/lib/lucide-icon"
+import { safeJsonParse } from "@/lib/validation"
 import type { PromptTemplate } from "@/types"
+import { PromptTemplateSchema } from "@/types/ui-state.schemas"
 
 export interface PromptTemplateActionsProps {
   onExport: () => void
@@ -39,15 +43,18 @@ export const PromptTemplateActions = ({
 
     const reader = new FileReader()
     reader.onload = (e) => {
-      try {
-        const imported = JSON.parse(
-          e.target?.result as string
-        ) as PromptTemplate[]
-        onImport(imported)
-      } catch (error) {
-        console.error("Failed to import templates:", error)
+      const result = safeJsonParse(
+        e.target?.result as string,
+        z.array(PromptTemplateSchema)
+      )
+      if (!result.success) {
+        logger.error("Failed to import templates", "PromptTemplateActions", {
+          error: result.error
+        })
         alert("Failed to import templates. Please check the file format.")
+        return
       }
+      onImport(result.data)
     }
     reader.readAsText(file)
 

--- a/src/features/prompt/components/prompt-template-actions.tsx
+++ b/src/features/prompt/components/prompt-template-actions.tsx
@@ -14,12 +14,10 @@ import { useConfirmAction } from "@/hooks/use-confirm-action"
 import { logger } from "@/lib/logger"
 import { Download, MoreHorizontal, RotateCcw, Upload } from "@/lib/lucide-icon"
 import { safeJsonParse } from "@/lib/validation"
-import type { PromptTemplate } from "@/types"
-import { PromptTemplateSchema } from "@/types/ui-state.schemas"
 
 export interface PromptTemplateActionsProps {
   onExport: () => void
-  onImport: (templates: PromptTemplate[]) => void
+  onImport: (templates: unknown) => void
   onReset: () => void
 }
 
@@ -43,9 +41,11 @@ export const PromptTemplateActions = ({
 
     const reader = new FileReader()
     reader.onload = (e) => {
+      // TODO: after production soak (2026-Q3), switch to z.array(PromptTemplateSchema)
+      // and let hook handle per-item skip. Remove the lenient unknown[] approach.
       const result = safeJsonParse(
         e.target?.result as string,
-        z.array(PromptTemplateSchema)
+        z.array(z.unknown())
       )
       if (!result.success) {
         logger.error("Failed to import templates", "PromptTemplateActions", {

--- a/src/features/prompt/components/prompt-template-list.tsx
+++ b/src/features/prompt/components/prompt-template-list.tsx
@@ -20,6 +20,7 @@ import {
   CollapsibleTrigger
 } from "@/components/ui/collapsible"
 import { Separator } from "@/components/ui/separator"
+import { logger } from "@/lib/logger"
 import {
   Calendar,
   ChevronRight,
@@ -56,7 +57,7 @@ export const PromptTemplateList = ({
       setCopiedId(id)
       setTimeout(() => setCopiedId(null), 2000)
     } catch (err) {
-      console.error("Failed to copy: ", err)
+      logger.error("Failed to copy", "PromptTemplateList", { error: err })
     }
   }
 

--- a/src/features/prompt/hooks/use-prompt-templates.ts
+++ b/src/features/prompt/hooks/use-prompt-templates.ts
@@ -1,6 +1,7 @@
 import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback } from "react"
 import { DEFAULT_PROMPT_TEMPLATES, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { PromptTemplate } from "@/types"
 import { PromptTemplateSchema } from "@/types/ui-state.schemas"
@@ -125,8 +126,24 @@ export const usePromptTemplates = () => {
     [setTemplates]
   )
 
-  const exportTemplates = useCallback(() => {
-    return effectiveTemplates
+  const exportTemplates = useCallback((): PromptTemplate[] => {
+    const validated: PromptTemplate[] = []
+    for (const t of effectiveTemplates) {
+      const result = PromptTemplateSchema.safeParse(t)
+      if (result.success) {
+        validated.push(result.data as PromptTemplate)
+      } else {
+        logger.warn(
+          "Skipping invalid template on export",
+          "usePromptTemplates",
+          {
+            id: t.id,
+            error: result.error.message
+          }
+        )
+      }
+    }
+    return validated
   }, [effectiveTemplates])
 
   const resetToDefaults = useCallback(() => {

--- a/src/features/prompt/hooks/use-prompt-templates.ts
+++ b/src/features/prompt/hooks/use-prompt-templates.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react"
 import { DEFAULT_PROMPT_TEMPLATES, STORAGE_KEYS } from "@/lib/constants"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { PromptTemplate } from "@/types"
+import { PromptTemplateSchema } from "@/types/ui-state.schemas"
 
 const normalizeCreatedAt = (value: unknown): Date => {
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value
@@ -17,48 +18,15 @@ const normalizeImportedTemplate = (
   value: unknown,
   existingIds: Set<string>
 ): PromptTemplate | null => {
-  if (!value || typeof value !== "object") return null
+  const parsed = PromptTemplateSchema.safeParse(value)
+  if (!parsed.success) return null
 
-  const candidate = value as Partial<PromptTemplate>
-  if (
-    typeof candidate.title !== "string" ||
-    !candidate.title.trim() ||
-    typeof candidate.userPrompt !== "string" ||
-    !candidate.userPrompt.trim()
-  ) {
-    return null
-  }
-
-  const rawId =
-    typeof candidate.id === "string" && candidate.id.trim()
-      ? candidate.id.trim()
-      : crypto.randomUUID()
+  const template = parsed.data
+  const rawId = template.id.trim() || crypto.randomUUID()
   const id = existingIds.has(rawId) ? crypto.randomUUID() : rawId
   existingIds.add(id)
 
-  return {
-    id,
-    title: candidate.title.trim(),
-    description:
-      typeof candidate.description === "string"
-        ? candidate.description
-        : undefined,
-    category:
-      typeof candidate.category === "string" ? candidate.category : undefined,
-    systemPrompt:
-      typeof candidate.systemPrompt === "string"
-        ? candidate.systemPrompt
-        : undefined,
-    userPrompt: candidate.userPrompt.trim(),
-    tags: Array.isArray(candidate.tags)
-      ? candidate.tags.filter((tag): tag is string => typeof tag === "string")
-      : undefined,
-    createdAt: normalizeCreatedAt(candidate.createdAt),
-    usageCount:
-      typeof candidate.usageCount === "number" && candidate.usageCount >= 0
-        ? candidate.usageCount
-        : 0
-  }
+  return { ...template, id }
 }
 
 export const usePromptTemplates = () => {
@@ -140,11 +108,14 @@ export const usePromptTemplates = () => {
   )
 
   const importTemplates = useCallback(
-    (newTemplates: unknown[]) => {
+    (newTemplates: unknown) => {
+      const items = Array.isArray(newTemplates) ? newTemplates : []
+      if (items.length === 0) return
+
       setTemplates((prev) => {
         const current = prev || []
         const existingIds = new Set(current.map((template) => template.id))
-        const normalized = newTemplates
+        const normalized = items
           .map((template) => normalizeImportedTemplate(template, existingIds))
           .filter((template): template is PromptTemplate => Boolean(template))
 

--- a/src/features/sessions/hooks/__tests__/use-import-chat.test.ts
+++ b/src/features/sessions/hooks/__tests__/use-import-chat.test.ts
@@ -179,7 +179,7 @@ describe("useImportChat", () => {
       }
     } as unknown as FileList
 
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
     await act(async () => {
       await result.current.importChat(fileList)

--- a/src/features/sessions/hooks/use-import-chat.ts
+++ b/src/features/sessions/hooks/use-import-chat.ts
@@ -1,53 +1,37 @@
 import { useCallback } from "react"
+import { z } from "zod"
 import { chatSessionStore } from "@/features/sessions/stores/chat-session-store"
 import { logger } from "@/lib/logger"
 import { bulkPutSessions } from "@/lib/repositories/chat-history"
 import type { ChatSession } from "@/types"
-
-function isValidChatSession(obj: unknown): obj is ChatSession {
-  if (!obj || typeof obj !== "object") return false
-  const candidate = obj as Record<string, unknown>
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.title === "string" &&
-    typeof candidate.createdAt === "number" &&
-    typeof candidate.updatedAt === "number" &&
-    Array.isArray(candidate.messages) &&
-    candidate.messages.every(
-      (m: unknown) =>
-        m &&
-        typeof m === "object" &&
-        typeof (m as Record<string, unknown>).role === "string" &&
-        typeof (m as Record<string, unknown>).content === "string"
-    )
-  )
-}
+import { ChatSessionImportSchema } from "@/types/chat.schemas"
 
 export const useImportChat = () => {
   const importChat = useCallback(async (files: FileList | null) => {
     if (!files) return
 
     const importedSessions: ChatSession[] = []
+    const ImportPayload = z.union([
+      z.array(ChatSessionImportSchema),
+      ChatSessionImportSchema.transform((s) => [s])
+    ])
 
     for (const file of Array.from(files)) {
       if (!file.name.endsWith(".json")) continue
 
       try {
         const text = await file.text()
-        const parsed = JSON.parse(text)
+        const parsed = ImportPayload.safeParse(JSON.parse(text))
 
-        const sessions = Array.isArray(parsed) ? parsed : [parsed]
-
-        for (const s of sessions) {
-          if (isValidChatSession(s)) {
-            importedSessions.push(s)
-          } else {
-            logger.warn("Invalid session in file", "useImportChat", {
-              fileName: file.name,
-              session: s
-            })
-          }
+        if (!parsed.success) {
+          logger.warn("Invalid session data in file", "useImportChat", {
+            fileName: file.name,
+            error: parsed.error.message
+          })
+          continue
         }
+
+        importedSessions.push(...(parsed.data as ChatSession[]))
       } catch (err) {
         logger.error("Failed to parse import file", "useImportChat", {
           fileName: file.name,

--- a/src/features/sessions/hooks/use-import-chat.ts
+++ b/src/features/sessions/hooks/use-import-chat.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react"
-import { z } from "zod"
 import { chatSessionStore } from "@/features/sessions/stores/chat-session-store"
 import { logger } from "@/lib/logger"
 import { bulkPutSessions } from "@/lib/repositories/chat-history"
@@ -11,29 +10,47 @@ export const useImportChat = () => {
     if (!files) return
 
     const importedSessions: ChatSession[] = []
-    const ImportPayload = z.union([
-      z.array(ChatSessionImportSchema),
-      ChatSessionImportSchema.transform((s) => [s])
-    ])
 
     for (const file of Array.from(files)) {
       if (!file.name.endsWith(".json")) continue
 
       try {
         const text = await file.text()
-        const parsed = ImportPayload.safeParse(JSON.parse(text))
-
-        if (!parsed.success) {
-          logger.warn("Invalid session data in file", "useImportChat", {
-            fileName: file.name,
-            error: parsed.error.message
+        let raw: unknown
+        try {
+          raw = JSON.parse(text)
+        } catch {
+          logger.warn("File is not valid JSON", "useImportChat", {
+            fileName: file.name
           })
           continue
         }
 
-        importedSessions.push(...(parsed.data as ChatSession[]))
+        const rawSessions = Array.isArray(raw) ? raw : [raw]
+        let fileHadErrors = false
+
+        for (const item of rawSessions) {
+          const parsed = ChatSessionImportSchema.safeParse(item)
+          if (parsed.success) {
+            importedSessions.push(parsed.data as unknown as ChatSession)
+          } else {
+            fileHadErrors = true
+            logger.warn("Skipping invalid session in file", "useImportChat", {
+              fileName: file.name,
+              error: parsed.error.message
+            })
+          }
+        }
+
+        if (fileHadErrors) {
+          logger.warn(
+            "Some sessions were skipped due to validation errors",
+            "useImportChat",
+            { fileName: file.name }
+          )
+        }
       } catch (err) {
-        logger.error("Failed to parse import file", "useImportChat", {
+        logger.error("Failed to import file", "useImportChat", {
           fileName: file.name,
           error: err
         })

--- a/src/features/tabs/hooks/use-open-tab.ts
+++ b/src/features/tabs/hooks/use-open-tab.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 import type { Tabs } from "webextension-polyfill"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import type { ChromeResponse } from "@/types"
 
 export const useOpenTabs = (enabled: boolean) => {
@@ -17,7 +18,7 @@ export const useOpenTabs = (enabled: boolean) => {
         setTabs(response.tabs)
       }
     } catch (error) {
-      console.error("Failed to fetch tabs:", error)
+      logger.error("Failed to fetch tabs", "useOpenTab", { error })
     }
   }, [enabled])
 

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { safeJsonParse } from "../validation"
+
+describe("safeJsonParse", () => {
+  const TestSchema = z.object({
+    name: z.string(),
+    age: z.number()
+  })
+
+  it("returns parsed data when JSON and schema both valid", () => {
+    const result = safeJsonParse('{"name":"Alice","age":30}', TestSchema)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ name: "Alice", age: 30 })
+    }
+  })
+
+  it("returns SyntaxError for malformed JSON", () => {
+    const result = safeJsonParse("not json", TestSchema)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(SyntaxError)
+    }
+  })
+
+  it("returns ZodError when JSON is valid but schema fails", () => {
+    const result = safeJsonParse('{"name":123}', TestSchema)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.constructor.name).toBe("ZodError")
+    }
+  })
+
+  it("works with passthrough schemas (extra keys preserved)", () => {
+    const Loose = z.object({ id: z.string() }).passthrough()
+    const result = safeJsonParse('{"id":"1","extra":"kept"}', Loose)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ id: "1", extra: "kept" })
+    }
+  })
+
+  it("works with array schemas", () => {
+    const ArraySchema = z.array(z.string())
+    const result = safeJsonParse('["a","b","c"]', ArraySchema)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(["a", "b", "c"])
+    }
+  })
+
+  it("applies transforms and defaults", () => {
+    const WithDefault = z.object({
+      name: z.string(),
+      count: z.number().default(0)
+    })
+    const result = safeJsonParse('{"name":"test"}', WithDefault)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.count).toBe(0)
+    }
+  })
+})

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -1,10 +1,20 @@
 import { exportDB, importInto } from "dexie-export-import"
 import JSZip from "jszip"
+import { z } from "zod"
 import { db as chatDb } from "./db"
 import { vectorDb } from "./embeddings/db"
 import { knowledgeDb } from "./knowledge/knowledge-sets"
 import { logger } from "./logger"
 import { exportDatabaseBytes, importDatabaseBytes } from "./sqlite/db"
+import { safeJsonParse } from "./validation"
+
+const BackupManifestSchema = z.object({
+  version: z.number(),
+  timestamp: z.string().optional(),
+  appVersion: z.string().optional()
+})
+
+const StorageObjectSchema = z.record(z.string(), z.unknown())
 
 export type ImportResult = {
   syncStorage: { ok: boolean; error?: string }
@@ -25,7 +35,7 @@ export const backupService = {
     const zip = new JSZip()
 
     // Manifest
-    console.log("[Backup] Exporting manifest...")
+    logger.info("Exporting manifest...", "Backup")
     const manifest = {
       version: MANIFEST_VERSION,
       timestamp: new Date().toISOString(),
@@ -34,23 +44,23 @@ export const backupService = {
     zip.file("manifest.json", JSON.stringify(manifest, null, 2))
 
     // Sync Storage
-    console.log("[Backup] Exporting sync storage...")
+    logger.info("Exporting sync storage...", "Backup")
     const syncData = await chrome.storage.sync.get(null)
     zip.file("sync-storage.json", JSON.stringify(syncData, null, 2))
 
     // Local Storage
-    console.log("[Backup] Exporting local storage...")
+    logger.info("Exporting local storage...", "Backup")
     const localData = await chrome.storage.local.get(null)
     zip.file("local-storage.json", JSON.stringify(localData, null, 2))
 
     // SQLite Database
     try {
-      console.log("[Backup] Exporting SQLite database...")
+      logger.info("Exporting SQLite database...", "Backup")
       const dbBytes = await exportDatabaseBytes()
       zip.file("database.sqlite", dbBytes)
-      console.log("[Backup] SQLite database exported.")
+      logger.info("SQLite database exported.", "Backup")
     } catch (e) {
-      console.error("[Backup] SQLite export failed:", e)
+      logger.error("SQLite export failed:", "Backup", e)
       throw e // Re-throw to see the full stack in the UI
     }
 
@@ -63,12 +73,12 @@ export const backupService = {
 
     for (const item of dexieDbs) {
       try {
-        console.log(`[Backup] Exporting ${item.name}...`)
+        logger.info(`Exporting ${item.name}...`, "Backup")
         const blob = await exportDB(item.db)
         zip.file(item.file, blob)
-        console.log(`[Backup] ${item.name} exported.`)
+        logger.info(`${item.name} exported.`, "Backup")
       } catch (e) {
-        console.error(`[Backup] ${item.name} export failed:`, e)
+        logger.error(`${item.name} export failed:`, "Backup", e)
         // We log but don't throw, allowing partial backups
         zip.file(
           `${item.file}.error.txt`,
@@ -104,7 +114,11 @@ export const backupService = {
       }
 
       const manifestStr = await manifestFile.async("string")
-      const manifest = JSON.parse(manifestStr)
+      const manifestResult = safeJsonParse(manifestStr, BackupManifestSchema)
+      if (!manifestResult.success) {
+        throw new Error("Invalid manifest: failed schema validation")
+      }
+      const manifest = manifestResult.data
       if (manifest.version !== MANIFEST_VERSION) {
         throw new Error(`Unsupported backup version: ${manifest.version}`)
       }
@@ -114,7 +128,11 @@ export const backupService = {
         const syncFile = zip.file("sync-storage.json")
         if (syncFile) {
           const syncStr = await syncFile.async("string")
-          const syncData = JSON.parse(syncStr)
+          const syncResult = safeJsonParse(syncStr, StorageObjectSchema)
+          if (!syncResult.success) {
+            throw new Error("Invalid sync storage: expected a JSON object")
+          }
+          const syncData = syncResult.data
 
           await chrome.storage.sync.clear()
 
@@ -156,7 +174,11 @@ export const backupService = {
         const localFile = zip.file("local-storage.json")
         if (localFile) {
           const localStr = await localFile.async("string")
-          const localData = JSON.parse(localStr)
+          const localResult = safeJsonParse(localStr, StorageObjectSchema)
+          if (!localResult.success) {
+            throw new Error("Invalid local storage: expected a JSON object")
+          }
+          const localData = localResult.data
           await chrome.storage.local.clear()
           await chrome.storage.local.set(localData)
           result.localStorage.ok = true

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -60,7 +60,7 @@ export const backupService = {
       zip.file("database.sqlite", dbBytes)
       logger.info("SQLite database exported.", "Backup")
     } catch (e) {
-      logger.error("SQLite export failed:", "Backup", e)
+      logger.error("SQLite export failed", "Backup", { error: e })
       throw e // Re-throw to see the full stack in the UI
     }
 
@@ -78,7 +78,7 @@ export const backupService = {
         zip.file(item.file, blob)
         logger.info(`${item.name} exported.`, "Backup")
       } catch (e) {
-        logger.error(`${item.name} export failed:`, "Backup", e)
+        logger.error(`${item.name} export failed`, "Backup", { error: e })
         // We log but don't throw, allowing partial backups
         zip.file(
           `${item.file}.error.txt`,

--- a/src/lib/exporters/markdown-utils.ts
+++ b/src/lib/exporters/markdown-utils.ts
@@ -26,7 +26,13 @@ export const createMarkdownParser = () => {
       if (lang && hljs.getLanguage(lang)) {
         try {
           return `<pre class="hljs"><code>${hljs.highlight(str, { language: lang, ignoreIllegals: true }).value}</code></pre>`
-        } catch (__) {}
+        } catch (e) {
+          logger.warn(
+            `Highlight failed for language: ${lang}`,
+            "markdownUtils",
+            { error: e }
+          )
+        }
       }
       return `<pre class="hljs"><code>${md.utils.escapeHtml(str)}</code></pre>`
     }

--- a/src/lib/migration/dexie-to-sqlite.ts
+++ b/src/lib/migration/dexie-to-sqlite.ts
@@ -1,9 +1,18 @@
+import { z } from "zod"
 import { db as dexieDb } from "@/lib/db"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { markSqliteHealthy } from "@/lib/repositories/sqlite-chat-history"
 import { SQLiteChatRepository } from "@/lib/repositories/sqlite-chat-repository"
 import { flushSave, initSQLite } from "@/lib/sqlite/db"
+import { safeJsonParse } from "@/lib/validation"
+
+const MigrationProgressSchema = z.object({
+  totalSessions: z.number(),
+  completedSessions: z.number().default(0),
+  currentSessionId: z.string().nullable(),
+  lastUpdated: z.number()
+})
 
 export const MIGRATION_STATUS_KEY = "sqlite_migration_status"
 const MIGRATION_PROGRESS_KEY = "sqlite_migration_progress"
@@ -68,15 +77,18 @@ export const runDexieToSQLiteMigration = async (
     let startIndex = 0
 
     if (savedProgress) {
-      try {
-        const progress = JSON.parse(savedProgress) as MigrationProgress
-        completedSessions = progress.completedSessions || 0
+      const progressResult = safeJsonParse(
+        savedProgress,
+        MigrationProgressSchema
+      )
+      if (progressResult.success) {
+        completedSessions = progressResult.data.completedSessions
         startIndex = completedSessions
         logger.info(
           `Resuming migration from session ${startIndex}/${totalSessions}`,
           "Migration"
         )
-      } catch (_e) {
+      } else {
         logger.warn(
           "Failed to parse saved progress, starting fresh",
           "Migration"
@@ -264,9 +276,10 @@ export const getMigrationStatus = async (): Promise<MigrationStatus> => {
 
   let progress: MigrationProgress | undefined
   if (progressStr) {
-    try {
-      progress = JSON.parse(progressStr)
-    } catch (_e) {
+    const progressResult = safeJsonParse(progressStr, MigrationProgressSchema)
+    if (progressResult.success) {
+      progress = progressResult.data as MigrationProgress
+    } else {
       logger.warn("Failed to parse migration progress", "Migration")
     }
   }

--- a/src/lib/providers/llama-cpp.ts
+++ b/src/lib/providers/llama-cpp.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import type { ProviderModel } from "@/types"
 import { OpenAIProvider } from "./openai"
 import { type EmbeddingSupport, type ProviderConfig, ProviderId } from "./types"
@@ -59,19 +60,19 @@ export class LlamaCppProvider extends OpenAIProvider {
     let response: Response | null = null
     for (const url of uniqueEndpoints) {
       try {
-        console.log(`[LlamaCpp] Fetching models from ${url}`)
+        logger.debug(`Fetching models from ${url}`, "LlamaCpp")
         const res = await fetch(url)
         if (res.ok) {
           response = res
           break
         }
       } catch (e) {
-        console.warn(`[LlamaCpp] Failed to fetch from ${url}`, e)
+        logger.warn(`Failed to fetch from ${url}`, "LlamaCpp", { error: e })
       }
     }
 
     if (!response) {
-      console.error("[LlamaCpp] All model fetch attempts failed.")
+      logger.error("All model fetch attempts failed.", "LlamaCpp")
       throw new Error(
         "Failed to connect to llama.cpp server. Check if the service is running and the URL is correct."
       )
@@ -80,7 +81,7 @@ export class LlamaCppProvider extends OpenAIProvider {
     try {
       const json = await response.json()
       // Llama.cpp returns { data: [ { id: "...", meta: { ... } } ] }
-      console.log("[LlamaCpp] Raw response:", JSON.stringify(json, null, 2))
+      logger.debug("Raw response", "LlamaCpp", { response: json })
 
       const list = Array.isArray(json.data)
         ? json.data
@@ -127,7 +128,7 @@ export class LlamaCppProvider extends OpenAIProvider {
         }
       })
     } catch (e) {
-      console.error("[LlamaCpp] Model parse failed", e)
+      logger.error("Model parse failed", "LlamaCpp", { error: e })
       throw new Error("Failed to parse response from llama.cpp server")
     }
   }

--- a/src/lib/providers/lm-studio.ts
+++ b/src/lib/providers/lm-studio.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import type { ProviderModel } from "@/types"
 import { OpenAIProvider } from "./openai"
 import { type EmbeddingSupport, type ProviderConfig, ProviderId } from "./types"
@@ -65,9 +66,10 @@ export class LMStudioProvider extends OpenAIProvider {
         }
       }))
     } catch (_e) {
-      console.warn(
-        "LMStudio /api/v0/models failed, falling back to openai compat",
-        _e
+      logger.warn(
+        "/api/v0/models failed, falling back to openai compat",
+        "LMStudio",
+        { error: _e }
       )
       return super.getModels()
     }

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -1,4 +1,5 @@
 import { LEGACY_STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import {
   type ProviderConfig,
@@ -116,7 +117,11 @@ export const ProviderManager = {
         // But if we return the legacy URL, the UI will show it, and if user saves, it updates.
       }
     } catch (e) {
-      console.warn("Failed to check legacy provider URL in getProviders", e)
+      logger.warn(
+        "Failed to check legacy provider URL in getProviders",
+        "ProviderManager",
+        { error: e }
+      )
     }
 
     if (missing.length > 0) {
@@ -161,7 +166,9 @@ export const ProviderManager = {
             updates.baseUrl
           )
         } catch (e) {
-          console.warn("Failed to sync legacy provider URL", e)
+          logger.warn("Failed to sync legacy provider URL", "ProviderManager", {
+            error: e
+          })
         }
       }
     }

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import type {
   ChatStreamMessage,
   OllamaChatRequest,
@@ -35,15 +36,16 @@ export class OllamaProvider implements LLMProvider {
       if (!this.config.baseUrl) {
         return []
       }
-      console.log(
-        `[OllamaProvider] Fetching models from ${this.config.baseUrl}`
+      logger.debug(
+        `Fetching models from ${this.config.baseUrl}`,
+        "OllamaProvider"
       )
       const response = await fetch(`${this.config.baseUrl}/api/tags`)
       if (!response.ok) return []
       const data = await response.json()
       return (data.models as ProviderModel[]) || []
     } catch (e) {
-      console.error("Failed to fetch Ollama models", e)
+      logger.error("Failed to fetch models", "OllamaProvider", { error: e })
       return []
     }
   }
@@ -165,7 +167,7 @@ export class OllamaProvider implements LLMProvider {
                 : undefined
             })
           } catch (e) {
-            console.warn("Failed to parse Ollama chunk", e)
+            logger.warn("Failed to parse chunk", "OllamaProvider", { error: e })
           }
         }
       }
@@ -188,7 +190,9 @@ export class OllamaProvider implements LLMProvider {
       if (!res.ok) return null
       return await res.json()
     } catch (e) {
-      console.error("Failed to fetch Ollama model details", e)
+      logger.error("Failed to fetch model details", "OllamaProvider", {
+        error: e
+      })
       return null
     }
   }
@@ -225,10 +229,9 @@ export class OllamaProvider implements LLMProvider {
         }
       } else {
         const errorText = await response.text()
-        console.warn(
-          `[Ollama] /api/embed failed: ${response.status}`,
-          errorText
-        )
+        logger.warn(`/api/embed failed: ${response.status}`, "OllamaProvider", {
+          error: errorText
+        })
       }
     } catch (_error) {
       // Continue to legacy fallback.
@@ -244,9 +247,10 @@ export class OllamaProvider implements LLMProvider {
 
       if (!legacyResponse.ok) {
         const errorText = await legacyResponse.text()
-        console.warn(
-          `[Ollama] /api/embeddings failed: ${legacyResponse.status}`,
-          errorText
+        logger.warn(
+          `/api/embeddings failed: ${legacyResponse.status}`,
+          "OllamaProvider",
+          { error: errorText }
         )
         const message = errorText
           ? `Ollama Embedding Error: ${legacyResponse.status} ${errorText}`
@@ -260,7 +264,7 @@ export class OllamaProvider implements LLMProvider {
       }
       return legacyData.embedding
     } catch (error) {
-      console.error("[Ollama] Both embed endpoints failed", error)
+      logger.error("Both embed endpoints failed", "OllamaProvider", { error })
       throw error
     }
   }

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -185,7 +185,11 @@ export class OpenAIProvider implements LLMProvider {
                   metrics: latestMetrics
                 })
               }
-            } catch (_e) {}
+            } catch (e) {
+              logger.warn("Failed to parse SSE data line", "OpenAIProvider", {
+                error: e
+              })
+            }
           }
         }
       }

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import type { ChatStreamMessage, ProviderModel } from "@/types"
 import {
   type ChatRequest,
@@ -56,7 +57,7 @@ export class OpenAIProvider implements LLMProvider {
         })) || []
       )
     } catch (e) {
-      console.error("Failed to fetch OpenAI models", e)
+      logger.error("Failed to fetch models", "OpenAIProvider", { error: e })
       return []
     }
   }

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -1,5 +1,6 @@
 import { query, resetSQLiteDatabase, run } from "@/lib/sqlite/db"
 import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
+import { ChatMessageMetricsSchema } from "@/types/chat.schemas"
 
 /**
  * SQLite-backed implementation of the chat-history persistence surface
@@ -32,7 +33,9 @@ const sessionFromRow = (row: Row): ChatSession => ({
 const parseMetrics = (raw: RowValue): ChatMessage["metrics"] => {
   if (typeof raw !== "string" || raw.length === 0) return undefined
   try {
-    return JSON.parse(raw) as ChatMessage["metrics"]
+    const parsed = JSON.parse(raw)
+    const result = ChatMessageMetricsSchema.safeParse(parsed)
+    return result.success ? (result.data as ChatMessage["metrics"]) : undefined
   } catch {
     return undefined
   }

--- a/src/lib/repositories/sqlite-chat-repository.ts
+++ b/src/lib/repositories/sqlite-chat-repository.ts
@@ -1,6 +1,7 @@
 import { logger } from "@/lib/logger"
 import { query, run } from "@/lib/sqlite/db"
 import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
+import { ChatMessageMetricsSchema } from "@/types/chat.schemas"
 import type { ChatRepository } from "./types"
 
 export class SQLiteChatRepository implements ChatRepository {
@@ -112,7 +113,10 @@ export class SQLiteChatRepository implements ChatRepository {
       timestamp: row.timestamp as number,
       parentId: row.parentId as number | undefined,
       done: Boolean(row.done),
-      metrics: row.metrics ? JSON.parse(row.metrics as string) : undefined,
+      metrics: row.metrics
+        ? (ChatMessageMetricsSchema.safeParse(JSON.parse(row.metrics as string))
+            .data as ChatMessage["metrics"])
+        : undefined,
       attachments: fileMap.get(row.id as number) || []
     }))
   }

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger"
+
 /**
  * Waits for an element to appear in the DOM with retries
  */
@@ -9,15 +11,17 @@ const waitForElement = async (
   for (let i = 0; i < maxAttempts; i++) {
     const element = document.querySelector<HTMLElement>(selector)
     if (element) {
-      console.log(
-        `[YouTube Transcript] Found element with selector "${selector}" after ${i + 1} attempts`
+      logger.debug(
+        `Found element with selector "${selector}" after ${i + 1} attempts`,
+        "TranscriptExtractor"
       )
       return element
     }
     await new Promise((resolve) => setTimeout(resolve, delayMs))
   }
-  console.log(
-    `[YouTube Transcript] Element "${selector}" not found after ${maxAttempts} attempts`
+  logger.debug(
+    `Element "${selector}" not found after ${maxAttempts} attempts`,
+    "TranscriptExtractor"
   )
   return null
 }
@@ -29,28 +33,32 @@ const waitForElement = async (
  * Returns true if transcript panel was opened or already exists
  */
 const openYouTubeTranscript = async (): Promise<boolean> => {
-  console.log("[YouTube Transcript] Starting transcript panel automation")
-  console.log(`[YouTube Transcript] Current URL: ${window.location.href}`)
+  logger.debug("Starting transcript panel automation", "TranscriptExtractor")
+  logger.debug(`Current URL: ${window.location.href}`, "TranscriptExtractor")
 
   if (!window.location.href.includes("youtube.com/watch")) {
-    console.log("[YouTube Transcript] Not a YouTube watch page, skipping")
+    logger.debug("Not a YouTube watch page, skipping", "TranscriptExtractor")
     return false
   }
 
-  console.log("[YouTube Transcript] Checking for existing transcript panel...")
+  logger.debug(
+    "Checking for existing transcript panel...",
+    "TranscriptExtractor"
+  )
   // Check if transcript is already open
   const existingTranscript = document.querySelector("ytd-transcript-renderer")
   if (existingTranscript) {
-    console.log("[YouTube Transcript] Transcript panel already exists!")
+    logger.debug("Transcript panel already exists!", "TranscriptExtractor")
     return true
   }
 
-  console.log(
-    "[YouTube Transcript] Transcript panel not found, attempting to open..."
+  logger.debug(
+    "Transcript panel not found, attempting to open...",
+    "TranscriptExtractor"
   )
 
   // Step 1: Try to click "more" button to expand description
-  console.log("[YouTube Transcript] Step 1: Looking for 'more' button...")
+  logger.debug("Step 1: Looking for 'more' button...", "TranscriptExtractor")
   const moreButton = await waitForElement(
     "tp-yt-paper-button#expand.button.style-scope.ytd-text-inline-expander",
     3,
@@ -59,37 +67,45 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
 
   if (moreButton) {
     const moreButtonText = moreButton.textContent?.trim() || ""
-    console.log(
-      `[YouTube Transcript] Found 'more' button with text: "${moreButtonText}"`
+    logger.debug(
+      `Found 'more' button with text: "${moreButtonText}"`,
+      "TranscriptExtractor"
     )
     if (moreButtonText.includes("more") || moreButtonText.includes("...")) {
-      console.log("[YouTube Transcript] Clicking 'more' button...")
+      logger.debug("Clicking 'more' button...", "TranscriptExtractor")
       moreButton.click()
       // Wait for description to expand
       await new Promise((resolve) => setTimeout(resolve, 500))
-      console.log("[YouTube Transcript] Waited 500ms for description to expand")
+      logger.debug(
+        "Waited 500ms for description to expand",
+        "TranscriptExtractor"
+      )
     } else {
-      console.log(
-        `[YouTube Transcript] 'more' button found but text doesn't match: "${moreButtonText}"`
+      logger.debug(
+        `'more' button found but text doesn't match: "${moreButtonText}"`,
+        "TranscriptExtractor"
       )
     }
   } else {
-    console.log(
-      "[YouTube Transcript] 'more' button not found (may already be expanded)"
+    logger.debug(
+      "'more' button not found (may already be expanded)",
+      "TranscriptExtractor"
     )
   }
 
   // Step 2: Try to find and click "Show transcript" button with retries
-  console.log(
-    "[YouTube Transcript] Step 2: Looking for 'Show transcript' button..."
+  logger.debug(
+    "Step 2: Looking for 'Show transcript' button...",
+    "TranscriptExtractor"
   )
 
   let transcriptButton: HTMLElement | null = null
   const maxRetries = 5
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    console.log(
-      `[YouTube Transcript] Attempt ${attempt}/${maxRetries} to find transcript button...`
+    logger.debug(
+      `Attempt ${attempt}/${maxRetries} to find transcript button...`,
+      "TranscriptExtractor"
     )
 
     // Strategy 1: Find the transcript section renderer and get the button from it
@@ -97,7 +113,7 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
       "ytd-video-description-transcript-section-renderer"
     )
     if (transcriptSection) {
-      console.log("[YouTube Transcript] Found transcript section renderer")
+      logger.debug("Found transcript section renderer", "TranscriptExtractor")
 
       // Try to find the button inside the section
       const buttonInside = transcriptSection.querySelector<HTMLElement>(
@@ -112,8 +128,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
           ariaLabel.toLowerCase().includes("transcript")
         ) {
           transcriptButton = buttonInside
-          console.log(
-            "[YouTube Transcript] Found button inside transcript section"
+          logger.debug(
+            "Found button inside transcript section",
+            "TranscriptExtractor"
           )
         }
       }
@@ -132,8 +149,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
               current.classList.contains("yt-spec-button-shape-next")
             ) {
               transcriptButton = current
-              console.log(
-                "[YouTube Transcript] Found button by traversing up from touch feedback"
+              logger.debug(
+                "Found button by traversing up from touch feedback",
+                "TranscriptExtractor"
               )
               break
             }
@@ -165,8 +183,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
             ariaLabel.toLowerCase().includes("transcript")
           ) {
             transcriptButton = button
-            console.log(
-              `[YouTube Transcript] Found button via selector: ${selector}`
+            logger.debug(
+              `Found button via selector: ${selector}`,
+              "TranscriptExtractor"
             )
             break
           }
@@ -182,8 +201,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
           "div.yt-spec-touch-feedback-shape__fill"
         )
       )
-      console.log(
-        `[YouTube Transcript] Found ${touchFeedbackDivs.length} touch feedback divs`
+      logger.debug(
+        `Found ${touchFeedbackDivs.length} touch feedback divs`,
+        "TranscriptExtractor"
       )
 
       for (const div of touchFeedbackDivs) {
@@ -200,8 +220,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
               current.classList.contains("yt-spec-button-shape-next")
             ) {
               transcriptButton = current
-              console.log(
-                "[YouTube Transcript] Found button by traversing touch feedback div"
+              logger.debug(
+                "Found button by traversing touch feedback div",
+                "TranscriptExtractor"
               )
               break
             }
@@ -217,8 +238,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
       const allButtons = Array.from(
         document.querySelectorAll<HTMLElement>("button, div[role='button']")
       )
-      console.log(
-        `[YouTube Transcript] Found ${allButtons.length} potential buttons for text search`
+      logger.debug(
+        `Found ${allButtons.length} potential buttons for text search`,
+        "TranscriptExtractor"
       )
 
       transcriptButton =
@@ -233,24 +255,20 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
         }) as HTMLElement | undefined) || null
 
       if (transcriptButton) {
-        console.log(`[YouTube Transcript] Found button via text search`)
+        logger.debug("Found button via text search", "TranscriptExtractor")
       }
     }
 
     if (transcriptButton) {
       const buttonText = transcriptButton.textContent?.trim() || ""
       const ariaLabel = transcriptButton.getAttribute("aria-label") || ""
-      console.log(`[YouTube Transcript] Found transcript button!`)
-      console.log(`[YouTube Transcript] Button text: "${buttonText}"`)
-      console.log(`[YouTube Transcript] Button aria-label: "${ariaLabel}"`)
-      console.log(
-        `[YouTube Transcript] Button tag: ${transcriptButton.tagName}`
-      )
-      console.log(
-        `[YouTube Transcript] Button classes: ${transcriptButton.className}`
-      )
-      console.log(`[YouTube Transcript] Button element:`, transcriptButton)
-      console.log(`[YouTube Transcript] Clicking transcript button...`)
+      logger.debug("Found transcript button!", "TranscriptExtractor", {
+        buttonText,
+        ariaLabel,
+        tag: transcriptButton.tagName,
+        classes: transcriptButton.className
+      })
+      logger.debug("Clicking transcript button...", "TranscriptExtractor")
 
       // Try multiple click methods to ensure it works
       // Method 1: Direct click
@@ -285,27 +303,31 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
 
       // Wait for transcript panel to appear
       await new Promise((resolve) => setTimeout(resolve, 1500))
-      console.log(
-        "[YouTube Transcript] Waited 1500ms for transcript panel to appear"
+      logger.debug(
+        "Waited 1500ms for transcript panel to appear",
+        "TranscriptExtractor"
       )
 
       // Verify transcript panel appeared
       const transcriptPanel = document.querySelector("ytd-transcript-renderer")
       if (transcriptPanel) {
-        console.log(
-          "[YouTube Transcript] Transcript panel successfully opened!"
+        logger.debug(
+          "Transcript panel successfully opened!",
+          "TranscriptExtractor"
         )
         return true
       } else {
-        console.log(
-          "[YouTube Transcript] Transcript panel not found after clicking, waiting longer..."
+        logger.debug(
+          "Transcript panel not found after clicking, waiting longer...",
+          "TranscriptExtractor"
         )
         // Wait a bit more and retry
         await new Promise((resolve) => setTimeout(resolve, 1500))
         const retryPanel = document.querySelector("ytd-transcript-renderer")
         if (retryPanel) {
-          console.log(
-            "[YouTube Transcript] Transcript panel appeared after longer wait!"
+          logger.debug(
+            "Transcript panel appeared after longer wait!",
+            "TranscriptExtractor"
           )
           return true
         }
@@ -313,13 +335,17 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
     }
 
     if (attempt < maxRetries) {
-      console.log(`[YouTube Transcript] Waiting before retry ${attempt + 1}...`)
+      logger.debug(
+        `Waiting before retry ${attempt + 1}...`,
+        "TranscriptExtractor"
+      )
       await new Promise((resolve) => setTimeout(resolve, 500))
     }
   }
 
-  console.log(
-    "[YouTube Transcript] Transcript button not found after all retries"
+  logger.debug(
+    "Transcript button not found after all retries",
+    "TranscriptExtractor"
   )
   // Log some button texts for debugging
   const allButtons = Array.from(
@@ -334,33 +360,35 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
       classes: btn.className
     }))
     .filter((info) => info.text || info.ariaLabel)
-  console.log("[YouTube Transcript] Sample buttons found:", buttonTexts)
+  logger.debug("Sample buttons found", "TranscriptExtractor", { buttonTexts })
   return false
 }
 
 const extractYouTubeTranscript = async (): Promise<string | null> => {
-  console.log("[YouTube Transcript] Starting transcript extraction...")
+  logger.debug("Starting transcript extraction...", "TranscriptExtractor")
 
   if (!window.location.href.includes("youtube.com/watch")) {
-    console.log("[YouTube Transcript] Not a YouTube watch page")
+    logger.debug("Not a YouTube watch page", "TranscriptExtractor")
     return null
   }
 
   // Try to open transcript panel if not already open
-  console.log("[YouTube Transcript] Attempting to open transcript panel...")
+  logger.debug("Attempting to open transcript panel...", "TranscriptExtractor")
   const opened = await openYouTubeTranscript()
-  console.log(`[YouTube Transcript] Panel open result: ${opened}`)
+  logger.debug(`Panel open result: ${opened}`, "TranscriptExtractor")
 
   const transcriptContainer = document.querySelector("ytd-transcript-renderer")
   if (!transcriptContainer) {
-    console.log(
-      "[YouTube Transcript] Transcript container not found after opening attempt"
+    logger.debug(
+      "Transcript container not found after opening attempt",
+      "TranscriptExtractor"
     )
     return null
   }
 
-  console.log(
-    "[YouTube Transcript] Transcript container found, extracting content..."
+  logger.debug(
+    "Transcript container found, extracting content...",
+    "TranscriptExtractor"
   )
 
   const transcriptLines = transcriptContainer.querySelectorAll("div.cue-group")
@@ -369,10 +397,10 @@ const extractYouTubeTranscript = async (): Promise<string | null> => {
   )
   const lines = transcriptLines.length > 0 ? transcriptLines : fallbackLines
 
-  console.log(`[YouTube Transcript] Found ${lines.length} transcript lines`)
+  logger.debug(`Found ${lines.length} transcript lines`, "TranscriptExtractor")
 
   if (lines.length === 0) {
-    console.log("[YouTube Transcript] No transcript lines found")
+    logger.debug("No transcript lines found", "TranscriptExtractor")
     return null
   }
 
@@ -386,11 +414,12 @@ const extractYouTubeTranscript = async (): Promise<string | null> => {
 
   const result = transcript.length > 0 ? transcript : null
   if (result) {
-    console.log(
-      `[YouTube Transcript] Successfully extracted transcript (${result.length} chars)`
+    logger.debug(
+      `Successfully extracted transcript (${result.length} chars)`,
+      "TranscriptExtractor"
     )
   } else {
-    console.log("[YouTube Transcript] Empty transcript after processing")
+    logger.debug("Empty transcript after processing", "TranscriptExtractor")
   }
 
   return result
@@ -436,33 +465,35 @@ const extractCourseraTranscript = (): string | null => {
 }
 
 export const getTranscript = async (): Promise<string | null> => {
-  console.log(
-    "[Transcript Extractor] Starting transcript extraction for current page"
+  logger.info(
+    "Starting transcript extraction for current page",
+    "TranscriptExtractor"
   )
-  console.log(`[Transcript Extractor] Current URL: ${window.location.href}`)
+  logger.debug(`Current URL: ${window.location.href}`, "TranscriptExtractor")
 
   const youtubeTranscript = await extractYouTubeTranscript()
   if (youtubeTranscript) {
-    console.log("[Transcript Extractor] YouTube transcript found")
+    logger.info("YouTube transcript found", "TranscriptExtractor")
     return youtubeTranscript
   }
 
-  console.log("[Transcript Extractor] Trying Udemy transcript...")
+  logger.debug("Trying Udemy transcript...", "TranscriptExtractor")
   const udemyTranscript = extractUdemyTranscript()
   if (udemyTranscript) {
-    console.log("[Transcript Extractor] Udemy transcript found")
+    logger.info("Udemy transcript found", "TranscriptExtractor")
     return udemyTranscript
   }
 
-  console.log("[Transcript Extractor] Trying Coursera transcript...")
+  logger.debug("Trying Coursera transcript...", "TranscriptExtractor")
   const courseraTranscript = extractCourseraTranscript()
   if (courseraTranscript) {
-    console.log("[Transcript Extractor] Coursera transcript found")
+    logger.info("Coursera transcript found", "TranscriptExtractor")
     return courseraTranscript
   }
 
-  console.log(
-    "[Transcript Extractor] No transcript found for any supported platform"
+  logger.debug(
+    "No transcript found for any supported platform",
+    "TranscriptExtractor"
   )
   return null
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,26 @@
+import type { ZodError, ZodSchema } from "zod"
+
+export type SafeJsonParseResult<T> =
+  | { success: true; data: T; error?: never }
+  | { success: false; data?: never; error: ZodError | SyntaxError }
+
+/**
+ * Combines `JSON.parse` with Zod `.safeParse()` in one step.
+ * Returns a discriminated union so callers never deal with thrown exceptions.
+ */
+export function safeJsonParse<T>(
+  raw: string,
+  schema: ZodSchema<T>
+): SafeJsonParseResult<T> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (e) {
+    return { success: false, error: e as SyntaxError }
+  }
+  const result = schema.safeParse(parsed)
+  if (result.success) {
+    return { success: true, data: result.data }
+  }
+  return { success: false, error: result.error }
+}

--- a/src/stores/shortcut-store.ts
+++ b/src/stores/shortcut-store.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware"
 
 import { STORAGE_KEYS } from "@/lib/constants"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { ZustandPersistedStateSchema } from "@/types/ui-state.schemas"
 
 export type ShortcutAction =
   | "newChat"
@@ -253,7 +254,12 @@ export const useShortcutStore = create<ShortcutState>()(
               return null
             }
           }
-          return value as unknown as ReturnType<typeof JSON.parse>
+          // Storage returned a pre-parsed object (chrome.storage does this)
+          const parsed = ZustandPersistedStateSchema.safeParse(value)
+          if (parsed.success) {
+            return value as ReturnType<typeof JSON.parse>
+          }
+          return null
         },
         setItem: async (name, value) => {
           await plasmoGlobalStorage.set(name, value)

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -5,6 +5,7 @@ import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ThemeState } from "@/types"
+import { ThemeSchema } from "@/types/ui-state.schemas"
 
 export const useThemeStore = create<ThemeState>()(
   persist(
@@ -17,7 +18,12 @@ export const useThemeStore = create<ThemeState>()(
       storage: {
         getItem: async (name) => {
           const value = await plasmoGlobalStorage.get(name)
-          return value ? JSON.parse(value) : null
+          if (!value) return null
+          try {
+            return JSON.parse(value)
+          } catch {
+            return null
+          }
         },
         setItem: async (name, value) => {
           await plasmoGlobalStorage.set(name, value)
@@ -41,8 +47,9 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
         const parsed =
           typeof newValue === "string" ? JSON.parse(newValue) : newValue
 
-        if (parsed?.state?.theme) {
-          useThemeStore.setState({ theme: parsed.state.theme })
+        const themeResult = ThemeSchema.safeParse(parsed?.state?.theme)
+        if (themeResult.success) {
+          useThemeStore.setState({ theme: themeResult.data })
         } else {
           // Fallback to rehydrate if structure doesn't match
           useThemeStore.persist.rehydrate()

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest"
+import {
+  ChatMessageMetricsSchema,
+  ChatMessageSchema,
+  ChatSessionImportSchema,
+  ChatSessionSchema
+} from "../chat.schemas"
+import { PromptTemplateSchema, ThemeSchema } from "../ui-state.schemas"
+
+describe("ChatMessageSchema", () => {
+  it("accepts a minimal valid message", () => {
+    const result = ChatMessageSchema.safeParse({
+      role: "user",
+      content: "hello"
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a full message with all optional fields", () => {
+    const result = ChatMessageSchema.safeParse({
+      role: "assistant",
+      content: "response",
+      thinking: "hmm",
+      done: true,
+      model: "llama3",
+      timestamp: 1700000000
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("strips unknown keys (default strip mode)", () => {
+    const result = ChatMessageSchema.safeParse({
+      role: "user",
+      content: "hello",
+      customField: 42
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(Object.keys(result.data)).not.toContain("customField")
+    }
+  })
+
+  it("rejects invalid role", () => {
+    const result = ChatMessageSchema.safeParse({
+      role: "invalid",
+      content: "hello"
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects missing content", () => {
+    const result = ChatMessageSchema.safeParse({ role: "user" })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("ChatSessionSchema", () => {
+  it("accepts a valid session without messages", () => {
+    const result = ChatSessionSchema.safeParse({
+      id: "abc",
+      title: "My Chat",
+      createdAt: 1700000000,
+      updatedAt: 1700000000
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a session with messages array", () => {
+    const result = ChatSessionSchema.safeParse({
+      id: "abc",
+      title: "My Chat",
+      createdAt: 1700000000,
+      updatedAt: 1700000000,
+      messages: [{ role: "user", content: "hi" }]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects missing id", () => {
+    const result = ChatSessionSchema.safeParse({
+      title: "My Chat",
+      createdAt: 1700000000,
+      updatedAt: 1700000000
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("ChatSessionImportSchema", () => {
+  it("requires messages array", () => {
+    const result = ChatSessionImportSchema.safeParse({
+      id: "abc",
+      title: "My Chat",
+      createdAt: 1700000000,
+      updatedAt: 1700000000
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts session with messages", () => {
+    const result = ChatSessionImportSchema.safeParse({
+      id: "abc",
+      title: "My Chat",
+      createdAt: 1700000000,
+      updatedAt: 1700000000,
+      messages: [{ role: "user", content: "hello" }]
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe("ChatMessageMetricsSchema", () => {
+  it("accepts empty object", () => {
+    const result = ChatMessageMetricsSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts typical ollama metrics", () => {
+    const result = ChatMessageMetricsSchema.safeParse({
+      total_duration: 1234567890,
+      eval_count: 100,
+      eval_duration: 500000000
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("strips unknown keys (default strip mode)", () => {
+    const result = ChatMessageMetricsSchema.safeParse({
+      total_duration: 100,
+      future_field: "ok"
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(Object.keys(result.data)).not.toContain("future_field")
+    }
+  })
+})
+
+describe("PromptTemplateSchema", () => {
+  it("accepts a valid template", () => {
+    const result = PromptTemplateSchema.safeParse({
+      id: "t1",
+      title: "Summarize",
+      userPrompt: "Please summarize the following:"
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.usageCount).toBe(0) // default
+      expect(result.data.createdAt).toBeInstanceOf(Date) // transformed
+    }
+  })
+
+  it("transforms string createdAt to Date", () => {
+    const result = PromptTemplateSchema.safeParse({
+      id: "t1",
+      title: "Test",
+      userPrompt: "test",
+      createdAt: "2024-01-01T00:00:00.000Z"
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.createdAt).toBeInstanceOf(Date)
+    }
+  })
+
+  it("transforms numeric createdAt to Date", () => {
+    const result = PromptTemplateSchema.safeParse({
+      id: "t1",
+      title: "Test",
+      userPrompt: "test",
+      createdAt: 1700000000000
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.createdAt).toBeInstanceOf(Date)
+    }
+  })
+
+  it("rejects empty title", () => {
+    const result = PromptTemplateSchema.safeParse({
+      id: "t1",
+      title: "",
+      userPrompt: "test"
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects empty userPrompt", () => {
+    const result = PromptTemplateSchema.safeParse({
+      id: "t1",
+      title: "Test",
+      userPrompt: ""
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects missing required fields", () => {
+    const result = PromptTemplateSchema.safeParse({
+      description: "only a description"
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("ThemeSchema", () => {
+  it("accepts valid themes", () => {
+    expect(ThemeSchema.safeParse("dark").success).toBe(true)
+    expect(ThemeSchema.safeParse("light").success).toBe(true)
+    expect(ThemeSchema.safeParse("system").success).toBe(true)
+  })
+
+  it("rejects invalid theme", () => {
+    expect(ThemeSchema.safeParse("auto").success).toBe(false)
+    expect(ThemeSchema.safeParse(123).success).toBe(false)
+  })
+})

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -43,16 +43,38 @@ export const ChatMessageMetricsSchema = z.object({
   contextBuildFailed: z.boolean().optional()
 })
 
+// ---- FileAttachment ----
+
+const FileAttachmentSchema = z.object({
+  id: z.number().optional(),
+  fileId: z.string(),
+  fileName: z.string(),
+  fileType: z.string(),
+  fileSize: z.number(),
+  textPreview: z.string().optional(),
+  processedAt: z.number(),
+  sessionId: z.string().optional(),
+  messageId: z.number().optional(),
+  data: z.array(z.number()).optional()
+})
+
+export type FileAttachmentParsed = z.infer<typeof FileAttachmentSchema>
+
 // ---- ChatMessage ----
 
 export const ChatMessageSchema = z.object({
+  id: z.union([z.number(), z.string()]).optional(),
   role: z.enum(["user", "assistant", "system"]),
   content: z.string(),
   thinking: z.string().optional(),
   done: z.boolean().optional(),
   model: z.string().optional(),
+  attachments: z.array(FileAttachmentSchema).optional(),
   timestamp: z.number().optional(),
-  metrics: ChatMessageMetricsSchema.optional()
+  metrics: ChatMessageMetricsSchema.optional(),
+  parentId: z.union([z.number(), z.string()]).optional(),
+  childrenIds: z.array(z.union([z.number(), z.string()])).optional(),
+  siblingIds: z.array(z.union([z.number(), z.string()])).optional()
 })
 
 // ---- ChatSession ----
@@ -62,6 +84,8 @@ export const ChatSessionSchema = z.object({
   title: z.string(),
   createdAt: z.number(),
   updatedAt: z.number(),
+  modelId: z.string().optional(),
+  currentLeafId: z.union([z.number(), z.string()]).optional(),
   messages: z.array(ChatMessageSchema).optional()
 })
 

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -1,0 +1,77 @@
+import { z } from "zod"
+
+// ---- Metrics (used inside messages and for SQLite parseMetrics) ----
+
+const RagSourceSchema = z.object({
+  id: z.union([z.number(), z.string()]),
+  title: z.string(),
+  content: z.string(),
+  score: z.number(),
+  source: z.string().optional(),
+  chunkIndex: z.number().optional(),
+  fileId: z.string().optional(),
+  type: z.string().optional()
+})
+
+const UsedContextChunkSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  title: z.string(),
+  excerpt: z.string(),
+  score: z.number(),
+  sectionPath: z.string().optional(),
+  source: z.string().optional(),
+  chunkIndex: z.number().optional()
+})
+
+export const ChatMessageMetricsSchema = z.object({
+  total_duration: z.number().optional(),
+  load_duration: z.number().optional(),
+  prompt_eval_count: z.number().optional(),
+  prompt_eval_duration: z.number().optional(),
+  eval_count: z.number().optional(),
+  eval_duration: z.number().optional(),
+  ragQuery: z.string().optional(),
+  ragSources: z.array(RagSourceSchema).optional(),
+  usedContextChunks: z.array(UsedContextChunkSchema).optional(),
+  groundedOnlyMode: z.boolean().optional(),
+  insufficientContext: z.boolean().optional(),
+  promptInputLength: z.number().optional(),
+  promptAugmentedLength: z.number().optional(),
+  tabContextLength: z.number().optional(),
+  ragContextLength: z.number().optional(),
+  tabContextTruncated: z.boolean().optional(),
+  contextBuildFailed: z.boolean().optional()
+})
+
+// ---- ChatMessage ----
+
+export const ChatMessageSchema = z.object({
+  role: z.enum(["user", "assistant", "system"]),
+  content: z.string(),
+  thinking: z.string().optional(),
+  done: z.boolean().optional(),
+  model: z.string().optional(),
+  timestamp: z.number().optional(),
+  metrics: ChatMessageMetricsSchema.optional()
+})
+
+// ---- ChatSession ----
+
+export const ChatSessionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  messages: z.array(ChatMessageSchema).optional()
+})
+
+/** Strict variant for import — messages are required. */
+export const ChatSessionImportSchema = ChatSessionSchema.extend({
+  messages: z.array(ChatMessageSchema)
+})
+
+// -- Output type aliases for consumers that need typed results --
+
+export type ChatMessageParsed = z.infer<typeof ChatMessageSchema>
+export type ChatSessionParsed = z.infer<typeof ChatSessionSchema>
+export type ChatSessionImportParsed = z.infer<typeof ChatSessionImportSchema>

--- a/src/types/ui-state.schemas.ts
+++ b/src/types/ui-state.schemas.ts
@@ -1,0 +1,47 @@
+import { z } from "zod"
+import type { PromptTemplate, Theme } from "./ui-state"
+
+// ---- PromptTemplate ----
+
+export const PromptTemplateSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1),
+  userPrompt: z.string().min(1),
+  description: z.string().optional(),
+  category: z.string().optional(),
+  systemPrompt: z.string().optional(),
+  tags: z
+    .unknown()
+    .optional()
+    .transform((v) =>
+      Array.isArray(v)
+        ? v.filter((t): t is string => typeof t === "string")
+        : undefined
+    ),
+  createdAt: z
+    .union([z.string(), z.number(), z.date()])
+    .optional()
+    .transform((v) =>
+      v instanceof Date ? v : v != null ? new Date(v) : new Date()
+    ),
+  usageCount: z.number().min(0).optional().default(0)
+})
+
+// ---- Theme ----
+
+export const ThemeSchema = z.enum(["dark", "light", "system"])
+
+// ---- Zustand persisted state wrapper (minimal) ----
+
+export const ZustandPersistedStateSchema = z
+  .object({
+    state: z.record(z.string(), z.unknown())
+  })
+  .passthrough()
+
+// ---- Compile-time conformance checks ----
+
+void (0 as unknown as z.infer<
+  typeof PromptTemplateSchema
+> satisfies PromptTemplate)
+void (0 as unknown as z.infer<typeof ThemeSchema> satisfies Theme)

--- a/src/types/ui-state.schemas.ts
+++ b/src/types/ui-state.schemas.ts
@@ -5,8 +5,8 @@ import type { PromptTemplate, Theme } from "./ui-state"
 
 export const PromptTemplateSchema = z.object({
   id: z.string(),
-  title: z.string().min(1),
-  userPrompt: z.string().min(1),
+  title: z.string().trim().min(1),
+  userPrompt: z.string().trim().min(1),
   description: z.string().optional(),
   category: z.string().optional(),
   systemPrompt: z.string().optional(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all `console.*` calls with structured `logger.*` calls across ~70 files and introduces Zod validation schemas for core domain types (`ChatSession`, `ChatMessage`, `PromptTemplate`, `Theme`) plus a `safeJsonParse` utility.

- **Logger migration**: Every `console.log/warn/error/debug` call now goes through the centralized `Logger` class with a consistent `(message, context, data)` signature, improving log discoverability and making context/module information explicit.
- **Zod schemas**: `ChatSessionImportSchema`, `ChatMessageSchema`, and `PromptTemplateSchema` replace hand-rolled validation guards, with compile-time `satisfies` checks ensuring the inferred types stay in sync with the existing TypeScript interfaces. The new schemas now include all previously-missing fields (`modelId`, `currentLeafId`, `id`, `attachments`, `parentId`, etc.) that were omitted from the old manual guards.
- **Import improvements**: Session import now validates items one-by-one so a single invalid record no longer rejects the entire file; backup restore now uses `safeJsonParse` with schema validation instead of bare `JSON.parse`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are a well-scoped logging refactor and schema introduction with no functional regressions found.

All functional paths affected by the refactor produce equivalent or improved behavior. The session/template import paths are strictly better (per-item validation, no silent whole-file rejection). The only finding is a single debug call that passes a pre-serialized string instead of a raw object, which has no runtime impact.

No files require special attention. The new schema files (src/types/chat.schemas.ts, src/types/ui-state.schemas.ts) and src/lib/validation.ts are straightforward and covered by new tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/types/chat.schemas.ts | New Zod schemas for ChatMessage, ChatSession, ChatSessionImport; all key fields (modelId, currentLeafId, attachments, parentId, etc.) are now declared. Schemas match the TypeScript interfaces in chat.ts. |
| src/types/ui-state.schemas.ts | New Zod schemas for PromptTemplate and Theme with compile-time satisfies checks; .trim().min(1) correctly rejects whitespace-only titles and user prompts. |
| src/lib/validation.ts | New safeJsonParse utility combining JSON.parse with Zod safeParse into a discriminated union result type; well-tested with good coverage. |
| src/features/sessions/hooks/use-import-chat.ts | Import now validates sessions one-by-one via ChatSessionImportSchema, continuing past invalid sessions; JSON parse errors are also caught individually per file. |
| src/features/prompt/hooks/use-prompt-templates.ts | Import/export now backed by PromptTemplateSchema; exportTemplates validates each template and logs a warning for corrupt entries instead of silently exporting invalid state. |
| src/lib/backup-service.ts | Backup import now validates manifest and storage JSON with Zod schemas via safeJsonParse; all console.* calls replaced with logger.*. |
| src/lib/transcript-extractor.ts | All ~40 console.* calls migrated to logger.debug/info; info-level used for success/found events, debug for step-by-step automation tracing. |
| src/features/chat/hooks/use-chat-stream.ts | Console calls replaced with logger; one logger.debug call passes a pre-serialized JSON string instead of the raw object (minor inconsistency with all other calls in the file). |
| src/lib/migration/dexie-to-sqlite.ts | MigrationProgressSchema matches MigrationProgress interface exactly; safeJsonParse replaces try/catch JSON.parse in both resume-progress and getMigrationStatus paths. |
| src/background/index.ts | All console.* replaced with logger.*; OPEN_TAB handler gained an error branch with proper error response on tabs.query failure — a small functional improvement alongside the logging refactor. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Import JSON file] --> B{JSON.parse}
    B -->|SyntaxError| C[logger.warn + skip file]
    B -->|Success| D[Split into rawSessions array]
    D --> E{For each item}
    E --> F[ChatSessionImportSchema.safeParse]
    F -->|success| G[Push to importedSessions]
    F -->|failure| H[logger.warn + skip item]
    E --> E
    G --> I{bulkPutSessions}
    I -->|ok| J[Toast: N sessions imported]
    I -->|error| K[logger.error + Toast error]

    style C fill:#fca5a5
    style H fill:#fca5a5
    style K fill:#fca5a5
    style J fill:#86efac
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/features/sessions/hooks/use-import-chat.ts`, line 24-38 ([link](https://github.com/shishir435/ollama-client/blob/4c6cb77f077fbd0a8948f8b3eadc5ee3a7c610a5/src/features/sessions/hooks/use-import-chat.ts#L24-L38)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Silent data loss on session import**

   `ChatSessionImportSchema` / `ChatSessionSchema` do not declare `modelId` or `currentLeafId`, and `ChatMessageSchema` does not declare `id`, `attachments`, `parentId`, `childrenIds`, or `siblingIds`. Zod strips unknown keys by default, so any previously-exported chat that contains these fields will silently lose them when re-imported. Users would lose their model association, conversation-branching structure, and file attachments.

   A second regression lives here too: `z.array(ChatSessionImportSchema).safeParse(…)` fails the **entire file** if any single session is malformed. The old `isValidChatSession` loop skipped bad sessions and imported the rest — a file with 99 good sessions and 1 corrupted one would now import nothing rather than 99.

   Both schemas need either `.passthrough()` (to forward unknown keys) or explicit declarations for the extra optional fields, and the per-session validation loop should be restored to allow partial import.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fsessions%2Fhooks%2Fuse-import-chat.ts%0ALine%3A%2024-38%0A%0AComment%3A%0A**Silent%20data%20loss%20on%20session%20import**%0A%0A%60ChatSessionImportSchema%60%20%2F%20%60ChatSessionSchema%60%20do%20not%20declare%20%60modelId%60%20or%20%60currentLeafId%60%2C%20and%20%60ChatMessageSchema%60%20does%20not%20declare%20%60id%60%2C%20%60attachments%60%2C%20%60parentId%60%2C%20%60childrenIds%60%2C%20or%20%60siblingIds%60.%20Zod%20strips%20unknown%20keys%20by%20default%2C%20so%20any%20previously-exported%20chat%20that%20contains%20these%20fields%20will%20silently%20lose%20them%20when%20re-imported.%20Users%20would%20lose%20their%20model%20association%2C%20conversation-branching%20structure%2C%20and%20file%20attachments.%0A%0AA%20second%20regression%20lives%20here%20too%3A%20%60z.array%28ChatSessionImportSchema%29.safeParse%28%E2%80%A6%29%60%20fails%20the%20**entire%20file**%20if%20any%20single%20session%20is%20malformed.%20The%20old%20%60isValidChatSession%60%20loop%20skipped%20bad%20sessions%20and%20imported%20the%20rest%20%E2%80%94%20a%20file%20with%2099%20good%20sessions%20and%201%20corrupted%20one%20would%20now%20import%20nothing%20rather%20than%2099.%0A%0ABoth%20schemas%20need%20either%20%60.passthrough%28%29%60%20%28to%20forward%20unknown%20keys%29%20or%20explicit%20declarations%20for%20the%20extra%20optional%20fields%2C%20and%20the%20per-session%20validation%20loop%20should%20be%20restored%20to%20allow%20partial%20import.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22refactor%2Fzod-and-logger%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fzod-and-logger%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fsessions%2Fhooks%2Fuse-import-chat.ts%0ALine%3A%2024-38%0A%0AComment%3A%0A**Silent%20data%20loss%20on%20session%20import**%0A%0A%60ChatSessionImportSchema%60%20%2F%20%60ChatSessionSchema%60%20do%20not%20declare%20%60modelId%60%20or%20%60currentLeafId%60%2C%20and%20%60ChatMessageSchema%60%20does%20not%20declare%20%60id%60%2C%20%60attachments%60%2C%20%60parentId%60%2C%20%60childrenIds%60%2C%20or%20%60siblingIds%60.%20Zod%20strips%20unknown%20keys%20by%20default%2C%20so%20any%20previously-exported%20chat%20that%20contains%20these%20fields%20will%20silently%20lose%20them%20when%20re-imported.%20Users%20would%20lose%20their%20model%20association%2C%20conversation-branching%20structure%2C%20and%20file%20attachments.%0A%0AA%20second%20regression%20lives%20here%20too%3A%20%60z.array%28ChatSessionImportSchema%29.safeParse%28%E2%80%A6%29%60%20fails%20the%20**entire%20file**%20if%20any%20single%20session%20is%20malformed.%20The%20old%20%60isValidChatSession%60%20loop%20skipped%20bad%20sessions%20and%20imported%20the%20rest%20%E2%80%94%20a%20file%20with%2099%20good%20sessions%20and%201%20corrupted%20one%20would%20now%20import%20nothing%20rather%20than%2099.%0A%0ABoth%20schemas%20need%20either%20%60.passthrough%28%29%60%20%28to%20forward%20unknown%20keys%29%20or%20explicit%20declarations%20for%20the%20extra%20optional%20fields%2C%20and%20the%20per-session%20validation%20loop%20should%20be%20restored%20to%20allow%20partial%20import.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-stream.ts%3A200%0AThe%20%60data%60%20argument%20to%20%60logger.debug%60%20is%20a%20pre-serialized%20JSON%20string%20rather%20than%20the%20raw%20object.%20The%20logger's%20%60data%60%20parameter%20accepts%20%60unknown%60%2C%20so%20this%20is%20valid%20TypeScript%2C%20but%20it%20means%20the%20console%20will%20show%20a%20flat%20string%20instead%20of%20an%20inspectable%20object%20%E2%80%94%20the%20opposite%20of%20what%20every%20other%20%60logger.debug%60%20call%20in%20this%20file%20does.%20Passing%20%60msg%60%20directly%20keeps%20it%20consistent%20and%20interactive%20in%20DevTools.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20logger.debug%28%22MSG%22%2C%20%22useChatStream%22%2C%20%7B%20msg%20%7D%29%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22refactor%2Fzod-and-logger%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fzod-and-logger%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-stream.ts%3A200%0AThe%20%60data%60%20argument%20to%20%60logger.debug%60%20is%20a%20pre-serialized%20JSON%20string%20rather%20than%20the%20raw%20object.%20The%20logger's%20%60data%60%20parameter%20accepts%20%60unknown%60%2C%20so%20this%20is%20valid%20TypeScript%2C%20but%20it%20means%20the%20console%20will%20show%20a%20flat%20string%20instead%20of%20an%20inspectable%20object%20%E2%80%94%20the%20opposite%20of%20what%20every%20other%20%60logger.debug%60%20call%20in%20this%20file%20does.%20Passing%20%60msg%60%20directly%20keeps%20it%20consistent%20and%20interactive%20in%20DevTools.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20logger.debug%28%22MSG%22%2C%20%22useChatStream%22%2C%20%7B%20msg%20%7D%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(prompt): per-item validation on impo..."](https://github.com/shishir435/ollama-client/commit/adeddad6129527730c967e5bee932b2cf79f23df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34711116)</sub>

<!-- /greptile_comment -->