### PR TITLE
Fix/youtube transcript 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-06-01
+### Fixed
+- YouTube watch pages now extract only the video title and transcript instead of falling back to generic page content.
+- YouTube transcript extraction now supports modern transcript panels, legacy segment renderers, and caption-track fallback data.
+- Udemy lecture pages now try the transcript panel first and fall back to normal page extraction when no transcript is available.
+- Removed stale provider configs, such as OpenAI entries no longer present in the provider UI, from saved provider settings.
+- Restored the lockfile dependency resolution for frozen CI installs.
+
+### Changed
+- Tab-context retrieval now respects the configured maximum context budget during RAG retrieval.
+- Local development logging defaults to debug level for easier extraction troubleshooting.
+
 ## [0.7.1] - 2026-05-30
 ### Added
 - Zod runtime validation across all JSON.parse sites in provider, storage, and prompt-import paths.
@@ -139,7 +151,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Documentation
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/Shishir435/ollama-client/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Shishir435/ollama-client/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Shishir435/ollama-client/compare/v0.6.5...v0.7.0
 [0.6.5]: https://github.com/Shishir435/ollama-client/compare/v0.6.4...v0.6.5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: 0.7.1
-        version: 0.7.1
+        version: 0.7.2
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: 0.7.1
-        version: 0.7.2
+        version: 0.7.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -90,6 +90,116 @@ const safeSendResponse = (
   }
 }
 
