### PR TITLE
Feature/error handling consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2026-06-02
+### Added
+- Standardized error handling across all background handlers, providers, and storage layers with typed error envelopes and centralized `error-handler.ts`.
+- Improved user-facing error display with guidance text mapped to common failure modes (connection refused, model not found, auth errors, etc.).
+
+### Fixed
+- System prompt now autosaves on change;
+- Astro docs BaseLayout: replaced invalid Tailwind v4 `supports-[backdrop-filter]` syntax with standard `supports-backdrop-filter`.
+- Theme toggle button on mobile screens: switched from duplicate `id` attributes to `data-theme-toggle` + `querySelectorAll` so multiple toggle instances work correctly.
+
 ## [0.7.2] - 2026-06-01
 ### Fixed
 - YouTube watch pages now extract only the video title and transcript instead of falling back to generic page content.

--- a/docs/src/components/starlight/ThemeSelect.astro
+++ b/docs/src/components/starlight/ThemeSelect.astro
@@ -7,12 +7,12 @@
 ---
 
 <button
-  id="theme-toggle"
   class="theme-toggle-btn"
+  data-theme-toggle
   aria-label="Toggle theme"
 >
   <svg
-    id="sun-icon"
+    data-sun-icon
     style="display:none"
     width="16"
     height="16"
@@ -34,7 +34,7 @@
     <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
   </svg>
   <svg
-    id="moon-icon"
+    data-moon-icon
     width="16"
     height="16"
     viewBox="0 0 24 24"
@@ -52,20 +52,35 @@
   .theme-toggle-btn {
     display: flex;
     align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
     background: none;
     border: none;
     padding: 0;
+    border-radius: 0.375rem;
     cursor: pointer;
     color: inherit;
+  }
+
+  .theme-toggle-btn:hover {
+    background: var(--sl-color-gray-6);
   }
 </style>
 
 <script>
   const html = document.documentElement
-  const btn = document.getElementById("theme-toggle")
-  if (btn) {
-    const sun = document.getElementById("sun-icon")
-    const moon = document.getElementById("moon-icon")
+  const buttons = document.querySelectorAll("[data-theme-toggle]")
+  if (buttons.length > 0) {
+    const syncIcons = () => {
+      const isDark = resolveDark()
+      for (const button of buttons) {
+        const sun = button.querySelector("[data-sun-icon]")
+        const moon = button.querySelector("[data-moon-icon]")
+        if (sun instanceof HTMLElement) sun.style.display = isDark ? "" : "none"
+        if (moon instanceof HTMLElement) moon.style.display = isDark ? "none" : ""
+      }
+    }
 
     function resolveDark() {
       if (html.dataset.theme) return html.dataset.theme === "dark"
@@ -75,23 +90,19 @@
       return window.matchMedia("(prefers-color-scheme: dark)").matches
     }
 
-    function syncIcons() {
-      const isDark = resolveDark()
-      if (sun) sun.style.display = isDark ? "" : "none"
-      if (moon) moon.style.display = isDark ? "none" : ""
-    }
-
     syncIcons()
 
     const mo = new MutationObserver(syncIcons)
     mo.observe(html, { attributes: true, attributeFilter: ["data-theme"] })
 
-    btn.addEventListener("click", () => {
-      const isDark = resolveDark()
-      html.dataset.theme = isDark ? "light" : "dark"
-      html.classList.toggle("dark", !isDark)
-      localStorage.setItem("theme", isDark ? "light" : "dark")
-      localStorage.setItem("starlight-theme", isDark ? "light" : "dark")
-    })
+    for (const button of buttons) {
+      button.addEventListener("click", () => {
+        const isDark = resolveDark()
+        html.dataset.theme = isDark ? "light" : "dark"
+        html.classList.toggle("dark", !isDark)
+        localStorage.setItem("theme", isDark ? "light" : "dark")
+        localStorage.setItem("starlight-theme", isDark ? "light" : "dark")
+      })
+    }
   }
 </script>

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -93,7 +93,7 @@ const ogUrl = new URL(ogPath, site)
   </head>
   <body class="min-h-screen bg-background text-foreground antialiased">
     <header
-      class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-backdrop-filter:bg-background/60"
     >
       <div
         class="mx-auto flex h-14 max-w-5xl items-center justify-between px-6"

--- a/src/background/handlers/handle-context-menu.ts
+++ b/src/background/handlers/handle-context-menu.ts
@@ -6,6 +6,7 @@ import {
   MESSAGE_KEYS,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ChromeSidePanel } from "@/types"
@@ -31,7 +32,7 @@ const removeContextMenu = (id: string) => {
     if (removal && typeof removal.catch === "function") {
       return removal.catch((error) => {
         logger.debug("Context menu cleanup skipped", "initializeContextMenu", {
-          error: error instanceof Error ? error.message : String(error)
+          error: getErrorMessage(error)
         })
       })
     }
@@ -39,7 +40,7 @@ const removeContextMenu = (id: string) => {
     return Promise.resolve()
   } catch (error) {
     logger.debug("Context menu cleanup skipped", "initializeContextMenu", {
-      error: error instanceof Error ? error.message : String(error)
+      error: getErrorMessage(error)
     })
     return Promise.resolve()
   }
@@ -83,7 +84,7 @@ export const initializeContextMenu = () => {
 
         sidePanel.open(options).catch((err: unknown) => {
           logger.warn("Failed to open sidepanel", "initializeContextMenu", {
-            error: err instanceof Error ? err.message : String(err)
+            error: getErrorMessage(err)
           })
         })
       }

--- a/src/background/handlers/handle-delete-model.ts
+++ b/src/background/handlers/handle-delete-model.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import type { SendResponseFunction } from "@/types"
 
@@ -29,13 +30,9 @@ export const handleDeleteModel = async (
       })
     }
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: {
-        status: 0,
-        message: error.message || "Unknown error occurred"
-      }
-    })
+    safeSendResponse(
+      sendResponse,
+      createErrorResponse(err, { fallbackMessage: "Unknown error occurred" })
+    )
   }
 }

--- a/src/background/handlers/handle-embed-chunks.ts
+++ b/src/background/handlers/handle-embed-chunks.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { generateEmbeddingsBatch } from "@/lib/embeddings/embedding-client"
 import { storeVector } from "@/lib/embeddings/storage"
 import { logger } from "@/lib/logger"
