### PR TITLE
Chore/test coverage selection actions

### DIFF
--- a/src/background/lib/__tests__/memory-manager.test.ts
+++ b/src/background/lib/__tests__/memory-manager.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { STORAGE_KEYS } from "@/lib/constants"
+
+const mockStoreChatMessage = vi.fn()
+vi.mock("@/lib/embeddings/vector-store", () => ({
+  storeChatMessage: mockStoreChatMessage
+}))
+
+const mockGet = vi.fn()
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  plasmoGlobalStorage: { get: mockGet }
+}))
+
+describe("memoryManager.saveChatToMemory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const payload = {
+    userMessage: "What is TypeScript?",
+    aiResponse: "TypeScript is a typed superset of JavaScript.",
+    sessionId: "session-123"
+  }
+
+  it("stores user and assistant messages when memory is enabled", async () => {
+    mockGet.mockResolvedValue(true)
+    mockStoreChatMessage.mockResolvedValue(undefined)
+
+    const { memoryManager } = await import("../memory-manager")
+    await memoryManager.saveChatToMemory(payload)
+
+    expect(mockStoreChatMessage).toHaveBeenCalledTimes(2)
+    expect(mockStoreChatMessage).toHaveBeenCalledWith(payload.userMessage, {
+      role: "user",
+      sessionId: "session-123",
+      chatId: undefined
+    })
+    expect(mockStoreChatMessage).toHaveBeenCalledWith(payload.aiResponse, {
+      role: "assistant",
+      sessionId: "session-123",
+      chatId: undefined
+    })
+  })
+
+  it("skips storage when memory is explicitly disabled", async () => {
+    mockGet.mockResolvedValue(false)
+
+    const { memoryManager } = await import("../memory-manager")
+    await memoryManager.saveChatToMemory(payload)
+
+    expect(mockStoreChatMessage).not.toHaveBeenCalled()
+  })
+
+  it("defaults to enabled when storage returns undefined", async () => {
+    mockGet.mockResolvedValue(undefined)
+    mockStoreChatMessage.mockResolvedValue(undefined)
+
+    const { memoryManager } = await import("../memory-manager")
+    await memoryManager.saveChatToMemory(payload)
+
+    expect(mockStoreChatMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("reads from STORAGE_KEYS.MEMORY.ENABLED key", async () => {
+    mockGet.mockResolvedValue(true)
+    mockStoreChatMessage.mockResolvedValue(undefined)
+
+    const { memoryManager } = await import("../memory-manager")
+    await memoryManager.saveChatToMemory(payload)
+
+    expect(mockGet).toHaveBeenCalledWith(STORAGE_KEYS.MEMORY.ENABLED)
+  })
+
+  it("does not throw when storeChatMessage fails", async () => {
+    mockGet.mockResolvedValue(true)
+    mockStoreChatMessage.mockRejectedValue(new Error("Vector store error"))
+
+    const { memoryManager } = await import("../memory-manager")
+    await expect(
+      memoryManager.saveChatToMemory(payload)
+    ).resolves.toBeUndefined()
+  })
+
+  it("passes chatId when provided", async () => {
+    mockGet.mockResolvedValue(true)
+    mockStoreChatMessage.mockResolvedValue(undefined)
+
+    const { memoryManager } = await import("../memory-manager")
+    await memoryManager.saveChatToMemory({ ...payload, chatId: "chat-42" })
+
+    expect(mockStoreChatMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ chatId: "chat-42" })
+    )
+  })
+})

