### PR TITLE
docs: add AI-readable docs outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,12 @@ docs/src/content/docs/reference/
 docs/src/content/docs/about/changelog.md
 docs/src/content/docs/concepts/provider-matrix.md
 
+# generated at build time by tools/generate-llms-docs.ts
+docs/public/llms.txt
+docs/public/llms-full.txt
+docs/public/ai.txt
+docs/public/**/*.md
+
 # astro / starlight build caches
 docs/.astro/
 docs/dist/

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,0 +1,1 @@
+PUBLIC_SITE_URL=https://ollama-client.shishirchaurasiya.in

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://ollama-client.shishirchaurasiya.in/sitemap-index.xml

--- a/docs/src/components/starlight/Head.astro
+++ b/docs/src/components/starlight/Head.astro
@@ -30,6 +30,7 @@ const base = Astro.site?.toString() ?? SITE_URL
 const site = base.replace(/\/$/, "")
 const ogUrl = `${site}/og/${slug}.png`
 const pageUrl = `${site}/${slug}/`
+const markdownUrl = `${site}/${slug}.md`
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -54,4 +55,5 @@ const jsonLd = {
 <meta property="og:image:height" content="630" />
 <meta name="twitter:image" content={ogUrl} />
 <meta name="twitter:image:alt" content={entry.data.title} />
+<link rel="alternate" type="text/markdown" href={markdownUrl} />
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -36,6 +36,7 @@ const ogUrl = new URL(ogPath, site)
     <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <link rel="canonical" href={canonical} />
+    <link rel="alternate" type="text/markdown" href="/llms.txt" />
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta name="keywords" content={KEYWORDS} />

--- a/docs/src/pages/robots.txt.ts
+++ b/docs/src/pages/robots.txt.ts
@@ -1,0 +1,44 @@
+import { SITE_URL } from "@/seo/constants.mjs"
+
+const content = `User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: ${SITE_URL}/sitemap-index.xml
+
+# AI-readable docs
+# ${SITE_URL}/llms.txt
+# ${SITE_URL}/llms-full.txt
+# ${SITE_URL}/ai.txt
+`
+
+export function GET() {
+  return new Response(content, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8"
+    }
+  })
+}

