### PR TITLE
chore: pause dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     versioning-strategy: increase
     commit-message:
       prefix: chore(deps)


### PR DESCRIPTION
Sets `open-pull-requests-limit: 0` to stop Dependabot from raising dependency update PRs. Change the value back to re-enable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pauses Dependabot npm dependency update PRs by setting `open-pull-requests-limit: 0`. The `github-actions` ecosystem block is left unchanged and continues updating on its monthly schedule.

- Sets `open-pull-requests-limit: 0` in the npm update block — no new Dependabot PRs will be opened for npm packages until the value is raised again.
- All other Dependabot configuration (groups, versioning strategy, commit-message prefix) is preserved as-is.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single intentional config value change with no runtime impact.

The change is a one-line edit to a CI configuration file that stops Dependabot from opening new npm update PRs. It has no effect on the application code, tests, or the github-actions update schedule.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Sets open-pull-requests-limit to 0 for the npm ecosystem, pausing all Dependabot dependency update PRs; github-actions ecosystem is unaffected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot Scheduler\nWeekly - Monday] --> B{open-pull-requests-limit}
    B -->|= 0 after this PR| C[No npm update PRs opened]
    B -->|> 0 previous value of 5| D[Up to N npm update PRs opened]

    E[Dependabot Scheduler\nMonthly] --> F[github-actions ecosystem\nunchanged - still active]
```

<sub>Reviews (1): Last reviewed commit: ["chore: pause dependabot npm updates (lim..."](https://github.com/shishir435/ollama-client/commit/c70577ad3e715240c57706860cc0d10fe19df62d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36773467)</sub>

<!-- /greptile_comment -->