--- a/src/background/lib/__tests__/memory-manager.test.ts
+++ b/src/background/lib/__tests__/memory-manager.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
 
 describe("memoryManager.saveChatToMemory", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
   })
 
   const payload = {

--- a/src/features/chat/hooks/__tests__/use-chat-keyboard-shortcuts.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-keyboard-shortcuts.test.ts
@@ -1,0 +1,264 @@
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useChatKeyboardShortcuts } from "../use-chat-keyboard-shortcuts"
+
+// Capture shortcut handlers so we can call them directly in tests
+type ShortcutHandlers = Record<string, (e: Partial<KeyboardEvent>) => void>
+let capturedHandlers: ShortcutHandlers = {}
+
+// vi.hoisted ensures these are initialized before vi.mock factory runs
+const mocks = vi.hoisted(() => ({
+  toggleSpeech: vi.fn(),
+  toast: vi.fn(),
+  exportSessionAsJson: vi.fn(),
+  exportSessionAsMarkdown: vi.fn(),
+  exportSessionAsPdf: vi.fn(),
+  exportSessionAsText: vi.fn(),
+  openOptionsInTab: vi.fn(),
+  openSearchDialog: vi.fn(),
+  setTheme: vi.fn()
+}))
+
+vi.mock("@/hooks/use-keyboard-shortcuts", () => ({
+  useKeyboardShortcuts: vi.fn((handlers: ShortcutHandlers) => {
+    capturedHandlers = handlers
+  })
+}))
+
+vi.mock("@/features/chat/hooks/use-speech-synthesis", () => ({
+  useSpeechSynthesis: () => ({ toggle: mocks.toggleSpeech })
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast })
+}))
+
+vi.mock("@/features/sessions/stores/chat-session-store", () => ({
+  useChatSessions: () => ({
+    sessions: [
+      { id: "s1", title: "Session 1", messages: [] },
+      { id: "s2", title: "Session 2", messages: [] }
+    ]
+  })
+}))
+
+vi.mock("@/features/sessions/hooks/use-export-chat", () => ({
+  useChatExport: () => ({
+    exportSessionAsJson: mocks.exportSessionAsJson,
+    exportSessionAsMarkdown: mocks.exportSessionAsMarkdown,
+    exportSessionAsPdf: mocks.exportSessionAsPdf,
+    exportSessionAsText: mocks.exportSessionAsText
+  })
+}))
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: {},
+  openOptionsInTab: mocks.openOptionsInTab,
+  isChromiumBased: vi.fn(() => true)
+}))
+
+vi.mock("@/stores/search-dialog-store", () => ({
+  useSearchDialogStore: {
+    getState: () => ({ openSearchDialog: mocks.openSearchDialog })
+  }
+}))
+
+vi.mock("@/stores/theme", () => ({
+  useThemeStore: {
+    getState: () => ({ theme: "dark", setTheme: mocks.setTheme })
+  }
+}))
+
+const fakeEvent = (): Partial<KeyboardEvent> => ({ preventDefault: vi.fn() })
+
+const sessions = [
+  { id: "s1", title: "Session 1", messages: [] },
+  { id: "s2", title: "Session 2", messages: [] }
+]
+
+const messages = [
+  { role: "user" as const, content: "Hello" },
+  { role: "assistant" as const, content: "Hi there", done: true }
+]
+
+const mockCreateSession = vi.fn().mockResolvedValue("new-session-id")
+const mockDeleteSession = vi.fn()
+
+const renderShortcuts = (
+  overrides: Partial<Parameters<typeof useChatKeyboardShortcuts>[0]> = {}
+) =>
+  renderHook(() =>
+    useChatKeyboardShortcuts({
+      messages,
+      currentSessionId: "s1",
+      createSession: mockCreateSession,
+      deleteSession: mockDeleteSession,
+      ...overrides
+    })
+  )
+
+describe("useChatKeyboardShortcuts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedHandlers = {}
+  })
+
+  it("registers all expected shortcut handlers", () => {
+    renderShortcuts()
+    expect(capturedHandlers).toHaveProperty("newChat")
+    expect(capturedHandlers).toHaveProperty("settings")
+    expect(capturedHandlers).toHaveProperty("toggleTheme")
+    expect(capturedHandlers).toHaveProperty("toggleSpeech")
+    expect(capturedHandlers).toHaveProperty("searchMessages")
+    expect(capturedHandlers).toHaveProperty("clearChat")
+    expect(capturedHandlers).toHaveProperty("copyLastResponse")
+    expect(capturedHandlers).toHaveProperty("exportJson")
+    expect(capturedHandlers).toHaveProperty("exportMarkdown")
+    expect(capturedHandlers).toHaveProperty("exportPdf")
+    expect(capturedHandlers).toHaveProperty("exportText")
+  })
+
+  it("newChat: calls createSession and shows toast", async () => {
+    renderShortcuts()
+    await capturedHandlers.newChat(fakeEvent())
+    expect(mockCreateSession).toHaveBeenCalledOnce()
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.stringContaining("new chat")
+      })
+    )
+  })
+
+  it("settings: calls openOptionsInTab", () => {
+    renderShortcuts()
+    capturedHandlers.settings(fakeEvent())
+    expect(mocks.openOptionsInTab).toHaveBeenCalledOnce()
+  })
+
+  it("toggleTheme: switches from dark to light and shows toast", () => {
+    renderShortcuts()
+    capturedHandlers.toggleTheme(fakeEvent())
+    expect(mocks.setTheme).toHaveBeenCalledWith("light")
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: expect.stringContaining("light") })
+    )
+  })
+
+  it("toggleSpeech: passes last assistant message to toggle()", () => {
+    renderShortcuts()
+    capturedHandlers.toggleSpeech(fakeEvent())
+    expect(mocks.toggleSpeech).toHaveBeenCalledWith("Hi there")
+  })
+
+  it("toggleSpeech: no-op when no assistant message exists", () => {
+    renderShortcuts({
+      messages: [{ role: "user", content: "question only" }]
+    })
+    capturedHandlers.toggleSpeech(fakeEvent())
+    expect(mocks.toggleSpeech).not.toHaveBeenCalled()
+  })
+
+  it("searchMessages: opens search dialog", () => {
+    renderShortcuts()
+    capturedHandlers.searchMessages(fakeEvent())
+    expect(mocks.openSearchDialog).toHaveBeenCalledOnce()
+  })
+
+  it("copyLastResponse: writes last assistant message to clipboard", async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      configurable: true
+    })
+
+    renderShortcuts()
+    await capturedHandlers.copyLastResponse(fakeEvent())
+
+    expect(mockWriteText).toHaveBeenCalledWith("Hi there")
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.stringContaining("Copied")
+      })
+    )
+  })
+
+  it("copyLastResponse: no-op when no assistant message", async () => {
+    const mockWriteText = vi.fn()
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      configurable: true
+    })
+
+    renderShortcuts({ messages: [{ role: "user", content: "question only" }] })
+    await capturedHandlers.copyLastResponse(fakeEvent())
+
+    expect(mockWriteText).not.toHaveBeenCalled()
+  })
+
+  it("exportJson: exports session and shows toast", () => {
+    renderShortcuts()
+    capturedHandlers.exportJson(fakeEvent())
+    expect(mocks.exportSessionAsJson).toHaveBeenCalledWith(sessions[0])
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: expect.stringContaining("JSON") })
+    )
+  })
+
+  it("exportMarkdown: exports session as markdown", () => {
+    renderShortcuts()
+    capturedHandlers.exportMarkdown(fakeEvent())
+    expect(mocks.exportSessionAsMarkdown).toHaveBeenCalledWith(sessions[0])
+  })
+
+  it("exportPdf: exports session as PDF", () => {
+    renderShortcuts()
+    capturedHandlers.exportPdf(fakeEvent())
+    expect(mocks.exportSessionAsPdf).toHaveBeenCalledWith(sessions[0])
+  })
+
+  it("exportText: exports session as plain text", () => {
+    renderShortcuts()
+    capturedHandlers.exportText(fakeEvent())
+    expect(mocks.exportSessionAsText).toHaveBeenCalledWith(sessions[0])
+  })
+
+  it("export: no-op when currentSessionId matches no session", () => {
+    renderShortcuts({ currentSessionId: "nonexistent" })
+    capturedHandlers.exportJson(fakeEvent())
+    expect(mocks.exportSessionAsJson).not.toHaveBeenCalled()
+  })
+
+  it("clearChat: deletes and recreates session after user confirms", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true)
+    )
+
+    renderShortcuts()
+    await capturedHandlers.clearChat(fakeEvent())
+
+    expect(mockDeleteSession).toHaveBeenCalledWith("s1")
+    expect(mockCreateSession).toHaveBeenCalledOnce()
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.stringContaining("cleared")
+      })
+    )
+
+    vi.unstubAllGlobals()
+  })
+
+  it("clearChat: no-op when user dismisses confirm dialog", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false)
+    )
+
+    renderShortcuts()
+    await capturedHandlers.clearChat(fakeEvent())
+
+    expect(mockDeleteSession).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/features/chat/hooks/__tests__/use-embedding-migration.test.ts
+++ b/src/features/chat/hooks/__tests__/use-embedding-migration.test.ts
@@ -1,0 +1,240 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useEmbeddingMigration } from "../use-embedding-migration"
+
+const mocks = vi.hoisted(() => ({
+  countMessages: vi.fn(),
+  getMessagesPaginated: vi.fn(),
+  // above(0).count() — how many vectors already have messageId
+  vectorsWithIdCount: vi.fn(),
+  // equals(id).first() — check if a specific message is already embedded
+  vectorFirst: vi.fn(),
+  deleteLegacy: vi.fn(),
+  generateEmbedding: vi.fn(),
+  storeVector: vi.fn(),
+  chunkTextAsync: vi.fn()
+}))
+
+vi.mock("@/lib/repositories/chat-history", () => ({
+  countMessages: mocks.countMessages,
+  getMessagesPaginated: mocks.getMessagesPaginated
+}))
+
+vi.mock("@/lib/embeddings/vector-store", () => ({
+  vectorDb: {
+    vectors: {
+      where: vi.fn(() => ({
+        above: vi.fn(() => ({ count: mocks.vectorsWithIdCount })),
+        equals: vi.fn(() => ({
+          first: mocks.vectorFirst,
+          count: vi.fn().mockResolvedValue(0),
+          filter: vi.fn(() => ({ delete: mocks.deleteLegacy }))
+        })),
+        filter: vi.fn(() => ({ delete: mocks.deleteLegacy }))
+      }))
+    }
+  },
+  storeVector: mocks.storeVector
+}))
+
+vi.mock("@/lib/embeddings/embedding-client", () => ({
+  generateEmbedding: mocks.generateEmbedding
+}))
+
+vi.mock("@/lib/embeddings/chunker", () => ({
+  chunkTextAsync: mocks.chunkTextAsync
+}))
+
+vi.mock("@/lib/embeddings/config", () => ({
+  getEmbeddingConfig: vi.fn().mockResolvedValue({
+    chunkSize: 512,
+    chunkOverlap: 50,
+    chunkingStrategy: "recursive"
+  })
+}))
+
+// Advance fake timers + drain microtask queue
+const flush = async (ticks = 30) => {
+  for (let i = 0; i < ticks; i++) {
+    vi.advanceTimersByTime(100)
+    await Promise.resolve()
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  mocks.deleteLegacy.mockResolvedValue(undefined)
+  mocks.storeVector.mockResolvedValue(undefined)
+  mocks.chunkTextAsync.mockResolvedValue([{ text: "chunk text" }])
+  mocks.generateEmbedding.mockResolvedValue({ embedding: [0.1, 0.2, 0.3] })
+  mocks.vectorFirst.mockResolvedValue(null)
+  mocks.vectorsWithIdCount.mockResolvedValue(0)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useEmbeddingMigration", () => {
+  it("starts with isMigrating=false, progress=0, total=0", () => {
+    mocks.countMessages.mockResolvedValue(0)
+    const { result } = renderHook(() => useEmbeddingMigration())
+    expect(result.current.isMigrating).toBe(false)
+    expect(result.current.progress).toBe(0)
+    expect(result.current.total).toBe(0)
+  })
+
+  it("does not start migration when there are zero messages", async () => {
+    mocks.countMessages.mockResolvedValue(0)
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await Promise.resolve()
+    })
+
+    expect(mocks.getMessagesPaginated).not.toHaveBeenCalled()
+  })
+
+  it("delays migration start by 5 seconds", async () => {
+    mocks.countMessages.mockResolvedValue(5)
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(4999)
+      await Promise.resolve()
+    })
+
+    expect(mocks.countMessages).not.toHaveBeenCalled()
+  })
+
+  it("cancels the startup timer on unmount", async () => {
+    mocks.countMessages.mockResolvedValue(5)
+
+    const { unmount } = renderHook(() => useEmbeddingMigration())
+    unmount()
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await Promise.resolve()
+    })
+
+    expect(mocks.countMessages).not.toHaveBeenCalled()
+  })
+
+  it("skips migration when vector coverage is already >= 90%", async () => {
+    mocks.countMessages.mockResolvedValue(10)
+    mocks.vectorsWithIdCount.mockResolvedValue(10)
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(5)
+    })
+
+    expect(mocks.getMessagesPaginated).not.toHaveBeenCalled()
+  })
+
+  it("skips system messages during migration", async () => {
+    mocks.countMessages.mockResolvedValue(1)
+    mocks.getMessagesPaginated
+      .mockResolvedValueOnce([
+        { id: 1, role: "system", content: "Be helpful.", sessionId: "s1" }
+      ])
+      .mockResolvedValue([])
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(20)
+    })
+
+    expect(mocks.generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it("skips incomplete assistant messages (done !== true)", async () => {
+    mocks.countMessages.mockResolvedValue(1)
+    mocks.getMessagesPaginated
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          role: "assistant",
+          content: "Partial...",
+          sessionId: "s1",
+          done: false
+        }
+      ])
+      .mockResolvedValue([])
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(20)
+    })
+
+    expect(mocks.generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it("skips messages that already have a vector with messageId", async () => {
+    mocks.countMessages.mockResolvedValue(1)
+    mocks.vectorFirst.mockResolvedValue({ id: 99, content: "already embedded" })
+    mocks.getMessagesPaginated
+      .mockResolvedValueOnce([
+        { id: 42, role: "user", content: "Already embedded?", sessionId: "s1" }
+      ])
+      .mockResolvedValue([])
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(20)
+    })
+
+    expect(mocks.generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it("calls generateEmbedding for unembedded messages and stores the vector", async () => {
+    mocks.countMessages.mockResolvedValue(1)
+    mocks.getMessagesPaginated
+      .mockResolvedValueOnce([
+        { id: 1, role: "user", content: "What is TypeScript?", sessionId: "s1" }
+      ])
+      .mockResolvedValue([])
+
+    renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(30)
+    })
+
+    expect(mocks.generateEmbedding).toHaveBeenCalledOnce()
+    expect(mocks.storeVector).toHaveBeenCalledOnce()
+  })
+
+  it("continues without throwing when generateEmbedding returns error", async () => {
+    mocks.countMessages.mockResolvedValue(1)
+    mocks.getMessagesPaginated
+      .mockResolvedValueOnce([
+        { id: 1, role: "user", content: "Embed this please", sessionId: "s1" }
+      ])
+      .mockResolvedValue([])
+    mocks.generateEmbedding.mockResolvedValue({ error: "Model unavailable" })
+
+    const { result } = renderHook(() => useEmbeddingMigration())
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await flush(30)
+    })
+
+    // Should complete migration without throwing
+    expect(result.current.isMigrating).toBe(false)
+  })
+})

