### PR TITLE
fix: address code review issues

### DIFF
--- a/src/features/file-upload/processors/pdf-processor.ts
+++ b/src/features/file-upload/processors/pdf-processor.ts
@@ -34,10 +34,10 @@ export class PdfProcessor implements FileProcessor {
 
       try {
         const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer })
-        // Race the loading task against a timeout to avoid hanging indefinitely
+        // Give the worker-backed load 2/3 of the full budget; the fallback gets the full timeout
         pdf = await promiseTimeout(
           loadingTask.promise,
-          PDF_LOAD_TIMEOUT_MS / 1.5
+          Math.floor(PDF_LOAD_TIMEOUT_MS * (2 / 3))
         )
       } catch (_firstErr) {
         // First attempt failed or timed out; retry without worker

--- a/src/features/file-upload/processors/pdf-processor.ts
+++ b/src/features/file-upload/processors/pdf-processor.ts
@@ -35,7 +35,10 @@ export class PdfProcessor implements FileProcessor {
       try {
         const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer })
         // Race the loading task against a timeout to avoid hanging indefinitely
-        pdf = await promiseTimeout(loadingTask.promise, PDF_LOAD_TIMEOUT_MS)
+        pdf = await promiseTimeout(
+          loadingTask.promise,
+          PDF_LOAD_TIMEOUT_MS / 1.5
+        )
       } catch (_firstErr) {
         // First attempt failed or timed out; retry without worker
         logger.warn(

--- a/src/features/selection-actions/content-result-actions.ts
+++ b/src/features/selection-actions/content-result-actions.ts
@@ -18,8 +18,8 @@ export async function openSelectionResultInChat(
   const parts: string[] = []
   if (capture?.text.trim()) {
     parts.push(capture.text.trim())
+    parts.push("---")
   }
-  parts.push("---")
   parts.push(result)
 
   await sendRuntimeMessage(MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT, {

--- a/src/features/selection-actions/selection-overlay-app.tsx
+++ b/src/features/selection-actions/selection-overlay-app.tsx
@@ -182,7 +182,7 @@ export function SelectionOverlayApp({
     const result = stateRef.current.resultText.trim()
     const capture = captureRef.current
 
-    if (result && capture?.text.trim()) {
+    if (result) {
       void openSelectionResultInChat(result, capture).then((didOpen) => {
         if (didOpen) onClose()
       })

--- a/src/features/sessions/components/chat-session-item.tsx
+++ b/src/features/sessions/components/chat-session-item.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next"
 import { useChatExport } from "@/features/sessions/hooks/use-export-chat"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import {
-  BookOpen,
   Code,
   FileDown,
   FileText,
@@ -47,7 +46,7 @@ export const ChatSessionItem = ({
         {
           key: "json",
           label: t("sessions.export.format_json"),
-          icon: <BookOpen className="icon-md" />,
+          icon: <FileDown className="icon-md" />,
           onClick: () => exportSessionAsJson(current)
         },
         {


### PR DESCRIPTION
#117 fix Pr comments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses code review feedback from #117 across four files, fixing a magic-number timeout, a stray separator bug, an overly-restrictive guard condition, and a mismatched export icon.

- **pdf-processor.ts**: Replaces the opaque `/ 1.5` divisor with `Math.floor(PDF_LOAD_TIMEOUT_MS * (2 / 3))`, making the 2/3 budget split explicit and integer-safe.
- **content-result-actions.ts + selection-overlay-app.tsx**: Moves the `"---"` separator inside the `capture?.text` guard so it's never sent without preceding context text, and relaxes the `handleOpenChat` condition to allow opening the chat panel whenever a result exists (even without a selection capture).
- **chat-session-item.tsx**: Swaps the `BookOpen` icon for the semantically correct `FileDown` icon on the JSON export menu item and removes the now-unused import.

<h3>Confidence Score: 5/5</h3>

All four changes are targeted, well-scoped fixes with no new logic paths introduced that could regress.

The timeout calculation is now explicit and integer-safe, the separator fix eliminates a stray "---" in chat messages when no selection context exists, the relaxed guard correctly allows results without a capture to reach the chat panel, and the icon swap is purely cosmetic. No regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/file-upload/processors/pdf-processor.ts | Timeout for the worker-backed PDF load path changed from `/ 1.5` to `Math.floor(...* (2/3))` — intent is now explicit and the result is always an integer millisecond value. |
| src/features/selection-actions/content-result-actions.ts | Moves `"---"` separator inside the `capture?.text` branch so it is only included when there is preceding context text to separate from the result. |
| src/features/selection-actions/selection-overlay-app.tsx | Broadens `handleOpenChat` guard from `result && capture?.text.trim()` to `result` alone, allowing the chat panel to open whenever there is result text regardless of whether a selection capture exists. |
| src/features/sessions/components/chat-session-item.tsx | Replaces the semantically-incorrect `BookOpen` icon with `FileDown` on the JSON export menu item and removes the unused import. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleOpenChat called] --> B{result text?}
    B -- yes --> C[openSelectionResultInChat\nresult, capture]
    C --> D{capture has text?}
    D -- yes --> E[parts: captureText + --- + result]
    D -- no --> F[parts: result only]
    E --> G[sendRuntimeMessage ADD_SELECTION_TO_CHAT]
    F --> G
    G --> H[onClose]
    B -- no --> I{capture text?}
    I -- yes --> J[sendRuntimeMessage\ncapture text only]
    J --> H
    I -- no --> K[return early / no-op]
```

<sub>Reviews (2): Last reviewed commit: ["fix(pdf): replace magic / 1.5 with Math...."](https://github.com/shishir435/ollama-client/commit/ddf716d0f9fba4f473cfc9c1072ce60947182083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36676620)</sub>

<!-- /greptile_comment -->