@@ -84,12 +85,8 @@ export const handleEmbedFileChunks = async (
       )
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
     try {
-      sendResponse({
-        success: false,
-        error: { status: 500, message: errorMessage }
-      })
+      sendResponse(createErrorResponse(error, { status: 500 }))
     } catch (e) {
       logger.warn(
         "Port closed before error response sent",

--- a/src/background/handlers/handle-embedding-download.ts
+++ b/src/background/handlers/handle-embedding-download.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl } from "@/background/lib/utils"
 import {
   DEFAULT_EMBEDDING_MODEL,
@@ -6,6 +7,7 @@ import {
   normalizeEmbeddingModelName,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ChromeResponse, DefaultProviderPullRequest } from "@/types"
@@ -31,7 +33,14 @@ export const checkEmbeddingModelExists = async (
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     const timeoutPromise = new Promise<T>((_, reject) => {
       timeoutId = setTimeout(
-        () => reject(new Error(`${label} timed out`)),
+        () =>
+          reject(
+            createAppError(`${label} timed out`, {
+              kind: "network",
+              retryable: true,
+              context: "embedding-download"
+            })
+          ),
         CHECK_TIMEOUT_MS
       )
     })
@@ -352,7 +361,7 @@ export const downloadEmbeddingModelSilently = async (
     )
     return { success: true }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = getErrorMessage(error)
     logger.error(
       "Error downloading embedding model",
       "downloadEmbeddingModelSilently",
@@ -428,12 +437,6 @@ export const handlePrepareEmbeddingModel = async (
         error
       }
     )
-    sendResponse({
-      success: false,
-      error: {
-        status: 0,
-        message: error instanceof Error ? error.message : String(error)
-      }
-    })
+    sendResponse(createErrorResponse(error))
   }
 }

--- a/src/background/handlers/handle-get-loaded-model.ts
+++ b/src/background/handlers/handle-get-loaded-model.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
@@ -37,10 +38,6 @@ export const handleGetLoadedModels = async (
     }
     safeSendResponse(sendResponse, { success: true, data })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-get-models.ts
+++ b/src/background/handlers/handle-get-models.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import type { ProviderModelListResponse, SendResponseFunction } from "@/types"
 
@@ -19,10 +20,6 @@ export const handleGetModels = async (
     const data: ProviderModelListResponse = await res.json()
     safeSendResponse(sendResponse, { success: true, data })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-get-provider-version.ts
+++ b/src/background/handlers/handle-get-provider-version.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import type { SendResponseFunction } from "@/types"
 
@@ -20,10 +21,6 @@ export const handleGetProviderVersion = async (
     const data = await res.json()
     safeSendResponse(sendResponse, { success: true, data })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-model-pull.ts
+++ b/src/background/handlers/handle-model-pull.ts
@@ -4,18 +4,19 @@ import {
   clearAbortController,
   setAbortController
 } from "@/background/lib/abort-controller-registry"
+import { normalizeError } from "@/background/lib/error-handler"
 import {
   getBaseUrl,
   getPullAbortControllerKey,
   safePostMessage
 } from "@/background/lib/utils"
+import { isAbortError } from "@/lib/error-utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
 import type {
   ChromePort,
   DefaultProviderPullRequest,
   ModelPullMessage,
-  NetworkError,
   PortStatusFunction
 } from "@/types"
 
@@ -94,12 +95,11 @@ export const handleModelPull = async (
 
     await handlePullStream(res, port, isPortClosed, modelName)
   } catch (err) {
-    const error = err as NetworkError
-    if (error.name === "AbortError") {
+    if (isAbortError(err)) {
       safePostMessage(port, { error: "Download cancelled" })
     } else {
       safePostMessage(port, {
-        error: { status: 0, message: error.message || "Failed to pull model" }
+        error: normalizeError(err, { fallbackMessage: "Failed to pull model" })
       })
     }
     clearAbortController(controllerKey)

--- a/src/background/handlers/handle-scrape-model-variants.ts
+++ b/src/background/handlers/handle-scrape-model-variants.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { safeSendResponse } from "@/background/lib/utils"
 import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import type { SendResponseFunction } from "@/types"
@@ -13,10 +14,6 @@ export const handleScrapeModelVariants = async (
     const html = await res.text()
     safeSendResponse(sendResponse, { success: true, html })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-scrape-model.ts
+++ b/src/background/handlers/handle-scrape-model.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { safeSendResponse } from "@/background/lib/utils"
 import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import type { SendResponseFunction } from "@/types"
@@ -13,10 +14,6 @@ export const handleScrapeModel = async (
     const html = await res.text()
     safeSendResponse(sendResponse, { success: true, html })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-show-model-details.ts
+++ b/src/background/handlers/handle-show-model-details.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { ProviderFactory } from "@/lib/providers/factory"
 import type { SendResponseFunction } from "@/types"
 
@@ -22,10 +23,6 @@ export const handleShowModelDetails = async (
     const data = await provider.getModelDetails(model)
     sendResponse({ success: true, data })
   } catch (err) {
-    const error = err as Error
-    sendResponse({
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    sendResponse(createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-unload-model.ts
+++ b/src/background/handlers/handle-unload-model.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { getBaseUrl, safeSendResponse } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
@@ -62,10 +63,6 @@ export const handleUnloadModel = async (
 
     safeSendResponse(sendResponse, { success: wasUnloaded, data })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-update-base-url.ts
+++ b/src/background/handlers/handle-update-base-url.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { safeSendResponse } from "@/background/lib/utils"
 import { isChromiumBased } from "@/lib/browser-api"
 import type { SendResponseFunction } from "@/types"
@@ -49,10 +50,6 @@ export const handleUpdateBaseUrl = async (
 
     safeSendResponse(sendResponse, { success: true })
   } catch (err) {
-    const error = err as Error
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 0, message: error.message }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(err))
   }
 }

--- a/src/background/handlers/handle-warmup-model.ts
+++ b/src/background/handlers/handle-warmup-model.ts
@@ -1,3 +1,4 @@
+import { createErrorResponse } from "@/background/lib/error-handler"
 import { safeSendResponse } from "@/background/lib/utils"
 import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
@@ -137,12 +138,6 @@ export const handleWarmupModel = async (
     safeSendResponse(sendResponse, { success: true })
   } catch (error) {
     logger.warn("Warmup model failed", "WarmupModel", { error })
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: {
-        status: 0,
-        message: error instanceof Error ? error.message : String(error)
-      }
-    })
+    safeSendResponse(sendResponse, createErrorResponse(error))
   }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -36,6 +36,7 @@ import {
   MESSAGE_KEYS,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { runEmbeddingDimensionMigration } from "@/lib/migration/embedding-dimension-migration"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
@@ -388,7 +389,7 @@ browser.runtime.onMessage.addListener(
               success: false,
               error: {
                 status: 0,
-                message: error instanceof Error ? error.message : String(error)
+                message: getErrorMessage(error)
               }
             })
           })
@@ -481,7 +482,7 @@ browser.runtime.onMessage.addListener(
               success: false,
               error: {
                 status: 0,
-                message: error instanceof Error ? error.message : String(error)
+                message: getErrorMessage(error)
               }
             })
           })

--- a/src/background/lib/__tests__/error-handler.test.ts
+++ b/src/background/lib/__tests__/error-handler.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest"
+import { isAbortError } from "@/lib/error-utils"
+import {
+  createErrorResponse,
+  normalizeError,
+  withErrorContext
+} from "../error-handler"
+
+describe("error-handler", () => {
+  describe("normalizeError", () => {
+    it("normalizes Error objects", () => {
+      expect(normalizeError(new Error("Network down"))).toEqual({
+        status: 0,
+        message: "Network down"
+      })
+    })
+
+    it("normalizes string errors", () => {
+      expect(normalizeError("String failure")).toEqual({
+        status: 0,
+        message: "String failure"
+      })
+    })
+
+    it("uses fallback for non-error values", () => {
+      expect(
+        normalizeError(undefined, { fallbackMessage: "Fallback" })
+      ).toEqual({
+        status: 0,
+        message: "Fallback"
+      })
+    })
+
+    it("preserves status and context", () => {
+      const error = Object.assign(new Error("Bad gateway"), { status: 502 })
+
+      expect(
+        normalizeError(error, {
+          context: "handler - operation",
+          providerId: "ollama"
+        })
+      ).toEqual({
+        status: 502,
+        message: "Bad gateway",
+        context: "handler - operation",
+        providerId: "ollama"
+      })
+    })
+  })
+
+  it("creates a standard failed response", () => {
+    expect(createErrorResponse("Nope")).toEqual({
+      success: false,
+      error: {
+        status: 0,
+        message: "Nope"
+      }
+    })
+  })
+
+  it("detects abort errors without assuming an Error instance", () => {
+    expect(isAbortError(new DOMException("Stop", "AbortError"))).toBe(true)
+    expect(isAbortError({ name: "AbortError" })).toBe(true)
+    expect(isAbortError("AbortError")).toBe(false)
+  })
+
+  it("uses the standard error shape in wrapped handlers", async () => {
+    const port = {
+      name: "test-port",
+      postMessage: vi.fn()
+    } as any
+    const handler = withErrorContext(
+      async () => {
+        throw Object.assign(new Error("Provider failed"), { status: 503 })
+      },
+      {
+        handler: "testHandler",
+        operation: "test operation",
+        providerId: "ollama"
+      }
+    )
+
+    await handler({} as never, port, () => false)
+
+    expect(port.postMessage).toHaveBeenCalledWith({
+      error: {
+        status: 503,
+        message: "Provider failed",
+        context: "testHandler - test operation",
+        providerId: "ollama"
+      }
+    })
+  })
+})

--- a/src/background/lib/__tests__/error-handler.test.ts
+++ b/src/background/lib/__tests__/error-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { isAbortError } from "@/lib/error-utils"
+import { createAppError, isAbortError } from "@/lib/error-utils"
 import {
   createErrorResponse,
   normalizeError,
@@ -44,6 +44,21 @@ describe("error-handler", () => {
         message: "Bad gateway",
         context: "handler - operation",
         providerId: "ollama"
+      })
+    })
+
+    it("does not expose internal debug payloads", () => {
+      expect(
+        normalizeError(
+          createAppError("Provider failed", {
+            kind: "provider",
+            debug: "raw provider payload"
+          })
+        )
+      ).toEqual({
+        status: 0,
+        message: "Provider failed",
+        kind: "provider"
       })
     })
   })

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -1,5 +1,11 @@
+import { getErrorMessage, isAbortError, isAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import type { ChromePort, NetworkError, PortStatusFunction } from "@/types"
+import type {
+  ChromePort,
+  ChromeResponse,
+  NetworkError,
+  PortStatusFunction
+} from "@/types"
 import { clearAbortController } from "./abort-controller-registry"
 import { safePostMessage } from "./utils"
 
@@ -15,6 +21,58 @@ interface ErrorContext {
   modelId?: string
   providerId?: string
 }
+
+type ErrorEnvelope = NonNullable<ChromeResponse["error"]>
+
+type ErrorEnvelopeOptions = {
+  status?: number
+  fallbackMessage?: string
+  context?: string
+  providerId?: string
+}
+
+const DEFAULT_ERROR_MESSAGE = "An unexpected error occurred"
+
+export const normalizeError = (
+  error: unknown,
+  options: ErrorEnvelopeOptions = {}
+): ErrorEnvelope => {
+  const networkError =
+    error && typeof error === "object" ? (error as Partial<NetworkError>) : {}
+  const message = getErrorMessage(error, options.fallbackMessage).trim()
+
+  return {
+    status: options.status ?? networkError.status ?? 0,
+    message: message || options.fallbackMessage || DEFAULT_ERROR_MESSAGE,
+    ...(isAppError(error) && { kind: error.kind }),
+    ...(isAppError(error) &&
+      error.userMessage && { userMessage: error.userMessage }),
+    ...(isAppError(error) &&
+      error.retryable !== undefined && { retryable: error.retryable }),
+    ...(options.context && { context: options.context }),
+    ...(!options.context &&
+      isAppError(error) &&
+      error.context && {
+        context: error.context
+      }),
+    ...(options.providerId && { providerId: options.providerId }),
+    ...(!options.providerId &&
+      isAppError(error) &&
+      error.providerId && {
+        providerId: error.providerId
+      }),
+    ...(isAppError(error) &&
+      error.debug !== undefined && { debug: error.debug })
+  }
+}
+
+export const createErrorResponse = (
+  error: unknown,
+  options: ErrorEnvelopeOptions = {}
+): ChromeResponse => ({
+  success: false,
+  error: normalizeError(error, options)
+})
 
 /**
  * Higher-order function to wrap background message handlers with:
@@ -34,10 +92,8 @@ export const withErrorContext = <T>(
     try {
       await handler(msg, port, isPortClosed)
     } catch (err) {
-      const error = err as NetworkError
-
       // 3. Handle AbortError specifically
-      if (error.name === "AbortError") {
+      if (isAbortError(err)) {
         if (!isPortClosed()) {
           safePostMessage(port, { done: true, aborted: true })
         }
@@ -49,22 +105,24 @@ export const withErrorContext = <T>(
         `Error during ${context.operation || "operation"}`,
         context.handler,
         {
-          message: error.message,
+          message: getErrorMessage(err),
           model: context.modelId,
           provider: context.providerId,
-          stack: error.stack
+          stack: err instanceof Error ? err.stack : undefined
         }
       )
 
       if (!isPortClosed()) {
-        safePostMessage(port, {
-          error: {
-            status: error.status ?? 500,
-            message: error.message || "An unexpected error occurred",
-            context: `${context.handler}${context.operation ? ` - ${context.operation}` : ""}`,
-            providerId: context.providerId
-          }
+        const response = createErrorResponse(err, {
+          status:
+            err && typeof err === "object" && "status" in err
+              ? ((err as Partial<NetworkError>).status ?? 500)
+              : 500,
+          fallbackMessage: DEFAULT_ERROR_MESSAGE,
+          context: `${context.handler}${context.operation ? ` - ${context.operation}` : ""}`,
+          providerId: context.providerId
         })
+        safePostMessage(port, { error: response.error })
       }
     } finally {
       // 5. Cleanup

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -31,8 +31,6 @@ type ErrorEnvelopeOptions = {
   providerId?: string
 }
 
-const DEFAULT_ERROR_MESSAGE = "An unexpected error occurred"
-
 export const normalizeError = (
   error: unknown,
   options: ErrorEnvelopeOptions = {}
@@ -43,7 +41,7 @@ export const normalizeError = (
 
   return {
     status: options.status ?? networkError.status ?? 0,
-    message: message || options.fallbackMessage || DEFAULT_ERROR_MESSAGE,
+    message,
     ...(isAppError(error) && { kind: error.kind }),
     ...(isAppError(error) &&
       error.userMessage && { userMessage: error.userMessage }),
@@ -60,9 +58,7 @@ export const normalizeError = (
       isAppError(error) &&
       error.providerId && {
         providerId: error.providerId
-      }),
-    ...(isAppError(error) &&
-      error.debug !== undefined && { debug: error.debug })
+      })
   }
 }
 
@@ -118,7 +114,6 @@ export const withErrorContext = <T>(
             err && typeof err === "object" && "status" in err
               ? ((err as Partial<NetworkError>).status ?? 500)
               : 500,
-          fallbackMessage: DEFAULT_ERROR_MESSAGE,
           context: `${context.handler}${context.operation ? ` - ${context.operation}` : ""}`,
           providerId: context.providerId
         })

--- a/src/background/lib/process-stream-chunk.ts
+++ b/src/background/lib/process-stream-chunk.ts
@@ -1,4 +1,5 @@
 import { safePostMessage } from "@/background/lib/utils"
+import { isNamedError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type {
   ChromePort,
@@ -57,13 +58,12 @@ export const processStreamChunk = (
         })
         return { buffer, fullText, isDone: true }
       }
-    } catch (err) {
-      const error = err as Error
+    } catch (error) {
       logger.warn("Failed to parse chunk line", "processStreamChunk", {
         error,
         line: trimmedLine
       })
-      if (error.name === "SyntaxError") {
+      if (isNamedError(error, "SyntaxError")) {
         logger.warn(
           "Multiple parse errors detected, connection may be corrupted",
           "processStreamChunk"

--- a/src/background/lib/selection-bridge.ts
+++ b/src/background/lib/selection-bridge.ts
@@ -1,4 +1,5 @@
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { ChromePort } from "@/types"
 
@@ -27,7 +28,7 @@ export const postSelectionToSidePanels = (selectionText: string) => {
       logger.warn(
         "Failed to post selection to side panel port",
         "SelectionBridge",
-        { error: error instanceof Error ? error.message : String(error) }
+        { error: getErrorMessage(error) }
       )
       selectionBridgePorts.delete(port)
     }

--- a/src/features/chat/components/chat-backfill-panel.tsx
+++ b/src/features/chat/components/chat-backfill-panel.tsx
@@ -8,6 +8,7 @@ import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messa
 import { getEmbeddableMessagesBySession } from "@/features/chat/utils/embedding-backfill"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { STORAGE_KEYS } from "@/lib/constants"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import { AlertCircle, Loader2, Sparkles } from "@/lib/lucide-icon"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
@@ -52,8 +53,7 @@ export const ChatBackfillPanel = () => {
 
       setCompleted(true)
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Backfill failed"
+      const errorMessage = getDisplayErrorMessage(err, "Backfill failed")
       setError(errorMessage)
       logger.error("Backfill error", "ChatBackfillPanel", { error: err })
     } finally {

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -6,6 +6,8 @@ import { logger } from "@/lib/logger"
 import type { UseChatStreamProps } from "../use-chat-stream"
 import { useChatStream } from "../use-chat-stream"
 
+const mockToast = vi.hoisted(() => vi.fn())
+
 // Mock browser API
 vi.mock("@/lib/browser-api", () => ({
   browser: {
@@ -22,6 +24,10 @@ vi.mock("@/lib/logger", () => ({
     warn: vi.fn(),
     error: vi.fn()
   }
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast })
 }))
 
 describe("useChatStream", () => {
@@ -178,6 +184,42 @@ describe("useChatStream", () => {
     expect(setIsLoading).toHaveBeenCalledWith(false)
     expect(setIsStreaming).toHaveBeenCalledWith(false)
     expect(mockPort.disconnect).toHaveBeenCalled()
+  })
+
+  it("should show typed provider errors with guidance", () => {
+    const { result } = renderHook(() =>
+      useChatStream({
+        setMessages,
+        setIsLoading,
+        setIsStreaming
+      })
+    )
+
+    const messages = [{ role: "user" as const, content: "Hello" }]
+
+    act(() => {
+      result.current.startStream({ model: "llama2", messages })
+    })
+
+    const listener = mockPort.onMessage.addListener.mock.calls[0][0]
+
+    act(() => {
+      listener({
+        error: {
+          status: 500,
+          kind: "provider",
+          message: "Provider failed",
+          retryable: true
+        }
+      })
+    })
+
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "Provider error",
+      description:
+        "Provider failed. Check the selected provider, model, and provider logs. This may be temporary; try again."
+    })
   })
 
   it("should stop stream correctly", () => {

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -4,6 +4,10 @@ import { useToast } from "@/hooks/use-toast"
 
 import { browser } from "@/lib/browser-api"
 import { ERROR_MESSAGES, MESSAGE_KEYS } from "@/lib/constants"
+import {
+  formatErrorForDisplay,
+  getDisplayErrorMessage
+} from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import type { ChatMessage } from "@/types"
 
@@ -36,6 +40,12 @@ interface StreamMessage {
   error?: {
     status: number
     message: string
+    kind?: import("@/types/errors").AppErrorKind
+    userMessage?: string
+    retryable?: boolean
+    context?: string
+    providerId?: string
+    debug?: unknown
   }
   aborted?: boolean
   metrics?: Record<string, unknown>
@@ -265,10 +275,16 @@ export const useChatStream = ({
         let finalMessages: ChatMessage[]
 
         if (msg.error) {
+          const displayError = formatErrorForDisplay(
+            msg.error,
+            t("chat.errors.unknown_error_description")
+          )
           const errMsg =
+            msg.error.userMessage ??
             ERROR_MESSAGES[msg.error.status] ??
             t("chat.errors.unknown_error", {
-              message: msg.error.message || t("chat.errors.no_message")
+              message:
+                getDisplayErrorMessage(msg.error) || t("chat.errors.no_message")
             })
           finalMessages = [
             ...currentMessagesRef.current.slice(0, -1),
@@ -276,9 +292,10 @@ export const useChatStream = ({
           ]
           toast({
             variant: "destructive",
-            title: t("chat.errors.response_failed_title"),
-            description:
-              msg.error.message || t("chat.errors.unknown_error_description")
+            title: displayError.kind
+              ? displayError.title
+              : t("chat.errors.response_failed_title"),
+            description: displayError.message
           })
         } else {
           finalMessages = [

--- a/src/features/chat/hooks/use-semantic-chat-search.ts
+++ b/src/features/chat/hooks/use-semantic-chat-search.ts
@@ -6,6 +6,8 @@ import { ensureKeywordIndexBuilt } from "@/lib/embeddings/auto-index"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
 import { searchHybrid } from "@/lib/embeddings/vector-store"
+import { getDisplayErrorMessage } from "@/lib/error-display"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
@@ -52,7 +54,7 @@ export const useSemanticChatSearch = () => {
         const embeddingResult = await generateEmbedding(query.trim())
 
         if ("error" in embeddingResult) {
-          throw new Error(embeddingResult.error)
+          throw createAppError(embeddingResult.error, { kind: "provider" })
         }
 
         // Get search options from config or provided options
@@ -102,8 +104,7 @@ export const useSemanticChatSearch = () => {
 
         return chatResults
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : "Search failed"
+        const errorMessage = getDisplayErrorMessage(err, "Search failed")
         setError(errorMessage)
         logger.error("Semantic search error", "useSemanticChatSearch", {
           error: err

--- a/src/features/context/components/context-settings.tsx
+++ b/src/features/context/components/context-settings.tsx
@@ -41,6 +41,7 @@ import {
   getStorageStats,
   removeDuplicateVectors
 } from "@/lib/embeddings/vector-store"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import {
   AlertTriangle,
@@ -243,8 +244,10 @@ export const ContextSettings = () => {
       setRebuildComplete(true)
       await loadStats()
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to rebuild embeddings"
+      const message = getDisplayErrorMessage(
+        error,
+        "Failed to rebuild embeddings"
+      )
       logger.error("Failed to rebuild embeddings", "ContextSettings", { error })
       setRebuildError(message)
     } finally {

--- a/src/features/file-upload/hooks/use-file-search.ts
+++ b/src/features/file-upload/hooks/use-file-search.ts
@@ -5,6 +5,8 @@ import { STORAGE_KEYS } from "@/lib/constants"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
 import { searchSimilarVectors } from "@/lib/embeddings/vector-store"
+import { getDisplayErrorMessage } from "@/lib/error-display"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
@@ -52,7 +54,7 @@ export const useFileSearch = () => {
         const embeddingResult = await generateEmbedding(query.trim())
 
         if ("error" in embeddingResult) {
-          throw new Error(embeddingResult.error)
+          throw createAppError(embeddingResult.error, { kind: "provider" })
         }
 
         // Get search options
@@ -87,8 +89,7 @@ export const useFileSearch = () => {
 
         return fileResults
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : "Search failed"
+        const errorMessage = getDisplayErrorMessage(err, "Search failed")
         setError(errorMessage)
         logger.error("File search error", "useFileSearch", { error: err })
         return []

--- a/src/features/file-upload/hooks/use-file-upload.ts
+++ b/src/features/file-upload/hooks/use-file-upload.ts
@@ -8,6 +8,7 @@ import {
   STORAGE_KEYS
 } from "@/lib/constants"
 import { chunkTextAsync } from "@/lib/embeddings/chunker"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { isFileTypeSupported, processFile } from "@/lib/file-processors"
 import type {
   FileProcessingState,
@@ -429,8 +430,7 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
             onFileProcessed(result)
           }
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : "Unknown error"
+          const errorMessage = getDisplayErrorMessage(error, "Unknown error")
           setProcessingStates((prev) => {
             const next = new Map(prev)
             next.set(file, {

--- a/src/features/file-upload/processors/csv-processor.ts
+++ b/src/features/file-upload/processors/csv-processor.ts
@@ -1,3 +1,4 @@
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 import { CsvLoader } from "@/lib/loaders/csv-loader"
 
@@ -56,9 +57,11 @@ export class CsvProcessor implements FileProcessor {
         }
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
-      throw new Error(`Failed to process CSV file: ${errorMessage}`)
+      const errorMessage = getErrorMessage(error, "Unknown error")
+      throw createAppError(`Failed to process CSV file: ${errorMessage}`, {
+        kind: "validation",
+        cause: error
+      })
     }
   }
 

--- a/src/features/file-upload/processors/docx-processor.ts
+++ b/src/features/file-upload/processors/docx-processor.ts
@@ -1,3 +1,4 @@
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 
 // Lazy load mammoth to reduce initial bundle size
@@ -49,9 +50,11 @@ export class DocxProcessor implements FileProcessor {
         }
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
-      throw new Error(`Failed to process DOCX: ${errorMessage}`)
+      const errorMessage = getErrorMessage(error, "Unknown error")
+      throw createAppError(`Failed to process DOCX: ${errorMessage}`, {
+        kind: "validation",
+        cause: error
+      })
     }
   }
 

--- a/src/features/file-upload/processors/html-processor.ts
+++ b/src/features/file-upload/processors/html-processor.ts
@@ -1,3 +1,4 @@
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 import { HtmlLoader } from "@/lib/loaders/html-loader"
 
@@ -49,9 +50,11 @@ export class HtmlProcessor implements FileProcessor {
         }
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
-      throw new Error(`Failed to process HTML file: ${errorMessage}`)
+      const errorMessage = getErrorMessage(error, "Unknown error")
+      throw createAppError(`Failed to process HTML file: ${errorMessage}`, {
+        kind: "validation",
+        cause: error
+      })
     }
   }
 

--- a/src/features/file-upload/processors/pdf-processor.ts
+++ b/src/features/file-upload/processors/pdf-processor.ts
@@ -1,3 +1,4 @@
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 import { logger } from "@/lib/logger"
 
@@ -83,9 +84,11 @@ export class PdfProcessor implements FileProcessor {
         }
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
-      throw new Error(`Failed to process PDF: ${errorMessage}`)
+      const errorMessage = getErrorMessage(error, "Unknown error")
+      throw createAppError(`Failed to process PDF: ${errorMessage}`, {
+        kind: "validation",
+        cause: error
+      })
     }
   }
 

--- a/src/features/file-upload/processors/text-processor.ts
+++ b/src/features/file-upload/processors/text-processor.ts
@@ -1,3 +1,4 @@
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 
 const BINARY_EXTENSIONS = [
@@ -83,9 +84,11 @@ export class TextProcessor implements FileProcessor {
         }
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
-      throw new Error(`Failed to process text file: ${errorMessage}`)
+      const errorMessage = getErrorMessage(error, "Unknown error")
+      throw createAppError(`Failed to process text file: ${errorMessage}`, {
+        kind: "validation",
+        cause: error
+      })
     }
   }
 

--- a/src/features/knowledge/components/data-migration-settings.tsx
+++ b/src/features/knowledge/components/data-migration-settings.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
 import { backupService, type ImportResult } from "@/lib/backup-service"
 import { MESSAGE_KEYS } from "@/lib/constants/keys"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { formatBackupFilenameTimestamp } from "@/lib/format-utils"
 import { logger } from "@/lib/logger"
 import {
@@ -58,8 +59,7 @@ export const DataMigrationSettings = () => {
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error"
+      const errorMessage = getDisplayErrorMessage(error, "Unknown error")
       toast({
         title: t("settings.migration.export.error_title"),
         description: errorMessage,
@@ -97,7 +97,7 @@ export const DataMigrationSettings = () => {
       setImportResult({
         syncStorage: {
           ok: false,
-          error: error instanceof Error ? error.message : "Unknown error"
+          error: getDisplayErrorMessage(error, "Unknown error")
         },
         localStorage: {
           ok: false,

--- a/src/features/model/components/__tests__/model-settings-form.test.tsx
+++ b/src/features/model/components/__tests__/model-settings-form.test.tsx
@@ -70,22 +70,6 @@ describe("ModelSettingsForm", () => {
     })
   })
 
-  it("saves system prompt edits when the explicit save button is clicked", () => {
-    render(<ModelSettingsForm />)
-    const prompt = screen.getByLabelText(
-      "settings.model.system.prompt_label"
-    ) as HTMLTextAreaElement
-
-    fireEvent.change(prompt, {
-      target: { value: "Always answer in one sentence." }
-    })
-    fireEvent.click(screen.getByRole("button", { name: /common.save/i }))
-
-    expect(updateConfig).toHaveBeenCalledWith({
-      system: "Always answer in one sentence."
-    })
-  })
-
   it("saves system prompt edits on blur", () => {
     render(<ModelSettingsForm />)
     const prompt = screen.getByLabelText(

--- a/src/features/model/components/__tests__/model-system-section.test.tsx
+++ b/src/features/model/components/__tests__/model-system-section.test.tsx
@@ -58,15 +58,6 @@ describe("ModelSystemSection", () => {
     )
   })
 
-  it("exposes an explicit save action for system prompt edits", () => {
-    const onSave = vi.fn()
-    renderSection({ onSave })
-
-    fireEvent.click(screen.getByRole("button", { name: /common.save/i }))
-
-    expect(onSave).toHaveBeenCalledTimes(1)
-  })
-
   it("exposes a reset-to-default action for the system prompt", () => {
     const onResetSystemPrompt = vi.fn()
     renderSection({ onResetSystemPrompt })

--- a/src/features/model/components/embedding-config/embedding-test-generation.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-generation.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { SettingsCard } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
-import { getErrorMessage } from "@/lib/error-utils"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { Loader2, Sparkles } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
@@ -29,7 +29,7 @@ export const EmbeddingTestGeneration = ({
       const embeddingResult = await generateEmbedding(testText)
 
       if ("error" in embeddingResult) {
-        setResult(`Error: ${embeddingResult.error}`)
+        setResult(`Error: ${getDisplayErrorMessage(embeddingResult.error)}`)
         return
       }
 
@@ -37,7 +37,7 @@ export const EmbeddingTestGeneration = ({
         `✅ Success! Embedding generated (${embeddingResult.embedding.length}D).`
       )
     } catch (error) {
-      setResult(`Error: ${getErrorMessage(error)}`)
+      setResult(`Error: ${getDisplayErrorMessage(error)}`)
     } finally {
       setIsTesting(false)
     }

--- a/src/features/model/components/embedding-config/embedding-test-generation.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-generation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { SettingsCard } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
+import { getErrorMessage } from "@/lib/error-utils"
 import { Loader2, Sparkles } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
@@ -36,9 +37,7 @@ export const EmbeddingTestGeneration = ({
         `✅ Success! Embedding generated (${embeddingResult.embedding.length}D).`
       )
     } catch (error) {
-      setResult(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
-      )
+      setResult(`Error: ${getErrorMessage(error)}`)
     } finally {
       setIsTesting(false)
     }

--- a/src/features/model/components/embedding-status-indicator.tsx
+++ b/src/features/model/components/embedding-status-indicator.tsx
@@ -20,6 +20,7 @@ import {
   normalizeEmbeddingModelName,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import {
   AlertTriangle,
@@ -106,11 +107,11 @@ export const EmbeddingStatusIndicator = () => {
       } else {
         setModelExists(false)
         if (resp?.error) {
-          setError(resp.error.message || "Unknown error")
+          setError(getDisplayErrorMessage(resp.error, "Unknown error"))
         }
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getDisplayErrorMessage(err, "Unknown error")
       logger.warn("Check failed", "EmbeddingStatusIndicator", {
         model: modelName,
         providerId,

--- a/src/features/model/components/model-system-section.tsx
+++ b/src/features/model/components/model-system-section.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import type { ProviderModelConfig } from "@/features/model/hooks/use-model-config"
-import { Check, MessageSquare, RotateCcw, StopCircle } from "@/lib/lucide-icon"
+import { MessageSquare, RotateCcw, StopCircle } from "@/lib/lucide-icon"
 
 export interface ModelSystemSectionProps {
   config: ProviderModelConfig
@@ -58,10 +58,6 @@ export const ModelSystemSection = ({
           className="min-h-25 resize-none"
         />
         <SettingsActionRow>
-          <Button type="button" variant="outline" onClick={onSave}>
-            <Check className="mr-0.5 size-3" />
-            {t("common.save")}
-          </Button>
           <Button type="button" variant="ghost" onClick={onResetSystemPrompt}>
             <RotateCcw className="mr-0.5 size-3" />
             {t("settings.prompts.reset")}

--- a/src/features/model/components/provider-settings.tsx
+++ b/src/features/model/components/provider-settings.tsx
@@ -37,6 +37,7 @@ import { ProviderGrid } from "@/features/model/components/provider-grid"
 import { useProviderHealth } from "@/features/model/hooks/use-provider-health"
 import { toast } from "@/hooks/use-toast"
 import { DEFAULT_PROVIDER_ID } from "@/lib/constants"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { DEFAULT_PROVIDERS, ProviderManager } from "@/lib/providers/manager"
@@ -199,8 +200,7 @@ export const ProviderSettings = () => {
       })
     } catch (error: unknown) {
       logger.error("Connection test failed", "ProviderSettings", { error })
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to connect"
+      const errorMessage = getDisplayErrorMessage(error, "Failed to connect")
       const shouldShowCspHint =
         errorMessage.toLowerCase().includes("failed to fetch") &&
         Boolean(cspCompatibilityHint)

--- a/src/features/model/hooks/__tests__/use-model-pull.test.ts
+++ b/src/features/model/hooks/__tests__/use-model-pull.test.ts
@@ -101,6 +101,32 @@ describe("useModelPull", () => {
     expect(result.current.pullingModel).toBeNull()
   })
 
+  it("should show provider guidance for typed pull errors", () => {
+    const { result } = renderHook(() => useModelPull())
+
+    act(() => {
+      result.current.pullModel("llama2")
+    })
+
+    const listener = mockPort.onMessage.addListener.mock.calls[0][0]
+
+    act(() => {
+      listener({
+        error: {
+          status: 500,
+          kind: "provider",
+          message: "Pull failed",
+          retryable: true
+        }
+      })
+    })
+
+    expect(result.current.progress).toBe(
+      "❌ Failed: Pull failed. Check the selected provider, model, and provider logs. This may be temporary; try again."
+    )
+    expect(result.current.pullingModel).toBeNull()
+  })
+
   it("should cancel pull", () => {
     const { result } = renderHook(() => useModelPull())
 

--- a/src/features/model/hooks/use-model-info.ts
+++ b/src/features/model/hooks/use-model-info.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { queryKeys } from "@/lib/query-keys"
 import type { ChromeResponse, ProviderModelDetails } from "@/types"
@@ -24,7 +25,13 @@ export const useModelInfo = (model: string, providerId?: string) => {
       })) as ChromeResponse & { data?: ProviderModelDetails }
 
       if (!res?.success) {
-        throw new Error("Failed to fetch model info")
+        throw createAppError(
+          res?.error?.message || "Failed to fetch model info",
+          {
+            kind: "provider",
+            cause: res?.error
+          }
+        )
       }
 
       return res.data ?? null

--- a/src/features/model/hooks/use-model-library-search.ts
+++ b/src/features/model/hooks/use-model-library-search.ts
@@ -3,6 +3,8 @@ import { useState } from "react"
 
 import { browser } from "@/lib/browser-api"
 import { DEFAULT_MODEL_LIBRARY_BASE_URL, MESSAGE_KEYS } from "@/lib/constants"
+import { getDisplayErrorMessage } from "@/lib/error-display"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { queryKeys } from "@/lib/query-keys"
 import type { ChromeResponse } from "@/types"
@@ -23,7 +25,14 @@ const fetchSearchResults = async (query: string): Promise<ModelMeta[]> => {
   })) as ChromeResponse & { html?: string }
 
   if (res.error || !res.success || !res.html) {
-    throw new Error(res.error?.message || "Failed to fetch search results")
+    throw createAppError(
+      getDisplayErrorMessage(res.error, "Failed to fetch search results"),
+      {
+        kind: "provider",
+        retryable: true,
+        cause: res.error
+      }
+    )
   }
 
   const parser = new DOMParser()
@@ -56,7 +65,14 @@ const fetchModelVariants = async (modelName: string): Promise<string[]> => {
   })) as ChromeResponse & { html?: string }
 
   if (res.error || !res.success || !res.html) {
-    throw new Error(res.error?.message || "Failed to fetch model variants")
+    throw createAppError(
+      getDisplayErrorMessage(res.error, "Failed to fetch model variants"),
+      {
+        kind: "provider",
+        retryable: true,
+        cause: res.error
+      }
+    )
   }
 
   const parser = new DOMParser()

--- a/src/features/model/hooks/use-model-pull.ts
+++ b/src/features/model/hooks/use-model-pull.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { formatErrorForDisplay } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import type { PullStreamMessage } from "@/types"
 
@@ -36,10 +37,7 @@ export const useModelPull = () => {
         port.disconnect()
       }
       if (message.error) {
-        const errorMessage =
-          typeof message.error === "string"
-            ? message.error
-            : message.error.message
+        const errorMessage = formatErrorForDisplay(message.error).message
         setProgress(`❌ Failed: ${errorMessage}`)
         setPullingModel(null)
         port.disconnect()

--- a/src/features/model/hooks/use-provider-models.ts
+++ b/src/features/model/hooks/use-provider-models.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 
 import { DEFAULT_PROVIDER_ID, STORAGE_KEYS } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
@@ -108,19 +109,31 @@ const fetchAllProviderModels = async (): Promise<ProviderModel[]> => {
 const fetchProviderVersion = async (providerId: string): Promise<string> => {
   const provider = await ProviderFactory.getProvider(providerId)
   if (!provider.capabilities.providerVersion) {
-    throw new Error("Version endpoint is not supported by this provider")
+    throw createAppError("Version endpoint is not supported by this provider", {
+      kind: "provider"
+    })
   }
 
   const baseUrl = provider.config.baseUrl || "http://localhost:11434"
 
   if (provider.id === ProviderId.OLLAMA) {
     const response = await fetch(`${baseUrl}/api/version`)
-    if (!response.ok) throw new Error("Failed to fetch version")
+    if (!response.ok) {
+      throw createAppError("Failed to fetch version", {
+        kind: "network",
+        retryable: true
+      })
+    }
     const data = await response.json()
     return data.version as string
   }
 
-  throw new Error("Version endpoint is not implemented for this provider")
+  throw createAppError(
+    "Version endpoint is not implemented for this provider",
+    {
+      kind: "provider"
+    }
+  )
 }
 
 /**
@@ -293,7 +306,9 @@ export const useProviderModels = () => {
 
       const provider = await ProviderFactory.getProvider(providerId)
       if (!provider.capabilities.modelDelete) {
-        throw new Error("Model delete is not supported by this provider")
+        throw createAppError("Model delete is not supported by this provider", {
+          kind: "provider"
+        })
       }
 
       if (provider.id === DEFAULT_PROVIDER_ID) {
@@ -303,12 +318,20 @@ export const useProviderModels = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name: modelName })
         })
-        if (!response.ok) throw new Error("Failed to delete model")
+        if (!response.ok) {
+          throw createAppError("Failed to delete model", {
+            kind: "network",
+            retryable: true
+          })
+        }
         return
       }
 
-      throw new Error(
-        "Model delete endpoint is not configured for this provider"
+      throw createAppError(
+        "Model delete endpoint is not configured for this provider",
+        {
+          kind: "provider"
+        }
       )
     },
     onSuccess: () => {

--- a/src/features/tabs/hooks/use-tab-contents.ts
+++ b/src/features/tabs/hooks/use-tab-contents.ts
@@ -5,6 +5,7 @@ import { useOpenTabs } from "@/features/tabs/hooks/use-open-tab"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { getDisplayErrorMessage } from "@/lib/error-display"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ChromeResponse } from "@/types"
 
@@ -85,7 +86,7 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
         }
       }))
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err)
+      const errorMessage = getDisplayErrorMessage(err)
       setErrors((prev) => ({ ...prev, [tabId]: errorMessage }))
       set((s) => {
         const newLoading = { ...s.loadingIds }

--- a/src/lib/__tests__/error-display.test.ts
+++ b/src/lib/__tests__/error-display.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { formatErrorForDisplay, getDisplayErrorMessage } from "../error-display"
+import { createAppError } from "../error-utils"
+
+describe("error-display", () => {
+  it("prefers user-facing messages from app errors", () => {
+    const error = createAppError("Raw provider payload", {
+      kind: "provider",
+      userMessage: "Provider failed",
+      retryable: true
+    })
+
+    expect(getDisplayErrorMessage(error)).toBe("Provider failed")
+    expect(formatErrorForDisplay(error)).toEqual({
+      title: "Provider error",
+      message:
+        "Provider failed. Check the selected provider, model, and provider logs. This may be temporary; try again.",
+      rawMessage: "Provider failed",
+      kind: "provider",
+      retryable: true
+    })
+  })
+
+  it("formats response envelopes", () => {
+    expect(
+      formatErrorForDisplay({
+        status: 0,
+        kind: "network",
+        message: "Failed to fetch"
+      }).message
+    ).toBe(
+      "Failed to fetch. Check that the provider server is running and the URL is reachable."
+    )
+  })
+
+  it("keeps plain string errors unchanged", () => {
+    expect(getDisplayErrorMessage("Download cancelled")).toBe(
+      "Download cancelled"
+    )
+  })
+})

--- a/src/lib/__tests__/error-display.test.ts
+++ b/src/lib/__tests__/error-display.test.ts
@@ -38,4 +38,10 @@ describe("error-display", () => {
       "Download cancelled"
     )
   })
+
+  it("uses fallback for app errors with no displayable message", () => {
+    expect(getDisplayErrorMessage(createAppError(""), "Fallback message")).toBe(
+      "Fallback message"
+    )
+  })
 })

--- a/src/lib/__tests__/error-utils.test.ts
+++ b/src/lib/__tests__/error-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { getErrorMessage, isAbortError, isNamedError } from "../error-utils"
+
+describe("error-utils", () => {
+  it("gets messages from common error shapes", () => {
+    expect(getErrorMessage(new Error("Native error"))).toBe("Native error")
+    expect(getErrorMessage("String error")).toBe("String error")
+    expect(getErrorMessage({ message: "Object error" })).toBe("Object error")
+  })
+
+  it("uses fallback for empty or unknown values", () => {
+    expect(getErrorMessage(undefined, "Fallback")).toBe("Fallback")
+    expect(getErrorMessage("", "Fallback")).toBe("Fallback")
+    expect(getErrorMessage({}, "Fallback")).toBe("Fallback")
+  })
+
+  it("detects named errors without assuming Error instances", () => {
+    expect(isAbortError(new DOMException("Stop", "AbortError"))).toBe(true)
+    expect(isNamedError({ name: "SyntaxError" }, "SyntaxError")).toBe(true)
+    expect(isAbortError("AbortError")).toBe(false)
+  })
+})

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -3,6 +3,7 @@ import JSZip from "jszip"
 import { z } from "zod"
 import { db as chatDb } from "./db"
 import { vectorDb } from "./embeddings/db"
+import { createAppError, getErrorMessage } from "./error-utils"
 import { knowledgeDb } from "./knowledge/knowledge-sets"
 import { logger } from "./logger"
 import { exportDatabaseBytes, importDatabaseBytes } from "./sqlite/db"
@@ -110,17 +111,26 @@ export const backupService = {
       // Manifest
       const manifestFile = zip.file("manifest.json")
       if (!manifestFile) {
-        throw new Error("Missing manifest.json in backup file")
+        throw createAppError("Missing manifest.json in backup file", {
+          kind: "validation"
+        })
       }
 
       const manifestStr = await manifestFile.async("string")
       const manifestResult = safeJsonParse(manifestStr, BackupManifestSchema)
       if (!manifestResult.success) {
-        throw new Error("Invalid manifest: failed schema validation")
+        throw createAppError("Invalid manifest: failed schema validation", {
+          kind: "validation"
+        })
       }
       const manifest = manifestResult.data
       if (manifest.version !== MANIFEST_VERSION) {
-        throw new Error(`Unsupported backup version: ${manifest.version}`)
+        throw createAppError(
+          `Unsupported backup version: ${manifest.version}`,
+          {
+            kind: "validation"
+          }
+        )
       }
 
       // Sync Storage
@@ -130,7 +140,10 @@ export const backupService = {
           const syncStr = await syncFile.async("string")
           const syncResult = safeJsonParse(syncStr, StorageObjectSchema)
           if (!syncResult.success) {
-            throw new Error("Invalid sync storage: expected a JSON object")
+            throw createAppError(
+              "Invalid sync storage: expected a JSON object",
+              { kind: "validation" }
+            )
           }
           const syncData = syncResult.data
 
@@ -176,7 +189,10 @@ export const backupService = {
           const localStr = await localFile.async("string")
           const localResult = safeJsonParse(localStr, StorageObjectSchema)
           if (!localResult.success) {
-            throw new Error("Invalid local storage: expected a JSON object")
+            throw createAppError(
+              "Invalid local storage: expected a JSON object",
+              { kind: "validation" }
+            )
           }
           const localData = localResult.data
           await chrome.storage.local.clear()
@@ -273,8 +289,11 @@ export const backupService = {
       return result
     } catch (e) {
       // If we completely fail to parse zip or manifest:
-      const errorMessage = e instanceof Error ? e.message : "Unknown error"
-      throw new Error(`Failed to read backup file: ${errorMessage}`)
+      const errorMessage = getErrorMessage(e, "Unknown error")
+      throw createAppError(`Failed to read backup file: ${errorMessage}`, {
+        kind: "validation",
+        cause: e
+      })
     }
   }
 }

--- a/src/lib/content-extractor.ts
+++ b/src/lib/content-extractor.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type {
   ContentExtractionConfig,
@@ -352,7 +353,7 @@ export const extractContentWithLoading = async (
           }
         )
       } catch (error) {
-        const errorMsg = `Scroll error: ${error instanceof Error ? error.message : String(error)}`
+        const errorMsg = `Scroll error: ${getErrorMessage(error)}`
         errors.push(errorMsg)
         logger.error("Scroll error", "extractContentWithLoading", {
           error: errorMsg
@@ -373,7 +374,7 @@ export const extractContentWithLoading = async (
           }
         )
       } catch (error) {
-        const errorMsg = `Mutation observer error: ${error instanceof Error ? error.message : String(error)}`
+        const errorMsg = `Mutation observer error: ${getErrorMessage(error)}`
         errors.push(errorMsg)
         logger.error("Mutation observer error", "extractContentWithLoading", {
           error: errorMsg
@@ -388,7 +389,7 @@ export const extractContentWithLoading = async (
         await waitForNetworkIdle(config.networkIdleTimeout)
         logger.verbose("Network idle detected", "extractContentWithLoading")
       } catch (error) {
-        const errorMsg = `Network idle error: ${error instanceof Error ? error.message : String(error)}`
+        const errorMsg = `Network idle error: ${getErrorMessage(error)}`
         errors.push(errorMsg)
         logger.error("Network idle error", "extractContentWithLoading", {
           error: errorMsg
@@ -468,7 +469,7 @@ export const extractContentWithLoading = async (
       logEntry
     }
   } catch (error) {
-    const errorMsg = `Extraction error: ${error instanceof Error ? error.message : String(error)}`
+    const errorMsg = `Extraction error: ${getErrorMessage(error)}`
     errors.push(errorMsg)
     logger.error("Extraction error", "extractContentWithLoading", {
       error: errorMsg

--- a/src/lib/embeddings/chunker.ts
+++ b/src/lib/embeddings/chunker.ts
@@ -1,4 +1,5 @@
 import type { ChunkingStrategy } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 
 /**
  * Configuration for the text chunking process.
@@ -375,11 +376,13 @@ export function chunkText(text: string, options: ChunkOptions): TextChunk[] {
 
   // Validate inputs
   if (chunkSize <= 0) {
-    throw new Error("Chunk size must be positive")
+    throw createAppError("Chunk size must be positive", { kind: "validation" })
   }
 
   if (chunkOverlap < 0 || chunkOverlap >= chunkSize) {
-    throw new Error("Overlap must be between 0 and chunk size")
+    throw createAppError("Overlap must be between 0 and chunk size", {
+      kind: "validation"
+    })
   }
 
   if (!text || text.trim().length === 0) {

--- a/src/lib/embeddings/embedding-client.ts
+++ b/src/lib/embeddings/embedding-client.ts
@@ -3,6 +3,7 @@ import {
   type EmbeddingConfig,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { getErrorMessage } from "@/lib/error-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import {
   type EmbeddingStrategyCapabilities,
@@ -179,7 +180,7 @@ export const generateEmbedding = async (
       providerId: resolved.providerId
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = getErrorMessage(error)
     return {
       error: `Error generating embedding: ${errorMessage}`,
       code: "NETWORK_ERROR"

--- a/src/lib/embeddings/embedding-strategy.ts
+++ b/src/lib/embeddings/embedding-strategy.ts
@@ -7,6 +7,7 @@ import {
   normalizeEmbeddingModelName,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
@@ -122,7 +123,7 @@ const getStoredEmbeddingModel = async (): Promise<string> => {
 }
 
 const isContextLengthError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = getErrorMessage(error)
   return /context length|input length|too long|max(?:imum)? context/i.test(
     message
   )
@@ -418,8 +419,7 @@ export const generateEmbeddingWithStrategy = async (
         return result
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
+      const errorMessage = getErrorMessage(error)
       routeErrors.push(`${attempt.route}: ${errorMessage}`)
       logger.warn(
         `Embedding route failed: ${attempt.route}`,
@@ -445,10 +445,15 @@ export const generateEmbeddingWithStrategy = async (
     }
   }
 
-  throw new Error(
+  throw createAppError(
     `All embedding routes failed. Attempted: ${attemptedRoutes.join(" -> ")}. Last error: ${
       routeErrors[routeErrors.length - 1] || "unknown"
-    }`
+    }`,
+    {
+      kind: "provider",
+      retryable: true,
+      debug: { attemptedRoutes, routeErrors }
+    }
   )
 }
 

--- a/src/lib/embeddings/reranker.ts
+++ b/src/lib/embeddings/reranker.ts
@@ -1,4 +1,5 @@
 import { cosineSimilarity } from "@/lib/embeddings/embedding-client"
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 
 export type RerankerBackend = "none" | "cosine"
@@ -91,7 +92,7 @@ class RerankerService {
       return ranked
     } catch (error) {
       logger.error("Reranking failed, using fallback", "RerankerService", {
-        error: error instanceof Error ? error.message : String(error)
+        error: getErrorMessage(error)
       })
       return documents.map((d) => ({ ...d, score: 0.5 }))
     }

--- a/src/lib/embeddings/storage.ts
+++ b/src/lib/embeddings/storage.ts
@@ -1,5 +1,6 @@
 import { hnswIndexManager } from "@/lib/embeddings/hnsw-index"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 // import logger to debug
 
@@ -152,8 +153,9 @@ export const storeVector = async (
       .count()
 
     if (fileVectors >= config.maxEmbeddingsPerFile) {
-      throw new Error(
-        `Maximum embeddings per file (${config.maxEmbeddingsPerFile}) reached`
+      throw createAppError(
+        `Maximum embeddings per file (${config.maxEmbeddingsPerFile}) reached`,
+        { kind: "validation" }
       )
     }
   }

--- a/src/lib/embeddings/test-embedding.ts
+++ b/src/lib/embeddings/test-embedding.ts
@@ -6,6 +6,7 @@
  * import('/src/lib/embeddings/test-embedding.ts').then(m => m.testEmbeddingGeneration('Hello world'))
  */
 
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { generateEmbedding } from "./embedding-client"
 import { storeVector } from "./vector-store"
@@ -65,7 +66,7 @@ export const testEmbeddingGeneration = async (
     )
     return { success: true, id }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = getErrorMessage(error)
     logger.error("[Test Embedding] Error", "testEmbeddingGeneration", {
       error: errorMessage
     })
@@ -131,7 +132,7 @@ export const testBatchEmbeddingGeneration = async (
         successCount++
       } catch (error) {
         errors.push(
-          `Storage error for text ${i + 1}: ${error instanceof Error ? error.message : String(error)}`
+          `Storage error for text ${i + 1}: ${getErrorMessage(error)}`
         )
       }
     }