--- a/src/features/chat/hooks/__tests__/use-speech-synthesis.test.ts
+++ b/src/features/chat/hooks/__tests__/use-speech-synthesis.test.ts
@@ -1,0 +1,231 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useSpeechSynthesis } from "../use-speech-synthesis"
+
+// --- Utterance mock ---
+type UtteranceHandlers = {
+  onstart: (() => void) | null
+  onend: (() => void) | null
+  onerror: (() => void) | null
+}
+
+let lastUtterance:
+  | (UtteranceHandlers & {
+      text: string
+      rate: number
+      pitch: number
+      voice: SpeechSynthesisVoice | null
+    })
+  | null = null
+
+class MockUtterance implements UtteranceHandlers {
+  text: string
+  rate = 1
+  pitch = 1
+  lang = ""
+  voice: SpeechSynthesisVoice | null = null
+  onstart: (() => void) | null = null
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(text: string) {
+    this.text = text
+    lastUtterance = this
+  }
+}
+
+// --- SpeechSynthesis mock ---
+const mockSynth = {
+  speaking: false,
+  speak: vi.fn(),
+  cancel: vi.fn()
+}
+
+// --- Store mock ---
+const mockSetSpeakingText = vi.fn()
+let mockSpeakingText: string | null = null
+
+vi.mock("@/features/chat/stores/speech-store", () => ({
+  useSpeechStore: () => ({
+    get speakingText() {
+      return mockSpeakingText
+    },
+    setSpeakingText: mockSetSpeakingText
+  })
+}))
+
+const mockVoice = {
+  voiceURI: "voice-en",
+  name: "English"
+} as SpeechSynthesisVoice
+
+vi.mock("@/features/chat/hooks/use-voice", () => ({
+  useVoices: () => ({ voices: [mockVoice], isLoading: false })
+}))
+
+vi.mock("@/features/chat/hooks/use-speech-settings", () => ({
+  useSpeechSettings: () => ({ rate: 1.2, pitch: 0.9, voiceURI: "voice-en" })
+}))
+
+vi.mock("@/lib/text-utils", () => ({
+  markdownToSpeechText: (text: string) => text.replace(/\*\*/g, "")
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastUtterance = null
+  mockSpeakingText = null
+  mockSynth.speaking = false
+  global.SpeechSynthesisUtterance = MockUtterance as never
+  Object.defineProperty(window, "speechSynthesis", {
+    value: mockSynth,
+    configurable: true,
+    writable: true
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useSpeechSynthesis", () => {
+  it("calls speechSynthesis.speak with a stripped utterance", async () => {
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("Hello **world**")
+    })
+
+    expect(mockSynth.speak).toHaveBeenCalledOnce()
+    expect(lastUtterance?.text).toBe("Hello world")
+  })
+
+  it("applies rate, pitch and matched voice to utterance", async () => {
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("Test")
+    })
+
+    expect(lastUtterance?.rate).toBe(1.2)
+    expect(lastUtterance?.pitch).toBe(0.9)
+    expect(lastUtterance?.voice).toBe(mockVoice)
+  })
+
+  it("does not speak when speakingText is already set", async () => {
+    mockSpeakingText = "already speaking"
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("New text")
+    })
+
+    expect(mockSynth.speak).not.toHaveBeenCalled()
+  })
+
+  it("cancels existing speech before starting new utterance", async () => {
+    mockSynth.speaking = true
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("New text")
+    })
+
+    expect(mockSynth.cancel).toHaveBeenCalledOnce()
+    expect(mockSynth.speak).toHaveBeenCalledOnce()
+  })
+
+  it("utterance.onstart sets speakingText to the markdown input", async () => {
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("Hello")
+    })
+
+    lastUtterance?.onstart?.()
+    expect(mockSetSpeakingText).toHaveBeenCalledWith("Hello")
+  })
+
+  it("utterance.onend clears speakingText", async () => {
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("Hello")
+    })
+
+    lastUtterance?.onend?.()
+    expect(mockSetSpeakingText).toHaveBeenCalledWith(null)
+  })
+
+  it("utterance.onerror clears speakingText", async () => {
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.speak("Hello")
+    })
+
+    lastUtterance?.onerror?.()
+    expect(mockSetSpeakingText).toHaveBeenCalledWith(null)
+  })
+
+  it("stop() cancels synthesis and clears speakingText when speaking", async () => {
+    mockSynth.speaking = true
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.stop()
+    })
+
+    expect(mockSynth.cancel).toHaveBeenCalledOnce()
+    expect(mockSetSpeakingText).toHaveBeenCalledWith(null)
+  })
+
+  it("stop() does nothing when synthesis is not speaking", async () => {
+    mockSynth.speaking = false
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.stop()
+    })
+
+    expect(mockSynth.cancel).not.toHaveBeenCalled()
+  })
+
+  it("toggle() stops when speakingText matches the argument", async () => {
+    mockSpeakingText = "current text"
+    mockSynth.speaking = true
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.toggle("current text")
+    })
+
+    expect(mockSynth.cancel).toHaveBeenCalledOnce()
+  })
+
+  it("toggle() speaks when speakingText does not match", async () => {
+    mockSpeakingText = null
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    await act(async () => {
+      result.current.toggle("new text")
+    })
+
+    expect(mockSynth.speak).toHaveBeenCalledOnce()
+  })
+
+  it("cancels speech on unmount", () => {
+    const { unmount } = renderHook(() => useSpeechSynthesis())
+    unmount()
+    expect(mockSynth.cancel).toHaveBeenCalledOnce()
+  })
+
+  it("exposes speakingText, isLoadingVoices, and voices from store/hook", () => {
+    mockSpeakingText = "reading..."
+    const { result } = renderHook(() => useSpeechSynthesis())
+
+    expect(result.current.speakingText).toBe("reading...")
+    expect(result.current.isLoadingVoices).toBe(false)
+    expect(result.current.voices).toContain(mockVoice)
+  })
+})