+const isYouTubeWatchPage = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    return (
+      (parsed.hostname === "youtube.com" ||
+        parsed.hostname.endsWith(".youtube.com")) &&
+      parsed.pathname === "/watch" &&
+      parsed.searchParams.has("v")
+    )
+  } catch {
+    return url.includes("youtube.com/watch?v=")
+  }
+}
+
+const buildExtractionDebug = ({
+  currentUrl,
+  pageTitle,
+  scraper,
+  transcript,
+  finalContent,
+  extractionResult,
+  selectedExtractor,
+  selectedReason
+}: {
+  currentUrl: string
+  pageTitle: string
+  scraper: string
+  transcript: string | null
+  finalContent: string
+  extractionResult: Awaited<ReturnType<typeof extractContentWithLoading>> | null
+  selectedExtractor: string
+  selectedReason: string
+}) => {
+  const profile = detectSiteProfile(currentUrl)
+  const contentHash = quickHash(finalContent)
+  const capturedAt = Date.now()
+  const reliability = measureReliability(finalContent)
+
+  return {
+    url: currentUrl,
+    title: pageTitle,
+    scraper,
+    profile,
+    hasTranscript: !!transcript,
+    transcriptLength: transcript?.length || 0,
+    contentLength: finalContent.length,
+    contentHash,
+    revisionId: `${capturedAt}-${contentHash}`,
+    capturedAt,
+    reliabilityScore: reliability.reliabilityScore,
+    reliabilitySignals: reliability.reliabilitySignals,
+    extractionDurationMs: extractionResult?.metrics?.duration,
+    scrollSteps: extractionResult?.metrics?.scrollSteps,
+    mutationsDetected: extractionResult?.metrics?.mutationsDetected,
+    detectedPatterns: extractionResult?.metrics?.detectedPatterns || [],
+    selectedExtractor,
+    selectedReason,
+    filteredSectionCount: 0,
+    keptSectionCount: 0,
+    effectiveContextLength: finalContent.length,
+    preview: finalContent.slice(0, 400)
+  }
+}
+
+const sendTranscriptOnlyResponse = ({
+  sendResponse,
+  currentUrl,
+  pageTitle,
+  transcript,
+  platform,
+  missingMessage,
+  allowMissing = false
+}: {
+  sendResponse: (response: unknown) => void
+  currentUrl: string
+  pageTitle: string
+  transcript: string | null
+  platform: "youtube"
+  missingMessage: string
+  allowMissing?: boolean
+}): boolean => {
+  const hasTranscript = !!transcript?.trim()
+  const finalContent = hasTranscript ? transcript.trim() : missingMessage
+
+  if (!hasTranscript && !allowMissing) return false
+
+  const extractionDebug = buildExtractionDebug({
+    currentUrl,
+    pageTitle,
+    scraper: `${platform}-transcript`,
+    transcript: hasTranscript ? finalContent : null,
+    finalContent,
+    extractionResult: null,
+    selectedExtractor: `${platform}-transcript`,
+    selectedReason: `${platform}-transcript-only`
+  })
+
+  ;(
+    window as unknown as { __lastProviderExtractionResult?: unknown }
+  ).__lastProviderExtractionResult = extractionDebug
+
+  safeSendResponse(sendResponse, {
+    html: finalContent,
+    title: pageTitle,
+    extractionDebug
+  })
+
+  return true
+}
+
 const handleGetPageContent = async (
   sendResponse: (response: unknown) => void
 ): Promise<void> => {
@@ -108,6 +218,7 @@ const handleGetPageContent = async (
 
   const currentUrl = window.location.href
   contentDebugLog(`[Content Script] Processing URL: ${currentUrl}`)
+  const youtubeWatchPage = isYouTubeWatchPage(currentUrl)
 
   if (await isExcludedUrl(currentUrl)) {
     contentDebugLog("[Content Script] URL is excluded")
@@ -127,6 +238,34 @@ const handleGetPageContent = async (
     scrollDepth: `${(effectiveConfig.scrollDepth * 100).toFixed(0)}%`,
     site: hasSiteOverride ? "Custom site config" : "Global config"
   })
+
+  if (youtubeWatchPage) {
+    logger.info(
+      "YouTube watch page detected; extracting title and transcript only",
+      "ContentScript",
+      { url: currentUrl }
+    )
+    const pageTitle = resolvePageTitle(document, "")
+    const transcript = await getTranscript()
+
+    if (!transcript?.trim()) {
+      logger.warn("YouTube transcript extraction failed", "ContentScript", {
+        url: currentUrl,
+        transcriptLength: transcript?.length || 0
+      })
+    }
+
+    sendTranscriptOnlyResponse({
+      sendResponse,
+      currentUrl,
+      pageTitle,
+      transcript,
+      platform: "youtube",
+      missingMessage: "No transcript found for this YouTube video.",
+      allowMissing: true
+    })
+    return
+  }
 
   let extractionResult: Awaited<
     ReturnType<typeof extractContentWithLoading>
@@ -183,35 +322,16 @@ const handleGetPageContent = async (
     )
   }
 
-  const profile = detectSiteProfile(currentUrl)
-  const contentHash = quickHash(finalContent)
-  const capturedAt = Date.now()
-  const reliability = measureReliability(finalContent)
-
-  const extractionDebug = {
-    url: currentUrl,
-    title: pageTitle,
+  const extractionDebug = buildExtractionDebug({
+    currentUrl,
+    pageTitle,
     scraper,
-    profile,
-    hasTranscript: !!transcript,
-    transcriptLength: transcript?.length || 0,
-    contentLength: finalContent.length,
-    contentHash,
-    revisionId: `${capturedAt}-${contentHash}`,
-    capturedAt,
-    reliabilityScore: reliability.reliabilityScore,
-    reliabilitySignals: reliability.reliabilitySignals,
-    extractionDurationMs: extractionResult?.metrics?.duration,
-    scrollSteps: extractionResult?.metrics?.scrollSteps,
-    mutationsDetected: extractionResult?.metrics?.mutationsDetected,
-    detectedPatterns: extractionResult?.metrics?.detectedPatterns || [],
+    transcript,
+    finalContent,
+    extractionResult,
     selectedExtractor: readable.selectedExtractor,
-    selectedReason: readable.selectedReason,
-    filteredSectionCount: 0,
-    keptSectionCount: 0,
-    effectiveContextLength: finalContent.length,
-    preview: finalContent.slice(0, 400)
-  }
+    selectedReason: readable.selectedReason
+  })
 
   ;(
     window as unknown as { __lastProviderExtractionResult?: unknown }

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -104,6 +104,20 @@ const isYouTubeWatchPage = (url: string): boolean => {
   }
 }
 
+const isUdemyLecturePage = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    return (
+      (parsed.hostname === "udemy.com" ||
+        parsed.hostname.endsWith(".udemy.com")) &&
+      parsed.pathname.includes("/course/") &&
+      parsed.pathname.includes("/learn/lecture/")
+    )
+  } catch {
+    return url.includes("udemy.com/course/") && url.includes("/learn/lecture/")
+  }
+}
+
 const buildExtractionDebug = ({
   currentUrl,
   pageTitle,
@@ -167,7 +181,7 @@ const sendTranscriptOnlyResponse = ({
   currentUrl: string
   pageTitle: string
   transcript: string | null
-  platform: "youtube"
+  platform: "youtube" | "udemy"
   missingMessage: string
   allowMissing?: boolean
 }): boolean => {
@@ -219,6 +233,7 @@ const handleGetPageContent = async (
   const currentUrl = window.location.href
   contentDebugLog(`[Content Script] Processing URL: ${currentUrl}`)
   const youtubeWatchPage = isYouTubeWatchPage(currentUrl)
+  const udemyLecturePage = isUdemyLecturePage(currentUrl)
 
   if (await isExcludedUrl(currentUrl)) {
     contentDebugLog("[Content Script] URL is excluded")
@@ -265,6 +280,34 @@ const handleGetPageContent = async (
       allowMissing: true
     })
     return
+  }
+
+  if (udemyLecturePage) {
+    logger.info(
+      "Udemy lecture page detected; trying transcript before page extraction",
+      "ContentScript",
+      { url: currentUrl }
+    )
+    const pageTitle = resolvePageTitle(document, "")
+    const transcript = await getTranscript()
+    const sent = sendTranscriptOnlyResponse({
+      sendResponse,
+      currentUrl,
+      pageTitle,
+      transcript,
+      platform: "udemy",
+      missingMessage: "No transcript found for this Udemy lecture."
+    })
+
+    if (sent) return
+
+    logger.info(
+      "Udemy transcript not found; falling back to regular page extraction",
+      "ContentScript",
+      {
+        url: currentUrl
+      }
+    )
   }
 
   let extractionResult: Awaited<

--- a/src/features/chat/hooks/__tests__/build-rag-context.test.ts
+++ b/src/features/chat/hooks/__tests__/build-rag-context.test.ts
@@ -246,6 +246,9 @@ describe("page (tab) context", () => {
     expect(result.contentWithRAG).toContain("<page>Page text</page>")
     expect(result.ragSources?.sources).toHaveLength(1)
     expect(result.promptContextStats.tabContextLength).toBeGreaterThan(0)
+    expect(mockedRetrieveFromSources.mock.calls[0]?.[2]).toMatchObject({
+      maxTokens: 4000
+    })
   })
 
   it("when hasTabContext is true but retriever returns empty, no page block is added; tab-fallback fires instead", async () => {

--- a/src/features/chat/hooks/build-rag-context.ts
+++ b/src/features/chat/hooks/build-rag-context.ts
@@ -245,6 +245,7 @@ export const buildRagContext = async (
                 retrievalOverrides?.topK ?? queryClassification.suggestedTopK,
                 4
               ),
+              maxTokens: maxTabContextChars,
               minSimilarity: retrievalOverrides?.minSimilarity
             }
           )

--- a/src/lib/__tests__/transcript-extractor.test.ts
+++ b/src/lib/__tests__/transcript-extractor.test.ts
@@ -108,7 +108,7 @@ describe("Transcript Extractor", () => {
         )
 
         const result = await getTranscript()
-        expect(result).toBe("Hello world Next line")
+        expect(result).toBe("Hello world\nNext line")
       })
 
       it("should extract transcript from modern YouTube transcript panel", async () => {

--- a/src/lib/__tests__/transcript-extractor.test.ts
+++ b/src/lib/__tests__/transcript-extractor.test.ts
@@ -7,10 +7,13 @@ describe("Transcript Extractor", () => {
   beforeEach(() => {
     // Reset DOM
     document.body.innerHTML = ""
+    document.head.innerHTML = ""
     vi.clearAllMocks()
 
     // Mock console to keep output clean
     vi.spyOn(console, "log").mockImplementation(() => {})
+    vi.spyOn(console, "info").mockImplementation(() => {})
+    vi.spyOn(console, "warn").mockImplementation(() => {})
   })
 
   afterEach(() => {
@@ -54,6 +57,81 @@ describe("Transcript Extractor", () => {
 
         const result = await getTranscript()
         expect(result).toBe("Hello world")
+      })
+
+      it("should extract transcript from legacy segment renderers", async () => {
+        const renderer = document.createElement("ytd-transcript-renderer")
+        renderer.innerHTML = `
+          <ytd-transcript-segment-renderer>
+            <yt-formatted-string>Legacy line one.</yt-formatted-string>
+          </ytd-transcript-segment-renderer>
+          <ytd-transcript-segment-renderer>
+            <yt-formatted-string>Legacy line two.</yt-formatted-string>
+          </ytd-transcript-segment-renderer>
+        `
+        document.body.appendChild(renderer)
+
+        const result = await getTranscript()
+        expect(result).toBe("Legacy line one.\nLegacy line two.")
+      })
+
+      it("should extract transcript from YouTube caption tracks", async () => {
+        const script = document.createElement("script")
+        script.textContent = `var ytInitialPlayerResponse = ${JSON.stringify({
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                {
+                  baseUrl: "https://www.youtube.com/api/timedtext?v=123",
+                  languageCode: "en",
+                  name: { simpleText: "English" }
+                }
+              ]
+            }
+          }
+        })};`
+        document.head.appendChild(script)
+
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue({
+            ok: true,
+            text: vi.fn().mockResolvedValue(
+              JSON.stringify({
+                events: [
+                  { segs: [{ utf8: "Hello " }, { utf8: "world" }] },
+                  { segs: [{ utf8: "Next line" }] }
+                ]
+              })
+            )
+          })
+        )
+
+        const result = await getTranscript()
+        expect(result).toBe("Hello world Next line")
+      })
+
+      it("should extract transcript from modern YouTube transcript panel", async () => {
+        const panel = document.createElement("yt-section-list-renderer")
+        panel.setAttribute("data-target-id", "PAmodern_transcript_view")
+        panel.innerHTML = `
+          <transcript-segment-view-model>
+            <div aria-hidden="true">0:00</div>
+            <span class="ytAttributedStringHost" role="text">
+              First transcript line.
+            </span>
+          </transcript-segment-view-model>
+          <transcript-segment-view-model>
+            <div aria-hidden="true">0:07</div>
+            <span class="ytAttributedStringHost" role="text">
+              Second transcript line.
+            </span>
+          </transcript-segment-view-model>
+        `
+        document.body.appendChild(panel)
+
+        const result = await getTranscript()
+        expect(result).toBe("First transcript line.\nSecond transcript line.")
       })
 
       it("should handle empty transcript", async () => {

--- a/src/lib/__tests__/transcript-extractor.test.ts
+++ b/src/lib/__tests__/transcript-extractor.test.ts
@@ -176,6 +176,95 @@ describe("Transcript Extractor", () => {
         expect(result).toBe("Line 1\nLine 2")
       })
 
+      it("should open Udemy transcript tab before extracting cues", async () => {
+        const transcriptTab = document.createElement("button")
+        transcriptTab.setAttribute("role", "tab")
+        transcriptTab.innerHTML = `<span class="ud-btn-label">Transcript</span>`
+        transcriptTab.addEventListener("click", () => {
+          if (document.querySelector('[data-purpose="transcript-panel"]')) {
+            return
+          }
+
+          const panel = document.createElement("div")
+          panel.setAttribute("data-purpose", "transcript-panel")
+          panel.innerHTML = `
+            <div class="transcript--cue-container--Vuwj6">
+              <p data-purpose="transcript-cue-active" role="button">
+                <span data-purpose="cue-text">All right, guys.</span>
+              </p>
+            </div>
+            <div class="transcript--cue-container--Vuwj6">
+              <p data-purpose="transcript-cue" role="button">
+                <span data-purpose="cue-text">
+                  So pending callbacks, the third phase.
+                </span>
+              </p>
+            </div>
+          `
+          document.body.appendChild(panel)
+        })
+        document.body.appendChild(transcriptTab)
+
+        const result = await getTranscript()
+        expect(result).toBe(
+          "All right, guys.\nSo pending callbacks, the third phase."
+        )
+      })
+
+      it("should open Udemy transcript from icon-only toggle", async () => {
+        const transcriptToggle = document.createElement("button")
+        transcriptToggle.setAttribute("type", "button")
+        transcriptToggle.setAttribute("data-purpose", "transcript-toggle")
+        transcriptToggle.setAttribute("aria-expanded", "false")
+        transcriptToggle.innerHTML = `
+          <svg aria-label="Transcript in sidebar region" role="img">
+            <use xlink:href="#icon-transcript"></use>
+          </svg>
+        `
+        transcriptToggle.addEventListener("click", () => {
+          const panel = document.createElement("div")
+          panel.setAttribute("data-purpose", "transcript-panel")
+          panel.innerHTML = `
+            <div class="transcript--cue-container--Vuwj6">
+              <p data-purpose="transcript-cue" role="button">
+                <span data-purpose="cue-text">Icon toggle transcript.</span>
+              </p>
+            </div>
+          `
+          document.body.appendChild(panel)
+        })
+        document.body.appendChild(transcriptToggle)
+
+        const result = await getTranscript()
+        expect(result).toBe("Icon toggle transcript.")
+      })
+
+      it("should press Udemy icon-only transcript control with pointer events", async () => {
+        const transcriptToggle = document.createElement("button")
+        transcriptToggle.setAttribute("type", "button")
+        transcriptToggle.setAttribute("aria-expanded", "false")
+        transcriptToggle.innerHTML = `
+          <svg aria-label="Transcript in sidebar region" role="img">
+            <use xlink:href="#icon-transcript"></use>
+          </svg>
+        `
+        transcriptToggle.addEventListener("mousedown", () => {
+          const panel = document.createElement("div")
+          panel.setAttribute("data-purpose", "transcript-panel")
+          panel.innerHTML = `
+            <div class="transcript--cue-container--Vuwj6">
+              <p data-purpose="transcript-cue" role="button">
+                <span data-purpose="cue-text">Pressed transcript.</span>
+              </p>
+            </div>
+          `
+          document.body.appendChild(panel)
+        })
+        document.body.appendChild(transcriptToggle)
+
+        const result = await getTranscript()
+        expect(result).toBe("Pressed transcript.")
+      })
       it("should return null if panel missing", async () => {
         const result = await getTranscript()
         expect(result).toBeNull()

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -46,6 +46,10 @@ export class Logger {
     this.currentLevel = defaultLevel
   }
 
+  setLevel(level: LogLevel) {
+    this.currentLevel = level
+  }
+
   private log(
     level: LogLevel,
     message: string,
@@ -106,4 +110,7 @@ export class Logger {
   }
 }
 
-export const logger = new Logger()
+const defaultLogLevel =
+  process.env.NODE_ENV === "development" ? LogLevel.DEBUG : LogLevel.INFO
+
+export const logger = new Logger(defaultLogLevel)

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const storage = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn()
+}))
+
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  plasmoGlobalStorage: storage
+}))
+
+import { DEFAULT_PROVIDERS, ProviderManager } from "../manager"
+import { ProviderId, ProviderStorageKey, ProviderType } from "../types"
+
+describe("ProviderManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.get.mockResolvedValue(undefined)
+    storage.set.mockResolvedValue(undefined)
+  })
+
+  it("removes stale OpenAI config that is no longer in the provider UI", async () => {
+    storage.get.mockImplementation(async (key: string) => {
+      if (key === ProviderStorageKey.CONFIG) {
+        return [
+          DEFAULT_PROVIDERS[0],
+          {
+            id: ProviderId.OPENAI,
+            type: ProviderType.OPENAI,
+            name: "OpenAI",
+            enabled: true,
+            baseUrl: "https://api.openai.com/v1"
+          },
+          {
+            id: ProviderId.LM_STUDIO,
+            type: ProviderType.OPENAI,
+            name: "LM Studio",
+            enabled: true,
+            baseUrl: "http://localhost:1234/v1"
+          }
+        ]
+      }
+      return undefined
+    })
+
+    const providers = await ProviderManager.getProviders()
+
+    expect(providers.map((provider) => provider.id)).not.toContain(
+      ProviderId.OPENAI
+    )
+    expect(providers.map((provider) => provider.id)).toContain(
+      ProviderId.LM_STUDIO
+    )
+    expect(storage.set).toHaveBeenCalledWith(
+      ProviderStorageKey.CONFIG,
+      expect.not.arrayContaining([
+        expect.objectContaining({ id: ProviderId.OPENAI })
+      ])
+    )
+  })
+})

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -53,6 +53,22 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
   }
 ]
 
