### PR TITLE
test: expand coverage from 63% to 69% across core modules

### DIFF
--- a/src/features/chat/rag/__tests__/query-classifier.test.ts
+++ b/src/features/chat/rag/__tests__/query-classifier.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+import {
+  classifyQueriesBatch,
+  classifyQuery,
+  getIntentDescription
+} from "../query-classifier"
+
+describe("classifyQuery — factual intent", () => {
+  it("classifies 'What is X' as factual", () => {
+    const result = classifyQuery("What is machine learning?")
+    expect(result.intent).toBe("factual")
+    expect(result.confidence).toBe(0.8)
+    expect(result.shouldUseRAG).toBe(true)
+    expect(result.suggestedTopK).toBe(3)
+    expect(result.suggestedMode).toBe("similarity")
+  })
+
+  it("classifies 'Who invented X' as factual", () => {
+    expect(classifyQuery("Who invented the internet?").intent).toBe("factual")
+  })
+
+  it("classifies 'Define X' as factual", () => {
+    expect(classifyQuery("Define recursion").intent).toBe("factual")
+  })
+
+  it("classifies 'Explain X' as factual", () => {
+    expect(classifyQuery("Explain transformer architecture").intent).toBe(
+      "factual"
+    )
+  })
+})
+
+describe("classifyQuery — procedural intent", () => {
+  it("classifies 'How do I X' as procedural", () => {
+    const result = classifyQuery("How do I deploy a Docker container?")
+    expect(result.intent).toBe("procedural")
+    expect(result.suggestedTopK).toBe(5)
+    expect(result.suggestedMode).toBe("similarity")
+  })
+
+  it("classifies 'Steps to X' as procedural", () => {
+    expect(classifyQuery("Steps to configure nginx").intent).toBe("procedural")
+  })
+
+  it("classifies 'Can I do X' as procedural", () => {
+    expect(classifyQuery("Can I use TypeScript with React?").intent).toBe(
+      "procedural"
+    )
+  })
+})
+
+describe("classifyQuery — comparison intent", () => {
+  it("classifies 'X vs Y' as comparison", () => {
+    const result = classifyQuery("React vs Vue performance")
+    expect(result.intent).toBe("comparison")
+    expect(result.suggestedTopK).toBe(10)
+  })
+
+  it("classifies 'X versus Y' as comparison", () => {
+    expect(classifyQuery("Python versus JavaScript for ML").intent).toBe(
+      "comparison"
+    )
+  })
+
+  it("classifies 'difference between X and Y' as comparison", () => {
+    expect(
+      classifyQuery("Performance difference between REST and GraphQL").intent
+    ).toBe("comparison")
+  })
+})
+
+describe("classifyQuery — summarization intent", () => {
+  it("classifies 'Summarize X' as summarization with full mode", () => {
+    const result = classifyQuery("Summarize the conversation so far")
+    expect(result.intent).toBe("summarization")
+    expect(result.suggestedMode).toBe("full")
+  })
+
+  it("classifies 'tl;dr' as summarization", () => {
+    expect(classifyQuery("tl;dr the document").intent).toBe("summarization")
+  })
+
+  it("classifies 'overview' as summarization", () => {
+    expect(classifyQuery("overview of the project").intent).toBe(
+      "summarization"
+    )
+  })
+})
+
+describe("classifyQuery — conversational intent", () => {
+  it("classifies short follow-up as conversational without RAG when no history", () => {
+    const result = classifyQuery("That sounds interesting")
+    expect(result.intent).toBe("conversational")
+    expect(result.shouldUseRAG).toBeFalsy()
+  })
+
+  it("uses RAG for conversational when chat history exists", () => {
+    const history = [{ role: "user", content: "Tell me about embeddings" }]
+    const result = classifyQuery("What about it?", history)
+    expect(result.shouldUseRAG).toBe(true)
+  })
+
+  it("does not classify long questions as conversational", () => {
+    const result = classifyQuery(
+      "Can you explain this entire topic in great detail?"
+    )
+    expect(result.intent).not.toBe("conversational")
+  })
+})
+
+describe("classifyQuery — exploratory default", () => {
+  it("falls back to exploratory for unmatched queries", () => {
+    const result = classifyQuery("Tell me about the history of computing")
+    expect(result.intent).toBe("exploratory")
+    expect(result.confidence).toBe(0.5)
+    expect(result.suggestedTopK).toBe(5)
+  })
+})
+
+describe("classifyQuery — entity extraction", () => {
+  it("extracts capitalized proper nouns", () => {
+    const result = classifyQuery("Tell me about React and Vue frameworks")
+    expect(result.entities).toContain("React")
+    expect(result.entities).toContain("Vue")
+  })
+
+  it("extracts camelCase technical terms", () => {
+    const result = classifyQuery("Explain useState hook")
+    expect(result.entities).toContain("useState")
+  })
+
+  it("extracts acronyms", () => {
+    const result = classifyQuery("Compare RAG and NLP approaches")
+    expect(result.entities).toContain("RAG")
+    expect(result.entities).toContain("NLP")
+  })
+
+  it("deduplicates entities", () => {
+    const result = classifyQuery("React vs React performance")
+    const reactCount = result.entities.filter((e) => e === "React").length
+    expect(reactCount).toBe(1)
+  })
+})
+
+describe("classifyQueriesBatch", () => {
+  it("classifies multiple queries", () => {
+    const results = classifyQueriesBatch([
+      "What is TypeScript?",
+      "How do I install npm?",
+      "React vs Angular"
+    ])
+    expect(results).toHaveLength(3)
+    expect(results[0].intent).toBe("factual")
+    expect(results[1].intent).toBe("procedural")
+    expect(results[2].intent).toBe("comparison")
+  })
+
+  it("returns empty array for empty input", () => {
+    expect(classifyQueriesBatch([])).toEqual([])
+  })
+
+  it("passes chat history to each query", () => {
+    const history = [{ role: "user", content: "context" }]
+    const results = classifyQueriesBatch(["What about it?"], history)
+    expect(results[0].shouldUseRAG).toBe(true)
+  })
+})
+
+describe("getIntentDescription", () => {
+  it("returns description for each intent", () => {
+    const intents = [
+      "factual",
+      "exploratory",
+      "procedural",
+      "comparison",
+      "summarization",
+      "conversational"
+    ] as const
+
+    for (const intent of intents) {
+      const desc = getIntentDescription(intent)
+      expect(typeof desc).toBe("string")
+      expect(desc.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("returns factual description", () => {
+    expect(getIntentDescription("factual")).toContain("facts")
+  })
+
+  it("returns procedural description", () => {
+    expect(getIntentDescription("procedural")).toContain("step")
+  })
+})

--- a/src/features/chat/rag/__tests__/rag-pipeline.test.ts
+++ b/src/features/chat/rag/__tests__/rag-pipeline.test.ts
@@ -28,7 +28,17 @@ vi.mock("@/lib/logger", () => ({
   logger: { info: vi.fn(), error: vi.fn(), verbose: vi.fn(), warn: vi.fn() }
 }))
 
+vi.mock("@/lib/embeddings/feedback-service", () => ({
+  feedbackService: { getFeedbackScore: vi.fn().mockResolvedValue(null) }
+}))
+
+vi.mock("@/lib/embeddings/recency-boost", () => ({
+  applyRecencyBoost: vi.fn()
+}))
+
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
+import { feedbackService } from "@/lib/embeddings/feedback-service"
+import { applyRecencyBoost } from "@/lib/embeddings/recency-boost"
 import { searchHybrid } from "@/lib/embeddings/search"
 
 const makeDoc = (id: number, content: string): VectorDocument => ({
@@ -72,6 +82,8 @@ describe("formatEnhancedResults", () => {
     expect(sources[0].page).toBe(3)
   })
 })
+
+import { getEmbeddingConfig } from "@/lib/embeddings/config"
 
 // ─── retrieveContextEnhanced — full mode (BUG-02) ────────────────────────────
 describe("retrieveContextEnhanced — full mode", () => {
@@ -119,5 +131,434 @@ describe("retrieveContextEnhanced — full mode", () => {
 
     expect(results).toEqual([])
     expect(searchHybrid).not.toHaveBeenCalled()
+  })
+})
+
+// ─── retrieveContextEnhanced — similarity mode ───────────────────────────────
+describe("retrieveContextEnhanced — similarity mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEmbeddingConfig).mockResolvedValue({
+      useReranking: false,
+      feedbackEnabled: false,
+      useTemporalBoosting: false
+    } as any)
+  })
+
+  it("returns up to topK results without calling reranker when embedding succeeds", async () => {
+    const fakeEmbedding = [0.1, 0.2]
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: fakeEmbedding,
+      model: "test-model",
+      providerId: "ollama"
+    })
+
+    const doc1 = makeDoc(1, "Result one")
+    const doc2 = makeDoc(2, "Result two")
+    const doc3 = makeDoc(3, "Result three")
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc1, similarity: 0.9 },
+      { document: doc2, similarity: 0.8 },
+      { document: doc3, similarity: 0.7 }
+    ] as any)
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      topK: 2,
+      minSimilarity: 0.3,
+      diversityEnabled: false
+    })
+
+    // Should return at most topK results
+    expect(results.length).toBeLessThanOrEqual(2)
+    expect(results[0].document.content).toBe("Result one")
+  })
+
+  it("returns empty array when generateEmbedding fails in similarity mode", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      error: "Embedding service unavailable"
+    } as any)
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity"
+    })
+
+    expect(results).toEqual([])
+    expect(searchHybrid).not.toHaveBeenCalled()
+  })
+
+  it("returns empty array when searchHybrid returns empty array", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.5, 0.5],
+      model: "test-model",
+      providerId: "ollama"
+    })
+    vi.mocked(searchHybrid).mockResolvedValue([])
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      diversityEnabled: false
+    })
+
+    expect(results).toEqual([])
+  })
+})
+
+// ─── retrieveContextEnhanced — with memory search ────────────────────────────
+describe("retrieveContextEnhanced — includeMemory: true", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEmbeddingConfig).mockResolvedValue({
+      useReranking: false,
+      feedbackEnabled: false,
+      useTemporalBoosting: false
+    } as any)
+  })
+
+  it("calls searchHybrid twice — once for file type, once for chat type", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.3, 0.7],
+      model: "test-model",
+      providerId: "ollama"
+    })
+
+    const fileDoc = makeDoc(10, "File result")
+    const memoryDoc: VectorDocument = {
+      id: 20,
+      content: "Memory result",
+      embedding: [0.4, 0.6],
+      metadata: {
+        source: "chat",
+        title: "Chat",
+        type: "chat",
+        timestamp: Date.now()
+      }
+    }
+
+    // First call → file candidates, second call → chat/memory candidates
+    vi.mocked(searchHybrid)
+      .mockResolvedValueOnce([{ document: fileDoc, similarity: 0.85 }] as any)
+      .mockResolvedValueOnce([{ document: memoryDoc, similarity: 0.75 }] as any)
+
+    await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      includeMemory: true,
+      memoryTopK: 2,
+      diversityEnabled: false
+    })
+
+    expect(searchHybrid).toHaveBeenCalledTimes(2)
+
+    const calls = vi.mocked(searchHybrid).mock.calls
+    // First call should be for file type
+    expect(calls[0][2]).toMatchObject({ type: "file" })
+    // Second call should be for chat type
+    expect(calls[1][2]).toMatchObject({ type: "chat" })
+  })
+
+  it("memory results have isMemory: true and score multiplied by 0.9", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.3, 0.7],
+      model: "test-model",
+      providerId: "ollama"
+    })
+
+    const fileDoc = makeDoc(10, "File result")
+    const memoryDoc: VectorDocument = {
+      id: 20,
+      content: "Memory result",
+      embedding: [0.4, 0.6],
+      metadata: {
+        source: "chat",
+        title: "Chat",
+        type: "chat",
+        timestamp: Date.now()
+      }
+    }
+    const memorySimilarity = 0.8
+
+    vi.mocked(searchHybrid)
+      .mockResolvedValueOnce([{ document: fileDoc, similarity: 0.9 }] as any)
+      .mockResolvedValueOnce([
+        { document: memoryDoc, similarity: memorySimilarity }
+      ] as any)
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      includeMemory: true,
+      memoryTopK: 1,
+      diversityEnabled: false
+    })
+
+    const memResult = results.find((r) => r.isMemory === true)
+    expect(memResult).toBeDefined()
+    expect(memResult!.isMemory).toBe(true)
+    // Score should be the original similarity * 0.9
+    expect(memResult!.score).toBeCloseTo(memorySimilarity * 0.9, 5)
+  })
+})
+
+// ─── formatEnhancedResults — token budget ────────────────────────────────────
+describe("formatEnhancedResults — token budget", () => {
+  it("includes at least one result even when it exceeds maxTokens", () => {
+    const bigDoc: VectorDocument = {
+      id: 1,
+      content: "X".repeat(10000), // ~2500 tokens — far exceeds any small budget
+      embedding: [0.1, 0.2],
+      metadata: {
+        source: "big.pdf",
+        title: "Big",
+        type: "file",
+        timestamp: Date.now()
+      }
+    }
+
+    const { documents, formattedContext } = formatEnhancedResults(
+      [{ document: bigDoc, score: 0.99 }],
+      1 // maxTokens = 1, impossibly small
+    )
+
+    // At-least-one guarantee
+    expect(documents).toHaveLength(1)
+    expect(formattedContext).toContain("X")
+  })
+
+  it("includes all results when no maxTokens is provided", () => {
+    const docs = [
+      makeDoc(1, "First"),
+      makeDoc(2, "Second"),
+      makeDoc(3, "Third")
+    ]
+    const results = docs.map((d, i) => ({ document: d, score: 0.9 - i * 0.1 }))
+
+    const { documents } = formatEnhancedResults(results)
+
+    expect(documents).toHaveLength(3)
+  })
+
+  it("sources for a memory result has type 'memory' and isMemory: true", () => {
+    const memDoc: VectorDocument = {
+      id: 5,
+      content: "From a previous chat.",
+      embedding: [0.1, 0.2],
+      metadata: {
+        source: "chat",
+        title: "Chat",
+        type: "chat",
+        timestamp: Date.now()
+      }
+    }
+
+    const { sources } = formatEnhancedResults(
+      [{ document: memDoc, score: 0.7, isMemory: true }],
+      1000
+    )
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0].type).toBe("memory")
+    expect((sources[0] as any).isMemory).toBe(true)
+  })
+})
+
+import { rerankerService } from "@/lib/embeddings/reranker"
+
+// ─── Stage 2 — reranking enabled ─────────────────────────────────────────────
+describe("retrieveContextEnhanced — reranking enabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEmbeddingConfig).mockResolvedValue({
+      useReranking: true,
+      rerankerBackend: "ollama",
+      minRerankScore: 0.5,
+      feedbackEnabled: false,
+      useTemporalBoosting: false
+    } as any)
+
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.5, 0.5],
+      model: "test-model",
+      providerId: "ollama"
+    })
+  })
+
+  it("returns results that pass the rerank score threshold", async () => {
+    const doc1 = makeDoc(1, "Relevant content A")
+    const doc2 = makeDoc(2, "Relevant content B")
+
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc1, similarity: 0.8 },
+      { document: doc2, similarity: 0.75 }
+    ] as any)
+
+    vi.mocked(rerankerService.rerank).mockResolvedValue([
+      { content: "Relevant content A", score: 0.85, metadata: doc1.metadata },
+      { content: "Relevant content B", score: 0.72, metadata: doc2.metadata }
+    ] as any)
+
+    const results = await retrieveContextEnhanced("test query", {
+      mode: "similarity",
+      topK: 5,
+      diversityEnabled: false
+    })
+
+    // Both have score >= 0.5, so both should be returned
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.every((r) => r.score >= 0.5)).toBe(true)
+  })
+
+  it("returns empty array when all reranked results score below threshold", async () => {
+    const doc1 = makeDoc(1, "Low relevance content")
+
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc1, similarity: 0.4 }
+    ] as any)
+
+    vi.mocked(rerankerService.rerank).mockResolvedValue([
+      { content: "Low relevance content", score: 0.2, metadata: doc1.metadata }
+    ] as any)
+
+    const results = await retrieveContextEnhanced("test query", {
+      mode: "similarity",
+      topK: 5,
+      diversityEnabled: false
+    })
+
+    expect(results).toEqual([])
+  })
+
+  it("calls rerankerService.setBackend and setEnabled with correct arguments", async () => {
+    const doc1 = makeDoc(1, "Some content")
+
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc1, similarity: 0.8 }
+    ] as any)
+
+    vi.mocked(rerankerService.rerank).mockResolvedValue([
+      { content: "Some content", score: 0.9, metadata: doc1.metadata }
+    ] as any)
+
+    await retrieveContextEnhanced("test query", {
+      mode: "similarity",
+      topK: 5,
+      diversityEnabled: false
+    })
+
+    expect(rerankerService.setBackend).toHaveBeenCalledWith("ollama")
+    expect(rerankerService.setEnabled).toHaveBeenCalledWith(true)
+  })
+})
+
+// ─── Stage 2.5 — feedback blending ───────────────────────────────────────────
+describe("retrieveContextEnhanced — feedback blending", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEmbeddingConfig).mockResolvedValue({
+      useReranking: false,
+      feedbackEnabled: true,
+      feedbackBlendWeight: 0.2,
+      useTemporalBoosting: false
+    } as any)
+
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.5, 0.5],
+      model: "test-model",
+      providerId: "ollama"
+    })
+  })
+
+  it("blends feedback score into result score when feedbackScore is non-null", async () => {
+    const doc = makeDoc(42, "Feedback content")
+    const originalSimilarity = 0.6
+
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc, similarity: originalSimilarity }
+    ] as any)
+
+    const feedbackScore = 0.9
+    vi.mocked(feedbackService.getFeedbackScore).mockResolvedValue(feedbackScore)
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      topK: 5,
+      diversityEnabled: false
+    })
+
+    expect(results).toHaveLength(1)
+    // blend formula: (1 - 0.2) * originalSimilarity + 0.2 * feedbackScore
+    const expected = (1 - 0.2) * originalSimilarity + 0.2 * feedbackScore
+    expect(results[0].score).toBeCloseTo(expected, 5)
+  })
+
+  it("leaves score unchanged when feedbackScore is null", async () => {
+    const doc = makeDoc(43, "No feedback content")
+    const originalSimilarity = 0.7
+
+    vi.mocked(searchHybrid).mockResolvedValue([
+      { document: doc, similarity: originalSimilarity }
+    ] as any)
+
+    vi.mocked(feedbackService.getFeedbackScore).mockResolvedValue(null)
+
+    const results = await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      topK: 5,
+      diversityEnabled: false
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].score).toBeCloseTo(originalSimilarity, 5)
+  })
+})
+
+// ─── Stage 2.6 — temporal boosting ───────────────────────────────────────────
+describe("retrieveContextEnhanced — temporal boosting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEmbeddingConfig).mockResolvedValue({
+      useReranking: false,
+      feedbackEnabled: false,
+      useTemporalBoosting: true,
+      temporalBoostWeight: 0.3,
+      temporalHalfLife: 90
+    } as any)
+
+    vi.mocked(generateEmbedding).mockResolvedValue({
+      embedding: [0.5, 0.5],
+      model: "test-model",
+      providerId: "ollama"
+    })
+  })
+
+  it("calls applyRecencyBoost on non-memory file results when useTemporalBoosting is true", async () => {
+    const fileDoc = makeDoc(10, "File result content")
+    const memoryDoc: VectorDocument = {
+      id: 20,
+      content: "Memory result content",
+      embedding: [0.4, 0.6],
+      metadata: {
+        source: "chat",
+        title: "Chat",
+        type: "chat",
+        timestamp: Date.now()
+      }
+    }
+
+    vi.mocked(searchHybrid)
+      .mockResolvedValueOnce([{ document: fileDoc, similarity: 0.85 }] as any)
+      .mockResolvedValueOnce([{ document: memoryDoc, similarity: 0.75 }] as any)
+
+    await retrieveContextEnhanced("query", {
+      mode: "similarity",
+      topK: 5,
+      includeMemory: true,
+      memoryTopK: 1,
+      diversityEnabled: false
+    })
+
+    expect(applyRecencyBoost).toHaveBeenCalledTimes(1)
+    // The argument passed to applyRecencyBoost should only contain non-memory results
+    const boostedResults = vi.mocked(applyRecencyBoost).mock
+      .calls[0][0] as any[]
+    expect(boostedResults.every((r: any) => !r.isMemory)).toBe(true)
   })
 })