--- a/src/features/chat/hooks/__tests__/use-voice.test.ts
+++ b/src/features/chat/hooks/__tests__/use-voice.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useVoices } from "../use-voice"
+
+const makeVoice = (uri: string): SpeechSynthesisVoice =>
+  ({
+    voiceURI: uri,
+    name: uri,
+    lang: "en-US",
+    localService: true,
+    default: false
+  }) as SpeechSynthesisVoice
+
+const mockSpeechSynthesis = {
+  getVoices: vi.fn<() => SpeechSynthesisVoice[]>(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  mockSpeechSynthesis.getVoices.mockReturnValue([])
+  Object.defineProperty(window, "speechSynthesis", {
+    value: mockSpeechSynthesis,
+    configurable: true,
+    writable: true
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useVoices", () => {
+  it("starts with isLoading=true and empty voices list", () => {
+    const { result } = renderHook(() => useVoices())
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.voices).toHaveLength(0)
+  })
+
+  it("populates voices immediately when getVoices returns results on mount", async () => {
+    mockSpeechSynthesis.getVoices.mockReturnValue([
+      makeVoice("voice-a"),
+      makeVoice("voice-b")
+    ])
+
+    const { result } = renderHook(() => useVoices())
+
+    await act(async () => {})
+
+    expect(result.current.voices).toHaveLength(2)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("loads voices via 100ms timeout fallback when initially empty", async () => {
+    mockSpeechSynthesis.getVoices
+      .mockReturnValueOnce([])
+      .mockReturnValue([makeVoice("delayed-voice")])
+
+    const { result } = renderHook(() => useVoices())
+
+    expect(result.current.voices).toHaveLength(0)
+
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(result.current.voices).toHaveLength(1)
+    expect(result.current.voices[0].voiceURI).toBe("delayed-voice")
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("registers voiceschanged event listener on mount", () => {
+    renderHook(() => useVoices())
+    expect(mockSpeechSynthesis.addEventListener).toHaveBeenCalledWith(
+      "voiceschanged",
+      expect.any(Function)
+    )
+  })
+
+  it("removes voiceschanged listener on unmount", () => {
+    const { unmount } = renderHook(() => useVoices())
+    unmount()
+    expect(mockSpeechSynthesis.removeEventListener).toHaveBeenCalledWith(
+      "voiceschanged",
+      expect.any(Function)
+    )
+  })
+
+  it("updates voices when voiceschanged fires", async () => {
+    const { result } = renderHook(() => useVoices())
+
+    const [, listener] =
+      mockSpeechSynthesis.addEventListener.mock.calls.find(
+        ([event]) => event === "voiceschanged"
+      ) ?? []
+    expect(listener).toBeDefined()
+
+    mockSpeechSynthesis.getVoices.mockReturnValue([makeVoice("new-voice")])
+
+    await act(async () => {
+      listener()
+    })
+
+    expect(result.current.voices).toHaveLength(1)
+    expect(result.current.voices[0].voiceURI).toBe("new-voice")
+  })
+
+  it("does not duplicate state update when voice list is unchanged", async () => {
+    const voice = makeVoice("stable-voice")
+    mockSpeechSynthesis.getVoices.mockReturnValue([voice])
+
+    const { result } = renderHook(() => useVoices())
+
+    await act(async () => {})
+    const firstRef = result.current.voices
+
+    const [, listener] =
+      mockSpeechSynthesis.addEventListener.mock.calls.find(
+        ([event]) => event === "voiceschanged"
+      ) ?? []
+
+    await act(async () => {
+      listener()
+    })
+
+    // Same URIs → same reference (no re-render triggered by the setter)
+    expect(result.current.voices).toHaveLength(1)
+    expect(firstRef).toBe(result.current.voices)
+  })
+})

--- a/src/features/chat/lib/__tests__/session-metrics-utils.test.ts
+++ b/src/features/chat/lib/__tests__/session-metrics-utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import type { ChatMessage } from "@/types"
+import {
+  calculateSessionMetrics,
+  formatSessionDuration
+} from "../session-metrics-utils"
+
+const makeAssistantMsg = (
+  overrides: Partial<ChatMessage> = {}
+): ChatMessage => ({
+  role: "assistant",
+  content: "Hello",
+  done: true,
+  metrics: {
+    total_duration: 1_000_000_000,
+    load_duration: 100_000_000,
+    prompt_eval_count: 10,
+    prompt_eval_duration: 200_000_000,
+    eval_count: 20,
+    eval_duration: 500_000_000
+  },
+  ...overrides
+})
+
+describe("calculateSessionMetrics", () => {
+  it("returns zeros for empty message list", () => {
+    const result = calculateSessionMetrics([])
+    expect(result.totalTokens).toBe(0)
+    expect(result.totalDuration).toBe(0)
+    expect(result.averageSpeed).toBe(0)
+    expect(result.messageCount).toBe(0)
+    expect(result.promptTokens).toBe(0)
+    expect(result.generatedTokens).toBe(0)
+  })
+
+  it("skips system messages", () => {
+    const msg: ChatMessage = { role: "system", content: "You are helpful." }
+    const result = calculateSessionMetrics([msg])
+    expect(result.messageCount).toBe(0)
+  })
+
+  it("skips user messages", () => {
+    const msg: ChatMessage = { role: "user", content: "Hi", done: true }
+    const result = calculateSessionMetrics([msg])
+    expect(result.messageCount).toBe(0)
+  })
+
+  it("skips assistant messages without done=true", () => {
+    const msg = makeAssistantMsg({ done: false })
+    const result = calculateSessionMetrics([msg])
+    expect(result.messageCount).toBe(0)
+  })
+
+  it("skips assistant messages without metrics", () => {
+    const msg: ChatMessage = {
+      role: "assistant",
+      content: "Hi",
+      done: true,
+      metrics: undefined
+    }
+    const result = calculateSessionMetrics([msg])
+    expect(result.messageCount).toBe(0)
+  })
+
+  it("counts single valid assistant message", () => {
+    const result = calculateSessionMetrics([makeAssistantMsg()])
+    expect(result.messageCount).toBe(1)
+    expect(result.promptTokens).toBe(10)
+    expect(result.generatedTokens).toBe(20)
+    expect(result.totalTokens).toBe(30)
+    expect(result.totalDuration).toBe(1_000_000_000)
+  })
+
+  it("sums metrics across multiple assistant messages", () => {
+    const result = calculateSessionMetrics([
+      makeAssistantMsg(),
+      makeAssistantMsg()
+    ])
+    expect(result.messageCount).toBe(2)
+    expect(result.promptTokens).toBe(20)
+    expect(result.generatedTokens).toBe(40)
+    expect(result.totalTokens).toBe(60)
+    expect(result.totalDuration).toBe(2_000_000_000)
+  })
+
+  it("calculates averageSpeed as tokens/second from eval_duration", () => {
+    // eval_count=20, eval_duration=500ms = 0.5s → 40 tok/s
+    const result = calculateSessionMetrics([makeAssistantMsg()])
+    expect(result.averageSpeed).toBeCloseTo(40, 1)
+  })
+
+  it("returns averageSpeed=0 when eval_duration is zero", () => {
+    const msg = makeAssistantMsg({
+      metrics: {
+        ...makeAssistantMsg().metrics!,
+        eval_duration: 0
+      }
+    })
+    const result = calculateSessionMetrics([msg])
+    expect(result.averageSpeed).toBe(0)
+  })
+})
+
+describe("formatSessionDuration", () => {
+  it("formats sub-second durations as ms", () => {
+    expect(formatSessionDuration(500_000_000)).toBe("500ms")
+    expect(formatSessionDuration(100_000_000)).toBe("100ms")
+  })
+
+  it("formats seconds with one decimal", () => {
+    expect(formatSessionDuration(1_500_000_000)).toBe("1.5s")
+    expect(formatSessionDuration(30_000_000_000)).toBe("30.0s")
+  })
+
+  it("formats minutes with one decimal", () => {
+    expect(formatSessionDuration(90_000_000_000)).toBe("1.5m")
+    expect(formatSessionDuration(120_000_000_000)).toBe("2.0m")
+  })
+
+  it("formats exactly 1 second as 1.0s not ms", () => {
+    expect(formatSessionDuration(1_000_000_000)).toBe("1.0s")
+  })
+})

--- a/src/features/chat/utils/__tests__/embedding-backfill.test.ts
+++ b/src/features/chat/utils/__tests__/embedding-backfill.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest"
+import type { ChatMessage } from "@/types"
+import {
+  getEmbeddableMessagesBySession,
+  isEmbeddableChatMessage
+} from "../embedding-backfill"
+
+vi.mock("@/lib/repositories/chat-history", () => ({
+  countMessages: vi.fn(),
+  getAllMessages: vi.fn(),
+  getAllSessions: vi.fn()
+}))
+
+describe("isEmbeddableChatMessage", () => {
+  it("rejects system messages", () => {
+    expect(
+      isEmbeddableChatMessage({ role: "system", content: "You are helpful." })
+    ).toBe(false)
+  })
+
+  it("rejects messages with no content", () => {
+    expect(isEmbeddableChatMessage({ role: "user", content: undefined })).toBe(
+      false
+    )
+  })
+
+  it("rejects messages with content shorter than 10 chars", () => {
+    expect(isEmbeddableChatMessage({ role: "user", content: "Hi" })).toBe(false)
+    expect(
+      isEmbeddableChatMessage({ role: "user", content: "123456789" })
+    ).toBe(false)
+  })
+
+  it("rejects assistant messages where done !== true", () => {
+    expect(
+      isEmbeddableChatMessage({
+        role: "assistant",
+        content: "Long enough content here",
+        done: false
+      })
+    ).toBe(false)
+    expect(
+      isEmbeddableChatMessage({
+        role: "assistant",
+        content: "Long enough content here"
+      })
+    ).toBe(false)
+  })
+
+  it("accepts user messages with sufficient content", () => {
+    expect(
+      isEmbeddableChatMessage({
+        role: "user",
+        content: "This is long enough"
+      })
+    ).toBe(true)
+  })
+
+  it("accepts assistant messages with done=true and sufficient content", () => {
+    expect(
+      isEmbeddableChatMessage({
+        role: "assistant",
+        content: "This is the AI response",
+        done: true
+      })
+    ).toBe(true)
+  })
+
+  it("rejects whitespace-only content", () => {
+    expect(
+      isEmbeddableChatMessage({ role: "user", content: "          " })
+    ).toBe(false)
+  })
+})
+
+describe("getEmbeddableMessagesBySession", () => {
+  it("groups embeddable messages from SQLite by sessionId", async () => {
+    const { countMessages, getAllMessages } = await import(
+      "@/lib/repositories/chat-history"
+    )
+    vi.mocked(countMessages).mockResolvedValue(2)
+    vi.mocked(getAllMessages).mockResolvedValue([
+      { role: "user", content: "Tell me about TypeScript", sessionId: "s1" },
+      {
+        role: "assistant",
+        content: "TypeScript is a typed superset of JavaScript",
+        done: true,
+        sessionId: "s1"
+      },
+      { role: "system", content: "You are helpful", sessionId: "s1" }
+    ] as never)
+
+    const { messagesBySession, totalMessages } =
+      await getEmbeddableMessagesBySession()
+    expect(totalMessages).toBe(2)
+    expect(messagesBySession.get("s1")).toHaveLength(2)
+  })
+
+  it("falls back to legacy sessions when SQLite count is 0", async () => {
+    const { countMessages, getAllSessions } = await import(
+      "@/lib/repositories/chat-history"
+    )
+    vi.mocked(countMessages).mockResolvedValue(0)
+    vi.mocked(getAllSessions).mockResolvedValue([
+      {
+        id: "legacy-1",
+        messages: [
+          { role: "user", content: "Long enough user message here" },
+          {
+            role: "assistant",
+            content: "Long enough assistant reply",
+            done: true
+          }
+        ]
+      }
+    ] as never)
+
+    const { messagesBySession, totalMessages } =
+      await getEmbeddableMessagesBySession()
+    expect(totalMessages).toBe(2)
+    expect(messagesBySession.get("legacy-1")).toHaveLength(2)
+  })
+
+  it("falls back to legacy sessions when countMessages throws", async () => {
+    const { countMessages, getAllSessions } = await import(
+      "@/lib/repositories/chat-history"
+    )
+    vi.mocked(countMessages).mockRejectedValue(new Error("DB unavailable"))
+    vi.mocked(getAllSessions).mockResolvedValue([
+      {
+        id: "s2",
+        messages: [{ role: "user", content: "Another valid message here" }]
+      }
+    ] as never)
+
+    const { messagesBySession, totalMessages } =
+      await getEmbeddableMessagesBySession()
+    expect(totalMessages).toBe(1)
+    expect(messagesBySession.has("s2")).toBe(true)
+  })
+
+  it("skips messages without sessionId in SQLite path", async () => {
+    const { countMessages, getAllMessages } = await import(
+      "@/lib/repositories/chat-history"
+    )
+    vi.mocked(countMessages).mockResolvedValue(1)
+    vi.mocked(getAllMessages).mockResolvedValue([
+      {
+        role: "user",
+        content: "No session id message here",
+        sessionId: undefined
+      }
+    ] as never)
+
+    const { totalMessages } = await getEmbeddableMessagesBySession()
+    expect(totalMessages).toBe(0)
+  })
+})

--- a/src/features/selection-actions/__tests__/dom.test.ts
+++ b/src/features/selection-actions/__tests__/dom.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 import {
-  getSelectionCapture,
   getRangeRect,
+  getSelectionCapture,
   insertAfterContentEditableSelection,
   insertAfterEditableSelection,
   isEditableInput,
@@ -26,6 +26,14 @@ describe("selection action DOM helpers", () => {
     expect(textarea.selectionStart).toBe(11)
     expect(inputListener).toHaveBeenCalledOnce()
     expect(changeListener).toHaveBeenCalledOnce()
+  })
+
+  it("replaceEditableSelection returns false when selection start equals end", () => {
+    const input = document.createElement("input")
+    input.value = "hello"
+    input.setSelectionRange(3, 3)
+    expect(replaceEditableSelection(input, "x")).toBe(false)
+    expect(input.value).toBe("hello")
   })
 
   it("inserts below textarea selection without replacing text", () => {
@@ -69,6 +77,66 @@ describe("selection action DOM helpers", () => {
     textarea.remove()
   })
 
+  it("returns null getSelectionCapture when nothing selected", () => {
+    expect(getSelectionCapture(document)).toBeNull()
+  })
+
+  it("returns null getSelectionCapture for empty textarea selection (cursor only)", () => {
+    const textarea = document.createElement("textarea")
+    textarea.value = "hello"
+    document.body.append(textarea)
+    textarea.focus()
+    textarea.setSelectionRange(2, 2)
+
+    expect(getSelectionCapture(document)).toBeNull()
+    textarea.remove()
+  })
+
+  it("maps SelectionCapture to SelectionPayload via toSelectionPayload", () => {
+    const textarea = document.createElement("textarea")
+    textarea.value = "pick me"
+    document.body.append(textarea)
+    textarea.focus()
+    textarea.setSelectionRange(0, 7)
+
+    const capture = getSelectionCapture(document)
+    expect(capture).not.toBeNull()
+    if (!capture) return
+
+    const mockDoc = {
+      location: { href: "https://example.com/page" },
+      title: "Test Page"
+    } as unknown as Document
+
+    const payload = toSelectionPayload(capture, mockDoc)
+    expect(payload.selectedText).toBe("pick me")
+    expect(payload.pageUrl).toBe("https://example.com/page")
+    expect(payload.pageTitle).toBe("Test Page")
+    expect(payload.selectionType).toBe("textarea")
+    expect(payload.canReplace).toBe(true)
+    expect(payload.canInsert).toBe(true)
+
+    textarea.remove()
+  })
+
+  it("isEditableInput accepts textarea and text input", () => {
+    const textarea = document.createElement("textarea")
+    const textInput = document.createElement("input")
+    textInput.type = "text"
+    expect(isEditableInput(textarea)).toBe(true)
+    expect(isEditableInput(textInput)).toBe(true)
+  })
+
+  it("isEditableInput rejects button, checkbox, file, password, submit inputs", () => {
+    for (const type of ["button", "checkbox", "file", "password", "submit"]) {
+      const input = document.createElement("input")
+      input.type = type
+      expect(isEditableInput(input), `type=${type}`).toBe(false)
+    }
+    expect(isEditableInput(null)).toBe(false)
+    expect(isEditableInput(document.createElement("div"))).toBe(false)
+  })
+
   it("preserves heading element when replacing contenteditable text", () => {
     const editor = document.createElement("div")
     editor.contentEditable = "true"
@@ -93,7 +161,7 @@ describe("selection action DOM helpers", () => {
     editor.remove()
   })
 
-  it("rejects multi-block contenteditable range replace", () => {
+  it("rejects multi-block contenteditable range for replace", () => {
     const editor = document.createElement("div")
     editor.contentEditable = "true"
     editor.innerHTML = "<p>First para</p><p>Second para</p>"
@@ -128,6 +196,7 @@ describe("selection action DOM helpers", () => {
     const textAfterBr = br!.nextSibling as Text
     expect(textAfterBr?.nodeType).toBe(Node.TEXT_NODE)
     expect(textAfterBr?.textContent).toBe("inserted")
+
     editor.remove()
   })
 
@@ -144,65 +213,6 @@ describe("selection action DOM helpers", () => {
 
     expect(insertAfterContentEditableSelection(range, editor, "x")).toBe(false)
     editor.remove()
-  })
-
-  it("returns null getSelectionCapture when nothing selected", () => {
-    expect(getSelectionCapture(document)).toBeNull()
-  })
-
-  it("returns null getSelectionCapture for empty textarea selection", () => {
-    const textarea = document.createElement("textarea")
-    textarea.value = "hello"
-    document.body.append(textarea)
-    textarea.focus()
-    textarea.setSelectionRange(2, 2)
-
-    expect(getSelectionCapture(document)).toBeNull()
-    textarea.remove()
-  })
-
-  it("maps SelectionCapture to SelectionPayload via toSelectionPayload", () => {
-    const textarea = document.createElement("textarea")
-    textarea.value = "pick me"
-    document.body.append(textarea)
-    textarea.focus()
-    textarea.setSelectionRange(0, 7)
-
-    const capture = getSelectionCapture(document)
-    expect(capture).not.toBeNull()
-
-    const mockDoc = {
-      location: { href: "https://example.com/page" },
-      title: "Test Page"
-    } as unknown as Document
-
-    const payload = toSelectionPayload(capture!, mockDoc)
-    expect(payload.selectedText).toBe("pick me")
-    expect(payload.pageUrl).toBe("https://example.com/page")
-    expect(payload.pageTitle).toBe("Test Page")
-    expect(payload.selectionType).toBe("textarea")
-    expect(payload.canReplace).toBe(true)
-    expect(payload.canInsert).toBe(true)
-
-    textarea.remove()
-  })
-
-  it("isEditableInput accepts textarea and text input", () => {
-    const textarea = document.createElement("textarea")
-    const textInput = document.createElement("input")
-    textInput.type = "text"
-    expect(isEditableInput(textarea)).toBe(true)
-    expect(isEditableInput(textInput)).toBe(true)
-  })
-
-  it("isEditableInput rejects button, checkbox, file, password inputs", () => {
-    for (const type of ["button", "checkbox", "file", "password", "submit"]) {
-      const input = document.createElement("input")
-      input.type = type
-      expect(isEditableInput(input), `type=${type}`).toBe(false)
-    }
-    expect(isEditableInput(null)).toBe(false)
-    expect(isEditableInput(document.createElement("div"))).toBe(false)
   })
 
   it("getRangeRect falls back to getClientRects when getBoundingClientRect is zero", () => {
@@ -269,13 +279,5 @@ describe("selection action DOM helpers", () => {
 
     expect(getRangeRect(range)).toBeNull()
     div.remove()
-  })
-
-  it("replaceEditableSelection returns false when selection start equals end", () => {
-    const input = document.createElement("input")
-    input.value = "hello"
-    input.setSelectionRange(3, 3)
-    expect(replaceEditableSelection(input, "x")).toBe(false)
-    expect(input.value).toBe("hello")
   })
 })

--- a/src/features/selection-actions/__tests__/overlay-stream.test.ts
+++ b/src/features/selection-actions/__tests__/overlay-stream.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import { connectSelectionStream } from "../overlay-stream"
+import type { SelectionActionRequest } from "../types"
+
+const request: SelectionActionRequest = {
+  actionId: "summarize",
+  selection: {
+    selectedText: "Some text to summarize.",
+    pageUrl: "https://example.com",
+    pageTitle: "Test",
+    selectionType: "plain-text",
+    canReplace: false,
+    canInsert: false
+  }
+}
+
+const makeMockPort = () => {
+  const messageListeners: Array<(msg: unknown) => void> = []
+  const disconnectListeners: Array<() => void> = []
+
+  return {
+    postMessage: vi.fn(),
+    onMessage: {
+      addListener: vi.fn((fn) => messageListeners.push(fn))
+    },
+    onDisconnect: {
+      addListener: vi.fn((fn) => disconnectListeners.push(fn))
+    },
+    _emit: (msg: unknown) => {
+      for (const fn of messageListeners) fn(msg)
+    },
+    _disconnect: () => {
+      for (const fn of disconnectListeners) fn()
+    }
+  }
+}
+
+beforeEach(() => {
+  global.chrome = {
+    ...global.chrome,
+    runtime: {
+      ...global.chrome.runtime,
+      connect: vi.fn(),
+      lastError: undefined
+    }
+  } as unknown as typeof chrome
+})
+
+describe("connectSelectionStream", () => {
+  it("posts START_SELECTION_ACTION message to port on connect", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError: vi.fn()
+    })
+
+    expect(chrome.runtime.connect).toHaveBeenCalledWith({
+      name: MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION
+    })
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
+      payload: request
+    })
+  })
+
+  it("calls onChunk with visibleDelta for SELECTION_ACTION_CHUNK message", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onChunk = vi.fn()
+    connectSelectionStream(request, {
+      onChunk,
+      onDone: vi.fn(),
+      onError: vi.fn()
+    })
+
+    port._emit({
+      type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK,
+      payload: { delta: "Hello world", thinkingDelta: "" }
+    })
+
+    expect(onChunk).toHaveBeenCalledOnce()
+    const result = onChunk.mock.calls[0][0]
+    expect(result.visibleDelta).toBe("Hello world")
+    expect(result.thinkingDelta).toBe("")
+    expect(result.isThinking).toBe(false)
+  })
+
+  it("calls onDone for SELECTION_ACTION_DONE message", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onDone = vi.fn()
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone,
+      onError: vi.fn()
+    })
+
+    port._emit({ type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE })
+
+    expect(onDone).toHaveBeenCalledOnce()
+  })
+
+  it("calls onError with message for SELECTION_ACTION_ERROR message", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onError = vi.fn()
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError
+    })
+
+    port._emit({
+      type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
+      error: { message: "Model not loaded" }
+    })
+
+    expect(onError).toHaveBeenCalledWith("Model not loaded")
+  })
+
+  it("calls onError with fallback when error message is missing", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onError = vi.fn()
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError
+    })
+
+    port._emit({ type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR })
+
+    expect(onError).toHaveBeenCalledWith("Selection action failed. Try again.")
+  })
+
+  it("calls onError on port disconnect with runtime.lastError", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    Object.defineProperty(chrome.runtime, "lastError", {
+      value: { message: "Connection lost" },
+      configurable: true
+    })
+
+    const onError = vi.fn()
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError
+    })
+
+    port._disconnect()
+
+    expect(onError).toHaveBeenCalledWith("Connection lost. Try again.")
+
+    Object.defineProperty(chrome.runtime, "lastError", {
+      value: undefined,
+      configurable: true
+    })
+  })
+
+  it("does not call onError on clean disconnect (no lastError)", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onError = vi.fn()
+    connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError
+    })
+
+    port._disconnect()
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it("tracks isThinking=true when only thinkingDelta arrives before visible text", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const onChunk = vi.fn()
+    connectSelectionStream(request, {
+      onChunk,
+      onDone: vi.fn(),
+      onError: vi.fn()
+    })
+
+    port._emit({
+      type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK,
+      payload: { delta: "", thinkingDelta: "...reasoning..." }
+    })
+
+    expect(onChunk).toHaveBeenCalledOnce()
+    const result = onChunk.mock.calls[0][0]
+    expect(result.isThinking).toBe(true)
+    expect(result.thinkingDelta).toBe("...reasoning...")
+  })
+
+  it("returns the port from connectSelectionStream", () => {
+    const port = makeMockPort()
+    vi.mocked(chrome.runtime.connect).mockReturnValue(
+      port as unknown as chrome.runtime.Port
+    )
+
+    const returned = connectSelectionStream(request, {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError: vi.fn()
+    })
+
+    expect(returned).toBe(port)
+  })
+})