@@ -148,7 +149,7 @@ export const testBatchEmbeddingGeneration = async (
 
     return { success: errors.length === 0, count: successCount, errors }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = getErrorMessage(error)
     logger.error("[Test Embedding] Error", "testBatchEmbeddingGeneration", {
       error: errorMessage
     })

--- a/src/lib/error-display.ts
+++ b/src/lib/error-display.ts
@@ -1,0 +1,80 @@
+import {
+  type AppErrorKind,
+  getErrorMessage,
+  isAppError
+} from "@/lib/error-utils"
+
+type ErrorEnvelope = {
+  status?: number
+  message?: string
+  kind?: AppErrorKind
+  userMessage?: string
+  retryable?: boolean
+  context?: string
+  providerId?: string
+}
+
+const KIND_HINTS: Partial<Record<AppErrorKind, string>> = {
+  network:
+    "Check that the provider server is running and the URL is reachable.",
+  provider: "Check the selected provider, model, and provider logs.",
+  storage: "Try again after refreshing. If it persists, export diagnostics.",
+  validation: "Review the input and try again.",
+  abort: "The operation was cancelled."
+}
+
+const titleFromKind = (kind?: AppErrorKind) => {
+  switch (kind) {
+    case "network":
+      return "Network error"
+    case "provider":
+      return "Provider error"
+    case "storage":
+      return "Storage error"
+    case "validation":
+      return "Invalid input"
+    case "abort":
+      return "Cancelled"
+    default:
+      return "Error"
+  }
+}
+
+const sentence = (value: string) =>
+  /[.!?]$/.test(value.trim()) ? value.trim() : `${value.trim()}.`
+
+export const getDisplayErrorMessage = (
+  error: unknown,
+  fallbackMessage = "Something went wrong"
+) => {
+  if (typeof error === "string") return error || fallbackMessage
+  if (isAppError(error)) return error.userMessage || error.message
+  if (error && typeof error === "object") {
+    const envelope = error as ErrorEnvelope
+    return envelope.userMessage || envelope.message || fallbackMessage
+  }
+
+  return getErrorMessage(error, fallbackMessage)
+}
+
+export const formatErrorForDisplay = (
+  error: unknown,
+  fallbackMessage = "Something went wrong"
+) => {
+  const envelope =
+    error && typeof error === "object" ? (error as ErrorEnvelope) : {}
+  const kind = isAppError(error) ? error.kind : envelope.kind
+  const retryable = isAppError(error) ? error.retryable : envelope.retryable
+  const baseMessage = getDisplayErrorMessage(error, fallbackMessage)
+  const hint = kind ? KIND_HINTS[kind] : undefined
+  const retryHint = retryable ? "This may be temporary; try again." : undefined
+  const details = [hint, retryHint].filter(Boolean).join(" ")
+
+  return {
+    title: titleFromKind(kind),
+    message: details ? `${sentence(baseMessage)} ${details}` : baseMessage,
+    rawMessage: baseMessage,
+    kind,
+    retryable: Boolean(retryable)
+  }
+}

--- a/src/lib/error-display.ts
+++ b/src/lib/error-display.ts
@@ -48,7 +48,9 @@ export const getDisplayErrorMessage = (
   fallbackMessage = "Something went wrong"
 ) => {
   if (typeof error === "string") return error || fallbackMessage
-  if (isAppError(error)) return error.userMessage || error.message
+  if (isAppError(error)) {
+    return error.userMessage || error.message || fallbackMessage
+  }
   if (error && typeof error === "object") {
     const envelope = error as ErrorEnvelope
     return envelope.userMessage || envelope.message || fallbackMessage

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,0 +1,77 @@
+const DEFAULT_ERROR_MESSAGE = "An unexpected error occurred"
+
+export type AppErrorKind =
+  | "network"
+  | "provider"
+  | "storage"
+  | "validation"
+  | "abort"
+  | "unknown"
+
+export type AppErrorOptions = {
+  kind?: AppErrorKind
+  status?: number
+  userMessage?: string
+  retryable?: boolean
+  context?: string
+  providerId?: string
+  debug?: unknown
+  cause?: unknown
+}
+
+export class AppError extends Error {
+  kind: AppErrorKind
+  status?: number
+  userMessage?: string
+  retryable?: boolean
+  context?: string
+  providerId?: string
+  debug?: unknown
+
+  constructor(message: string, options: AppErrorOptions = {}) {
+    super(message, { cause: options.cause })
+    this.name = "AppError"
+    this.kind = options.kind || "unknown"
+    this.status = options.status
+    this.userMessage = options.userMessage
+    this.retryable = options.retryable
+    this.context = options.context
+    this.providerId = options.providerId
+    this.debug = options.debug
+  }
+}
+
+export const createAppError = (
+  message: string,
+  options: AppErrorOptions = {}
+) => new AppError(message, options)
+
+export const isAppError = (error: unknown): error is AppError =>
+  error instanceof AppError
+
+export const getErrorMessage = (
+  error: unknown,
+  fallbackMessage = DEFAULT_ERROR_MESSAGE
+) => {
+  if (error instanceof Error) return error.message || fallbackMessage
+  if (typeof error === "string") return error || fallbackMessage
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === "string" && message) return message
+  }
+
+  return fallbackMessage
+}
+
+export const isNamedError = (error: unknown, name: string) =>
+  error instanceof Error
+    ? error.name === name
+    : !!(
+        error &&
+        typeof error === "object" &&
+        "name" in error &&
+        (error as { name?: unknown }).name === name
+      )
+
+export const isAbortError = (error: unknown) =>
+  isNamedError(error, "AbortError")

--- a/src/lib/exporters/pdf-exporter.ts
+++ b/src/lib/exporters/pdf-exporter.ts
@@ -1,5 +1,6 @@
 import type { TFunction } from "i18next"
 
+import { createAppError } from "@/lib/error-utils"
 import type { ChatMessage, ChatSession } from "@/types"
 
 import { createMarkdownParser, parseMessageContent } from "./markdown-utils"
@@ -16,8 +17,9 @@ const renderPdf = async (html: string, filename: string) => {
   if (!printWindow) {
     localStorage.removeItem("print_html")
     localStorage.removeItem("print_filename")
-    throw new Error(
-      "Failed to open print window. Please check if popups are blocked."
+    throw createAppError(
+      "Failed to open print window. Please check if popups are blocked.",
+      { kind: "validation" }
     )
   }
 }

--- a/src/lib/file-processors/index.ts
+++ b/src/lib/file-processors/index.ts
@@ -3,6 +3,7 @@ import { DocxProcessor } from "@/features/file-upload/processors/docx-processor"
 import { HtmlProcessor } from "@/features/file-upload/processors/html-processor"
 import { PdfProcessor } from "@/features/file-upload/processors/pdf-processor"
 import { TextProcessor } from "@/features/file-upload/processors/text-processor"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { FileProcessor, ProcessedFile } from "./types"
 
@@ -61,8 +62,9 @@ export async function processFile(file: File): Promise<ProcessedFile> {
       fileName: file.name,
       fileType: file.type
     })
-    throw new Error(
-      `No processor available for file type: ${file.type || file.name}`
+    throw createAppError(
+      `No processor available for file type: ${file.type || file.name}`,
+      { kind: "validation" }
     )
   }
 

--- a/src/lib/knowledge/knowledge-processor.ts
+++ b/src/lib/knowledge/knowledge-processor.ts
@@ -1,4 +1,5 @@
 import { fromDocuments } from "@/lib/embeddings/vector-store"
+import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { getTextSplitter } from "@/lib/text-processing"
 import type { Document } from "@/lib/text-processing/types"
@@ -132,7 +133,7 @@ export async function processKnowledge(
       chunkCount: chunks.length
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = getErrorMessage(error)
 
     logger.error("Error processing document", "processKnowledge", {
       fileName,

--- a/src/lib/loaders/csv-loader.ts
+++ b/src/lib/loaders/csv-loader.ts
@@ -1,4 +1,5 @@
 import { dsvFormat } from "d3-dsv"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { CsvLoaderOptions, DocumentLoader, LoaderDocument } from "./types"
 
@@ -30,15 +31,18 @@ export class CsvLoader implements DocumentLoader {
     const parsed = psv.parseRows(raw.trim())
 
     if (parsed.length === 0) {
-      throw new Error("CSV file is empty or invalid")
+      throw createAppError("CSV file is empty or invalid", {
+        kind: "validation"
+      })
     }
 
     // Extract specific column if requested
     if (this.column !== undefined) {
       const headers = parsed[0]
       if (!headers?.includes(this.column)) {
-        throw new Error(
-          `Column "${this.column}" not found in CSV. Available columns: ${headers?.join(", ")}`
+        throw createAppError(
+          `Column "${this.column}" not found in CSV. Available columns: ${headers?.join(", ")}`,
+          { kind: "validation" }
         )
       }
 
@@ -66,8 +70,13 @@ export class CsvLoader implements DocumentLoader {
       const res = await fetch(this.url)
 
       if (!res.ok) {
-        throw new Error(
-          `Failed to fetch CSV file: ${res.status} ${res.statusText}`
+        throw createAppError(
+          `Failed to fetch CSV file: ${res.status} ${res.statusText}`,
+          {
+            kind: "network",
+            status: res.status,
+            retryable: res.status >= 500
+          }
         )
       }
 
@@ -82,8 +91,9 @@ export class CsvLoader implements DocumentLoader {
       // Validate parsed data
       for (let i = 0; i < parsed.length; i++) {
         if (typeof parsed[i] !== "string") {
-          throw new Error(
-            `Expected string at row ${i}, got ${typeof parsed[i]}`
+          throw createAppError(
+            `Expected string at row ${i}, got ${typeof parsed[i]}`,
+            { kind: "validation" }
           )
         }
       }

--- a/src/lib/providers/factory.ts
+++ b/src/lib/providers/factory.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PROVIDER_ID } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 import { KoboldCppProvider } from "./koboldcpp"
 import { LlamaCppProvider } from "./llama-cpp"
 import { LMStudioProvider } from "./lm-studio"
@@ -35,7 +36,9 @@ function instantiate(config: ProviderConfig): LLMProvider {
       return new Ctor(config)
     }
     default:
-      throw new Error(`Unsupported provider type: ${config.type}`)
+      throw createAppError(`Unsupported provider type: ${config.type}`, {
+        kind: "validation"
+      })
   }
 }
 
@@ -59,7 +62,12 @@ export const ProviderFactory = {
 
   async getProvider(providerId: string): Promise<LLMProvider> {
     const config = await ProviderManager.getProviderConfig(providerId)
-    if (!config) throw new Error(`Provider ${providerId} not found`)
+    if (!config) {
+      throw createAppError(`Provider ${providerId} not found`, {
+        kind: "provider",
+        providerId
+      })
+    }
 
     const provider = instantiate(config)
     instances.set(providerId, provider)

--- a/src/lib/providers/llama-cpp.ts
+++ b/src/lib/providers/llama-cpp.ts
@@ -1,3 +1,4 @@
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { ProviderModel } from "@/types"
 import { OpenAIProvider } from "./openai"
@@ -73,8 +74,13 @@ export class LlamaCppProvider extends OpenAIProvider {
 
     if (!response) {
       logger.error("All model fetch attempts failed.", "LlamaCpp")
-      throw new Error(
-        "Failed to connect to llama.cpp server. Check if the service is running and the URL is correct."
+      throw createAppError(
+        "Failed to connect to llama.cpp server. Check if the service is running and the URL is correct.",
+        {
+          kind: "provider",
+          providerId: ProviderId.LLAMA_CPP,
+          retryable: true
+        }
       )
     }
 
@@ -129,7 +135,11 @@ export class LlamaCppProvider extends OpenAIProvider {
       })
     } catch (e) {
       logger.error("Model parse failed", "LlamaCpp", { error: e })
-      throw new Error("Failed to parse response from llama.cpp server")
+      throw createAppError("Failed to parse response from llama.cpp server", {
+        kind: "provider",
+        providerId: ProviderId.LLAMA_CPP,
+        cause: e
+      })
     }
   }
 }

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -1,4 +1,5 @@
 import { LEGACY_STORAGE_KEYS } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import {
@@ -75,15 +76,21 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
   try {
     parsed = new URL(baseUrl)
   } catch {
-    throw new Error(`Invalid provider URL: ${baseUrl}`)
+    throw createAppError(`Invalid provider URL: ${baseUrl}`, {
+      kind: "validation"
+    })
   }
 
   if (!["http:", "https:"].includes(parsed.protocol)) {
-    throw new Error("Only HTTP(S) provider URLs are supported")
+    throw createAppError("Only HTTP(S) provider URLs are supported", {
+      kind: "validation"
+    })
   }
 
   if (parsed.username || parsed.password) {
-    throw new Error("Provider URL must not include embedded credentials")
+    throw createAppError("Provider URL must not include embedded credentials", {
+      kind: "validation"
+    })
   }
 }
 

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -1,3 +1,4 @@
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type {
   ChatStreamMessage,
@@ -114,11 +115,22 @@ export class OllamaProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(`Ollama Error (${response.status}): ${errorText}`)
+      throw createAppError(`Ollama Error (${response.status}): ${errorText}`, {
+        kind: "provider",
+        status: response.status,
+        providerId: ProviderId.OLLAMA,
+        retryable: response.status >= 500,
+        debug: errorText
+      })
     }
 
     const reader = response.body?.getReader()
-    if (!reader) throw new Error("Response body is null")
+    if (!reader) {
+      throw createAppError("Response body is null", {
+        kind: "provider",
+        providerId: ProviderId.OLLAMA
+      })
+    }
 
     const decoder = new TextDecoder()
     try {
@@ -136,7 +148,12 @@ export class OllamaProvider implements LLMProvider {
           if (!line.trim()) continue
           try {
             const data = JSON.parse(line)
-            if (data.error) throw new Error(data.error)
+            if (data.error) {
+              throw createAppError(data.error, {
+                kind: "provider",
+                providerId: ProviderId.OLLAMA
+              })
+            }
 
             const thinkingDelta =
               data.message?.thinking ||
@@ -255,12 +272,24 @@ export class OllamaProvider implements LLMProvider {
         const message = errorText
           ? `Ollama Embedding Error: ${legacyResponse.status} ${errorText}`
           : `Ollama Embedding Error: ${legacyResponse.status}`
-        throw new Error(message)
+        throw createAppError(message, {
+          kind: "provider",
+          status: legacyResponse.status,
+          providerId: ProviderId.OLLAMA,
+          retryable: legacyResponse.status >= 500,
+          debug: errorText
+        })
       }
 
       const legacyData = await legacyResponse.json()
       if (!Array.isArray(legacyData.embedding)) {
-        throw new Error("Ollama Embedding Error: invalid embedding response")
+        throw createAppError(
+          "Ollama Embedding Error: invalid embedding response",
+          {
+            kind: "provider",
+            providerId: ProviderId.OLLAMA
+          }
+        )
       }
       return legacyData.embedding
     } catch (error) {

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -1,3 +1,4 @@
+import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { ChatStreamMessage, ProviderModel } from "@/types"
 import {
@@ -97,7 +98,13 @@ export class OpenAIProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(`OpenAI Error (${response.status}): ${errorText}`)
+      throw createAppError(`OpenAI Error (${response.status}): ${errorText}`, {
+        kind: "provider",
+        status: response.status,
+        providerId: this.id,
+        retryable: response.status >= 500,
+        debug: errorText
+      })
     }
 
     const startTime = Date.now()
@@ -110,7 +117,12 @@ export class OpenAIProvider implements LLMProvider {
     startTime: number
   ) {
     const reader = response.body?.getReader()
-    if (!reader) throw new Error("Response body is null")
+    if (!reader) {
+      throw createAppError("Response body is null", {
+        kind: "provider",
+        providerId: this.id
+      })
+    }
 
     const decoder = new TextDecoder()
     let buffer = ""
@@ -229,8 +241,15 @@ export class OpenAIProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(
-        `OpenAI Embedding Error (${response.status}): ${errorText}`
+      throw createAppError(
+        `OpenAI Embedding Error (${response.status}): ${errorText}`,
+        {
+          kind: "provider",
+          status: response.status,
+          providerId: this.id,
+          retryable: response.status >= 500,
+          debug: errorText
+        }
       )
     }
 
@@ -257,8 +276,15 @@ export class OpenAIProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(
-        `OpenAI Embedding Error (${response.status}): ${errorText}`
+      throw createAppError(
+        `OpenAI Embedding Error (${response.status}): ${errorText}`,
+        {
+          kind: "provider",
+          status: response.status,
+          providerId: this.id,
+          retryable: response.status >= 500,
+          debug: errorText
+        }
       )
     }
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -82,8 +82,12 @@ export interface ChatStreamMessage {
   error?: {
     status: number
     message: string
+    kind?: import("./errors").AppErrorKind
+    userMessage?: string
+    retryable?: boolean
     context?: string
     providerId?: string
+    debug?: unknown
   }
   metrics?: {
     total_duration?: number

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -87,7 +87,6 @@ export interface ChatStreamMessage {
     retryable?: boolean
     context?: string
     providerId?: string
-    debug?: unknown
   }
   metrics?: {
     total_duration?: number

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -7,3 +7,5 @@ export interface ParseError extends Error {
   line?: string
   data?: unknown
 }
+
+export type { AppErrorKind } from "@/lib/error-utils"

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -42,7 +42,6 @@ export interface ChromeResponse {
     retryable?: boolean
     context?: string
     providerId?: string
-    debug?: unknown
   }
   tabs?: browser.Tabs.Tab[]
   html?: string

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -37,8 +37,12 @@ export interface ChromeResponse {
   error?: {
     status: number
     message: string
+    kind?: import("./errors").AppErrorKind
+    userMessage?: string
+    retryable?: boolean
     context?: string
     providerId?: string
+    debug?: unknown
   }
   tabs?: browser.Tabs.Tab[]
   html?: string

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -180,8 +180,12 @@ export interface PullStreamMessage {
     | {
         status: number
         message: string
+        kind?: import("./errors").AppErrorKind
+        userMessage?: string
+        retryable?: boolean
         context?: string
         providerId?: string
+        debug?: unknown
       }
 }
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -185,7 +185,6 @@ export interface PullStreamMessage {
         retryable?: boolean
         context?: string
         providerId?: string
-        debug?: unknown
       }
 }
 


### PR DESCRIPTION
## Summary
Better error handeling

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a structured error-handling layer (`AppError`, `createAppError`, `normalizeError`, `formatErrorForDisplay`) that replaces ad-hoc `instanceof Error` checks and bare `new Error(…)` throws across 70+ files. Errors now carry `kind`, `status`, `retryable`, `userMessage`, and `providerId` metadata, and the background→popup boundary correctly strips the internal `debug` field via `normalizeError`.

- **New core modules** — `src/lib/error-utils.ts` and `src/lib/error-display.ts` provide the classification and UI-formatting utilities; `normalizeError`/`createErrorResponse` in `error-handler.ts` standardize the wire envelope.
- **Provider upgrades** — `OllamaProvider`, `OpenAIProvider`, and `LlamaCppProvider` now throw `AppError` with HTTP status, `retryable` flag, and `debug` payload (kept internal); all existing handler files use `createErrorResponse` instead of hand-rolling error shapes.
- **Richer UI feedback** — `useChatStream` and `useModelPull` consume `formatErrorForDisplay` to surface kind-aware toast titles and retry hints to the user.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the wrong error kind applied to model-library scraping calls, which currently shows provider troubleshooting guidance for network connectivity failures.

The error-handling refactor is well-structured and internally consistent. The one concrete correctness issue is in use-model-library-search.ts, where errors from fetching the online model library are classified as provider rather than network. A user who cannot reach ollama.com would be told to check their provider logs instead of their network connection.

src/features/model/hooks/use-model-library-search.ts — both fetchSearchResults and fetchModelVariants hardcode kind: provider for what are external network requests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/error-utils.ts | New utility module introducing AppError class, createAppError, getErrorMessage, isAbortError, and isNamedError — forms the foundation of the new error handling system. |
| src/lib/error-display.ts | New UI-layer utility adding getDisplayErrorMessage and formatErrorForDisplay with per-kind hints and retry messaging; correctly prefers userMessage over raw message. |
| src/background/lib/error-handler.ts | Adds normalizeError and createErrorResponse to centralize error serialization; debug field is correctly stripped; status fallback in withErrorContext (500) diverges from normalizeError's own fallback (0) when no status is on the error object. |
| src/features/model/hooks/use-model-library-search.ts | Wraps background scrape errors as kind provider, but these are network fetches to ollama.com — failures should be kind network or preserve the original kind so users see the correct troubleshooting guidance. |
| src/features/chat/hooks/use-chat-stream.ts | Integrates formatErrorForDisplay for richer toast titles/descriptions; local StreamMessage.error includes debug?: unknown which normalizeError already strips, making the field unreachable at runtime. |
| src/lib/providers/ollama.ts | Replaces generic Error throws with createAppError carrying kind, status, providerId, retryable, and debug fields; debug correctly stays within AppError and is stripped by normalizeError. |
| src/lib/providers/openai.ts | Same pattern as ollama.ts — provider errors now carry structured metadata; no issues found. |
| src/background/lib/__tests__/error-handler.test.ts | New test suite covers normalizeError, createErrorResponse, and withErrorContext; includes an explicit assertion that debug payloads are stripped from the wire envelope. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Provider fetch fails] -->|throws createAppError| B[AppError]
    B -->|withErrorContext catches| C[normalizeError]
    C -->|strips debug, maps fields| D[ErrorEnvelope]
    D -->|safePostMessage| E[Chrome Port]
    E -->|useChatStream / useModelPull| F[formatErrorForDisplay]
    F -->|kind-aware title + hints| G[Toast UI]
    F -->|rawMessage| H[Chat assistant message]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Ffeatures%2Fmodel%2Fhooks%2Fuse-model-library-search.ts%3A27-36%0AThe%20%60kind%60%20is%20hardcoded%20to%20%60%22provider%22%60%20in%20both%20%60fetchSearchResults%60%20and%20%60fetchModelVariants%60%2C%20but%20these%20operations%20scrape%20the%20model%20library%20over%20the%20network%20%28fetching%20from%20%60DEFAULT_MODEL_LIBRARY_BASE_URL%60%29.%20A%20connectivity%20failure%20would%20show%20provider%20guidance%20%28%22Check%20the%20selected%20provider%2C%20model%2C%20and%20provider%20logs%22%29%20when%20network%20guidance%20%28%22Check%20that%20the%20provider%20server%20is%20running%20and%20the%20URL%20is%20reachable%22%29%20is%20more%20appropriate.%20The%20fix%20applies%20to%20both%20callsites%20%E2%80%94%20only%20the%20first%20is%20shown%20here.%0A%0A%60%60%60suggestion%0A%20%20if%20%28res.error%20%7C%7C%20!res.success%20%7C%7C%20!res.html%29%20%7B%0A%20%20%20%20throw%20createAppError%28%0A%20%20%20%20%20%20getDisplayErrorMessage%28res.error%2C%20%22Failed%20to%20fetch%20search%20results%22%29%2C%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20kind%3A%20res.error%3F.kind%20%3F%3F%20%22network%22%2C%0A%20%20%20%20%20%20%20%20retryable%3A%20true%2C%0A%20%20%20%20%20%20%20%20cause%3A%20res.error%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ffeatures%2Fmodel%2Fhooks%2Fuse-model-library-search.ts%3A67-76%0ASame%20issue%20as%20above%20%E2%80%94%20%60fetchModelVariants%60%20also%20hardcodes%20%60kind%3A%20%22provider%22%60%20for%20what%20is%20effectively%20a%20network%20scraping%20call.%20Using%20%60res.error%3F.kind%20%3F%3F%20%22network%22%60%20preserves%20the%20background's%20classification%20when%20present%2C%20and%20defaults%20to%20the%20semantically%20correct%20category%20when%20absent.%0A%0A%60%60%60suggestion%0A%20%20if%20%28res.error%20%7C%7C%20!res.success%20%7C%7C%20!res.html%29%20%7B%0A%20%20%20%20throw%20createAppError%28%0A%20%20%20%20%20%20getDisplayErrorMessage%28res.error%2C%20%22Failed%20to%20fetch%20model%20variants%22%29%2C%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20kind%3A%20res.error%3F.kind%20%3F%3F%20%22network%22%2C%0A%20%20%20%20%20%20%20%20retryable%3A%20true%2C%0A%20%20%20%20%20%20%20%20cause%3A%20res.error%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-stream.ts%3A40-49%0A%60debug%3F%3A%20unknown%60%20was%20added%20to%20the%20local%20%60StreamMessage.error%60%20shape%2C%20but%20%60normalizeError%60%20explicitly%20omits%20the%20%60debug%60%20field%20before%20any%20message%20crosses%20the%20Chrome%20port%20boundary%20%28verified%20in%20%60error-handler.test.ts%60%29.%20This%20field%20will%20never%20be%20populated%20at%20runtime%2C%20making%20the%20type%20annotation%20misleading.%0A%0A%60%60%60suggestion%0A%20%20error%3F%3A%20%7B%0A%20%20%20%20status%3A%20number%0A%20%20%20%20message%3A%20string%0A%20%20%20%20kind%3F%3A%20import%28%22%40%2Ftypes%2Ferrors%22%29.AppErrorKind%0A%20%20%20%20userMessage%3F%3A%20string%0A%20%20%20%20retryable%3F%3A%20boolean%0A%20%20%20%20context%3F%3A%20string%0A%20%20%20%20providerId%3F%3A%20string%0A%20%20%7D%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2Ferror-handling-consistency%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Ferror-handling-consistency%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Ffeatures%2Fmodel%2Fhooks%2Fuse-model-library-search.ts%3A27-36%0AThe%20%60kind%60%20is%20hardcoded%20to%20%60%22provider%22%60%20in%20both%20%60fetchSearchResults%60%20and%20%60fetchModelVariants%60%2C%20but%20these%20operations%20scrape%20the%20model%20library%20over%20the%20network%20%28fetching%20from%20%60DEFAULT_MODEL_LIBRARY_BASE_URL%60%29.%20A%20connectivity%20failure%20would%20show%20provider%20guidance%20%28%22Check%20the%20selected%20provider%2C%20model%2C%20and%20provider%20logs%22%29%20when%20network%20guidance%20%28%22Check%20that%20the%20provider%20server%20is%20running%20and%20the%20URL%20is%20reachable%22%29%20is%20more%20appropriate.%20The%20fix%20applies%20to%20both%20callsites%20%E2%80%94%20only%20the%20first%20is%20shown%20here.%0A%0A%60%60%60suggestion%0A%20%20if%20%28res.error%20%7C%7C%20!res.success%20%7C%7C%20!res.html%29%20%7B%0A%20%20%20%20throw%20createAppError%28%0A%20%20%20%20%20%20getDisplayErrorMessage%28res.error%2C%20%22Failed%20to%20fetch%20search%20results%22%29%2C%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20kind%3A%20res.error%3F.kind%20%3F%3F%20%22network%22%2C%0A%20%20%20%20%20%20%20%20retryable%3A%20true%2C%0A%20%20%20%20%20%20%20%20cause%3A%20res.error%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ffeatures%2Fmodel%2Fhooks%2Fuse-model-library-search.ts%3A67-76%0ASame%20issue%20as%20above%20%E2%80%94%20%60fetchModelVariants%60%20also%20hardcodes%20%60kind%3A%20%22provider%22%60%20for%20what%20is%20effectively%20a%20network%20scraping%20call.%20Using%20%60res.error%3F.kind%20%3F%3F%20%22network%22%60%20preserves%20the%20background's%20classification%20when%20present%2C%20and%20defaults%20to%20the%20semantically%20correct%20category%20when%20absent.%0A%0A%60%60%60suggestion%0A%20%20if%20%28res.error%20%7C%7C%20!res.success%20%7C%7C%20!res.html%29%20%7B%0A%20%20%20%20throw%20createAppError%28%0A%20%20%20%20%20%20getDisplayErrorMessage%28res.error%2C%20%22Failed%20to%20fetch%20model%20variants%22%29%2C%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20kind%3A%20res.error%3F.kind%20%3F%3F%20%22network%22%2C%0A%20%20%20%20%20%20%20%20retryable%3A%20true%2C%0A%20%20%20%20%20%20%20%20cause%3A%20res.error%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-stream.ts%3A40-49%0A%60debug%3F%3A%20unknown%60%20was%20added%20to%20the%20local%20%60StreamMessage.error%60%20shape%2C%20but%20%60normalizeError%60%20explicitly%20omits%20the%20%60debug%60%20field%20before%20any%20message%20crosses%20the%20Chrome%20port%20boundary%20%28verified%20in%20%60error-handler.test.ts%60%29.%20This%20field%20will%20never%20be%20populated%20at%20runtime%2C%20making%20the%20type%20annotation%20misleading.%0A%0A%60%60%60suggestion%0A%20%20error%3F%3A%20%7B%0A%20%20%20%20status%3A%20number%0A%20%20%20%20message%3A%20string%0A%20%20%20%20kind%3F%3A%20import%28%22%40%2Ftypes%2Ferrors%22%29.AppErrorKind%0A%20%20%20%20userMessage%3F%3A%20string%0A%20%20%20%20retryable%3F%3A%20boolean%0A%20%20%20%20context%3F%3A%20string%0A%20%20%20%20providerId%3F%3A%20string%0A%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["update CHANGELOG.md"](https://github.com/shishir435/ollama-client/commit/280e4d387da9e623d7a379edfb8fe8cbd0d9f0ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35190144)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->