--- a/src/features/chat/rag/__tests__/rag-pipeline.test.ts
+++ b/src/features/chat/rag/__tests__/rag-pipeline.test.ts
@@ -36,9 +36,11 @@ vi.mock("@/lib/embeddings/recency-boost", () => ({
   applyRecencyBoost: vi.fn()
 }))
 
+import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { applyRecencyBoost } from "@/lib/embeddings/recency-boost"
+import { rerankerService } from "@/lib/embeddings/reranker"
 import { searchHybrid } from "@/lib/embeddings/search"
 
 const makeDoc = (id: number, content: string): VectorDocument => ({
@@ -82,8 +84,6 @@ describe("formatEnhancedResults", () => {
     expect(sources[0].page).toBe(3)
   })
 })
-
-import { getEmbeddingConfig } from "@/lib/embeddings/config"
 
 // ─── retrieveContextEnhanced — full mode (BUG-02) ────────────────────────────
 describe("retrieveContextEnhanced — full mode", () => {
@@ -359,8 +359,6 @@ describe("formatEnhancedResults — token budget", () => {
     expect((sources[0] as any).isMemory).toBe(true)
   })
 })
-
-import { rerankerService } from "@/lib/embeddings/reranker"
 
 // ─── Stage 2 — reranking enabled ─────────────────────────────────────────────
 describe("retrieveContextEnhanced — reranking enabled", () => {

--- a/src/features/chat/rag/__tests__/rag-retriever.test.ts
+++ b/src/features/chat/rag/__tests__/rag-retriever.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 import * as vectorStore from "@/lib/embeddings/vector-store"
-import { retrieveContext } from "../rag-retriever"
+import {
+  reformulateQuestion,
+  retrieveContext,
+  retrieveContextFromSources
+} from "../rag-retriever"
 
 // Mock dependencies
 vi.mock("@/lib/embeddings/vector-store")
@@ -8,12 +12,36 @@ vi.mock("@/lib/config/knowledge-config", () => ({
   knowledgeConfig: {
     getRetrievalTopK: vi.fn().mockResolvedValue(4),
     getMinSimilarity: vi.fn().mockResolvedValue(0.5),
-    getMaxContextSize: vi.fn().mockResolvedValue(1000)
+    getMaxContextSize: vi.fn().mockResolvedValue(1000),
+    getQuestionPrompt: vi
+      .fn()
+      .mockResolvedValue("Context: {chat_history}\nQuestion: {question}")
   }
 }))
 
 vi.mock("@/lib/embeddings/embedding-client", () => ({
-  generateEmbedding: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] })
+  generateEmbedding: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+  generateEmbeddingsBatch: vi
+    .fn()
+    .mockResolvedValue([{ embedding: [0.1, 0.2] }]),
+  cosineSimilarity: vi.fn().mockReturnValue(0.85)
+}))
+
+vi.mock("@/lib/text-processing", () => ({
+  getTextSplitter: vi.fn().mockResolvedValue({
+    splitDocuments: vi.fn().mockResolvedValue([
+      {
+        pageContent: "chunk content",
+        metadata: {
+          source: "Test Title",
+          title: "Test Title",
+          fileId: "src-1",
+          chunkIndex: 0,
+          totalChunks: 1
+        }
+      }
+    ])
+  })
 }))
 
 vi.mock("../rag-pipeline", () => ({
@@ -140,5 +168,122 @@ describe("retrieveContext", () => {
       expect.objectContaining({ fileId: "file1", type: "file" })
     )
     expect(result.documents).toHaveLength(2)
+  })
+})
+
+describe("retrieveContextFromSources", () => {
+  it("returns empty context when sources array is empty", async () => {
+    const result = await retrieveContextFromSources("query", [])
+
+    expect(result).toEqual({ documents: [], formattedContext: "", sources: [] })
+  })
+
+  it("returns formatted results when embedding succeeds", async () => {
+    const { generateEmbedding, generateEmbeddingsBatch } = await import(
+      "@/lib/embeddings/embedding-client"
+    )
+    const { formatEnhancedResults } = await import("../rag-pipeline")
+
+    vi.mocked(generateEmbedding).mockResolvedValueOnce({
+      embedding: [0.1, 0.2],
+      model: "test-model",
+      providerId: "ollama"
+    } as any)
+    vi.mocked(generateEmbeddingsBatch).mockResolvedValueOnce([
+      { embedding: [0.1, 0.2], model: "test-model", providerId: "ollama" }
+    ] as any)
+
+    const sources = [
+      {
+        id: "src-1",
+        title: "Test Title",
+        content: "Some content about the topic"
+      }
+    ]
+    const result = await retrieveContextFromSources("test query", sources)
+
+    expect(formatEnhancedResults).toHaveBeenCalled()
+    expect(result).toHaveProperty("formattedContext")
+    expect(result).toHaveProperty("documents")
+    expect(result).toHaveProperty("sources")
+    expect(result.formattedContext).not.toBe("")
+  })
+
+  it("falls back to keyword context when embedding fails", async () => {
+    const { generateEmbedding } = await import(
+      "@/lib/embeddings/embedding-client"
+    )
+
+    vi.mocked(generateEmbedding).mockResolvedValueOnce({ error: "failed" })
+
+    const sources = [
+      {
+        id: "src-1",
+        title: "Test Title",
+        content: "keyword content for fallback"
+      }
+    ]
+    const result = await retrieveContextFromSources("keyword", sources)
+
+    expect(result).toHaveProperty("documents")
+    expect(result).toHaveProperty("formattedContext")
+    expect(result).toHaveProperty("sources")
+  })
+})
+
+describe("reformulateQuestion", () => {
+  const chatHistory = [
+    { role: "user" as const, content: "Tell me about modules." },
+    {
+      role: "assistant" as const,
+      content: "Modules are reusable units of code."
+    }
+  ]
+
+  it("returns the reformulated question from modelInvokeFn", async () => {
+    const modelInvokeFn = vi
+      .fn()
+      .mockResolvedValue("What is the purpose of this module?")
+
+    const result = await reformulateQuestion(
+      "What does it do?",
+      chatHistory,
+      modelInvokeFn
+    )
+
+    expect(result).toBe("What is the purpose of this module?")
+    expect(modelInvokeFn).toHaveBeenCalledOnce()
+  })
+
+  it("returns original question when modelInvokeFn returns empty string", async () => {
+    const modelInvokeFn = vi.fn().mockResolvedValue("")
+
+    const result = await reformulateQuestion(
+      "What does it do?",
+      chatHistory,
+      modelInvokeFn
+    )
+
+    expect(result).toBe("What does it do?")
+  })
+
+  it("uses questionPromptOverride instead of config when provided", async () => {
+    const { knowledgeConfig } = await import("@/lib/config/knowledge-config")
+    const modelInvokeFn = vi.fn().mockResolvedValue("Reformulated question")
+    const overrideTemplate =
+      "Custom history: {chat_history}\nCustom question: {question}"
+
+    const result = await reformulateQuestion(
+      "What does it do?",
+      chatHistory,
+      modelInvokeFn,
+      overrideTemplate
+    )
+
+    expect(knowledgeConfig.getQuestionPrompt).not.toHaveBeenCalled()
+    expect(modelInvokeFn).toHaveBeenCalledWith(
+      expect.stringContaining("Custom history:")
+    )
+    expect(result).toBe("Reformulated question")
   })
 })

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -1,0 +1,572 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import * as repo from "@/lib/repositories/chat-history"
+import { chatSessionStore } from "../chat-session-store"
+
+vi.mock("@/lib/repositories/chat-history")
+vi.mock("@/lib/embeddings/vector-store", () => ({
+  deleteVectors: vi.fn().mockResolvedValue(0)
+}))
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() }
+}))
+
+const mockRepo = vi.mocked(repo)
+
+// Import deleteVectors after mocking so we get the mock instance
+import { deleteVectors } from "@/lib/embeddings/vector-store"
+
+const SESSION_ID = "session-abc"
+
+/** Minimal helpers to avoid repeating loadSessionMessages dependencies */
+function setupLoadSessionMessagesMocks(
+  messages: unknown[] = [],
+  session: unknown = { id: SESSION_ID, title: "Test", currentLeafId: undefined }
+) {
+  mockRepo.getSession.mockResolvedValue(session as any)
+  mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue(
+    messages as any
+  )
+  mockRepo.getFilesByMessageIds.mockResolvedValue([])
+}
+
+function resetStore() {
+  chatSessionStore.setState({
+    sessions: [],
+    currentSessionId: null,
+    hasSession: false,
+    hydrated: false,
+    highlightedMessage: null,
+    hasMoreMessages: false
+  })
+}
+
+beforeEach(() => {
+  resetStore()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// addMessage
+// ---------------------------------------------------------------------------
+
+describe("addMessage", () => {
+  it("calls repo.addMessage with the correct shape", async () => {
+    mockRepo.addMessage.mockResolvedValue(99)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    const message = {
+      role: "user" as const,
+      content: "hello",
+      timestamp: 1000
+    }
+    await chatSessionStore.getState().addMessage(SESSION_ID, message as any)
+
+    expect(mockRepo.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION_ID,
+        role: "user",
+        content: "hello",
+        timestamp: 1000
+      })
+    )
+  })
+
+  it("calls repo.updateSession with updatedAt and currentLeafId after adding", async () => {
+    mockRepo.addMessage.mockResolvedValue(42)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore
+      .getState()
+      .addMessage(SESSION_ID, { role: "user", content: "hi" } as any)
+
+    expect(mockRepo.updateSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ currentLeafId: 42 })
+    )
+    expect(
+      (mockRepo.updateSession.mock.calls[0][1] as any).updatedAt
+    ).toBeDefined()
+  })
+
+  it("calls repo.bulkAddFiles when message has attachments", async () => {
+    mockRepo.addMessage.mockResolvedValue(10)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    mockRepo.bulkAddFiles.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    const attachment = {
+      fileId: "f1",
+      fileType: "image/png",
+      fileName: "photo.png",
+      fileSize: 100,
+      data: new Uint8Array([1])
+    }
+    await chatSessionStore.getState().addMessage(SESSION_ID, {
+      role: "user",
+      content: "pic",
+      attachments: [attachment]
+    } as any)
+
+    expect(mockRepo.bulkAddFiles).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fileId: "f1",
+          messageId: 10,
+          sessionId: SESSION_ID
+        })
+      ])
+    )
+  })
+
+  it("calls loadSessionMessages after adding (repo.getSession is called)", async () => {
+    mockRepo.addMessage.mockResolvedValue(5)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore
+      .getState()
+      .addMessage(SESSION_ID, { role: "user", content: "x" } as any)
+
+    expect(mockRepo.getSession).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it("uses last message id as parentId when currentLeafId is not set", async () => {
+    mockRepo.addMessage.mockResolvedValue(7)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          currentLeafId: undefined,
+          messages: [{ id: 55, role: "user" as const, content: "prev" }]
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore
+      .getState()
+      .addMessage(SESSION_ID, { role: "assistant", content: "resp" } as any)
+
+    expect(mockRepo.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentId: 55 })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateMessage
+// ---------------------------------------------------------------------------
+
+describe("updateMessage", () => {
+  beforeEach(() => {
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 11, role: "user" as const, content: "original" }],
+          currentLeafId: 11
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+  })
+
+  it("calls repo.updateMessage when skipDb=false (default)", async () => {
+    mockRepo.updateMessage.mockResolvedValue(undefined as any)
+
+    await chatSessionStore
+      .getState()
+      .updateMessage(11, { content: "updated" }, false)
+
+    expect(mockRepo.updateMessage).toHaveBeenCalledWith(11, {
+      content: "updated"
+    })
+  })
+
+  it("does NOT call repo.updateMessage when skipDb=true", async () => {
+    await chatSessionStore
+      .getState()
+      .updateMessage(11, { content: "skip" }, true)
+
+    expect(mockRepo.updateMessage).not.toHaveBeenCalled()
+  })
+
+  it("updates the message content in store state", async () => {
+    mockRepo.updateMessage.mockResolvedValue(undefined as any)
+
+    await chatSessionStore
+      .getState()
+      .updateMessage(11, { content: "new content" }, false)
+
+    const session = chatSessionStore
+      .getState()
+      .sessions.find((s) => s.id === SESSION_ID)
+    const msg = session?.messages?.find((m) => m.id === 11)
+    expect(msg?.content).toBe("new content")
+  })
+
+  it("calls deleteVectors when content changes (skipDb=false)", async () => {
+    mockRepo.updateMessage.mockResolvedValue(undefined as any)
+    vi.mocked(deleteVectors).mockResolvedValue(0)
+
+    await chatSessionStore
+      .getState()
+      .updateMessage(11, { content: "changed" }, false)
+
+    // deleteVectors is called asynchronously — flush microtasks
+    await Promise.resolve()
+    expect(deleteVectors).toHaveBeenCalledWith({ messageId: 11 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// forkMessage
+// ---------------------------------------------------------------------------
+
+describe("forkMessage", () => {
+  it("calls repo.getMessage to get the original message", async () => {
+    mockRepo.getMessage.mockResolvedValue({
+      id: 20,
+      role: "user",
+      content: "original",
+      sessionId: SESSION_ID,
+      parentId: 10,
+      model: "llama3"
+    } as any)
+    mockRepo.addMessage.mockResolvedValue(21)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: 20
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().forkMessage(SESSION_ID, 20, "forked")
+
+    expect(mockRepo.getMessage).toHaveBeenCalledWith(20)
+  })
+
+  it("calls repo.addMessage with parentId and role from original message", async () => {
+    mockRepo.getMessage.mockResolvedValue({
+      id: 20,
+      role: "user",
+      content: "original",
+      sessionId: SESSION_ID,
+      parentId: 10,
+      model: "llama3"
+    } as any)
+    mockRepo.addMessage.mockResolvedValue(21)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: 20
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().forkMessage(SESSION_ID, 20, "forked")
+
+    expect(mockRepo.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "user",
+        content: "forked",
+        parentId: 10,
+        sessionId: SESSION_ID
+      })
+    )
+  })
+
+  it("calls repo.updateSession with new currentLeafId", async () => {
+    mockRepo.getMessage.mockResolvedValue({
+      id: 20,
+      role: "user",
+      content: "original",
+      sessionId: SESSION_ID,
+      parentId: 10,
+      model: "llama3"
+    } as any)
+    mockRepo.addMessage.mockResolvedValue(21)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: 20
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().forkMessage(SESSION_ID, 20, "forked")
+
+    expect(mockRepo.updateSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ currentLeafId: 21 })
+    )
+  })
+
+  it("returns the new message id", async () => {
+    mockRepo.getMessage.mockResolvedValue({
+      id: 20,
+      role: "user",
+      content: "original",
+      sessionId: SESSION_ID,
+      parentId: 10,
+      model: "llama3"
+    } as any)
+    mockRepo.addMessage.mockResolvedValue(99)
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: 20
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    const newId = await chatSessionStore
+      .getState()
+      .forkMessage(SESSION_ID, 20, "forked")
+
+    expect(newId).toBe(99)
+  })
+
+  it("returns undefined when original message is not found", async () => {
+    mockRepo.getMessage.mockResolvedValue(undefined as any)
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    const result = await chatSessionStore
+      .getState()
+      .forkMessage(SESSION_ID, 999, "forked")
+
+    expect(result).toBeUndefined()
+    expect(mockRepo.addMessage).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// navigateToNode
+// ---------------------------------------------------------------------------
+
+describe("navigateToNode", () => {
+  beforeEach(() => {
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    setupLoadSessionMessagesMocks()
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [],
+          currentLeafId: undefined
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+  })
+
+  it("calls repo.updateSession with nodeId when exact=true", async () => {
+    await chatSessionStore.getState().navigateToNode(SESSION_ID, 30, true)
+
+    expect(mockRepo.updateSession).toHaveBeenCalledWith(SESSION_ID, {
+      currentLeafId: 30
+    })
+  })
+
+  it("calls repo.getMessagesBySessionOrderedByTimestamp when exact=false", async () => {
+    mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue([
+      {
+        id: 30,
+        role: "user",
+        content: "msg",
+        sessionId: SESSION_ID,
+        parentId: undefined
+      }
+    ] as any)
+
+    await chatSessionStore.getState().navigateToNode(SESSION_ID, 30, false)
+
+    expect(
+      mockRepo.getMessagesBySessionOrderedByTimestamp
+    ).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it("default (no exact arg) behaves like exact=false and fetches messages", async () => {
+    mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue([
+      {
+        id: 30,
+        role: "user",
+        content: "msg",
+        sessionId: SESSION_ID,
+        parentId: undefined
+      }
+    ] as any)
+
+    await chatSessionStore.getState().navigateToNode(SESSION_ID, 30)
+
+    expect(
+      mockRepo.getMessagesBySessionOrderedByTimestamp
+    ).toHaveBeenCalledWith(SESSION_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadSessions — already-hydrated guard
+// ---------------------------------------------------------------------------
+
+describe("loadSessions when hydrated=true", () => {
+  it("is a no-op when hydrated=true", async () => {
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "existing",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: []
+        }
+      ],
+      currentSessionId: SESSION_ID,
+      hasSession: true,
+      hydrated: true
+    })
+
+    await chatSessionStore.getState().loadSessions()
+
+    expect(mockRepo.getAllSessionsOrderedByRecency).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateMessages — no-op
+// ---------------------------------------------------------------------------
+
+describe("updateMessages", () => {
+  it("resolves without throwing and without calling any repo function", async () => {
+    await expect(
+      chatSessionStore.getState().updateMessages(SESSION_ID, [])
+    ).resolves.toBeUndefined()
+
+    // None of the repo functions should have been called
+    for (const fn of Object.values(mockRepo)) {
+      if (typeof fn === "function") {
+        expect(fn).not.toHaveBeenCalled()
+      }
+    }
+  })
+})

--- a/src/hooks/__tests__/use-toast.test.ts
+++ b/src/hooks/__tests__/use-toast.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("sonner", () => {
+  const toastFn = vi.fn().mockReturnValue("toast-1") as ReturnType<
+    typeof vi.fn
+  > & {
+    error: ReturnType<typeof vi.fn>
+    dismiss: ReturnType<typeof vi.fn>
+  }
+  toastFn.error = vi.fn().mockReturnValue("toast-err-1")
+  toastFn.dismiss = vi.fn()
+  return { toast: toastFn }
+})
+
+import { toast as sonnerToast } from "sonner"
+import { toast, useToast } from "../use-toast"
+
+const mockedSonnerToast = sonnerToast as unknown as ReturnType<typeof vi.fn> & {
+  error: ReturnType<typeof vi.fn>
+  dismiss: ReturnType<typeof vi.fn>
+}
+
+describe("toast", () => {
+  it("calls sonnerToast (not error) for default variant", () => {
+    toast({ title: "Hello" })
+
+    expect(mockedSonnerToast).toHaveBeenCalledWith("Hello", expect.any(Object))
+    expect(mockedSonnerToast.error).not.toHaveBeenCalled()
+  })
+
+  it("calls sonnerToast.error for destructive variant", () => {
+    toast({ title: "Oops", variant: "destructive" })
+
+    expect(mockedSonnerToast.error).toHaveBeenCalledWith(
+      "Oops",
+      expect.any(Object)
+    )
+    expect(mockedSonnerToast).not.toHaveBeenCalled()
+  })
+
+  it("uses description as first arg when no title is provided", () => {
+    toast({ description: "Only a description" })
+
+    expect(mockedSonnerToast).toHaveBeenCalledWith(
+      "Only a description",
+      expect.objectContaining({ description: undefined })
+    )
+  })
+
+  it("returns object with id, dismiss, and update", () => {
+    const result = toast({ title: "Test" })
+
+    expect(result).toHaveProperty("id", "toast-1")
+    expect(result.dismiss).toBeTypeOf("function")
+    expect(result.update).toBeTypeOf("function")
+  })
+
+  it("dismiss() calls sonnerToast.dismiss with the toast id", () => {
+    const result = toast({ title: "Dismiss me" })
+    result.dismiss()
+
+    expect(mockedSonnerToast.dismiss).toHaveBeenCalledWith("toast-1")
+  })
+
+  it("update() calls sonnerToast with { id } merged into options", () => {
+    const result = toast({ title: "Original" })
+    result.update({ title: "Updated" })
+
+    expect(mockedSonnerToast).toHaveBeenLastCalledWith(
+      "Updated",
+      expect.objectContaining({ id: "toast-1" })
+    )
+  })
+
+  it("passes Infinity duration to sonner", () => {
+    toast({ title: "Sticky", duration: Infinity })
+
+    expect(mockedSonnerToast).toHaveBeenCalledWith(
+      "Sticky",
+      expect.objectContaining({ duration: Infinity })
+    )
+  })
+
+  it("passes undefined duration to sonner when duration is undefined", () => {
+    toast({ title: "Default timeout" })
+
+    expect(mockedSonnerToast).toHaveBeenCalledWith(
+      "Default timeout",
+      expect.objectContaining({ duration: undefined })
+    )
+  })
+})
+
+describe("useToast", () => {
+  it("returns object containing a toast function", () => {
+    const { result } = renderHook(() => useToast())
+
+    expect(result.current.toast).toBeTypeOf("function")
+  })
+
+  it("dismiss(id) calls sonnerToast.dismiss with the given id", () => {
+    const { result } = renderHook(() => useToast())
+    result.current.dismiss("some-id")
+
+    expect(mockedSonnerToast.dismiss).toHaveBeenCalledWith("some-id")
+  })
+})

--- a/src/lib/embeddings/__tests__/chunker.test.ts
+++ b/src/lib/embeddings/__tests__/chunker.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { type ChunkOptions, chunkText, estimateTokens } from "../chunker"
+import {
+  type ChunkOptions,
+  chunkText,
+  chunkTextAsync,
+  estimateTokens,
+  getChunkStats,
+  mergeChunks
+} from "../chunker"
 
 describe("Chunker", () => {
   const defaultOptions: ChunkOptions = {
@@ -73,6 +80,47 @@ Content under header 2.
       // Should be kept together
       expect(chunks.some((c) => c.text.includes("```javascript"))).toBe(true)
     })
+
+    it("falls back to hybrid chunking when a section between headers exceeds chunkSize", () => {
+      // A section body that is much larger than chunkSize triggers the
+      // `if (estimateTokens(section) > chunkSize)` branch inside markdownChunking.
+      // 1 token ≈ 4 chars, so chunkSize=10 means ~40 chars per chunk.
+      // Build a body of ~400 chars (100 tokens) so it definitely exceeds chunkSize=10.
+      const largeBody = "Word ".repeat(80) // 400 chars ≈ 100 tokens
+      const text = `# Big Section\n${largeBody}`
+
+      const chunks = chunkText(text, {
+        ...defaultOptions,
+        strategy: "markdown",
+        chunkSize: 10,
+        chunkOverlap: 1
+      })
+
+      // The large section must have been split into more than one chunk
+      expect(chunks.length).toBeGreaterThan(1)
+      // Every chunk must be non-empty
+      chunks.forEach((c) => {
+        expect(c.text.trim().length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  it("chunkText falls back to hybrid for an unknown strategy string", () => {
+    // The `default:` branch in chunkText's switch should behave identically to "hybrid".
+    const para1 = "A".repeat(100) // ~25 tokens
+    const para2 = "B".repeat(100)
+    const text = `${para1}\n\n${para2}`
+    const options = {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "unknown-strategy" as any
+    }
+
+    const unknownChunks = chunkText(text, options)
+    const hybridChunks = chunkText(text, { ...options, strategy: "hybrid" })
+
+    expect(unknownChunks.length).toBeGreaterThan(1)
+    expect(unknownChunks).toEqual(hybridChunks)
   })
 
   describe("Fallback behavior", () => {
@@ -86,5 +134,270 @@ Content under header 2.
       expect(chunks).toHaveLength(1)
       expect(chunks[0].text).toBe(text)
     })
+  })
+})
+
+describe("chunkText — validation errors", () => {
+  it("throws when chunkSize <= 0", () => {
+    expect(() =>
+      chunkText("some text", {
+        chunkSize: 0,
+        chunkOverlap: 0,
+        strategy: "fixed"
+      })
+    ).toThrow()
+    expect(() =>
+      chunkText("some text", {
+        chunkSize: -5,
+        chunkOverlap: 0,
+        strategy: "fixed"
+      })
+    ).toThrow()
+  })
+
+  it("throws an AppError with kind 'validation' when chunkSize <= 0", () => {
+    try {
+      chunkText("some text", {
+        chunkSize: 0,
+        chunkOverlap: 0,
+        strategy: "fixed"
+      })
+      expect.fail("should have thrown")
+    } catch (err: any) {
+      expect(err.kind).toBe("validation")
+    }
+  })
+
+  it("throws when chunkOverlap < 0", () => {
+    expect(() =>
+      chunkText("some text", {
+        chunkSize: 10,
+        chunkOverlap: -1,
+        strategy: "fixed"
+      })
+    ).toThrow()
+
+    try {
+      chunkText("some text", {
+        chunkSize: 10,
+        chunkOverlap: -1,
+        strategy: "fixed"
+      })
+      expect.fail("should have thrown")
+    } catch (err: any) {
+      expect(err.kind).toBe("validation")
+    }
+  })
+
+  it("throws when chunkOverlap >= chunkSize", () => {
+    expect(() =>
+      chunkText("some text", {
+        chunkSize: 10,
+        chunkOverlap: 10,
+        strategy: "fixed"
+      })
+    ).toThrow()
+    expect(() =>
+      chunkText("some text", {
+        chunkSize: 10,
+        chunkOverlap: 15,
+        strategy: "fixed"
+      })
+    ).toThrow()
+
+    try {
+      chunkText("some text", {
+        chunkSize: 10,
+        chunkOverlap: 10,
+        strategy: "fixed"
+      })
+      expect.fail("should have thrown")
+    } catch (err: any) {
+      expect(err.kind).toBe("validation")
+    }
+  })
+})
+
+describe("semanticChunking", () => {
+  it("splits multi-paragraph text into multiple chunks", () => {
+    // Each paragraph is ~25 tokens (100 chars). chunkSize=20 so second paragraph triggers new chunk.
+    const para1 = "A".repeat(80) // ~20 tokens
+    const para2 = "B".repeat(80)
+    const para3 = "C".repeat(80)
+    const text = `${para1}\n\n${para2}\n\n${para3}`
+
+    const chunks = chunkText(text, {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "semantic"
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+  })
+
+  it("chunks contain paragraph content", () => {
+    const para1 = "First paragraph content here."
+    const para2 =
+      "Second paragraph content here with more words to force split."
+    const para3 = "Third paragraph content here."
+    // Make para2 large enough to force a split
+    const bigPara2 = "B".repeat(200) // ~50 tokens
+    const text = `${para1}\n\n${bigPara2}\n\n${para3}`
+
+    const chunks = chunkText(text, {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "semantic"
+    })
+
+    const allText = chunks.map((c) => c.text).join(" ")
+    expect(allText).toContain(para1)
+    expect(allText).toContain(para3)
+  })
+
+  it("final leftover paragraph becomes the last chunk", () => {
+    const para1 = "A".repeat(100) // ~25 tokens — exceeds chunkSize
+    const lastPara = "Last paragraph stands alone."
+    const text = `${para1}\n\n${lastPara}`
+
+    const chunks = chunkText(text, {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "semantic"
+    })
+
+    const lastChunk = chunks[chunks.length - 1]
+    expect(lastChunk.text).toContain("Last paragraph stands alone.")
+  })
+})
+
+describe("hybridChunking", () => {
+  it("accumulates normal-sized paragraphs together", () => {
+    // Two small paragraphs that together fit within chunkSize
+    const para1 = "Short paragraph one."
+    const para2 = "Short paragraph two."
+    const text = `${para1}\n\n${para2}`
+
+    const chunks = chunkText(text, {
+      chunkSize: 100,
+      chunkOverlap: 5,
+      strategy: "hybrid"
+    })
+
+    // Both fit in one chunk since combined tokens << 100
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].text).toContain(para1)
+    expect(chunks[0].text).toContain(para2)
+  })
+
+  it("splits a large paragraph by sentences", () => {
+    // One very large paragraph that exceeds chunkSize — should be split by sentences
+    const longPara =
+      "This is the first sentence of a very long paragraph. " +
+      "This is the second sentence. ".repeat(5) +
+      "This is the final sentence here."
+    // Force a small chunkSize so the paragraph exceeds it
+    const text = longPara
+
+    const chunks = chunkText(text, {
+      chunkSize: 10, // 40 chars — triggers sentence splitting
+      chunkOverlap: 1,
+      strategy: "hybrid"
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+  })
+
+  it("produces at least 1 chunk from non-empty text", () => {
+    const text = "Hello world."
+
+    const chunks = chunkText(text, {
+      chunkSize: 100,
+      chunkOverlap: 5,
+      strategy: "hybrid"
+    })
+
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe("chunkTextAsync", () => {
+  it("resolves to the same result as chunkText for the same input", async () => {
+    const text = "A".repeat(200)
+    const options: ChunkOptions = {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "fixed"
+    }
+
+    const syncResult = chunkText(text, options)
+    const asyncResult = await chunkTextAsync(text, options)
+
+    expect(asyncResult).toEqual(syncResult)
+  })
+
+  it("resolves to empty array for empty text", async () => {
+    const options: ChunkOptions = {
+      chunkSize: 20,
+      chunkOverlap: 2,
+      strategy: "fixed"
+    }
+    const result = await chunkTextAsync("", options)
+    expect(result).toEqual([])
+  })
+})
+
+describe("mergeChunks", () => {
+  it("returns empty string for 0 chunks", () => {
+    expect(mergeChunks([])).toBe("")
+  })
+
+  it("returns just the chunk text for a single chunk (no separator)", () => {
+    const chunks = [{ text: "Only chunk", index: 0, startPos: 0, endPos: 10 }]
+    expect(mergeChunks(chunks)).toBe("Only chunk")
+  })
+
+  it("joins 2+ chunks with the separator", () => {
+    const chunks = [
+      { text: "First chunk", index: 0, startPos: 0, endPos: 11 },
+      { text: "Second chunk", index: 1, startPos: 11, endPos: 23 },
+      { text: "Third chunk", index: 2, startPos: 23, endPos: 34 }
+    ]
+    const result = mergeChunks(chunks)
+    expect(result).toBe(
+      "First chunk\n\n---CHUNK---\n\nSecond chunk\n\n---CHUNK---\n\nThird chunk"
+    )
+  })
+})
+
+describe("getChunkStats", () => {
+  const chunks = [
+    { text: "Hello", index: 0, startPos: 0, endPos: 5 }, // 5 chars
+    { text: "World!", index: 1, startPos: 5, endPos: 11 }, // 6 chars
+    { text: "Hi there", index: 2, startPos: 11, endPos: 19 } // 8 chars
+  ]
+  // totalChars = 19, avgChunkSize = ceil(19/3) = 6 (rounded), min = 5, max = 8
+
+  it("returns correct totalChunks", () => {
+    expect(getChunkStats(chunks).totalChunks).toBe(3)
+  })
+
+  it("returns correct totalCharacters", () => {
+    expect(getChunkStats(chunks).totalCharacters).toBe(19)
+  })
+
+  it("returns correct estimatedTokens (ceil of totalChars / 4)", () => {
+    // ceil(19 / 4) = 5
+    expect(getChunkStats(chunks).estimatedTokens).toBe(5)
+  })
+
+  it("returns correct avgChunkSize (rounded)", () => {
+    // avg = 19 / 3 ≈ 6.33 → rounds to 6
+    expect(getChunkStats(chunks).avgChunkSize).toBe(Math.round(19 / 3))
+  })
+
+  it("returns correct minChunkSize and maxChunkSize", () => {
+    expect(getChunkStats(chunks).minChunkSize).toBe(5)
+    expect(getChunkStats(chunks).maxChunkSize).toBe(8)
   })
 })

--- a/src/lib/exporters/__tests__/exporters.test.ts
+++ b/src/lib/exporters/__tests__/exporters.test.ts
@@ -1,0 +1,272 @@
+import type { TFunction } from "i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { ChatMessage, ChatSession } from "@/types"
+
+vi.mock("../utils", () => ({
+  downloadFile: vi.fn()
+}))
+
+import { jsonExporter } from "../json-exporter"
+import { markdownExporter } from "../markdown-exporter"
+import { textExporter } from "../text-exporter"
+import { downloadFile } from "../utils"
+
+const mockT = vi.fn((key: string) => key) as unknown as TFunction
+
+const makeSession = (overrides: Partial<ChatSession> = {}): ChatSession =>
+  ({
+    id: "s1",
+    title: "My Chat",
+    modelId: "llama2",
+    createdAt: 1000,
+    updatedAt: 2000,
+    messages: [
+      {
+        id: "m1",
+        role: "user",
+        content: "Hello",
+        timestamp: 1000,
+        done: true
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "Hi there",
+        timestamp: 1100,
+        done: true
+      }
+    ],
+    ...overrides
+  }) as unknown as ChatSession
+
+const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage =>
+  ({
+    id: "m1",
+    role: "user",
+    content: "Test message",
+    timestamp: 1000,
+    done: true,
+    ...overrides
+  }) as unknown as ChatMessage
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ─── downloadFile util ────────────────────────────────────────────────────────
+
+describe("downloadFile", () => {
+  it("creates object URL, clicks anchor, then revokes URL", async () => {
+    const { downloadFile: realDownloadFile } =
+      await vi.importActual<typeof import("../utils")>("../utils")
+
+    const clickSpy = vi.fn()
+    const anchor = {
+      href: "",
+      download: "",
+      click: clickSpy
+    } as unknown as HTMLAnchorElement
+    vi.spyOn(document, "createElement").mockReturnValue(anchor)
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake")
+    const revokeSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {})
+
+    realDownloadFile(new Blob(["hi"]), "out.txt")
+
+    expect(anchor.download).toBe("out.txt")
+    expect(anchor.href).toBe("blob:fake")
+    expect(clickSpy).toHaveBeenCalled()
+    expect(revokeSpy).toHaveBeenCalledWith("blob:fake")
+
+    vi.restoreAllMocks()
+  })
+})
+
+// ─── jsonExporter ─────────────────────────────────────────────────────────────
+
+describe("jsonExporter", () => {
+  it("exportSession calls downloadFile with JSON blob and correct filename", () => {
+    const session = makeSession()
+    jsonExporter.exportSession(session, mockT)
+
+    expect(downloadFile).toHaveBeenCalledOnce()
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("My Chat.json")
+    expect(blob.type).toBe("application/json")
+    const text = blob
+    // verify content is valid JSON containing session id
+    expect(blob).toBeInstanceOf(Blob)
+  })
+
+  it("exportSession uses custom fileName from options", () => {
+    const session = makeSession()
+    jsonExporter.exportSession(session, mockT, { fileName: "custom.json" })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("custom.json")
+  })
+
+  it("exportSession uses fallback title when session has no title", () => {
+    const session = makeSession({ title: undefined })
+    jsonExporter.exportSession(session, mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("chat-session.json")
+  })
+
+  it("exportAllSessions downloads all-chat-sessions.json", () => {
+    jsonExporter.exportAllSessions(
+      [makeSession(), makeSession({ id: "s2" })],
+      mockT
+    )
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("all-chat-sessions.json")
+    expect(blob.type).toBe("application/json")
+  })
+
+  it("exportMessage downloads message JSON with correct filename", () => {
+    const msg = makeMessage()
+    jsonExporter.exportMessage(msg, mockT)
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-m1.json")
+    expect(blob.type).toBe("application/json")
+  })
+
+  it("exportMessage uses custom fileName from options", () => {
+    jsonExporter.exportMessage(makeMessage(), mockT, { fileName: "msg.json" })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("msg.json")
+  })
+
+  it("exportMessage falls back to 'export' when message has no id", () => {
+    jsonExporter.exportMessage(makeMessage({ id: undefined }), mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-export.json")
+  })
+})
+
+// ─── textExporter ─────────────────────────────────────────────────────────────
+
+describe("textExporter", () => {
+  it("exportSession creates plain text blob with title and messages", () => {
+    const session = makeSession()
+    textExporter.exportSession(session, mockT)
+
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("My Chat.txt")
+    expect(blob.type).toBe("text/plain")
+  })
+
+  it("exportSession uses custom fileName", () => {
+    textExporter.exportSession(makeSession(), mockT, { fileName: "out.txt" })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("out.txt")
+  })
+
+  it("exportSession uses default title key when session has no title", () => {
+    textExporter.exportSession(makeSession({ title: undefined }), mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("sessions.export.default_title.txt")
+  })
+
+  it("exportAllSessions downloads all-chat-sessions.txt", () => {
+    textExporter.exportAllSessions([makeSession()], mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("all-chat-sessions.txt")
+  })
+
+  it("exportMessage creates text blob for single message", () => {
+    textExporter.exportMessage(makeMessage(), mockT)
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-m1.txt")
+    expect(blob.type).toBe("text/plain")
+  })
+
+  it("exportMessage uses custom fileName", () => {
+    textExporter.exportMessage(makeMessage(), mockT, { fileName: "msg.txt" })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("msg.txt")
+  })
+
+  it("exportMessage falls back to 'export' in filename when no id", () => {
+    textExporter.exportMessage(makeMessage({ id: undefined }), mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-export.txt")
+  })
+})
+
+// ─── markdownExporter ─────────────────────────────────────────────────────────
+
+describe("markdownExporter", () => {
+  it("exportSession creates markdown blob with .md extension", () => {
+    markdownExporter.exportSession(makeSession(), mockT)
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("My Chat.md")
+    expect(blob.type).toBe("text/markdown")
+  })
+
+  it("exportSession uses custom fileName", () => {
+    markdownExporter.exportSession(makeSession(), mockT, {
+      fileName: "chat.md"
+    })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("chat.md")
+  })
+
+  it("exportSession uses default title key when no title", () => {
+    markdownExporter.exportSession(makeSession({ title: undefined }), mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("sessions.export.default_title.md")
+  })
+
+  it("exportAllSessions downloads all-chat-sessions.md", () => {
+    markdownExporter.exportAllSessions([makeSession()], mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("all-chat-sessions.md")
+  })
+
+  it("exportMessage creates markdown blob", () => {
+    markdownExporter.exportMessage(makeMessage(), mockT)
+    const [blob, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-m1.md")
+    expect(blob.type).toBe("text/markdown")
+  })
+
+  it("exportMessage uses custom fileName", () => {
+    markdownExporter.exportMessage(makeMessage(), mockT, { fileName: "m.md" })
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("m.md")
+  })
+
+  it("exportMessage falls back to 'export' in filename when no id", () => {
+    markdownExporter.exportMessage(makeMessage({ id: undefined }), mockT)
+    const [, filename] = (downloadFile as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(filename).toBe("message-export.md")
+  })
+
+  it("exportMessage uses assistant role label for assistant messages", () => {
+    markdownExporter.exportMessage(makeMessage({ role: "assistant" }), mockT)
+    expect(downloadFile).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/exporters/__tests__/exporters.test.ts
+++ b/src/lib/exporters/__tests__/exporters.test.ts
@@ -96,8 +96,6 @@ describe("jsonExporter", () => {
       .calls[0]
     expect(filename).toBe("My Chat.json")
     expect(blob.type).toBe("application/json")
-    const text = blob
-    // verify content is valid JSON containing session id
     expect(blob).toBeInstanceOf(Blob)
   })
 

--- a/src/lib/knowledge/__tests__/knowledge-sets.test.ts
+++ b/src/lib/knowledge/__tests__/knowledge-sets.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  plasmoGlobalStorage: {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+import {
+  addFileToKnowledgeSet,
+  createKnowledgeSet,
+  DEFAULT_KNOWLEDGE_SET_ID,
+  DEFAULT_KNOWLEDGE_SET_NAME,
+  DEFAULT_RAG_PROMPT,
+  deleteKnowledgeSet,
+  ensureDefaultKnowledgeSet,
+  getActiveKnowledgeSetId,
+  getKnowledgeSet,
+  getKnowledgeSetFileIds,
+  type KnowledgeFileRecord,
+  knowledgeDb,
+  listKnowledgeSets,
+  markKnowledgeFileEmbedded,
+  setActiveKnowledgeSetId,
+  updateKnowledgeSet
+} from "../knowledge-sets"
+
+const mockedStorage = plasmoGlobalStorage as unknown as {
+  get: ReturnType<typeof vi.fn>
+  set: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+}
+
+beforeEach(async () => {
+  await knowledgeDb.knowledgeSets.clear()
+  await knowledgeDb.knowledgeFiles.clear()
+  vi.clearAllMocks()
+  mockedStorage.get.mockResolvedValue(undefined)
+  mockedStorage.set.mockResolvedValue(undefined)
+  mockedStorage.remove.mockResolvedValue(undefined)
+})
+
+describe("ensureDefaultKnowledgeSet", () => {
+  it("creates default knowledge set when none exists", async () => {
+    const record = await ensureDefaultKnowledgeSet()
+
+    expect(record.id).toBe(DEFAULT_KNOWLEDGE_SET_ID)
+    expect(record.name).toBe(DEFAULT_KNOWLEDGE_SET_NAME)
+    expect(record.id).toBe("default")
+    expect(record.name).toBe("Default")
+  })
+
+  it("returns existing record without creating a duplicate when called twice", async () => {
+    const first = await ensureDefaultKnowledgeSet()
+    const second = await ensureDefaultKnowledgeSet()
+
+    expect(second.id).toBe(first.id)
+    expect(second.createdAt).toBe(first.createdAt)
+
+    const all = await knowledgeDb.knowledgeSets.toArray()
+    expect(all).toHaveLength(1)
+  })
+})
+
+describe("listKnowledgeSets", () => {
+  it("returns array including the default knowledge set", async () => {
+    const sets = await listKnowledgeSets()
+
+    expect(sets.some((s) => s.id === DEFAULT_KNOWLEDGE_SET_ID)).toBe(true)
+  })
+
+  it("returns all created sets", async () => {
+    await ensureDefaultKnowledgeSet()
+    await createKnowledgeSet({ name: "Alpha" })
+    await createKnowledgeSet({ name: "Beta" })
+
+    const sets = await listKnowledgeSets()
+
+    const names = sets.map((s) => s.name)
+    expect(names).toContain("Default")
+    expect(names).toContain("Alpha")
+    expect(names).toContain("Beta")
+    expect(sets).toHaveLength(3)
+  })
+})
+
+describe("getKnowledgeSet", () => {
+  it("returns the set by id", async () => {
+    await ensureDefaultKnowledgeSet()
+    const found = await getKnowledgeSet(DEFAULT_KNOWLEDGE_SET_ID)
+
+    expect(found).toBeDefined()
+    expect(found!.id).toBe(DEFAULT_KNOWLEDGE_SET_ID)
+  })
+
+  it("returns undefined for unknown id", async () => {
+    const found = await getKnowledgeSet("does-not-exist")
+
+    expect(found).toBeUndefined()
+  })
+})
+
+describe("createKnowledgeSet", () => {
+  it("creates a new set with name and optional description", async () => {
+    const record = await createKnowledgeSet({
+      name: "My Set",
+      description: "A description"
+    })
+
+    expect(record.name).toBe("My Set")
+    expect(record.description).toBe("A description")
+
+    const stored = await getKnowledgeSet(record.id)
+    expect(stored).toBeDefined()
+  })
+
+  it("created set has ragPrompt equal to DEFAULT_RAG_PROMPT", async () => {
+    const record = await createKnowledgeSet({ name: "Prompt Check" })
+
+    expect(record.ragPrompt).toBe(DEFAULT_RAG_PROMPT)
+  })
+
+  it("created set has unique id that is not 'default'", async () => {
+    const a = await createKnowledgeSet({ name: "Set A" })
+    const b = await createKnowledgeSet({ name: "Set B" })
+
+    expect(a.id).not.toBe(DEFAULT_KNOWLEDGE_SET_ID)
+    expect(b.id).not.toBe(DEFAULT_KNOWLEDGE_SET_ID)
+    expect(a.id).not.toBe(b.id)
+  })
+})
+
+describe("updateKnowledgeSet", () => {
+  it("updates the name of an existing set", async () => {
+    const created = await createKnowledgeSet({ name: "Original" })
+    await updateKnowledgeSet(created.id, { name: "Renamed" })
+
+    const updated = await getKnowledgeSet(created.id)
+    expect(updated!.name).toBe("Renamed")
+  })
+
+  it("does nothing for an unknown id", async () => {
+    await expect(
+      updateKnowledgeSet("nonexistent-id", { name: "Ghost" })
+    ).resolves.toBeUndefined()
+
+    const notCreated = await getKnowledgeSet("nonexistent-id")
+    expect(notCreated).toBeUndefined()
+  })
+})
+
+describe("deleteKnowledgeSet", () => {
+  it("cannot delete the default set (no-op)", async () => {
+    await ensureDefaultKnowledgeSet()
+    await deleteKnowledgeSet(DEFAULT_KNOWLEDGE_SET_ID)
+
+    const stillExists = await getKnowledgeSet(DEFAULT_KNOWLEDGE_SET_ID)
+    expect(stillExists).toBeDefined()
+  })
+
+  it("deletes a non-default set", async () => {
+    const created = await createKnowledgeSet({ name: "Temporary" })
+    await deleteKnowledgeSet(created.id)
+
+    const gone = await getKnowledgeSet(created.id)
+    expect(gone).toBeUndefined()
+  })
+})
+
+describe("addFileToKnowledgeSet + getKnowledgeSetFileIds", () => {
+  it("adding a file and listing ids returns the file's id", async () => {
+    await ensureDefaultKnowledgeSet()
+
+    const file: KnowledgeFileRecord = {
+      id: "file-abc-123",
+      knowledgeSetId: DEFAULT_KNOWLEDGE_SET_ID,
+      fileName: "doc.pdf",
+      fileType: "application/pdf",
+      fileSize: 1024,
+      createdAt: Date.now()
+    }
+
+    await addFileToKnowledgeSet(file)
+
+    const ids = await getKnowledgeSetFileIds(DEFAULT_KNOWLEDGE_SET_ID)
+    expect(ids).toContain("file-abc-123")
+  })
+})
+
+describe("markKnowledgeFileEmbedded", () => {
+  it("updates lastEmbeddedAt on the file record", async () => {
+    await ensureDefaultKnowledgeSet()
+
+    const file: KnowledgeFileRecord = {
+      id: "file-embed-1",
+      knowledgeSetId: DEFAULT_KNOWLEDGE_SET_ID,
+      fileName: "embed.txt",
+      fileType: "text/plain",
+      fileSize: 256,
+      createdAt: Date.now()
+    }
+    await addFileToKnowledgeSet(file)
+
+    const embeddedAt = Date.now() + 1000
+    await markKnowledgeFileEmbedded("file-embed-1", embeddedAt)
+
+    const stored = await knowledgeDb.knowledgeFiles.get("file-embed-1")
+    expect(stored!.lastEmbeddedAt).toBe(embeddedAt)
+  })
+
+  it("does nothing for an unknown file id", async () => {
+    await expect(
+      markKnowledgeFileEmbedded("no-such-file", Date.now())
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe("getActiveKnowledgeSetId / setActiveKnowledgeSetId", () => {
+  it("returns DEFAULT_KNOWLEDGE_SET_ID when nothing is stored", async () => {
+    mockedStorage.get.mockResolvedValue(undefined)
+
+    const id = await getActiveKnowledgeSetId()
+
+    expect(id).toBe(DEFAULT_KNOWLEDGE_SET_ID)
+  })
+
+  it("returns the stored id when plasmoGlobalStorage.get returns a value", async () => {
+    mockedStorage.get.mockResolvedValue("my-custom-set")
+
+    const id = await getActiveKnowledgeSetId()
+
+    expect(id).toBe("my-custom-set")
+  })
+})

--- a/src/lib/sqlite/__tests__/sqlite-module.test.ts
+++ b/src/lib/sqlite/__tests__/sqlite-module.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for the sqlite/db.ts module functions.
+ *
+ * The module opens IndexedDB via its private helpers. fake-indexeddb works
+ * fine for single-call scenarios but an open connection that is never
+ * explicitly closed causes indexedDB.deleteDatabase to receive `onblocked`
+ * in fake-indexeddb, and any subsequent `indexedDB.open` on that same name
+ * then hangs indefinitely.
+ *
+ * To avoid this we replace `globalThis.indexedDB` with a minimal in-memory
+ * stub before each test. The stub is rebuilt on every `beforeEach` call so
+ * that `vi.clearAllMocks()` (called by the global afterEach in setup.ts)
+ * cannot wipe its implementations.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("sql.js/dist/sql-wasm.js", () => ({ default: vi.fn() }))
+vi.mock("./migrations/add-thinking-column", () => ({
+  ensureMessagesThinkingColumn: vi.fn()
+}))
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}))
+
+import initSqlJs from "sql.js/dist/sql-wasm.js"
+import {
+  exportDatabaseBytes,
+  flushSave,
+  initSQLite,
+  query,
+  resetSQLiteDatabase,
+  run,
+  saveDatabase
+} from "../db"
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory IndexedDB stub
+// ---------------------------------------------------------------------------
+
+/** Bytes last written to the stub IDB store — simulates IndexedDB persistence. */
+let storedBytes: Uint8Array | null = null
+
+/**
+ * Build a fresh indexedDB stub object (plain JS, not vi.fn) so that
+ * vi.clearAllMocks() cannot accidentally clear its implementations.
+ */
+function buildIndexedDBStub() {
+  function makeRequest<T>(
+    resolver: (cb: (v: T) => void) => void
+  ): IDBRequest<T> {
+    const req = {
+      result: undefined as unknown as T,
+      onsuccess: null as ((e: Event) => void) | null,
+      onerror: null as ((e: Event) => void) | null
+    }
+    resolver((value) => {
+      req.result = value
+      if (req.onsuccess) {
+        req.onsuccess({ target: req } as unknown as Event)
+      }
+    })
+    return req as unknown as IDBRequest<T>
+  }
+
+  const fakeObjectStore = {
+    get: (key: string) =>
+      makeRequest<Uint8Array | null>((done) => {
+        Promise.resolve().then(() =>
+          done(key === "database" ? storedBytes : null)
+        )
+      }),
+    put: (data: Uint8Array, _key: string) =>
+      makeRequest<IDBValidKey>((done) => {
+        Promise.resolve().then(() => {
+          storedBytes = data
+          done("database" as unknown as IDBValidKey)
+        })
+      })
+  }
+
+  const fakeTx = {
+    objectStore: (_name: string) => fakeObjectStore
+  }
+
+  const fakeDB = {
+    transaction: (_names: string[], _mode: string) => fakeTx,
+    objectStoreNames: { contains: (_name: string) => true }
+  }
+
+  return {
+    open(_name: string, _version: number): IDBOpenDBRequest {
+      const req = {
+        result: fakeDB as unknown as IDBDatabase,
+        onsuccess: null as ((e: Event) => void) | null,
+        onerror: null as ((e: Event) => void) | null,
+        onupgradeneeded: null as ((e: IDBVersionChangeEvent) => void) | null,
+        onblocked: null as ((e: Event) => void) | null
+      }
+      Promise.resolve().then(() => {
+        if (req.onsuccess) {
+          req.onsuccess({ target: req } as unknown as Event)
+        }
+      })
+      return req as unknown as IDBOpenDBRequest
+    },
+    deleteDatabase(_name: string): IDBOpenDBRequest {
+      const req = {
+        onsuccess: null as ((e: Event) => void) | null,
+        onerror: null as ((e: Event) => void) | null,
+        onblocked: null as ((e: Event) => void) | null
+      }
+      Promise.resolve().then(() => {
+        storedBytes = null
+        if (req.onsuccess) {
+          req.onsuccess({ target: req } as unknown as Event)
+        }
+      })
+      return req as unknown as IDBOpenDBRequest
+    }
+  } as unknown as IDBFactory
+}
+
+// ---------------------------------------------------------------------------
+// SQL.js mock factories
+// ---------------------------------------------------------------------------
+
+function buildSQLMocks() {
+  const mockStmt = {
+    bind: vi.fn(),
+    step: vi.fn().mockReturnValue(false),
+    getAsObject: vi.fn().mockReturnValue({}),
+    free: vi.fn(),
+    reset: vi.fn()
+  }
+  const mockDb = {
+    prepare: vi.fn().mockReturnValue(mockStmt),
+    run: vi.fn(),
+    export: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+    close: vi.fn()
+  }
+  // Must be a real constructor so `new SQL.Database()` doesn't throw.
+  const DatabaseSpy = vi.fn().mockImplementation(function (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this: any
+  ) {
+    Object.assign(this, mockDb)
+  })
+  return { mockStmt, mockDb, mockSQL: { Database: DatabaseSpy } }
+}
+
+// ---------------------------------------------------------------------------
+// chrome + fetch helpers
+// ---------------------------------------------------------------------------
+
+function setupChrome() {
+  Object.assign(globalThis.chrome, {
+    runtime: {
+      id: "test-ext",
+      getURL: vi
+        .fn()
+        .mockReturnValue("chrome-extension://test/assets/sql-wasm.wasm")
+    }
+  })
+}
+
+function setupFetch() {
+  global.fetch = vi.fn().mockResolvedValue({
+    arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("SQLite DB module", () => {
+  beforeEach(async () => {
+    // Install fresh IDB stub (rebuilt each time so clearAllMocks can't wipe it)
+    vi.stubGlobal("indexedDB", buildIndexedDBStub())
+    storedBytes = null
+
+    // Reset module singletons (db, initPromise)
+    await resetSQLiteDatabase().catch(() => undefined)
+
+    // vi.clearAllMocks is called by setup.ts afterEach, but we call it here
+    // too so tests within this suite start with clean call counts.
+    vi.clearAllMocks()
+
+    // Reinstall chrome/fetch mocks (may have been cleared)
+    setupChrome()
+    setupFetch()
+
+    // Reinstall a fresh IDB stub after clearAllMocks
+    vi.stubGlobal("indexedDB", buildIndexedDBStub())
+    storedBytes = null
+  })
+
+  afterEach(async () => {
+    // Null out singletons before restoring globals
+    await resetSQLiteDatabase().catch(() => undefined)
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // 1. initSQLite — new database (no existing data in IndexedDB)
+  // -------------------------------------------------------------------------
+
+  it("initSQLite creates a new empty database when no existing data in IndexedDB", async () => {
+    const { mockSQL, mockDb } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+
+    // Database() with no args → new empty DB
+    expect(mockSQL.Database).toHaveBeenCalledWith()
+    // Schema SQL applied on new DB
+    expect(mockDb.run).toHaveBeenCalledWith(
+      expect.stringContaining("CREATE TABLE")
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. initSQLite — loads existing database from IndexedDB
+  // -------------------------------------------------------------------------
+
+  it("initSQLite loads existing database from IndexedDB when data is present", async () => {
+    // Pre-seed stored bytes so loadDatabaseFromIndexedDB returns them
+    storedBytes = new Uint8Array([42, 43, 44, 45])
+
+    const { mockSQL } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+
+    // Database constructor called with a Uint8Array → loaded from IDB
+    expect(mockSQL.Database).toHaveBeenCalledWith(expect.any(Uint8Array))
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. query — returns array of row objects
+  // -------------------------------------------------------------------------
+
+  it("query returns array of row objects", async () => {
+    const { mockSQL } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    // Get the DB instance and wire up a statement mock that returns one row
+    const db = await initSQLite()
+
+    // Build a fresh statement mock AFTER initSQLite so no calls have happened
+    let stepCount = 0
+    const rowStmt = {
+      bind: vi.fn(),
+      step: vi.fn().mockImplementation(() => {
+        stepCount++
+        return stepCount === 1 // true only on the first call
+      }),
+      getAsObject: vi.fn().mockReturnValue({ id: 1, name: "test" }),
+      free: vi.fn(),
+      reset: vi.fn()
+    }
+    // Override the prepare mock on the live DB instance to return our row stmt
+    ;(db as any).prepare = vi.fn().mockReturnValue(rowStmt)
+
+    const results = await query("SELECT * FROM test")
+
+    expect(results).toEqual([{ id: 1, name: "test" }])
+    expect(rowStmt.free).toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. run — executes statement with bind params
+  // -------------------------------------------------------------------------
+
+  it("run executes statement and binds parameters", async () => {
+    const { mockSQL, mockStmt, mockDb } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+
+    await run("INSERT INTO test VALUES (?)", [42])
+
+    expect(mockDb.prepare).toHaveBeenCalledWith("INSERT INTO test VALUES (?)")
+    expect(mockStmt.bind).toHaveBeenCalledWith([42])
+    expect(mockStmt.step).toHaveBeenCalled()
+    expect(mockStmt.free).toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. flushSave — calls db.export and saves to IndexedDB
+  // -------------------------------------------------------------------------
+
+  it("flushSave calls db.export after initSQLite", async () => {
+    const { mockSQL, mockDb } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+    mockDb.export.mockClear()
+
+    await flushSave()
+
+    expect(mockDb.export).toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 6. saveDatabase — alias of flushSave
+  // -------------------------------------------------------------------------
+
+  it("saveDatabase is an alias for flushSave and calls db.export", async () => {
+    const { mockSQL, mockDb } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+    mockDb.export.mockClear()
+
+    await saveDatabase()
+
+    expect(mockDb.export).toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 7. exportDatabaseBytes — returns Uint8Array
+  // -------------------------------------------------------------------------
+
+  it("exportDatabaseBytes returns a Uint8Array", async () => {
+    const { mockSQL } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+
+    const bytes = await exportDatabaseBytes()
+
+    expect(bytes).toBeInstanceOf(Uint8Array)
+  })
+
+  // -------------------------------------------------------------------------
+  // 8. resetSQLiteDatabase — resolves without throwing
+  // -------------------------------------------------------------------------
+
+  it("resetSQLiteDatabase resolves without throwing", async () => {
+    const { mockSQL } = buildSQLMocks()
+    vi.mocked(initSqlJs).mockResolvedValue(mockSQL as any)
+
+    await initSQLite()
+
+    await expect(resetSQLiteDatabase()).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/sqlite/__tests__/sqlite-module.test.ts
+++ b/src/lib/sqlite/__tests__/sqlite-module.test.ts
@@ -15,7 +15,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("sql.js/dist/sql-wasm.js", () => ({ default: vi.fn() }))
-vi.mock("./migrations/add-thinking-column", () => ({
+vi.mock("../migrations/add-thinking-column", () => ({
   ensureMessagesThinkingColumn: vi.fn()
 }))
 vi.mock("@/lib/logger", () => ({

--- a/src/lib/sqlite/migrations/__tests__/migrations.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migrations.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest"
+import { ensureMessagesThinkingColumn } from "../add-thinking-column"
+import {
+  applyChunkFeedbackMigration,
+  CHUNK_FEEDBACK_MIGRATION
+} from "../chunk-feedback"
+
+// ─── add-thinking-column ──────────────────────────────────────────────────────
+
+const makeDb = (columns: string[]) => {
+  const rows = columns.map((name) => ({ name }))
+  let idx = 0
+  return {
+    prepare: vi.fn().mockReturnValue({
+      step: vi.fn().mockImplementation(() => idx < rows.length),
+      getAsObject: vi.fn().mockImplementation(() => rows[idx++] ?? {}),
+      free: vi.fn()
+    }),
+    run: vi.fn()
+  }
+}
+
+describe("ensureMessagesThinkingColumn", () => {
+  it("does nothing when thinking column already exists", () => {
+    const db = makeDb(["id", "content", "thinking"])
+    ensureMessagesThinkingColumn(db as any)
+    expect(db.run).not.toHaveBeenCalled()
+  })
+
+  it("runs ALTER TABLE when thinking column is missing", () => {
+    const db = makeDb(["id", "content"])
+    ensureMessagesThinkingColumn(db as any)
+    expect(db.run).toHaveBeenCalledWith(
+      "ALTER TABLE messages ADD COLUMN thinking TEXT"
+    )
+  })
+
+  it("frees the prepared statement regardless", () => {
+    const db = makeDb(["id", "thinking"])
+    const stmt = db.prepare()
+    // reset to get fresh spy
+    const freshDb = makeDb(["id"])
+    ensureMessagesThinkingColumn(freshDb as any)
+    // prepare was called — statement was freed
+    expect(freshDb.prepare).toHaveBeenCalledWith("PRAGMA table_info(messages)")
+  })
+})
+
+// ─── chunk-feedback migration ─────────────────────────────────────────────────
+
+describe("CHUNK_FEEDBACK_MIGRATION SQL", () => {
+  it("contains chunk_feedback table creation", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain(
+      "CREATE TABLE IF NOT EXISTS chunk_feedback"
+    )
+  })
+
+  it("contains primary key definition", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain(
+      "INTEGER PRIMARY KEY AUTOINCREMENT"
+    )
+  })
+
+  it("contains was_helpful column", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain("was_helpful INTEGER NOT NULL")
+  })
+
+  it("contains lookup index", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain("idx_chunk_feedback_lookup")
+  })
+
+  it("contains timestamp index", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain("idx_chunk_feedback_timestamp")
+  })
+
+  it("contains chunk_quality_scores view", () => {
+    expect(CHUNK_FEEDBACK_MIGRATION).toContain(
+      "CREATE VIEW IF NOT EXISTS chunk_quality_scores"
+    )
+  })
+})
+
+describe("applyChunkFeedbackMigration", () => {
+  it("resolves when exec succeeds", async () => {
+    const db = {
+      exec: vi.fn().mockImplementation((_sql, cb) => cb(null))
+    }
+    await expect(applyChunkFeedbackMigration(db)).resolves.toBeUndefined()
+    expect(db.exec).toHaveBeenCalledWith(
+      CHUNK_FEEDBACK_MIGRATION,
+      expect.any(Function)
+    )
+  })
+
+  it("rejects when exec returns an error", async () => {
+    const err = new Error("SQL error")
+    const db = {
+      exec: vi.fn().mockImplementation((_sql, cb) => cb(err))
+    }
+    await expect(applyChunkFeedbackMigration(db)).rejects.toThrow("SQL error")
+  })
+})

--- a/src/stores/__tests__/search-dialog-store.test.ts
+++ b/src/stores/__tests__/search-dialog-store.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useSearchDialogStore } from "../search-dialog-store"
+
+beforeEach(() => {
+  useSearchDialogStore.setState({ isOpen: false })
+})
+
+describe("useSearchDialogStore", () => {
+  it("initializes closed", () => {
+    expect(useSearchDialogStore.getState().isOpen).toBe(false)
+  })
+
+  it("opens dialog", () => {
+    useSearchDialogStore.getState().openSearchDialog()
+    expect(useSearchDialogStore.getState().isOpen).toBe(true)
+  })
+
+  it("closes dialog", () => {
+    useSearchDialogStore.setState({ isOpen: true })
+    useSearchDialogStore.getState().closeSearchDialog()
+    expect(useSearchDialogStore.getState().isOpen).toBe(false)
+  })
+
+  it("toggles from closed to open", () => {
+    useSearchDialogStore.getState().toggleSearchDialog()
+    expect(useSearchDialogStore.getState().isOpen).toBe(true)
+  })
+
+  it("toggles from open to closed", () => {
+    useSearchDialogStore.setState({ isOpen: true })
+    useSearchDialogStore.getState().toggleSearchDialog()
+    expect(useSearchDialogStore.getState().isOpen).toBe(false)
+  })
+
+  it("double toggle returns to original state", () => {
+    useSearchDialogStore.getState().toggleSearchDialog()
+    useSearchDialogStore.getState().toggleSearchDialog()
+    expect(useSearchDialogStore.getState().isOpen).toBe(false)
+  })
+})

--- a/src/stores/__tests__/shortcut-store.test.ts
+++ b/src/stores/__tests__/shortcut-store.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  plasmoGlobalStorage: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+globalThis.chrome = {
+  storage: { onChanged: { addListener: vi.fn() } }
+} as unknown as typeof chrome
+
+import { DEFAULT_SHORTCUTS, useShortcutStore } from "../shortcut-store"
+
+beforeEach(() => {
+  useShortcutStore.setState({ shortcuts: { ...DEFAULT_SHORTCUTS } })
+  vi.clearAllMocks()
+})
+
+describe("useShortcutStore — initial state", () => {
+  it("initializes with default shortcuts", () => {
+    const { shortcuts } = useShortcutStore.getState()
+    expect(shortcuts.newChat).toBeDefined()
+    expect(shortcuts.newChat.key).toBe(DEFAULT_SHORTCUTS.newChat.defaultKey)
+  })
+
+  it("all default shortcuts have key equal to defaultKey", () => {
+    const { shortcuts } = useShortcutStore.getState()
+    for (const shortcut of Object.values(shortcuts)) {
+      expect(shortcut.key).toBe(shortcut.defaultKey)
+    }
+  })
+})
+
+describe("useShortcutStore — updateShortcut", () => {
+  it("updates key for an action", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    expect(useShortcutStore.getState().shortcuts.newChat.key).toBe("Ctrl+N")
+  })
+
+  it("preserves other shortcuts when updating one", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    expect(useShortcutStore.getState().shortcuts.focusInput.key).toBe(
+      DEFAULT_SHORTCUTS.focusInput.defaultKey
+    )
+  })
+
+  it("preserves defaultKey after update", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    expect(useShortcutStore.getState().shortcuts.newChat.defaultKey).toBe(
+      DEFAULT_SHORTCUTS.newChat.defaultKey
+    )
+  })
+})
+
+describe("useShortcutStore — resetShortcut", () => {
+  it("resets single shortcut to defaultKey", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    useShortcutStore.getState().resetShortcut("newChat")
+    expect(useShortcutStore.getState().shortcuts.newChat.key).toBe(
+      DEFAULT_SHORTCUTS.newChat.defaultKey
+    )
+  })
+
+  it("does not affect other shortcuts", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    useShortcutStore.getState().updateShortcut("focusInput", "Ctrl+F")
+    useShortcutStore.getState().resetShortcut("newChat")
+    expect(useShortcutStore.getState().shortcuts.focusInput.key).toBe("Ctrl+F")
+  })
+})
+
+describe("useShortcutStore — resetShortcuts", () => {
+  it("resets all shortcuts to defaults", () => {
+    useShortcutStore.getState().updateShortcut("newChat", "Ctrl+N")
+    useShortcutStore.getState().updateShortcut("focusInput", "Ctrl+F")
+    useShortcutStore.getState().resetShortcuts()
+
+    const { shortcuts } = useShortcutStore.getState()
+    for (const [action, shortcut] of Object.entries(shortcuts)) {
+      expect(shortcut.key).toBe(
+        DEFAULT_SHORTCUTS[action as keyof typeof DEFAULT_SHORTCUTS].defaultKey
+      )
+    }
+  })
+})
+
+describe("useShortcutStore — hasConflict", () => {
+  it("returns null when key is unique", () => {
+    const result = useShortcutStore.getState().hasConflict("Ctrl+Shift+Z")
+    expect(result).toBeNull()
+  })
+
+  it("detects conflict with existing shortcut", () => {
+    const existingKey = DEFAULT_SHORTCUTS.newChat.defaultKey
+    const conflict = useShortcutStore.getState().hasConflict(existingKey)
+    expect(conflict).toBe("newChat")
+  })
+
+  it("excludeAction skips the excluded action when checking", () => {
+    const existingKey = DEFAULT_SHORTCUTS.newChat.defaultKey
+    const conflict = useShortcutStore
+      .getState()
+      .hasConflict(existingKey, "newChat")
+    expect(conflict).toBeNull()
+  })
+
+  it("finds conflict after a shortcut is updated", () => {
+    useShortcutStore.getState().updateShortcut("focusInput", "Alt+N")
+    const conflict = useShortcutStore.getState().hasConflict("Alt+N")
+    expect(conflict).toBe("focusInput")
+  })
+})


### PR DESCRIPTION
# summary
add more test cases

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 12 test files (new or expanded) across the RAG pipeline, session store, exporters, chunker, SQLite layer, Zustand stores, and toast hook, growing coverage from 63% to 69%.

- **New suites**: `query-classifier`, `chat-session-store-actions`, `use-toast`, `exporters`, `knowledge-sets`, `sqlite-module`, `migrations`, `search-dialog-store`, and `shortcut-store` tests are all new; each uses the project's `vi.mock` + Vitest pattern consistently.
- **Expanded suites**: `rag-pipeline` gains ~430 lines covering similarity mode, memory search, reranking, feedback blending, and temporal boosting; `rag-retriever` adds `retrieveContextFromSources` and `reformulateQuestion` coverage; `chunker` covers semantic/hybrid strategies, validation errors, `chunkTextAsync`, `mergeChunks`, and `getChunkStats`.
- **sqlite-module** uses a hand-rolled IndexedDB stub (rebuilt in every `beforeEach`) to work around the `fake-indexeddb` hang-on-`deleteDatabase` issue — a sound approach given the existing teardown constraints.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no production code changes — safe to merge.

All 12 changed files are test-only; no production logic is modified. The two minor findings are both style/quality nits in test bodies. The newly added tests correctly mock their dependencies, reset Zustand state between cases, and rely on the global afterEach mock-clearing from setup.ts.

src/lib/sqlite/migrations/__tests__/migrations.test.ts — one test claims to verify statement cleanup but doesn't assert on the free() spy.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/features/chat/rag/__tests__/query-classifier.test.ts | New file: 194-line test suite covering all intent types, entity extraction, batch classification, and getIntentDescription — clean and well-structured. |
| src/features/chat/rag/__tests__/rag-pipeline.test.ts | Expanded with 430 lines of new tests for similarity mode, memory search, formatEnhancedResults token budget, reranking, feedback blending, and temporal boosting. |
| src/features/chat/rag/__tests__/rag-retriever.test.ts | Expanded with tests for retrieveContextFromSources and reformulateQuestion. |
| src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts | New file: 572-line test suite covering addMessage, updateMessage, forkMessage, navigateToNode, loadSessions hydration guard, and updateMessages no-op. |
| src/hooks/__tests__/use-toast.test.ts | New file: tests toast() for default/destructive variants, description fallback, return shape, dismiss, update, duration. |
| src/lib/embeddings/__tests__/chunker.test.ts | Expanded with tests for markdown large-section fallback, unknown strategy default, validation errors, semanticChunking, hybridChunking, chunkTextAsync, mergeChunks, and getChunkStats. |
| src/lib/exporters/__tests__/exporters.test.ts | New file: tests downloadFile util and all three exporters across exportSession/exportAllSessions/exportMessage. |
| src/lib/knowledge/__tests__/knowledge-sets.test.ts | New file: integration-style tests against live Dexie (fake-indexeddb) covering CRUD operations and file embedding. |
| src/lib/sqlite/__tests__/sqlite-module.test.ts | New file: uses a hand-rolled IndexedDB stub (rebuilt per beforeEach) to avoid fake-indexeddb hang issues. |
| src/lib/sqlite/migrations/__tests__/migrations.test.ts | New file: one test ("frees the prepared statement regardless") doesn't actually assert that free() is called — the captured stmt is dead code. |
| src/stores/__tests__/search-dialog-store.test.ts | New file: straightforward Zustand store tests for open/close/toggle. |
| src/stores/__tests__/shortcut-store.test.ts | New file: tests default state, updateShortcut, resetShortcut, resetShortcuts, and hasConflict; beforeAll is imported but never used. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph New Test Coverage
        A[query-classifier.test.ts] --> B[classifyQuery / classifyQueriesBatch / getIntentDescription]
        C[rag-pipeline.test.ts expanded] --> D[similarity mode\nmemory search\nreranking\nfeedback blending\ntemporal boosting]
        E[rag-retriever.test.ts expanded] --> F[retrieveContextFromSources\nreformulateQuestion]
        G[chat-session-store-actions.test.ts] --> H[addMessage / updateMessage\nforkMessage / navigateToNode\nloadSessions / updateMessages]
        I[use-toast.test.ts] --> J[toast variants\ndismiss / update / duration]
        K[exporters.test.ts] --> L[jsonExporter / textExporter\nmarkdownExporter / downloadFile]
        M[knowledge-sets.test.ts] --> N[CRUD on Dexie\nactive set / file embedding]
        O[sqlite-module.test.ts] --> P[initSQLite / query / run\nflushSave / exportDatabaseBytes]
        Q[migrations.test.ts] --> R[ensureMessagesThinkingColumn\napplyChunkFeedbackMigration]
        S[search-dialog-store.test.ts] --> T[open / close / toggle]
        U[shortcut-store.test.ts] --> V[update / reset / hasConflict]
        W[chunker.test.ts expanded] --> X[semantic / hybrid / validation\nchunkTextAsync / mergeChunks / getChunkStats]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/features/chat/rag/__tests__/rag-pipeline.test.ts`, line 95-98 ([link](https://github.com/shishir435/ollama-client/blob/0fd832f54edaccbb7bfc74e863a7b8a90ee578e7/src/features/chat/rag/__tests__/rag-pipeline.test.ts#L95-L98)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Mid-file import placement — imports for `getEmbeddingConfig` (line ~95) and `rerankerService` (near the reranking suite) appear between `describe` blocks rather than at the top of the file. ES module static analysis hoists all imports before execution, so this works at runtime, but it makes the dependency surface harder to scan and is inconsistent with the rest of the project's test style.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fchat%2Frag%2F__tests__%2Frag-pipeline.test.ts%0ALine%3A%2095-98%0A%0AComment%3A%0AMid-file%20import%20placement%20%E2%80%94%20imports%20for%20%60getEmbeddingConfig%60%20%28line%20~95%29%20and%20%60rerankerService%60%20%28near%20the%20reranking%20suite%29%20appear%20between%20%60describe%60%20blocks%20rather%20than%20at%20the%20top%20of%20the%20file.%20ES%20module%20static%20analysis%20hoists%20all%20imports%20before%20execution%2C%20so%20this%20works%20at%20runtime%2C%20but%20it%20makes%20the%20dependency%20surface%20harder%20to%20scan%20and%20is%20inconsistent%20with%20the%20rest%20of%20the%20project's%20test%20style.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=110&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22chore%2Fadd-test-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fadd-test-coverage%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fchat%2Frag%2F__tests__%2Frag-pipeline.test.ts%0ALine%3A%2095-98%0A%0AComment%3A%0AMid-file%20import%20placement%20%E2%80%94%20imports%20for%20%60getEmbeddingConfig%60%20%28line%20~95%29%20and%20%60rerankerService%60%20%28near%20the%20reranking%20suite%29%20appear%20between%20%60describe%60%20blocks%20rather%20than%20at%20the%20top%20of%20the%20file.%20ES%20module%20static%20analysis%20hoists%20all%20imports%20before%20execution%2C%20so%20this%20works%20at%20runtime%2C%20but%20it%20makes%20the%20dependency%20surface%20harder%20to%20scan%20and%20is%20inconsistent%20with%20the%20rest%20of%20the%20project's%20test%20style.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fsqlite%2Fmigrations%2F__tests__%2Fmigrations.test.ts%3A2776-2783%0A**Test%20doesn't%20verify%20%60free%28%29%60%20was%20called**%0A%0AThe%20%60stmt%60%20captured%20from%20%60db.prepare%28%29%60%20belongs%20to%20a%20different%20%60db%60%20instance%20that%20is%20never%20passed%20to%20%60ensureMessagesThinkingColumn%60%2C%20so%20the%20assignment%20is%20dead%20code.%20The%20final%20assertion%20only%20checks%20that%20%60freshDb.prepare%60%20was%20called%20with%20the%20right%20SQL%20%E2%80%94%20which%20the%20other%20two%20tests%20already%20cover%20%E2%80%94%20but%20it%20never%20checks%20that%20%60freshDb%60's%20returned%20statement%20had%20%60free%28%29%60%20called%20on%20it.%20The%20test%20will%20pass%20regardless%20of%20whether%20the%20statement%20is%20freed%2C%20making%20it%20a%20no-op%20for%20its%20stated%20purpose.%0A%0ATo%20actually%20verify%20cleanup%2C%20capture%20the%20mock%20statement%20returned%20by%20%60freshDb.prepare%60%20and%20assert%20on%20its%20%60free%60%20spy%2C%20e.g.%20%60vi.mocked%28freshDb.prepare%29.mock.results%5B0%5D.value.free%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fstores%2F__tests__%2Fshortcut-store.test.ts%3A1%0A%60beforeAll%60%20is%20imported%20but%20never%20used%20anywhere%20in%20the%20file.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=110&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22chore%2Fadd-test-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fadd-test-coverage%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fsqlite%2Fmigrations%2F__tests__%2Fmigrations.test.ts%3A2776-2783%0A**Test%20doesn't%20verify%20%60free%28%29%60%20was%20called**%0A%0AThe%20%60stmt%60%20captured%20from%20%60db.prepare%28%29%60%20belongs%20to%20a%20different%20%60db%60%20instance%20that%20is%20never%20passed%20to%20%60ensureMessagesThinkingColumn%60%2C%20so%20the%20assignment%20is%20dead%20code.%20The%20final%20assertion%20only%20checks%20that%20%60freshDb.prepare%60%20was%20called%20with%20the%20right%20SQL%20%E2%80%94%20which%20the%20other%20two%20tests%20already%20cover%20%E2%80%94%20but%20it%20never%20checks%20that%20%60freshDb%60's%20returned%20statement%20had%20%60free%28%29%60%20called%20on%20it.%20The%20test%20will%20pass%20regardless%20of%20whether%20the%20statement%20is%20freed%2C%20making%20it%20a%20no-op%20for%20its%20stated%20purpose.%0A%0ATo%20actually%20verify%20cleanup%2C%20capture%20the%20mock%20statement%20returned%20by%20%60freshDb.prepare%60%20and%20assert%20on%20its%20%60free%60%20spy%2C%20e.g.%20%60vi.mocked%28freshDb.prepare%29.mock.results%5B0%5D.value.free%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fstores%2F__tests__%2Fshortcut-store.test.ts%3A1%0A%60beforeAll%60%20is%20imported%20but%20never%20used%20anywhere%20in%20the%20file.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["test: fix code review issues in test fil..."](https://github.com/shishir435/ollama-client/commit/b791a57b3aeffdf0d0b87084c4c4a6873506974e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35449476)</sub>

<!-- /greptile_comment -->