--- a/src/features/selection-actions/__tests__/prompt-builder.test.ts
+++ b/src/features/selection-actions/__tests__/prompt-builder.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { SELECTION_ACTIONS } from "../actions"
+import {
+  DEFAULT_SELECTION_ACTION_IDS,
+  getSelectionAction,
+  SELECTION_ACTIONS
+} from "../actions"
 import { buildSelectionActionPrompt } from "../prompt-builder"
 import type { SelectionPayload } from "../types"
 
@@ -48,5 +52,41 @@ describe("selection action prompt builder", () => {
     })
 
     expect(prompt.messages[1].content).toContain("Make this more polite.")
+  })
+
+  it("ignores customInstruction for non-custom actions", () => {
+    const prompt = buildSelectionActionPrompt({
+      actionId: "shorten",
+      selection,
+      customInstruction: "This should be ignored."
+    })
+
+    expect(prompt.messages[1].content).not.toContain("This should be ignored.")
+    expect(prompt.messages[1].content).toContain("Action: Shorten")
+  })
+
+  it("uses 'Untitled' when pageTitle is empty", () => {
+    const prompt = buildSelectionActionPrompt({
+      actionId: "explain",
+      selection: { ...selection, pageTitle: "" }
+    })
+    expect(prompt.messages[1].content).toContain("Page title: Untitled")
+  })
+})
+
+describe("getSelectionAction", () => {
+  it("returns correct definition for every registered action", () => {
+    for (const id of DEFAULT_SELECTION_ACTION_IDS) {
+      const action = getSelectionAction(id)
+      expect(action.id).toBe(id)
+      expect(action.label).toBeTruthy()
+      expect(action.shortLabel).toBeTruthy()
+      expect(action.instruction).toBeTruthy()
+    }
+  })
+
+  it("falls back to first action (summarize) for unknown id", () => {
+    const action = getSelectionAction("nonexistent" as never)
+    expect(action.id).toBe("summarize")
   })
 })

