### PR TITLE
Refactor/frontend refactor

### DIFF
--- a/src/features/chat/components/chat-input/chat-input-attachment-sheet.tsx
+++ b/src/features/chat/components/chat-input/chat-input-attachment-sheet.tsx
@@ -88,6 +88,7 @@ export function ChatInputAttachmentSheet({
                         })}
                       </span>
                     </CollapsibleTrigger>
+                    {previewText && <CopyButton text={previewText} />}
                     <Button
                       type="button"
                       variant="ghost"
@@ -109,11 +110,6 @@ export function ChatInputAttachmentSheet({
                           className="p-3"
                         />
                       </div>
-                      {previewText && (
-                        <div className="flex justify-end border-t border-border/35 px-2 py-1">
-                          <CopyButton text={previewText} />
-                        </div>
-                      )}
                     </div>
                   </CollapsibleContent>
                 </div>

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -102,34 +102,36 @@ export function MessageSourcesSheet({
                         key={value}
                         value={value}
                         className="rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
-                        <AccordionTrigger className="px-2 py-1.5 text-xs font-medium hover:no-underline">
-                          <div className="flex min-w-0 flex-col gap-0.5">
-                            <span className="truncate text-xs font-medium">
-                              {item.title}
-                            </span>
-                            {meta && (
-                              <span className="text-[10px] text-muted-foreground">
-                                {meta}
+                        <div className="flex items-center gap-1 pr-1">
+                          <AccordionTrigger className="flex-1 px-2 py-1.5 text-xs font-medium hover:no-underline">
+                            <div className="flex min-w-0 flex-col gap-0.5">
+                              <span className="truncate text-xs font-medium">
+                                {item.title}
                               </span>
-                            )}
-                          </div>
-                        </AccordionTrigger>
+                              {meta && (
+                                <span className="text-[10px] text-muted-foreground">
+                                  {meta}
+                                </span>
+                              )}
+                            </div>
+                          </AccordionTrigger>
+                          <CopyButton text={item.content} />
+                        </div>
                         <AccordionContent>
                           <div className="max-h-[min(16rem,40vh)] overflow-y-auto overflow-x-hidden">
                             <div className="whitespace-pre-wrap text-[11px] text-muted-foreground wrap-anywhere">
                               {item.content}
                             </div>
                           </div>
-                          <div className="mt-2 flex items-center gap-1">
-                            {feedback && (
+                          {feedback && (
+                            <div className="mt-2 flex items-center gap-1">
                               <ChunkFeedbackButton
                                 chunkId={value}
                                 query={feedback.query}
                                 sessionId={feedback.sessionId}
                               />
-                            )}
-                            <CopyButton text={item.content} />
-                          </div>
+                            </div>
+                          )}
                         </AccordionContent>
                       </AccordionItem>
                     )

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -115,7 +115,9 @@ export function MessageSourcesSheet({
                               )}
                             </div>
                           </AccordionTrigger>
-                          <CopyButton text={item.content} />
+                          <div className="mt-1.5 shrink-0">
+                            <CopyButton text={item.content} />
+                          </div>
                         </div>
                         <AccordionContent>
                           <div className="max-h-[min(16rem,40vh)] overflow-y-auto overflow-x-hidden">

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -101,23 +101,21 @@ export function MessageSourcesSheet({
                       <AccordionItem
                         key={value}
                         value={value}
-                        className="rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
-                        <div className="flex items-start gap-1 pr-1">
-                          <AccordionTrigger className="flex-1 px-2 py-1.5 text-xs font-medium hover:no-underline">
-                            <div className="flex min-w-0 flex-col gap-0.5">
-                              <span className="truncate text-xs font-medium">
-                                {item.title}
+                        className="relative rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
+                        <AccordionTrigger className="px-2 py-1.5 pr-14 text-xs font-medium hover:no-underline">
+                          <div className="flex min-w-0 flex-col gap-0.5">
+                            <span className="truncate text-xs font-medium">
+                              {item.title}
+                            </span>
+                            {meta && (
+                              <span className="text-[10px] text-muted-foreground">
+                                {meta}
                               </span>
-                              {meta && (
-                                <span className="text-[10px] text-muted-foreground">
-                                  {meta}
-                                </span>
-                              )}
-                            </div>
-                          </AccordionTrigger>
-                          <div className="mt-1.5 shrink-0">
-                            <CopyButton text={item.content} />
+                            )}
                           </div>
+                        </AccordionTrigger>
+                        <div className="absolute right-7 top-1">
+                          <CopyButton text={item.content} />
                         </div>
                         <AccordionContent>
                           <div className="max-h-[min(16rem,40vh)] overflow-y-auto overflow-x-hidden">

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -102,7 +102,7 @@ export function MessageSourcesSheet({
                         key={value}
                         value={value}
                         className="relative rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
-                        <AccordionTrigger className="pr-14 px-2 py-1.5 text-xs font-medium hover:no-underline">
+                        <AccordionTrigger className="pr-16 px-2 py-1.5 text-xs font-medium hover:no-underline">
                           <div className="flex min-w-0 overflow-hidden flex-col gap-0.5">
                             <span className="truncate text-xs font-medium">
                               {item.title}

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -102,7 +102,7 @@ export function MessageSourcesSheet({
                         key={value}
                         value={value}
                         className="rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
-                        <div className="flex items-center gap-1 pr-1">
+                        <div className="flex items-start gap-1 pr-1">
                           <AccordionTrigger className="flex-1 px-2 py-1.5 text-xs font-medium hover:no-underline">
                             <div className="flex min-w-0 flex-col gap-0.5">
                               <span className="truncate text-xs font-medium">

--- a/src/features/chat/components/message-sources-sheet.tsx
+++ b/src/features/chat/components/message-sources-sheet.tsx
@@ -102,19 +102,19 @@ export function MessageSourcesSheet({
                         key={value}
                         value={value}
                         className="relative rounded-control border border-border/35 bg-muted/15 data-open:bg-muted/30">
-                        <AccordionTrigger className="px-2 py-1.5 pr-14 text-xs font-medium hover:no-underline">
-                          <div className="flex min-w-0 flex-col gap-0.5">
+                        <AccordionTrigger className="pr-14 px-2 py-1.5 text-xs font-medium hover:no-underline">
+                          <div className="flex min-w-0 overflow-hidden flex-col gap-0.5">
                             <span className="truncate text-xs font-medium">
                               {item.title}
                             </span>
                             {meta && (
-                              <span className="text-[10px] text-muted-foreground">
+                              <span className="truncate text-[10px] text-muted-foreground">
                                 {meta}
                               </span>
                             )}
                           </div>
                         </AccordionTrigger>
-                        <div className="absolute right-7 top-1">
+                        <div className="absolute right-7 top-1.5">
                           <CopyButton text={item.content} />
                         </div>
                         <AccordionContent>


### PR DESCRIPTION
# refactor

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `CopyButton` from inside the expanded/collapsed content area to an always-visible position in the header row for both the chat-input attachment sheet and the message sources sheet, so users can copy content without first expanding a panel.

- **`chat-input-attachment-sheet.tsx`**: `CopyButton` is lifted out of `CollapsibleContent` and placed directly in the header row (between `CollapsibleTrigger` and the remove button), visible whenever `previewText` is non-empty regardless of collapsed state.
- **`message-sources-sheet.tsx`**: `CopyButton` is removed from inside `AccordionContent` and is now an absolutely-positioned sibling of `AccordionTrigger` within a `relative`-positioned `AccordionItem`; `pr-16` is added to the trigger to prevent text/chevron overlap, and the feedback button container is now correctly conditional on `feedback` being truthy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both files are pure UI layout refactors with no data-flow or logic changes.

Both changes are straightforward relocation of the CopyButton from inside expanded content to an always-visible header position. The AccordionItem/CollapsibleTrigger structures remain intact, event propagation is correct (CopyButton is a sibling of the trigger, not a descendant), and pr-16 on the trigger provides adequate clearance from the chevron icon. No state, API, or business-logic changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/chat/components/chat-input/chat-input-attachment-sheet.tsx | CopyButton moved from CollapsibleContent footer to the always-visible header row; clean change with no functional issues. |
| src/features/chat/components/message-sources-sheet.tsx | CopyButton repositioned as an absolutely-placed element over the AccordionTrigger header; AccordionItem gains `relative`, trigger gets `pr-16` to keep content clear of the button; feedback container correctly made conditional. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffeatures%2Fchat%2Fcomponents%2Fmessage-sources-sheet.tsx%3A105%0AThe%20class%20order%20puts%20the%20longhand%20%28%60pr-16%60%29%20before%20the%20shorthand%20%28%60px-2%60%29.%20Both%20are%20kept%20by%20%60tailwind-merge%60%20%28they're%20in%20separate%20conflict%20groups%29%2C%20so%20the%20final%20right%20padding%20is%20resolved%20by%20the%20CSS%20cascade%20%E2%80%94%20Tailwind%20v4%20emits%20%60padding-inline-end%60%20after%20%60padding-inline%60%2C%20so%20%60pr-16%60%20wins%20correctly.%20Listing%20the%20shorthand%20first%20keeps%20the%20intent%20readable%20and%20matches%20the%20conventional%20narrow-to-wide%20specificity%20order.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CAccordionTrigger%20className%3D%22px-2%20py-1.5%20pr-16%20text-xs%20font-medium%20hover%3Ano-underline%22%3E%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22refactor%2Ffrontend-refactor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Ffrontend-refactor%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffeatures%2Fchat%2Fcomponents%2Fmessage-sources-sheet.tsx%3A105%0AThe%20class%20order%20puts%20the%20longhand%20%28%60pr-16%60%29%20before%20the%20shorthand%20%28%60px-2%60%29.%20Both%20are%20kept%20by%20%60tailwind-merge%60%20%28they're%20in%20separate%20conflict%20groups%29%2C%20so%20the%20final%20right%20padding%20is%20resolved%20by%20the%20CSS%20cascade%20%E2%80%94%20Tailwind%20v4%20emits%20%60padding-inline-end%60%20after%20%60padding-inline%60%2C%20so%20%60pr-16%60%20wins%20correctly.%20Listing%20the%20shorthand%20first%20keeps%20the%20intent%20readable%20and%20matches%20the%20conventional%20narrow-to-wide%20specificity%20order.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CAccordionTrigger%20className%3D%22px-2%20py-1.5%20pr-16%20text-xs%20font-medium%20hover%3Ano-underline%22%3E%0A%60%60%60%0A%0A&repo=shishir435%2Follama-client&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): increase accordion trigger pr t..."](https://github.com/shishir435/ollama-client/commit/12a65e5d9c68caf01944fa9bea0d72c105c5d66e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36786432)</sub>

<!-- /greptile_comment -->