+const DEFAULT_PROVIDER_IDS = new Set(DEFAULT_PROVIDERS.map((p) => p.id))
+
+const sanitizeStoredProviders = (
+  providers: ProviderConfig[]
+): { providers: ProviderConfig[]; removed: ProviderConfig[] } => {
+  const sanitized = providers.filter((provider) =>
+    DEFAULT_PROVIDER_IDS.has(provider.id)
+  )
+  return {
+    providers: sanitized,
+    removed: providers.filter(
+      (provider) => !DEFAULT_PROVIDER_IDS.has(provider.id)
+    )
+  }
+}
+
 const validateProviderBaseUrl = (baseUrl?: string): void => {
   if (!baseUrl) return
   let parsed: URL
@@ -82,6 +98,18 @@ export const ProviderManager = {
     if (!stored || stored.length === 0) {
       await ProviderManager.saveProviders(DEFAULT_PROVIDERS)
       return DEFAULT_PROVIDERS
+    }
+
+    const sanitized = sanitizeStoredProviders(stored)
+    if (sanitized.removed.length > 0) {
+      logger.info(
+        "Removed provider configs not present in the provider UI",
+        "ProviderManager",
+        {
+          providers: sanitized.removed.map((provider) => provider.id)
+        }
+      )
+      stored = sanitized.providers
     }
 
     // Merge new defaults if they are missing from stored config
@@ -128,6 +156,10 @@ export const ProviderManager = {
       const merged = [...stored, ...missing]
       await ProviderManager.saveProviders(merged)
       return merged
+    }
+
+    if (sanitized.removed.length > 0) {
+      await ProviderManager.saveProviders(stored)
     }
 
     return stored

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -536,12 +536,21 @@ const fetchYouTubeCaptionTranscript = async (): Promise<string | null> => {
     []
   const selectedTrack = selectCaptionTrack(tracks)
 
-  logger.info("YouTube caption tracks found", "TranscriptExtractor", {
-    count: tracks.length,
-    selected: selectedTrack ? getCaptionTrackLabel(selectedTrack) : null
-  })
+  if (!selectedTrack?.baseUrl) {
+    logger.debug(
+      "No usable YouTube caption tracks found",
+      "TranscriptExtractor",
+      {
+        count: tracks.length
+      }
+    )
+    return null
+  }
 
-  if (!selectedTrack?.baseUrl) return null
+  logger.info("Using YouTube caption track", "TranscriptExtractor", {
+    count: tracks.length,
+    selected: getCaptionTrackLabel(selectedTrack)
+  })
 
   try {
     const captionUrl = new URL(selectedTrack.baseUrl)
@@ -813,7 +822,6 @@ const clickUdemyTranscriptButton = async (
   dispatchPointerEvent(transcriptButton, "pointerup")
   dispatchMouseEvent(transcriptButton, "mouseup")
   transcriptButton.click()
-  dispatchMouseEvent(transcriptButton, "click")
 
   await sleep(500)
 }
@@ -863,7 +871,9 @@ const openUdemyTranscript = async (): Promise<boolean> => {
           .length
       }
     )
-    await wakeUdemyPlayerControls()
+    if (attempt < 10) {
+      await wakeUdemyPlayerControls()
+    }
   }
 
   if (!transcriptButton) {

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -24,6 +24,10 @@ const YOUTUBE_TRANSCRIPT_PANEL_SELECTOR =
 const MODERN_TRANSCRIPT_SEGMENT_SELECTOR = "transcript-segment-view-model"
 const LEGACY_TRANSCRIPT_SEGMENT_SELECTOR =
   "div.cue-group, ytd-transcript-segment-renderer"
+const UDEMY_TRANSCRIPT_PANEL_SELECTOR = '[data-purpose="transcript-panel"]'
+const UDEMY_TRANSCRIPT_CUE_SELECTOR = '[data-purpose="cue-text"]'
+const UDEMY_TRANSCRIPT_TOGGLE_SELECTOR =
+  'button[data-purpose="transcript-toggle"], [data-purpose="transcript-toggle"], svg[aria-label*="transcript" i]'
 
 /**
  * Waits for an element to appear in the DOM with retries
@@ -50,6 +54,9 @@ const waitForElement = async (
   )
   return null
 }
+
+const sleep = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, delayMs))
 
 /**
  * Attempts to open the YouTube transcript panel by clicking:
@@ -687,29 +694,212 @@ const extractYouTubeTranscript = async (): Promise<string | null> => {
   return result
 }
 
-const extractUdemyTranscript = (): string | null => {
-  if (
-    !(
-      window.location.href.includes("udemy.com/course/") &&
-      window.location.href.includes("/learn/lecture/")
-    )
-  )
-    return null
+const isUdemyLecturePage = (): boolean =>
+  window.location.href.includes("udemy.com/course/") &&
+  window.location.href.includes("/learn/lecture/")
 
+const extractUdemyPanelTranscript = (): string | null => {
   const transcriptPanel = document.querySelector(
-    '[data-purpose="transcript-panel"]'
+    UDEMY_TRANSCRIPT_PANEL_SELECTOR
   )
   if (!transcriptPanel) return null
 
-  const cues = transcriptPanel.querySelectorAll('[data-purpose="cue-text"]')
+  const cues = transcriptPanel.querySelectorAll(UDEMY_TRANSCRIPT_CUE_SELECTOR)
+  logger.info(
+    `Found ${cues.length} Udemy transcript cues`,
+    "TranscriptExtractor"
+  )
   if (!cues || cues.length === 0) return null
 
   const transcript = Array.from(cues)
-    .map((cue) => cue.textContent?.trim())
+    .map((cue) => normalizeTranscriptLine(cue.textContent || ""))
     .filter(Boolean)
     .join("\n")
 
   return transcript.length > 0 ? transcript : null
+}
+
+const findUdemyTranscriptButton = (): HTMLElement | null => {
+  const clickableSelector = 'button, [role="button"], [role="tab"]'
+  const toClickable = (element: HTMLElement): HTMLElement =>
+    element.closest<HTMLElement>(clickableSelector) || element
+  const isVisible = (element: HTMLElement): boolean => {
+    const style = window.getComputedStyle(element)
+    const rect = element.getBoundingClientRect()
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.pointerEvents !== "none" &&
+      rect.width > 0 &&
+      rect.height > 0
+    )
+  }
+  const candidates = Array.from(
+    new Set(
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          [
+            UDEMY_TRANSCRIPT_TOGGLE_SELECTOR,
+            'button[aria-label*="transcript" i]',
+            'button[data-purpose*="transcript" i]',
+            '[role="tab"][aria-label*="transcript" i]',
+            '[role="tab"][data-purpose*="transcript" i]',
+            'svg[aria-label*="transcript" i]',
+            clickableSelector
+          ].join(", ")
+        )
+      ).map(toClickable)
+    )
+  )
+
+  const transcriptCandidates = candidates.filter((candidate) => {
+    const text = normalizeTranscriptLine(candidate.textContent || "")
+    const ariaLabel = candidate.getAttribute("aria-label") || ""
+    const dataPurpose = candidate.getAttribute("data-purpose") || ""
+    const iconAriaLabel =
+      candidate
+        .querySelector<HTMLElement>('svg[aria-label*="transcript" i]')
+        ?.getAttribute("aria-label") || ""
+
+    return (
+      text.toLowerCase() === "transcript" ||
+      text.toLowerCase().includes("transcript") ||
+      ariaLabel.toLowerCase().includes("transcript") ||
+      dataPurpose.toLowerCase().includes("transcript") ||
+      iconAriaLabel.toLowerCase().includes("transcript")
+    )
+  })
+
+  return transcriptCandidates.find(isVisible) || transcriptCandidates[0] || null
+}
+
+const dispatchMouseEvent = (element: HTMLElement, type: string): void => {
+  element.dispatchEvent(
+    new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      view: window
+    })
+  )
+}
+
+const dispatchPointerEvent = (element: HTMLElement, type: string): void => {
+  if (typeof PointerEvent === "function") {
+    element.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true
+      })
+    )
+    return
+  }
+
+  dispatchMouseEvent(element, type.replace("pointer", "mouse"))
+}
+
+const clickUdemyTranscriptButton = async (
+  transcriptButton: HTMLElement
+): Promise<void> => {
+  transcriptButton.scrollIntoView({ block: "center", inline: "center" })
+  transcriptButton.focus()
+
+  dispatchPointerEvent(transcriptButton, "pointerover")
+  dispatchMouseEvent(transcriptButton, "mouseover")
+  dispatchPointerEvent(transcriptButton, "pointerdown")
+  dispatchMouseEvent(transcriptButton, "mousedown")
+  dispatchPointerEvent(transcriptButton, "pointerup")
+  dispatchMouseEvent(transcriptButton, "mouseup")
+  transcriptButton.click()
+  dispatchMouseEvent(transcriptButton, "click")
+
+  await sleep(500)
+}
+
+const wakeUdemyPlayerControls = async (): Promise<void> => {
+  const targets = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      [
+        '[data-purpose="video-player"]',
+        '[class*="video-player"]',
+        '[class*="video-viewer"]',
+        "video",
+        "body"
+      ].join(", ")
+    )
+  )
+
+  logger.debug("Waking Udemy player controls", "TranscriptExtractor", {
+    targets: targets.length,
+    toggles: document.querySelectorAll(UDEMY_TRANSCRIPT_TOGGLE_SELECTOR).length
+  })
+
+  for (const target of targets.slice(0, 5)) {
+    dispatchPointerEvent(target, "pointerover")
+    dispatchMouseEvent(target, "mouseover")
+    dispatchPointerEvent(target, "pointermove")
+    dispatchMouseEvent(target, "mousemove")
+  }
+
+  await sleep(300)
+}
+
+const openUdemyTranscript = async (): Promise<boolean> => {
+  if (!isUdemyLecturePage()) return false
+  if (document.querySelector(UDEMY_TRANSCRIPT_PANEL_SELECTOR)) return true
+
+  let transcriptButton: HTMLElement | null = null
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    transcriptButton = findUdemyTranscriptButton()
+    if (transcriptButton) break
+
+    logger.debug(
+      `Udemy transcript button not found, retrying (${attempt}/10)`,
+      "TranscriptExtractor",
+      {
+        toggles: document.querySelectorAll(UDEMY_TRANSCRIPT_TOGGLE_SELECTOR)
+          .length
+      }
+    )
+    await wakeUdemyPlayerControls()
+  }
+
+  if (!transcriptButton) {
+    logger.debug("Udemy transcript button not found", "TranscriptExtractor")
+    return false
+  }
+
+  logger.info("Clicking Udemy transcript button", "TranscriptExtractor", {
+    text: normalizeTranscriptLine(transcriptButton.textContent || ""),
+    ariaLabel: transcriptButton.getAttribute("aria-label"),
+    ariaExpanded: transcriptButton.getAttribute("aria-expanded"),
+    dataPurpose: transcriptButton.getAttribute("data-purpose"),
+    iconAriaLabel:
+      transcriptButton
+        .querySelector<HTMLElement>('svg[aria-label*="transcript" i]')
+        ?.getAttribute("aria-label") || null,
+    role: transcriptButton.getAttribute("role"),
+    tag: transcriptButton.tagName.toLowerCase()
+  })
+
+  await clickUdemyTranscriptButton(transcriptButton)
+
+  const panel = await waitForElement(UDEMY_TRANSCRIPT_PANEL_SELECTOR, 30, 300)
+  return !!panel
+}
+
+const extractUdemyTranscript = async (): Promise<string | null> => {
+  if (!isUdemyLecturePage()) return null
+
+  const existingTranscript = extractUdemyPanelTranscript()
+  if (existingTranscript) return existingTranscript
+
+  const opened = await openUdemyTranscript()
+  logger.debug(`Udemy panel open result: ${opened}`, "TranscriptExtractor")
+
+  return extractUdemyPanelTranscript()
 }
 
 const extractCourseraTranscript = (): string | null => {
@@ -740,7 +930,7 @@ export const getTranscript = async (): Promise<string | null> => {
   }
 
   logger.debug("Trying Udemy transcript...", "TranscriptExtractor")
-  const udemyTranscript = extractUdemyTranscript()
+  const udemyTranscript = await extractUdemyTranscript()
   if (udemyTranscript) {
     logger.info("Udemy transcript found", "TranscriptExtractor")
     return udemyTranscript

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -506,15 +506,17 @@ const parseJson3Transcript = (payload: unknown): string | null => {
   if (!Array.isArray(events)) return null
 
   const transcript = events
-    .flatMap((event) => {
+    .map((event) => {
       const segs = (event as { segs?: unknown }).segs
-      if (!Array.isArray(segs)) return []
-      return segs.map((seg) => (seg as { utf8?: unknown }).utf8)
+      if (!Array.isArray(segs)) return ""
+      return segs
+        .map((seg) => (seg as { utf8?: unknown }).utf8)
+        .filter((text): text is string => typeof text === "string")
+        .join("")
     })
-    .filter((text): text is string => typeof text === "string")
     .map(normalizeTranscriptLine)
     .filter(Boolean)
-    .join(" ")
+    .join("\n")
 
   return transcript || null
 }

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -1,5 +1,30 @@
 import { logger } from "@/lib/logger"
 
+type YouTubeCaptionTrack = {
+  baseUrl?: string
+  kind?: string
+  languageCode?: string
+  name?: {
+    simpleText?: string
+    runs?: Array<{ text?: string }>
+  }
+}
+
+type YouTubePlayerResponse = {
+  captions?: {
+    playerCaptionsTracklistRenderer?: {
+      captionTracks?: YouTubeCaptionTrack[]
+    }
+  }
+}
+
+const YOUTUBE_TRANSCRIPT_PANEL_SELECTOR =
+  'ytd-transcript-renderer, yt-section-list-renderer[data-target-id="PAmodern_transcript_view"], yt-section-list-renderer[panel-target-id="PAmodern_transcript_view"]'
+
+const MODERN_TRANSCRIPT_SEGMENT_SELECTOR = "transcript-segment-view-model"
+const LEGACY_TRANSCRIPT_SEGMENT_SELECTOR =
+  "div.cue-group, ytd-transcript-segment-renderer"
+
 /**
  * Waits for an element to appear in the DOM with retries
  */
@@ -46,7 +71,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
     "TranscriptExtractor"
   )
   // Check if transcript is already open
-  const existingTranscript = document.querySelector("ytd-transcript-renderer")
+  const existingTranscript = document.querySelector(
+    YOUTUBE_TRANSCRIPT_PANEL_SELECTOR
+  )
   if (existingTranscript) {
     logger.debug("Transcript panel already exists!", "TranscriptExtractor")
     return true
@@ -309,7 +336,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
       )
 
       // Verify transcript panel appeared
-      const transcriptPanel = document.querySelector("ytd-transcript-renderer")
+      const transcriptPanel = document.querySelector(
+        YOUTUBE_TRANSCRIPT_PANEL_SELECTOR
+      )
       if (transcriptPanel) {
         logger.debug(
           "Transcript panel successfully opened!",
@@ -323,7 +352,9 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
         )
         // Wait a bit more and retry
         await new Promise((resolve) => setTimeout(resolve, 1500))
-        const retryPanel = document.querySelector("ytd-transcript-renderer")
+        const retryPanel = document.querySelector(
+          YOUTUBE_TRANSCRIPT_PANEL_SELECTOR
+        )
         if (retryPanel) {
           logger.debug(
             "Transcript panel appeared after longer wait!",
@@ -364,25 +395,211 @@ const openYouTubeTranscript = async (): Promise<boolean> => {
   return false
 }
 
-const extractYouTubeTranscript = async (): Promise<string | null> => {
-  logger.debug("Starting transcript extraction...", "TranscriptExtractor")
+const extractBalancedJson = (
+  source: string,
+  startIndex: number
+): string | null => {
+  let depth = 0
+  let inString = false
+  let escapeNext = false
 
-  if (!window.location.href.includes("youtube.com/watch")) {
-    logger.debug("Not a YouTube watch page", "TranscriptExtractor")
-    return null
+  for (let i = startIndex; i < source.length; i++) {
+    const char = source[i]
+
+    if (escapeNext) {
+      escapeNext = false
+      continue
+    }
+
+    if (char === "\\") {
+      escapeNext = true
+      continue
+    }
+
+    if (char === '"') {
+      inString = !inString
+      continue
+    }
+
+    if (inString) continue
+
+    if (char === "{") {
+      depth++
+    } else if (char === "}") {
+      depth--
+      if (depth === 0) return source.slice(startIndex, i + 1)
+    }
   }
 
-  // Try to open transcript panel if not already open
-  logger.debug("Attempting to open transcript panel...", "TranscriptExtractor")
-  const opened = await openYouTubeTranscript()
-  logger.debug(`Panel open result: ${opened}`, "TranscriptExtractor")
+  return null
+}
 
-  const transcriptContainer = document.querySelector("ytd-transcript-renderer")
-  if (!transcriptContainer) {
-    logger.debug(
-      "Transcript container not found after opening attempt",
-      "TranscriptExtractor"
+const getYouTubePlayerResponse = (): YouTubePlayerResponse | null => {
+  const scripts = Array.from(document.querySelectorAll("script"))
+
+  for (const script of scripts) {
+    const text = script.textContent || ""
+    const markerIndex = text.indexOf("ytInitialPlayerResponse")
+    if (markerIndex === -1) continue
+
+    const jsonStart = text.indexOf("{", markerIndex)
+    if (jsonStart === -1) continue
+
+    const jsonText = extractBalancedJson(text, jsonStart)
+    if (!jsonText) continue
+
+    try {
+      return JSON.parse(jsonText) as YouTubePlayerResponse
+    } catch (error) {
+      logger.debug(
+        "Failed to parse ytInitialPlayerResponse",
+        "TranscriptExtractor",
+        {
+          error
+        }
+      )
+    }
+  }
+
+  return null
+}
+
+const normalizeTranscriptLine = (text: string): string =>
+  text.replace(/\s+/g, " ").trim()
+
+const getCaptionTrackLabel = (track: YouTubeCaptionTrack): string => {
+  return (
+    track.name?.simpleText ||
+    track.name?.runs?.map((run) => run.text || "").join("") ||
+    ""
+  )
+}
+
+const selectCaptionTrack = (
+  tracks: YouTubeCaptionTrack[]
+): YouTubeCaptionTrack | null => {
+  const usableTracks = tracks.filter((track) => track.baseUrl)
+  if (usableTracks.length === 0) return null
+
+  return (
+    usableTracks.find(
+      (track) => track.languageCode?.startsWith("en") && track.kind !== "asr"
+    ) ||
+    usableTracks.find((track) => track.languageCode?.startsWith("en")) ||
+    usableTracks.find((track) => track.kind !== "asr") ||
+    usableTracks[0] ||
+    null
+  )
+}
+
+const parseJson3Transcript = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== "object") return null
+
+  const events = (payload as { events?: unknown }).events
+  if (!Array.isArray(events)) return null
+
+  const transcript = events
+    .flatMap((event) => {
+      const segs = (event as { segs?: unknown }).segs
+      if (!Array.isArray(segs)) return []
+      return segs.map((seg) => (seg as { utf8?: unknown }).utf8)
+    })
+    .filter((text): text is string => typeof text === "string")
+    .map(normalizeTranscriptLine)
+    .filter(Boolean)
+    .join(" ")
+
+  return transcript || null
+}
+
+const parseXmlTranscript = (payload: string): string | null => {
+  const doc = new DOMParser().parseFromString(payload, "text/xml")
+  const transcript = Array.from(doc.querySelectorAll("text"))
+    .map((node) => normalizeTranscriptLine(node.textContent || ""))
+    .filter(Boolean)
+    .join("\n")
+
+  return transcript || null
+}
+
+const fetchYouTubeCaptionTranscript = async (): Promise<string | null> => {
+  const playerResponse = getYouTubePlayerResponse()
+  const tracks =
+    playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ||
+    []
+  const selectedTrack = selectCaptionTrack(tracks)
+
+  logger.info("YouTube caption tracks found", "TranscriptExtractor", {
+    count: tracks.length,
+    selected: selectedTrack ? getCaptionTrackLabel(selectedTrack) : null
+  })
+
+  if (!selectedTrack?.baseUrl) return null
+
+  try {
+    const captionUrl = new URL(selectedTrack.baseUrl)
+    captionUrl.searchParams.set("fmt", "json3")
+    const response = await fetch(captionUrl.toString())
+    if (!response.ok) {
+      logger.warn("YouTube caption fetch failed", "TranscriptExtractor", {
+        status: response.status
+      })
+      return null
+    }
+
+    const text = await response.text()
+    if (!text.trim()) {
+      logger.warn("YouTube caption response was empty", "TranscriptExtractor", {
+        languageCode: selectedTrack.languageCode,
+        kind: selectedTrack.kind
+      })
+      return null
+    }
+
+    try {
+      return parseJson3Transcript(JSON.parse(text))
+    } catch {
+      return parseXmlTranscript(text)
+    }
+  } catch (error) {
+    logger.warn("YouTube caption transcript failed", "TranscriptExtractor", {
+      error
+    })
+    return null
+  }
+}
+
+const extractTextFromYouTubeSegment = (segment: Element): string => {
+  const modernText = segment.querySelector<HTMLElement>(
+    '.ytAttributedStringHost[role="text"], span[role="text"]'
+  )
+  if (modernText?.textContent)
+    return normalizeTranscriptLine(modernText.textContent)
+
+  const legacyText = segment.querySelector<HTMLElement>(
+    ".cue, .segment-text, yt-formatted-string"
+  )
+  if (legacyText?.textContent)
+    return normalizeTranscriptLine(legacyText.textContent)
+
+  const clone = segment.cloneNode(true) as Element
+  clone
+    .querySelectorAll(
+      '[aria-hidden="true"], .ytwTranscriptSegmentViewModelTimestamp, .ytwTranscriptSegmentViewModelTimestampA11yLabel'
     )
+    .forEach((node) => {
+      node.remove()
+    })
+
+  return normalizeTranscriptLine(clone.textContent || "")
+}
+
+const extractYouTubePanelTranscript = (): string | null => {
+  const transcriptContainer = document.querySelector(
+    YOUTUBE_TRANSCRIPT_PANEL_SELECTOR
+  )
+  if (!transcriptContainer) {
+    logger.debug("Transcript container not found", "TranscriptExtractor")
     return null
   }
 
@@ -391,30 +608,75 @@ const extractYouTubeTranscript = async (): Promise<string | null> => {
     "TranscriptExtractor"
   )
 
-  const transcriptLines = transcriptContainer.querySelectorAll("div.cue-group")
-  const fallbackLines = transcriptContainer.querySelectorAll(
-    "yt-formatted-string"
+  const modernSegments = transcriptContainer.querySelectorAll(
+    MODERN_TRANSCRIPT_SEGMENT_SELECTOR
   )
-  const lines = transcriptLines.length > 0 ? transcriptLines : fallbackLines
+  const legacySegments = transcriptContainer.querySelectorAll(
+    LEGACY_TRANSCRIPT_SEGMENT_SELECTOR
+  )
+  const segments =
+    modernSegments.length > 0
+      ? modernSegments
+      : legacySegments.length > 0
+        ? legacySegments
+        : transcriptContainer.querySelectorAll(
+            ".cue, .segment-text, ytd-transcript-segment-renderer yt-formatted-string"
+          )
 
-  logger.debug(`Found ${lines.length} transcript lines`, "TranscriptExtractor")
+  logger.info(
+    `Found ${segments.length} transcript segments in panel`,
+    "TranscriptExtractor",
+    {
+      panelTag: transcriptContainer.tagName.toLowerCase(),
+      modernSegments: modernSegments.length,
+      legacySegments: legacySegments.length
+    }
+  )
 
-  if (lines.length === 0) {
-    logger.debug("No transcript lines found", "TranscriptExtractor")
-    return null
-  }
+  if (segments.length === 0) return null
 
-  const transcript = Array.from(lines)
-    .map((group) => {
-      const cueText = group.querySelector?.(".cue")?.textContent?.trim()
-      return cueText ?? group.textContent?.trim() ?? ""
-    })
+  const transcript = Array.from(segments)
+    .map(extractTextFromYouTubeSegment)
     .filter(Boolean)
     .join("\n")
 
-  const result = transcript.length > 0 ? transcript : null
+  return transcript || null
+}
+
+const extractYouTubeTranscript = async (): Promise<string | null> => {
+  if (!window.location.href.includes("youtube.com/watch")) {
+    logger.debug("Not a YouTube watch page", "TranscriptExtractor")
+    return null
+  }
+
+  logger.info("Starting YouTube transcript extraction", "TranscriptExtractor")
+
+  const existingPanelTranscript = extractYouTubePanelTranscript()
+  if (existingPanelTranscript) {
+    logger.info(
+      `Successfully extracted open panel transcript (${existingPanelTranscript.length} chars)`,
+      "TranscriptExtractor"
+    )
+    return existingPanelTranscript
+  }
+
+  const captionTranscript = await fetchYouTubeCaptionTranscript()
+  if (captionTranscript) {
+    logger.info(
+      `Successfully extracted caption transcript (${captionTranscript.length} chars)`,
+      "TranscriptExtractor"
+    )
+    return captionTranscript
+  }
+
+  // Try to open transcript panel if not already open
+  logger.debug("Attempting to open transcript panel...", "TranscriptExtractor")
+  const opened = await openYouTubeTranscript()
+  logger.debug(`Panel open result: ${opened}`, "TranscriptExtractor")
+
+  const result = extractYouTubePanelTranscript()
   if (result) {
-    logger.debug(
+    logger.info(
       `Successfully extracted transcript (${result.length} chars)`,
       "TranscriptExtractor"
     )


### PR DESCRIPTION
- youtube transcript extraction fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes YouTube transcript extraction by adding three extraction strategies (already-open panel → caption API via `ytInitialPlayerResponse` → UI-driven panel open), and upgrades Udemy extraction to actively click the transcript panel before falling back to generic page content. It also sanitises stale provider configs (e.g. a previously stored OpenAI entry) on first `getProviders` call, wires `maxTabContextChars` into the RAG tab-context retrieval budget, and defaults the logger to DEBUG in development.

- **YouTube**: three-tier extraction with new `fetchYouTubeCaptionTranscript` (JSON3/XML fallback), `extractYouTubePanelTranscript` supporting both modern `transcript-segment-view-model` and legacy `ytd-transcript-segment-renderer` layouts, and a custom `extractBalancedJson` scanner to extract `ytInitialPlayerResponse` without evaluating arbitrary script content.
- **Udemy**: `openUdemyTranscript` simulates pointer/mouse/click events to reveal the transcript panel, with up to 10 retry attempts and `wakeUdemyPlayerControls` to surface hidden controls; the content script now short-circuits to transcript-only output for Udemy lecture pages.
- **Provider manager**: `sanitizeStoredProviders` filters out any stored provider whose ID is not in `DEFAULT_PROVIDERS`, with a write-back triggered only when removals occurred and no new defaults were needed (avoiding a duplicate save when both conditions are true).

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new extraction strategies add fallbacks rather than replacing proven paths, and the provider sanitisation is covered by a new test.

The changes are well-scoped: YouTube and Udemy extraction are handled in clearly isolated code paths with new tests, the dual-save logic in manager.ts is correct for all combinations of removed/missing providers, and the RAG budget fix is a one-line addition with a passing test assertion. The remaining notes are minor logging style concerns that do not affect correctness.

src/lib/transcript-extractor.ts — the INFO-level log in extractYouTubePanelTranscript fires unconditionally when segments are absent, and the broad catch-all selector in findUdemyTranscriptButton queries every button on the page as a last resort.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/transcript-extractor.ts | Major rewrite: adds three-tier YouTube extraction (open panel → caption API → open panel), new Udemy panel-click flow with pointer/mouse event simulation, and supporting helpers (extractBalancedJson, parseJson3Transcript, parseXmlTranscript). INFO log fires unconditionally at 0 segments; broad catch-all selector in findUdemyTranscriptButton is inefficient but functionally correct. |
| src/contents/index.ts | Adds specialised YouTube-only and Udemy-only response paths that short-circuit the generic page extraction; helper functions isYouTubeWatchPage, isUdemyLecturePage, buildExtractionDebug, and sendTranscriptOnlyResponse are well-structured. YouTube always sends a response (allowMissing: true), which is intentional per the PR description. |
| src/lib/providers/manager.ts | Adds sanitizeStoredProviders to evict provider configs not present in DEFAULT_PROVIDERS; the dual-save paths (missing.length > 0 vs removed.length > 0) are logically correct and the test covers the primary case. Removal is logged at INFO; no data is lost for known providers with user-customised settings. |
| src/features/chat/hooks/build-rag-context.ts | Single-line addition passes maxTabContextChars as maxTokens to retrieveContextFromSources so tab-context retrieval respects the configured budget; covered by the updated test. |
| src/lib/logger.ts | Adds setLevel() method and defaults the exported logger to DEBUG in development, INFO in production. Straightforward and low-risk change. |
| src/lib/providers/__tests__/manager.test.ts | New test file covering the stale-OpenAI sanitisation path; mocks storage correctly and asserts both the returned list and the write-back call. |
| src/lib/__tests__/transcript-extractor.test.ts | Adds tests for modern panel, legacy segment renderer, caption-track API, and Udemy click-based extraction; DOM setup improvements (head reset, console.info/warn spies) keep test output clean. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleGetPageContent] --> B{isYouTubeWatchPage?}
    B -- Yes --> C[getTranscript]
    C --> D[extractYouTubePanelTranscript\nalready open?]
    D -- found --> E[Return panel transcript]
    D -- null --> F[fetchYouTubeCaptionTranscript\nytInitialPlayerResponse]
    F -- found --> G[Return caption transcript]
    F -- null --> H[openYouTubeTranscript\nUI automation]
    H --> I[extractYouTubePanelTranscript\nafter open]
    I --> J[sendTranscriptOnlyResponse\nallowMissing=true]
    B -- No --> K{isUdemyLecturePage?}
    K -- Yes --> L[getTranscript → extractUdemyTranscript]
    L --> M[extractUdemyPanelTranscript\nalready open?]
    M -- found --> N[sendTranscriptOnlyResponse\nallowMissing=false → return]
    M -- null --> O[openUdemyTranscript\nclick button up to 10x]
    O --> P[extractUdemyPanelTranscript\nafter open]
    P -- found --> N
    P -- null --> Q[Fall through to generic extraction]
    K -- No --> Q
    Q --> R[extractContentWithLoading]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A644-654%0A**INFO%20log%20fires%20when%20zero%20segments%20are%20present**%0A%0A%60logger.info%28%5C%60Found%20%24%7Bsegments.length%7D%20transcript%20segments%20in%20panel%5C%60%2C%20...%29%60%20is%20emitted%20before%20the%20%60if%20%28segments.length%20%3D%3D%3D%200%29%20return%20null%60%20guard.%20In%20production%20%28INFO%20level%29%2C%20any%20YouTube%20page%20where%20the%20panel%20is%20open%20but%20contains%20no%20segments%20will%20emit%20a%20%22Found%200%20transcript%20segments%20in%20panel%22%20entry%2C%20which%20is%20misleading%20and%20mirrors%20the%20same%20pattern%20that%20was%20flagged%20for%20caption%20tracks%20in%20the%20previous%20review.%20Consider%20logging%20at%20DEBUG%20when%20%60segments.length%20%3D%3D%3D%200%60%2C%20or%20moving%20the%20INFO%20log%20inside%20a%20%60segments.length%20%3E%200%60%20branch.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A748-764%0A**Broad%20%60clickableSelector%60%20included%20as%20catch-all%20may%20produce%20enormous%20candidate%20lists**%0A%0A%60findUdemyTranscriptButton%60%20builds%20a%20single%20giant%20query%20that%20includes%20the%20bare%20%60clickableSelector%60%20%28%60button%2C%20%5Brole%3D%22button%22%5D%2C%20%5Brole%3D%22tab%22%5D%60%29%20alongside%20every%20specific%20transcript%20selector.%20On%20a%20complex%20page%20like%20a%20Udemy%20lecture%20this%20matches%20every%20button%20on%20the%20page%20%E2%80%94%20potentially%20hundreds%20of%20elements%20%E2%80%94%20before%20the%20%60transcriptCandidates.filter%60%20narrows%20them%20down.%20The%20%60new%20Set%60%20deduplicates%20by%20object%20identity%20after%20%60toClickable%60%20re-maps%20each%20node%20to%20its%20closest%20ancestor%2C%20which%20means%20duplicate%20ancestor%20references%20are%20correctly%20collapsed.%20However%2C%20including%20the%20bare%20%60clickableSelector%60%20adds%20unnecessary%20work.%20Moving%20it%20to%20a%20separate%2C%20lower-priority%20fallback%20%28i.e.%2C%20only%20query%20all%20buttons%20if%20none%20of%20the%20specific%20selectors%20matched%29%20would%20be%20safer%20and%20cheaper.%0A%0A&repo=shishir435%2Follama-client&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22fix%2Fyoutube-transcript-0.7.2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fyoutube-transcript-0.7.2%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A644-654%0A**INFO%20log%20fires%20when%20zero%20segments%20are%20present**%0A%0A%60logger.info%28%5C%60Found%20%24%7Bsegments.length%7D%20transcript%20segments%20in%20panel%5C%60%2C%20...%29%60%20is%20emitted%20before%20the%20%60if%20%28segments.length%20%3D%3D%3D%200%29%20return%20null%60%20guard.%20In%20production%20%28INFO%20level%29%2C%20any%20YouTube%20page%20where%20the%20panel%20is%20open%20but%20contains%20no%20segments%20will%20emit%20a%20%22Found%200%20transcript%20segments%20in%20panel%22%20entry%2C%20which%20is%20misleading%20and%20mirrors%20the%20same%20pattern%20that%20was%20flagged%20for%20caption%20tracks%20in%20the%20previous%20review.%20Consider%20logging%20at%20DEBUG%20when%20%60segments.length%20%3D%3D%3D%200%60%2C%20or%20moving%20the%20INFO%20log%20inside%20a%20%60segments.length%20%3E%200%60%20branch.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A748-764%0A**Broad%20%60clickableSelector%60%20included%20as%20catch-all%20may%20produce%20enormous%20candidate%20lists**%0A%0A%60findUdemyTranscriptButton%60%20builds%20a%20single%20giant%20query%20that%20includes%20the%20bare%20%60clickableSelector%60%20%28%60button%2C%20%5Brole%3D%22button%22%5D%2C%20%5Brole%3D%22tab%22%5D%60%29%20alongside%20every%20specific%20transcript%20selector.%20On%20a%20complex%20page%20like%20a%20Udemy%20lecture%20this%20matches%20every%20button%20on%20the%20page%20%E2%80%94%20potentially%20hundreds%20of%20elements%20%E2%80%94%20before%20the%20%60transcriptCandidates.filter%60%20narrows%20them%20down.%20The%20%60new%20Set%60%20deduplicates%20by%20object%20identity%20after%20%60toClickable%60%20re-maps%20each%20node%20to%20its%20closest%20ancestor%2C%20which%20means%20duplicate%20ancestor%20references%20are%20correctly%20collapsed.%20However%2C%20including%20the%20bare%20%60clickableSelector%60%20adds%20unnecessary%20work.%20Moving%20it%20to%20a%20separate%2C%20lower-priority%20fallback%20%28i.e.%2C%20only%20query%20all%20buttons%20if%20none%20of%20the%20specific%20selectors%20matched%29%20would%20be%20safer%20and%20cheaper.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["docs(changelog): add 0.7.2 release notes"](https://github.com/shishir435/ollama-client/commit/ecf35e372cbff3a1fc8e82359527270b3f518ea8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34809940)</sub>

<!-- /greptile_comment -->