--- a/src/lib/__tests__/thinking-parser.test.ts
+++ b/src/lib/__tests__/thinking-parser.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { makeThinkingParserState, splitThinkingDelta } from "../thinking-parser"
+
+describe("makeThinkingParserState", () => {
+  it("initializes with inThinking=false and empty pending", () => {
+    const state = makeThinkingParserState()
+    expect(state.inThinking).toBe(false)
+    expect(state.pending).toBe("")
+  })
+})
+
+describe("splitThinkingDelta — plain text", () => {
+  it("returns all text as visible when no tags", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta("Hello world", state)
+    expect(result.visible).toBe("Hello world")
+    expect(result.thinking).toBe("")
+  })
+
+  it("empty delta returns empty strings", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta("", state)
+    expect(result.visible).toBe("")
+    expect(result.thinking).toBe("")
+  })
+})
+
+describe("splitThinkingDelta — think block", () => {
+  it("routes <think> content to thinking output", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta(
+      "<think>internal reasoning</think>final answer",
+      state
+    )
+    expect(result.thinking).toBe("internal reasoning")
+    expect(result.visible).toBe("final answer")
+    expect(state.inThinking).toBe(false)
+  })
+
+  it("routes <thinking> tag variant", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta(
+      "<thinking>deep thought</thinking>output",
+      state
+    )
+    expect(result.thinking).toBe("deep thought")
+    expect(result.visible).toBe("output")
+  })
+
+  it("routes <reasoning> tag variant", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta(
+      "<reasoning>step by step</reasoning>answer",
+      state
+    )
+    expect(result.thinking).toBe("step by step")
+    expect(result.visible).toBe("answer")
+  })
+
+  it("captures text before think tag as visible", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta(
+      "preamble <think>thought</think> epilogue",
+      state
+    )
+    expect(result.visible).toBe("preamble  epilogue")
+    expect(result.thinking).toBe("thought")
+  })
+
+  it("handles think block with no content after close tag", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta("<think>only thoughts</think>", state)
+    expect(result.thinking).toBe("only thoughts")
+    expect(result.visible).toBe("")
+  })
+})
+
+describe("splitThinkingDelta — streaming / partial tags", () => {
+  it("accumulates pending when chunk ends mid-open-tag", () => {
+    const state = makeThinkingParserState()
+    // Chunk ends with partial open tag
+    const r1 = splitThinkingDelta("Some text <thi", state)
+    expect(r1.visible).toBe("Some text ")
+    expect(state.pending).toBe("<thi")
+
+    // Next chunk completes the tag and provides content + close
+    const r2 = splitThinkingDelta("nk>thought</think>done", state)
+    expect(r2.thinking).toBe("thought")
+    expect(r2.visible).toBe("done")
+    expect(state.pending).toBe("")
+    expect(state.inThinking).toBe(false)
+  })
+
+  it("stays inThinking across chunks when no close tag yet", () => {
+    const state = makeThinkingParserState()
+    splitThinkingDelta("<think>part one ", state)
+    expect(state.inThinking).toBe(true)
+
+    const r2 = splitThinkingDelta("part two</think>visible", state)
+    expect(r2.thinking).toContain("part two")
+    expect(r2.visible).toBe("visible")
+    expect(state.inThinking).toBe(false)
+  })
+
+  it("accumulates pending when chunk ends mid-close-tag", () => {
+    const state = makeThinkingParserState()
+    splitThinkingDelta("<think>", state)
+    expect(state.inThinking).toBe(true)
+
+    const r1 = splitThinkingDelta("thinking content </thi", state)
+    expect(r1.thinking).toBe("thinking content ")
+    expect(state.pending).toBe("</thi")
+
+    const r2 = splitThinkingDelta("nk>end", state)
+    expect(r2.visible).toBe("end")
+    expect(state.inThinking).toBe(false)
+  })
+
+  it("handles multiple think blocks in one delta", () => {
+    const state = makeThinkingParserState()
+    const result = splitThinkingDelta(
+      "a<think>t1</think>b<think>t2</think>c",
+      state
+    )
+    expect(result.visible).toBe("abc")
+    expect(result.thinking).toBe("t1t2")
+  })
+})