--- a/docs/src/seo/constants.mjs
+++ b/docs/src/seo/constants.mjs
@@ -16,7 +16,12 @@ const findAppPackageJson = () => {
 
       if (existsSync(packagePath)) {
         const candidate = JSON.parse(readFileSync(packagePath, "utf-8"))
-        if (candidate.name === "ollama-client") return candidate
+        if (candidate.name === "ollama-client") {
+          return {
+            path: packagePath,
+            packageJson: candidate
+          }
+        }
       }
 
       const parentDir = dirname(currentDir)
@@ -28,11 +33,45 @@ const findAppPackageJson = () => {
   throw new Error("Could not find root ollama-client package.json")
 }
 
-const packageJson = findAppPackageJson()
+const appPackage = findAppPackageJson()
+const appRoot = dirname(appPackage.path)
 
-export const APP_VERSION = packageJson.version
+const loadEnvFile = (path) => {
+  if (!existsSync(path)) return
 
-export const SITE_URL = "https://ollama-client.shishirchaurasiya.in"
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)\s*$/)
+    if (!match || process.env[match[1]] !== undefined) continue
+
+    process.env[match[1]] = match[2].replace(/^["']|["']$/g, "")
+  }
+}
+
+for (const envPath of [
+  join(appRoot, ".env"),
+  join(appRoot, ".env.local"),
+  join(appRoot, "docs/.env"),
+  join(appRoot, "docs/.env.local")
+]) {
+  loadEnvFile(envPath)
+}
+
+export const APP_VERSION = appPackage.packageJson.version
+
+const DEFAULT_SITE_URL = "https://ollama-client.shishirchaurasiya.in"
+
+const normalizeSiteUrl = (url) => {
+  const trimmed = (url || DEFAULT_SITE_URL).trim().replace(/\/+$/, "")
+  if (!trimmed) return DEFAULT_SITE_URL
+  return /^https?:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`
+}
+
+export const SITE_URL = normalizeSiteUrl(
+  process.env.PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL
+)
 
 export const SITE_TITLE = "Ollama Client"
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "docs:dev": "pnpm docs:generate && pnpm --dir docs dev",
     "docs:build": "pnpm docs:generate && pnpm --dir docs build",
     "docs:preview": "pnpm --dir docs preview",
-    "docs:generate": "npx tsx tools/generate-docs.ts",
+    "docs:generate": "npx tsx tools/generate-docs.ts && npx tsx tools/generate-llms-docs.ts",
     "package": "pnpm generate:resources && WXT_OUTPUT_DIR=build/chrome-mv3-prod wxt zip",
     "dev:firefox": "pnpm generate:resources && WXT_OUTPUT_DIR=build/firefox-mv2-dev wxt -b firefox --mv2",
     "build:firefox": "pnpm generate:resources && WXT_OUTPUT_DIR=build/firefox-mv2-prod wxt build -b firefox --mv2 --mode production",

--- a/src/lib/constants-ui.ts
+++ b/src/lib/constants-ui.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
+import { EXTERNAL_URLS } from "@/lib/constants/urls"
 import {
   BookOpen,
   Bug,
@@ -103,7 +104,7 @@ export const CONTENT_SCRAPER_OPTIONS = [
 export const GUIDES = [
   {
     labelKey: "guides.items.setup.label",
-    href: "https://ollama-client.shishirchaurasiya.in/ollama-setup-guide",
+    href: EXTERNAL_URLS.SETUP_GUIDE,
     icon: BookOpen,
     descriptionKey: "guides.items.setup.description",
     badgeKey: "guides.items.setup.badge"

--- a/src/lib/constants/errors.ts
+++ b/src/lib/constants/errors.ts
@@ -1,5 +1,7 @@
 // Shared script content from tools/ollama-env.sh
 // This ensures both error messages have the same script content
+import { EXTERNAL_URLS } from "@/lib/constants/urls"
+
 const OLLAMA_ENV_SCRIPT_CONTENT = `#!/bin/bash
 
 # Cross-platform Ollama environment setup script
@@ -258,7 +260,7 @@ OLLAMA_ORIGINS=chrome-extension://*,moz-extension://*,http://localhost:3000
 
 </details>
 
-📖 For step-by-step instructions: [ollama-setup-guide](https://ollama-client.shishirchaurasiya.in/ollama-setup-guide)  
+📖 For step-by-step instructions: [provider-setup](${EXTERNAL_URLS.SETUP_GUIDE})  
 🔗 Official docs: [https://ollama.com](https://ollama.com)
 `,
 

--- a/src/lib/constants/urls.ts
+++ b/src/lib/constants/urls.ts
@@ -2,8 +2,12 @@
  * External URLs used throughout the extension.
  * Keep all hardcoded links here so they can be updated in one place.
  */
+const DEFAULT_DOCS_HOME = "https://ollama-client.shishirchaurasiya.in"
+const DOCS_HOME = DEFAULT_DOCS_HOME.replace(/\/+$/, "")
+
 export const EXTERNAL_URLS = {
-  SETUP_GUIDE: "https://ollama-client.shishirchaurasiya.in/ollama-setup-guide",
+  DOCS_HOME,
+  SETUP_GUIDE: `${DOCS_HOME}/guides/provider-setup/`,
   FIREFOX_CORS_SCRIPT:
     "https://github.com/Shishir435/ollama-client/blob/main/tools/ollama-env.sh"
 } as const

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env tsx
+/**
+ * Generates static Markdown entrypoints for AI agents.
+ *
+ * Output lives in docs/public so Vercel serves:
+ * - /llms.txt
+ * - /llms-full.txt
+ * - /ai.txt
+ * - /<docs-page>.md
+ */
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import {
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL
+} from "../docs/src/seo/constants.mjs"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, "..")
+const DOCS_CONTENT_DIR = join(REPO_ROOT, "docs/src/content/docs")
+const PUBLIC_DIR = join(REPO_ROOT, "docs/public")
+
+type DocPage = {
+  title: string
+  description: string
+  slug: string
+  sourcePath: string
+  markdownPath: string
+  url: string
+  markdownUrl: string
+  body: string
+}
+
+const DOC_ORDER = [
+  "guides/provider-setup",
+  "concepts/architecture",
+  "concepts/provider-matrix",
+  "internal/frontend-design-system",
+  "legal/privacy-policy",
+  "about/changelog",
+  "about/keyboard-shortcuts"
+]
+
+function walk(dir: string): string[] {
+  return readdirSync(dir)
+    .flatMap((entry) => {
+      const path = join(dir, entry)
+      if (statSync(path).isDirectory()) return walk(path)
+      return path
+    })
+    .filter((path) => /\.(md|mdx)$/.test(path))
+}
+
+function parseFrontmatter(markdown: string) {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n?/)
+  if (!match) {
+    return { data: new Map<string, string>(), body: markdown }
+  }
+
+  const data = new Map<string, string>()
+  for (const line of match[1].split("\n")) {
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
+    if (!field) continue
+    data.set(field[1], field[2].replace(/^["']|["']$/g, "").trim())
+  }
+
+  return { data, body: markdown.slice(match[0].length) }
+}
+
+function routeFromSource(path: string) {
+  const rel = relative(DOCS_CONTENT_DIR, path).replace(/\\/g, "/")
+  const withoutExt = rel.replace(/\.(md|mdx)$/, "")
+  return withoutExt.endsWith("/index")
+    ? withoutExt.slice(0, -"/index".length)
+    : withoutExt
+}
+
+function cleanMarkdown(body: string) {
+  return body
+    .replace(/^import\s+.*$/gm, "")
+    .replace(/<([A-Z][A-Za-z0-9]*)\s*\/>/g, "_Rendered component: $1._")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+function sortPages(a: DocPage, b: DocPage) {
+  const aIndex = DOC_ORDER.indexOf(a.slug)
+  const bIndex = DOC_ORDER.indexOf(b.slug)
+  if (aIndex !== -1 || bIndex !== -1) {
+    if (aIndex === -1) return 1
+    if (bIndex === -1) return -1
+    return aIndex - bIndex
+  }
+  return a.slug.localeCompare(b.slug)
+}
+
+function loadPages() {
+  return walk(DOCS_CONTENT_DIR)
+    .filter((path) => !relative(DOCS_CONTENT_DIR, path).startsWith("reference/"))
+    .map((sourcePath) => {
+      const raw = readFileSync(sourcePath, "utf-8")
+      const { data, body } = parseFrontmatter(raw)
+      const slug = routeFromSource(sourcePath)
+      const title = data.get("title") || slug
+      const description = data.get("description") || SITE_DESCRIPTION
+      const url = `${SITE_URL}/${slug}/`
+      const markdownUrl = `${SITE_URL}/${slug}.md`
+      const markdownPath = join(PUBLIC_DIR, `${slug}.md`)
+
+      return {
+        title,
+        description,
+        slug,
+        sourcePath,
+        markdownPath,
+        url,
+        markdownUrl,
+        body: cleanMarkdown(body)
+      }
+    })
+    .sort(sortPages)
+}
+
+function pageMarkdown(page: DocPage) {
+  return `# ${page.title}
+
+Source: ${page.url}
+Markdown: ${page.markdownUrl}
+Description: ${page.description}
+
+${page.body}
+`
+}
+
+function writePageMarkdown(pages: DocPage[]) {
+  for (const page of pages) {
+    mkdirSync(dirname(page.markdownPath), { recursive: true })
+    writeFileSync(page.markdownPath, pageMarkdown(page), "utf-8")
+  }
+}
+
+function writeLlmsTxt(pages: DocPage[]) {
+  const lines = pages.map(
+    (page) => `- [${page.title}](${page.markdownUrl}): ${page.description}`
+  )
+
+  const content = `# ${SITE_TITLE}
+
+> ${SITE_DESCRIPTION}
+
+Ollama Client is a local-first browser extension for private LLM chat, provider management, and local RAG workflows.
+
+## Docs
+
+${lines.join("\n")}
+
+## Reference
+
+- [API Reference](${SITE_URL}/reference/): Generated TypeScript API reference.
+- [Full Markdown Docs](${SITE_URL}/llms-full.txt): All public docs in one Markdown file.
+- [GitHub Repository](https://github.com/Shishir435/ollama-client): Source code and issue tracker.
+`
+
+  writeFileSync(join(PUBLIC_DIR, "llms.txt"), content, "utf-8")
+}
+
+function writeLlmsFullTxt(pages: DocPage[]) {
+  const sections = pages.map(pageMarkdown)
+  const content = `# ${SITE_TITLE} Full Documentation
+
+Source: ${SITE_URL}
+
+${SITE_DESCRIPTION}
+
+${sections.join("\n---\n\n")}
+`
+
+  writeFileSync(join(PUBLIC_DIR, "llms-full.txt"), content, "utf-8")
+}
+
+function writeAiTxt(pages: DocPage[]) {
+  const lines = pages.map(
+    (page) => `- ${page.title}: ${page.markdownUrl}`
+  )
+
+  const content = `# AI crawler guidance for ${SITE_TITLE}
+
+Purpose: Help AI agents fetch clean, canonical documentation without parsing HTML navigation, CSS, or scripts.
+
+Canonical site: ${SITE_URL}
+Primary AI docs index: ${SITE_URL}/llms.txt
+Full Markdown docs: ${SITE_URL}/llms-full.txt
+Sitemap: ${SITE_URL}/sitemap-index.xml
+Repository: https://github.com/Shishir435/ollama-client
+
+Preferred fetch order:
+1. Fetch /llms.txt for the docs map.
+2. Fetch linked .md pages for targeted answers.
+3. Fetch /llms-full.txt only when broad project context is needed.
+4. Use canonical HTML pages for citations shown to users.
+
+Markdown pages:
+${lines.join("\n")}
+`
+
+  writeFileSync(join(PUBLIC_DIR, "ai.txt"), content, "utf-8")
+}
+
+function cleanOldMarkdown() {
+  rmSync(join(PUBLIC_DIR, "llms.txt"), { force: true })
+  rmSync(join(PUBLIC_DIR, "llms-full.txt"), { force: true })
+  rmSync(join(PUBLIC_DIR, "ai.txt"), { force: true })
+  rmSync(join(PUBLIC_DIR, "robots.txt"), { force: true })
+
+  for (const path of walk(PUBLIC_DIR)) {
+    if (path.endsWith(".md")) {
+      rmSync(path, { force: true })
+    }
+  }
+}
+
+function main() {
+  console.log("Generating AI-readable docs...")
+  cleanOldMarkdown()
+
+  const pages = loadPages()
+  writePageMarkdown(pages)
+  writeLlmsTxt(pages)
+  writeLlmsFullTxt(pages)
+  writeAiTxt(pages)
+
+  console.log(`Generated llms.txt, llms-full.txt, ai.txt, and ${pages.length} page markdown files`)
+}
+
+main()

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -88,7 +88,14 @@ function routeFromSource(path: string) {
 function cleanMarkdown(body: string) {
   return body
     .replace(/^import\s+.*$/gm, "")
-    .replace(/<([A-Z][A-Za-z0-9]*)\s*\/>/g, "_Rendered component: $1._")
+    .replace(
+      /<([A-Z][A-Za-z0-9.]*)\b[^>]*>([\s\S]*?)<\/\1>/g,
+      "\n\n$2\n\n"
+    )
+    .replace(
+      /<([A-Z][A-Za-z0-9.]*)\b[^>]*\/>/g,
+      "_Rendered component: $1._"
+    )
     .replace(/\n{3,}/g, "\n\n")
     .trim()
 }


### PR DESCRIPTION
## Summary

- add AI-readable docs outputs for `/llms.txt`, `/llms-full.txt`, `/ai.txt`, and per-page Markdown files
- advertise Markdown alternatives from docs HTML and landing page metadata
- generate `robots.txt` from the docs site URL so sitemap and AI docs links follow domain config
- make docs site URL configurable with `PUBLIC_SITE_URL` while keeping a fallback constant
- centralize extension docs links in `src/lib/constants/urls.ts`

## Vercel

`vercel.json` already uses `pnpm docs:build` and `docs/dist`, so generated AI docs are created before deployment output is produced.

## Validation

- `pnpm docs:build`
- `pnpm typecheck`
- `pnpm lint:check`
- pre-commit hook: typecheck, format, lint, related tests
- pre-push hook: `pnpm test:run` (117 files, 947 tests)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds AI-readable documentation endpoints (`/llms.txt`, `/llms-full.txt`, `/ai.txt`, per-page `.md` files) generated at build time, migrates `robots.txt` to a dynamic Astro endpoint that uses the configured site URL, and centralises extension docs links into a single constants file.

- `tools/generate-llms-docs.ts` walks the docs content directory, strips MDX/JSX, and writes the AI-readable outputs into `docs/public/` before Astro runs its build.
- `docs/src/seo/constants.mjs` now resolves `SITE_URL` from `PUBLIC_SITE_URL`, Vercel system variables, or a hardcoded default, allowing the docs domain to be overridden via env without touching source files.
- `src/lib/constants/urls.ts` and `src/lib/constants-ui.ts` are updated to consume `EXTERNAL_URLS.SETUP_GUIDE` instead of the former inline hardcoded path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are build-time documentation generation and docs-site configuration with no effect on the extension runtime.

Every changed file is either a build tool, a docs layout, or a constants refactor that centralises previously duplicated hardcoded strings. The extension's runtime behaviour is untouched. The two data-quality gaps in the Markdown generator (YAML block scalars, nested JSX) affect only the AI-readable docs output and both degrade gracefully rather than causing build failures or incorrect app behaviour.

tools/generate-llms-docs.ts — the frontmatter parser and JSX cleaner have two edge-case gaps worth revisiting if more complex MDX pages are added in future.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/generate-llms-docs.ts | New build-time script that generates llms.txt, llms-full.txt, ai.txt, and per-page .md files; frontmatter parser has two edge-case data-quality gaps (block scalars, nested JSX). |
| docs/src/seo/constants.mjs | Refactored to load env files and derive SITE_URL from PUBLIC_SITE_URL / VERCEL_PROJECT_PRODUCTION_URL / VERCEL_URL with a sensible default fallback; normalization handles missing protocol and trailing slashes correctly. |
| docs/src/pages/robots.txt.ts | Replaces the static robots.txt with a dynamic Astro endpoint that embeds the configured SITE_URL in the Sitemap directive and enumerates common AI crawler user-agents. |
| src/lib/constants/urls.ts | Centralises extension docs URLs; SETUP_GUIDE path updated to /guides/provider-setup/ (redirect confirmed by developer in prior thread). |
| docs/src/layouts/BaseLayout.astro | Adds alternate link to /llms.txt on the landing page; uses a root-relative path which resolves correctly in practice. |
| .gitignore | Correctly ignores all build-time generated outputs (llms.txt, llms-full.txt, ai.txt, docs/public/**/*.md). |
| package.json | docs:generate script extended to run generate-llms-docs.ts after generate-docs.ts, ensuring AI docs are produced before the Astro build. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant pkg as pnpm docs:build
    participant gen1 as generate-docs.ts
    participant gen2 as generate-llms-docs.ts
    participant astro as Astro Build
    participant dist as docs/dist/

    pkg->>gen1: npx tsx generate-docs.ts
    gen1-->>pkg: provider-matrix.md, changelog.md …
    pkg->>gen2: npx tsx generate-llms-docs.ts
    gen2->>gen2: cleanOldMarkdown()
    gen2->>gen2: loadPages() — walk + parseFrontmatter + cleanMarkdown
    gen2-->>pkg: docs/public/llms.txt
    gen2-->>pkg: docs/public/llms-full.txt
    gen2-->>pkg: docs/public/ai.txt
    gen2-->>pkg: docs/public/slug.md (per page)
    pkg->>astro: pnpm --dir docs build
    astro->>astro: compile robots.txt.ts → robots.txt
    astro-->>dist: dist/ (HTML + static assets + AI docs)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atools%2Fgenerate-llms-docs.ts%3A70-77%0A**YAML%20block-scalar%20values%20stored%20as%20%60%7C%60%20or%20%60%3E%60**%0A%0AThe%20field%20regex%20%60%2F%5E%28%5BA-Za-z0-9_-%5D%2B%29%3A%5Cs*%28.*%29%24%2F%60%20captures%20only%20the%20indicator%20character%20when%20a%20frontmatter%20field%20uses%20a%20YAML%20block%20scalar%2C%20e.g.%20%60description%3A%20%7C%60.%20The%20%60Map%60%20then%20stores%20the%20literal%20%60%7C%60%20%28a%20truthy%20string%29%2C%20so%20%60data.get%28%22description%22%29%20%7C%7C%20SITE_DESCRIPTION%60%20returns%20%60%7C%60%20rather%20than%20falling%20back%20to%20the%20site-wide%20description%20or%20reading%20the%20actual%20content.%20Any%20docs%20page%20that%20writes%20a%20multi-line%20description%20with%20a%20block%20scalar%20will%20emit%20%60%7C%60%20as%20the%20page%20description%20in%20%60llms.txt%60%2C%20%60llms-full.txt%60%2C%20and%20the%20individual%20%60.md%60%20files.%0A%0A%23%23%23%20Issue%202%20of%202%0Atools%2Fgenerate-llms-docs.ts%3A88-101%0A**Nested%20MDX%20components%20leave%20inner%20tags%20in%20generated%20Markdown**%0A%0AThe%20outer-tag%20replacement%20%60%2F%3C%28%5BA-Z%5D%E2%80%A6%29%5Cb%5B%5E%3E%5D*%3E%28%5B%5Cs%5CS%5D*%3F%29%3C%5C%2F%5C1%3E%2Fg%60%20uses%20a%20backreference%20to%20match%20the%20correct%20closing%20tag%2C%20so%20%60%3CTabs%3E%E2%80%A6%3C%2FTabs%3E%60%20is%20handled%20correctly.%20However%2C%20the%20substitution%20emits%20%60%242%60%20verbatim%2C%20which%20still%20contains%20the%20inner%20%60%3CTab%3EContent%3C%2FTab%3E%60%20nodes%20%E2%80%94%20those%20inner%20tags%20are%20not%20processed%20by%20the%20same%20%60g%60-flagged%20pass%20because%20it%20has%20already%20advanced%20past%20the%20outer%20match.%20The%20second%20replacement%20%28self-closing%29%20only%20targets%20%60%2F%3E%60-terminated%20tags%20and%20doesn't%20catch%20them%20either.%20Any%20docs%20page%20with%20nested%20compound%20components%20%28e.g.%2C%20%60%3CTabs%3E%2F%3CTab%3E%60%2C%20%60%3CSteps%3E%2F%3CStep%3E%60%29%20will%20emit%20raw%20JSX%20opening%2Fclosing%20tags%20into%20the%20AI-readable%20output.%0A%0A&repo=shishir435%2Follama-client&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2Fai-docs-markdown%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fai-docs-markdown%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atools%2Fgenerate-llms-docs.ts%3A70-77%0A**YAML%20block-scalar%20values%20stored%20as%20%60%7C%60%20or%20%60%3E%60**%0A%0AThe%20field%20regex%20%60%2F%5E%28%5BA-Za-z0-9_-%5D%2B%29%3A%5Cs*%28.*%29%24%2F%60%20captures%20only%20the%20indicator%20character%20when%20a%20frontmatter%20field%20uses%20a%20YAML%20block%20scalar%2C%20e.g.%20%60description%3A%20%7C%60.%20The%20%60Map%60%20then%20stores%20the%20literal%20%60%7C%60%20%28a%20truthy%20string%29%2C%20so%20%60data.get%28%22description%22%29%20%7C%7C%20SITE_DESCRIPTION%60%20returns%20%60%7C%60%20rather%20than%20falling%20back%20to%20the%20site-wide%20description%20or%20reading%20the%20actual%20content.%20Any%20docs%20page%20that%20writes%20a%20multi-line%20description%20with%20a%20block%20scalar%20will%20emit%20%60%7C%60%20as%20the%20page%20description%20in%20%60llms.txt%60%2C%20%60llms-full.txt%60%2C%20and%20the%20individual%20%60.md%60%20files.%0A%0A%23%23%23%20Issue%202%20of%202%0Atools%2Fgenerate-llms-docs.ts%3A88-101%0A**Nested%20MDX%20components%20leave%20inner%20tags%20in%20generated%20Markdown**%0A%0AThe%20outer-tag%20replacement%20%60%2F%3C%28%5BA-Z%5D%E2%80%A6%29%5Cb%5B%5E%3E%5D*%3E%28%5B%5Cs%5CS%5D*%3F%29%3C%5C%2F%5C1%3E%2Fg%60%20uses%20a%20backreference%20to%20match%20the%20correct%20closing%20tag%2C%20so%20%60%3CTabs%3E%E2%80%A6%3C%2FTabs%3E%60%20is%20handled%20correctly.%20However%2C%20the%20substitution%20emits%20%60%242%60%20verbatim%2C%20which%20still%20contains%20the%20inner%20%60%3CTab%3EContent%3C%2FTab%3E%60%20nodes%20%E2%80%94%20those%20inner%20tags%20are%20not%20processed%20by%20the%20same%20%60g%60-flagged%20pass%20because%20it%20has%20already%20advanced%20past%20the%20outer%20match.%20The%20second%20replacement%20%28self-closing%29%20only%20targets%20%60%2F%3E%60-terminated%20tags%20and%20doesn't%20catch%20them%20either.%20Any%20docs%20page%20with%20nested%20compound%20components%20%28e.g.%2C%20%60%3CTabs%3E%2F%3CTab%3E%60%2C%20%60%3CSteps%3E%2F%3CStep%3E%60%29%20will%20emit%20raw%20JSX%20opening%2Fclosing%20tags%20into%20the%20AI-readable%20output.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix mdx cleanup for ai docs"](https://github.com/shishir435/ollama-client/commit/8128928fbd6d124639f3fc3eafc4a2c9752b6a83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35180779)</sub>

<!-- /greptile_comment -->