### PR DESCRIPTION
# Summary
test case coverage

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unit test coverage for several hooks, utilities, and features that were previously untested, including `useEmbeddingMigration`, `useSpeechSynthesis`, `useVoices`, `useChatKeyboardShortcuts`, `connectSelectionStream`, session metrics utilities, embedding backfill helpers, and the thinking-tag parser.

- New test files are added for 9 modules spanning `background/`, `features/chat/`, `features/selection-actions/`, and `src/lib/`, all following the project's Vitest + happy-dom conventions and `__tests__/` directory layout.
- Two existing test files (`dom.test.ts`, `prompt-builder.test.ts`) are extended with additional cases and minor test description improvements.

<h3>Confidence Score: 5/5</h3>

Test-only PR adding coverage for previously untested modules; no production code is changed.

All changes are new or extended test files. The logic under test was verified against the actual source implementations and all assertions are correct. The three observations are about mock-reset hygiene that could theoretically cause silent order-dependency failures, but in the current test structure every affected test explicitly sets up its own mock state, so no test failure is induced today.

use-embedding-migration.test.ts, use-chat-keyboard-shortcuts.test.ts, and embedding-backfill.test.ts — all for mock-reset consistency, not correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/chat/hooks/__tests__/use-embedding-migration.test.ts | Good coverage of the migration hook. Uses vi.clearAllMocks() instead of vi.resetAllMocks() — countMessages and getMessagesPaginated implementations are not reset between tests, creating order dependency. |
| src/features/chat/hooks/__tests__/use-chat-keyboard-shortcuts.test.ts | Comprehensive shortcut handler coverage. vi.stubGlobal is called inside clearChat test bodies without afterEach cleanup, leaving stubs dangling if any assertion throws before vi.unstubAllGlobals(). |
| src/features/chat/utils/__tests__/embedding-backfill.test.ts | Tests correctly cover the SQLite, legacy, and error fallback paths. No beforeEach to reset mock state between tests — mock implementations from one test persist to the next by default. |
| src/features/selection-actions/__tests__/overlay-stream.test.ts | New test file covering the port lifecycle, chunk routing, error handling, and isThinking logic for connectSelectionStream. All assertions match the source implementation. |
| src/features/chat/hooks/__tests__/use-speech-synthesis.test.ts | Well-structured tests with proper beforeEach/afterEach (clearAllMocks + restoreAllMocks). Covers speak, stop, toggle, unmount, and utterance lifecycle callbacks. |
| src/lib/__tests__/thinking-parser.test.ts | Pure-function tests for the streaming think-tag parser. Covers full tags, partial/split tags across chunks, multi-block deltas, and all three tag variants. |
| src/background/lib/__tests__/memory-manager.test.ts | Uses vi.resetAllMocks() (addressed from prior review). Correctly tests enabled/disabled/undefined memory states, chatId forwarding, and error resilience. |
| src/features/selection-actions/__tests__/dom.test.ts | Refactors existing tests into a more logical order and adds new cases for replaceEditableSelection, getSelectionCapture (cursor-only), isEditableInput, and toSelectionPayload. Also adds missing editor.remove() cleanup. |
| src/features/selection-actions/__tests__/prompt-builder.test.ts | Adds tests for non-custom action customInstruction pass-through, empty pageTitle fallback, and a round-trip test for all DEFAULT_SELECTION_ACTION_IDS via getSelectionAction. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2F__tests__%2Fuse-embedding-migration.test.ts%3A64-66%0AMissing%20%60countMessages%60%20and%20%60getMessagesPaginated%60%20resets%20in%20%60beforeEach%60.%20%60vi.clearAllMocks%28%29%60%20only%20wipes%20call%20history%20%E2%80%94%20not%20implementations%20%E2%80%94%20so%20whatever%20%60mockResolvedValue%60%20a%20test%20sets%20on%20these%20two%20mocks%20persists%20into%20the%20next%20test.%20Every%20test%20in%20this%20file%20happens%20to%20call%20the%20mocks%20explicitly%2C%20so%20this%20passes%20today%2C%20but%20if%20a%20future%20test%20omits%20the%20setup%20%28or%20if%20test%20order%20is%20shuffled%29%20it%20will%20silently%20inherit%20a%20stale%20return%20value.%20Using%20%60vi.resetAllMocks%28%29%60%20%28consistent%20with%20%60memory-manager.test.ts%60%29%20avoids%20the%20dependency%20entirely.%0A%0A%60%60%60suggestion%0AbeforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20vi.useFakeTimers%28%29%0A%20%20vi.resetAllMocks%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2F__tests__%2Fuse-chat-keyboard-shortcuts.test.ts%3A100-104%0A%60vi.unstubAllGlobals%28%29%60%20is%20called%20at%20the%20bottom%20of%20each%20%60clearChat%60%20test%20body.%20If%20any%20%60expect%28...%29%60%20assertion%20above%20it%20throws%2C%20the%20cleanup%20is%20skipped%20and%20%60window.confirm%60%20stays%20stubbed%20for%20subsequent%20tests.%20The%20safe%20pattern%20is%20to%20move%20the%20teardown%20into%20%60afterEach%60%2C%20where%20it%20runs%20unconditionally.%0A%0A%60%60%60suggestion%0Adescribe%28%22useChatKeyboardShortcuts%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.clearAllMocks%28%29%0A%20%20%20%20capturedHandlers%20%3D%20%7B%7D%0A%20%20%7D%29%0A%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllGlobals%28%29%0A%20%20%7D%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Ffeatures%2Fchat%2Futils%2F__tests__%2Fembedding-backfill.test.ts%3A1129-1141%0A**Missing%20%60beforeEach%60%20mock%20reset**%0A%0AThere%20is%20no%20%60beforeEach%60%20that%20calls%20%60vi.resetAllMocks%28%29%60%20%28or%20%60vi.clearAllMocks%28%29%60%29.%20Implementations%20set%20via%20%60vi.mocked%28...%29.mockRejectedValue%28...%29%60%20or%20%60mockResolvedValue%28...%29%60%20in%20one%20test%20bleed%20into%20the%20next.%20For%20example%2C%20after%20the%20%22falls%20back%20to%20legacy%20sessions%20when%20countMessages%20throws%22%20test%2C%20%60countMessages%60%20still%20carries%20the%20%60mockRejectedValue%60%20implementation%20until%20the%20next%20test%20explicitly%20overrides%20it.%20Adding%20a%20%60beforeEach%28%28%29%20%3D%3E%20vi.resetAllMocks%28%29%29%60%20makes%20each%20test%20fully%20self-contained.%0A%0A&repo=shishir435%2Follama-client&pr=109&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22chore%2Ftest-coverage-selection-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Ftest-coverage-selection-actions%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2F__tests__%2Fuse-embedding-migration.test.ts%3A64-66%0AMissing%20%60countMessages%60%20and%20%60getMessagesPaginated%60%20resets%20in%20%60beforeEach%60.%20%60vi.clearAllMocks%28%29%60%20only%20wipes%20call%20history%20%E2%80%94%20not%20implementations%20%E2%80%94%20so%20whatever%20%60mockResolvedValue%60%20a%20test%20sets%20on%20these%20two%20mocks%20persists%20into%20the%20next%20test.%20Every%20test%20in%20this%20file%20happens%20to%20call%20the%20mocks%20explicitly%2C%20so%20this%20passes%20today%2C%20but%20if%20a%20future%20test%20omits%20the%20setup%20%28or%20if%20test%20order%20is%20shuffled%29%20it%20will%20silently%20inherit%20a%20stale%20return%20value.%20Using%20%60vi.resetAllMocks%28%29%60%20%28consistent%20with%20%60memory-manager.test.ts%60%29%20avoids%20the%20dependency%20entirely.%0A%0A%60%60%60suggestion%0AbeforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20vi.useFakeTimers%28%29%0A%20%20vi.resetAllMocks%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ffeatures%2Fchat%2Fhooks%2F__tests__%2Fuse-chat-keyboard-shortcuts.test.ts%3A100-104%0A%60vi.unstubAllGlobals%28%29%60%20is%20called%20at%20the%20bottom%20of%20each%20%60clearChat%60%20test%20body.%20If%20any%20%60expect%28...%29%60%20assertion%20above%20it%20throws%2C%20the%20cleanup%20is%20skipped%20and%20%60window.confirm%60%20stays%20stubbed%20for%20subsequent%20tests.%20The%20safe%20pattern%20is%20to%20move%20the%20teardown%20into%20%60afterEach%60%2C%20where%20it%20runs%20unconditionally.%0A%0A%60%60%60suggestion%0Adescribe%28%22useChatKeyboardShortcuts%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.clearAllMocks%28%29%0A%20%20%20%20capturedHandlers%20%3D%20%7B%7D%0A%20%20%7D%29%0A%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllGlobals%28%29%0A%20%20%7D%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Ffeatures%2Fchat%2Futils%2F__tests__%2Fembedding-backfill.test.ts%3A1129-1141%0A**Missing%20%60beforeEach%60%20mock%20reset**%0A%0AThere%20is%20no%20%60beforeEach%60%20that%20calls%20%60vi.resetAllMocks%28%29%60%20%28or%20%60vi.clearAllMocks%28%29%60%29.%20Implementations%20set%20via%20%60vi.mocked%28...%29.mockRejectedValue%28...%29%60%20or%20%60mockResolvedValue%28...%29%60%20in%20one%20test%20bleed%20into%20the%20next.%20For%20example%2C%20after%20the%20%22falls%20back%20to%20legacy%20sessions%20when%20countMessages%20throws%22%20test%2C%20%60countMessages%60%20still%20carries%20the%20%60mockRejectedValue%60%20implementation%20until%20the%20next%20test%20explicitly%20overrides%20it.%20Adding%20a%20%60beforeEach%28%28%29%20%3D%3E%20vi.resetAllMocks%28%29%29%60%20makes%20each%20test%20fully%20self-contained.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["test(memory-manager): use resetAllMocks ..."](https://github.com/shishir435/ollama-client/commit/25851bae124012b7436e91d46517b79d64eefb5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35424113)</sub>

<!-- /greptile_comment -->