### PR TITLE
fix: tune long-context chat defaults

### DIFF
--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -257,6 +257,40 @@ describe("handleChatWithModel", () => {
         expect.any(AbortSignal)
       )
     })
+
+    it("should upgrade legacy default context before streaming", async () => {
+      const { plasmoGlobalStorage } = await import(
+        "@/lib/plasmo-global-storage"
+      )
+      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+        if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
+          return {
+            "llama3:latest": {
+              num_ctx: 6144
+            }
+          }
+        }
+        return undefined
+      })
+
+      const message: ChatWithModelMessage = {
+        type: "CHAT_WITH_MODEL",
+        payload: {
+          model: "llama3:latest",
+          messages: [{ role: "user", content: "Hello" }]
+        }
+      }
+
+      await handleChatWithModel(message, mockPort, mockIsPortClosed)
+
+      expect(mockStreamChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          num_ctx: 65536
+        }),
+        expect.any(Function),
+        expect.any(AbortSignal)
+      )
+    })
   })
 
   describe("message limiting for small models", () => {

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -1,8 +1,9 @@
 import { setAbortController } from "@/background/lib/abort-controller-registry"
 import { withErrorContext } from "@/background/lib/error-handler"
 import { safePostMessage } from "@/background/lib/utils"
-import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import type { ChatMessage, ChatWithModelMessage, ModelConfigMap } from "@/types"
@@ -49,7 +50,7 @@ export const handleChatWithModel = withErrorContext(
       (await plasmoGlobalStorage.get<ModelConfigMap>(
         STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
       )) ?? {}
-    const modelParams = modelConfigMap[model] ?? DEFAULT_MODEL_CONFIG
+    const modelParams = resolveModelConfig(modelConfigMap[model])
 
     const limitedMessages = limitMessagesForModel(model, messages)
     const preparedMessages = [...limitedMessages]

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -2,13 +2,10 @@ import { setAbortController } from "@/background/lib/abort-controller-registry"
 import { safePostMessage } from "@/background/lib/utils"
 import { buildSelectionActionPrompt } from "@/features/selection-actions/prompt-builder"
 import type { SelectionActionMessage } from "@/features/selection-actions/types"
-import {
-  DEFAULT_MODEL_CONFIG,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { isSelectedModelRef } from "@/lib/providers/selected-model"
@@ -52,7 +49,7 @@ export const handleSelectionAction = async (
       (await plasmoGlobalStorage.get<ModelConfigMap>(
         STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
       )) ?? {}
-    const modelParams = modelConfigMap[model] ?? DEFAULT_MODEL_CONFIG
+    const modelParams = resolveModelConfig(modelConfigMap[model])
     const provider = await ProviderFactory.getProviderForModel(
       model,
       providerId

--- a/src/background/handlers/handle-warmup-model.ts
+++ b/src/background/handlers/handle-warmup-model.ts
@@ -1,7 +1,8 @@
 import { createErrorResponse } from "@/background/lib/error-handler"
 import { safeSendResponse } from "@/background/lib/utils"
-import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
@@ -42,10 +43,7 @@ const getModelConfig = async (model: string) => {
     (await plasmoGlobalStorage.get<ModelConfigMap>(
       STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
     )) ?? {}
-  return {
-    ...DEFAULT_MODEL_CONFIG,
-    ...(configs[model] ?? {})
-  }
+  return resolveModelConfig(configs[model])
 }
 
 const DEFAULT_WARMUP_COOLDOWN_MS = 5 * 60 * 1000

--- a/src/features/chat/components/__tests__/session-metrics-bar.test.tsx
+++ b/src/features/chat/components/__tests__/session-metrics-bar.test.tsx
@@ -40,7 +40,8 @@ describe("SessionMetricsBar", () => {
   it("renders compact header trigger and shows all session stats in popover", () => {
     render(<SessionMetricsBar messages={messages} />)
 
-    const trigger = screen.getByRole("button", { name: "Session Metrics" })
+    const trigger = screen.getByRole("button", { name: /Session Metrics/ })
+    expect(trigger).toHaveAccessibleName(/Speed/)
     expect(trigger).toHaveTextContent("40.0 t/s")
 
     fireEvent.click(trigger)
@@ -52,5 +53,30 @@ describe("SessionMetricsBar", () => {
     expect(screen.getByText("60")).toBeInTheDocument()
     expect(screen.getByText("2.0s")).toBeInTheDocument()
     expect(screen.getByText("1")).toBeInTheDocument()
+  })
+
+  it("does not show bogus million-token speeds", () => {
+    render(
+      <SessionMetricsBar
+        messages={[
+          {
+            role: "assistant",
+            content: "hi",
+            done: true,
+            metrics: {
+              total_duration: 2_000_000_000,
+              eval_count: 100,
+              eval_duration: 100_000,
+              prompt_eval_count: 20
+            }
+          }
+        ]}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /Session Metrics/ })
+    expect(trigger).toHaveAccessibleName(/Tokens/)
+    expect(trigger).not.toHaveTextContent("1000000")
+    expect(trigger).toHaveTextContent("120")
   })
 })

--- a/src/features/chat/components/session-metrics-bar.tsx
+++ b/src/features/chat/components/session-metrics-bar.tsx
@@ -1,7 +1,6 @@
 import {
   Clock,
   FileText,
-  Gauge,
   type LucideIcon,
   MessageSquare,
   Zap
@@ -25,6 +24,7 @@ interface MetricItem {
   icon: LucideIcon
   iconColor: string
   value: string
+  isAvailable?: boolean
   labelKey: string
   tooltipKey: string
 }
@@ -64,7 +64,11 @@ export const SessionMetricsBar = ({
     {
       icon: Zap,
       iconColor: "text-muted-foreground",
-      value: `${metrics.averageSpeed.toFixed(1)} ${t("chat.metrics.speed_unit")}`,
+      value:
+        metrics.averageSpeed > 0
+          ? `${metrics.averageSpeed.toFixed(1)} ${t("chat.metrics.speed_unit")}`
+          : "—",
+      isAvailable: metrics.averageSpeed > 0,
       labelKey: "chat.session_metrics.label_speed",
       tooltipKey: "chat.session_metrics.tooltip_speed"
     },
@@ -76,9 +80,11 @@ export const SessionMetricsBar = ({
       tooltipKey: "chat.session_metrics.tooltip_messages"
     }
   ]
-  const summary =
-    metricItems.find((item) => item.tooltipKey.includes("speed"))?.value ??
-    metricItems[0]?.value
+  const summaryItem =
+    metricItems.find(
+      (item) => item.tooltipKey.includes("speed") && item.isAvailable
+    ) ?? metricItems[0]
+  const SummaryIcon = summaryItem.icon
   const label = t("settings.chat_display.session_metrics_label")
 
   return (
@@ -91,11 +97,11 @@ export const SessionMetricsBar = ({
               "inline-flex h-8 items-center gap-1.5 rounded-control px-2 text-[11px] text-muted-foreground transition-colors hover:bg-muted/55 hover:text-foreground",
               className
             )}
-            aria-label={label}
+            aria-label={`${label}: ${t(summaryItem.labelKey)} ${summaryItem.value}`}
           />
         }>
-        <Gauge className="icon-sm" />
-        <span className="font-mono tabular-nums">{summary}</span>
+        <SummaryIcon className="icon-sm" />
+        <span className="font-mono tabular-nums">{summaryItem.value}</span>
       </PopoverTrigger>
       <PopoverContent
         align="center"

--- a/src/features/chat/lib/__tests__/session-metrics-utils.test.ts
+++ b/src/features/chat/lib/__tests__/session-metrics-utils.test.ts
@@ -99,6 +99,18 @@ describe("calculateSessionMetrics", () => {
     const result = calculateSessionMetrics([msg])
     expect(result.averageSpeed).toBe(0)
   })
+
+  it("returns averageSpeed=0 for tiny bogus eval_duration", () => {
+    const msg = makeAssistantMsg({
+      metrics: {
+        ...(makeAssistantMsg().metrics ?? {}),
+        eval_count: 100,
+        eval_duration: 100_000
+      }
+    })
+    const result = calculateSessionMetrics([msg])
+    expect(result.averageSpeed).toBe(0)
+  })
 })
 
 describe("formatSessionDuration", () => {

--- a/src/features/chat/lib/session-metrics-utils.ts
+++ b/src/features/chat/lib/session-metrics-utils.ts
@@ -1,3 +1,7 @@
+import {
+  MAX_REASONABLE_TOKENS_PER_SECOND,
+  MIN_EVAL_DURATION_FOR_SPEED_NS
+} from "@/lib/constants"
 import type { ChatMessage } from "@/types"
 
 export interface SessionMetrics {
@@ -48,7 +52,7 @@ export function calculateSessionMetrics(
       generatedTokens += m.eval_count
     }
 
-    if (m.eval_duration) {
+    if (m.eval_duration && m.eval_duration >= MIN_EVAL_DURATION_FOR_SPEED_NS) {
       totalEvalDuration += m.eval_duration
     }
   }
@@ -58,7 +62,11 @@ export function calculateSessionMetrics(
   // Calculate average speed: tokens / seconds
   // eval_duration is in nanoseconds, convert to seconds
   const evalSeconds = totalEvalDuration / 1_000_000_000
-  const averageSpeed = evalSeconds > 0 ? generatedTokens / evalSeconds : 0
+  const rawAverageSpeed = evalSeconds > 0 ? generatedTokens / evalSeconds : 0
+  const averageSpeed =
+    rawAverageSpeed > 0 && rawAverageSpeed <= MAX_REASONABLE_TOKENS_PER_SECOND
+      ? rawAverageSpeed
+      : 0
 
   return {
     totalTokens,

--- a/src/features/model/hooks/__tests__/use-model-config.test.ts
+++ b/src/features/model/hooks/__tests__/use-model-config.test.ts
@@ -52,6 +52,42 @@ describe("useModelConfig", () => {
     expect(config.num_ctx).toBe(DEFAULT_MODEL_CONFIG.num_ctx)
   })
 
+  it("should upgrade legacy default context size", async () => {
+    const storedConfigs = {
+      "llama3:latest": {
+        num_ctx: 6144
+      }
+    }
+
+    const { useStorage } = await import("@plasmohq/storage/hook")
+    vi.mocked(useStorage).mockReturnValue([
+      storedConfigs,
+      mockSetModelConfigs
+    ] as any)
+
+    const { result } = renderHook(() => useModelConfig("llama3:latest"))
+
+    expect(result.current[0].num_ctx).toBe(DEFAULT_MODEL_CONFIG.num_ctx)
+  })
+
+  it("should preserve custom context size", async () => {
+    const storedConfigs = {
+      "llama3:latest": {
+        num_ctx: 32768
+      }
+    }
+
+    const { useStorage } = await import("@plasmohq/storage/hook")
+    vi.mocked(useStorage).mockReturnValue([
+      storedConfigs,
+      mockSetModelConfigs
+    ] as any)
+
+    const { result } = renderHook(() => useModelConfig("llama3:latest"))
+
+    expect(result.current[0].num_ctx).toBe(32768)
+  })
+
   it("should update config correctly", async () => {
     const { useStorage } = await import("@plasmohq/storage/hook")
     vi.mocked(useStorage).mockReturnValue([{}, mockSetModelConfigs] as any)

--- a/src/features/model/hooks/use-model-config.ts
+++ b/src/features/model/hooks/use-model-config.ts
@@ -1,6 +1,7 @@
 import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useMemo } from "react"
 import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { normalizeStoredModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
 export type ProviderModelConfig = typeof DEFAULT_MODEL_CONFIG
@@ -14,7 +15,7 @@ export const useModelConfig = (modelName: string) => {
   )
 
   const config = useMemo(() => {
-    const stored = modelConfigs?.[modelName]
+    const stored = normalizeStoredModelConfig(modelConfigs?.[modelName])
     return {
       ...DEFAULT_MODEL_CONFIG,
       ...(stored ?? {})
@@ -24,7 +25,7 @@ export const useModelConfig = (modelName: string) => {
   const update = useCallback(
     (newConfig: Partial<typeof DEFAULT_MODEL_CONFIG>) => {
       setModelConfigs((prev) => {
-        const prevConfig = prev?.[modelName] ?? {}
+        const prevConfig = normalizeStoredModelConfig(prev?.[modelName]) ?? {}
         return {
           ...prev,
           [modelName]: {

--- a/src/lib/__tests__/format-utils.test.ts
+++ b/src/lib/__tests__/format-utils.test.ts
@@ -27,8 +27,12 @@ describe("format-utils", () => {
     })
 
     it("should handle undefined/zero", () => {
-      expect(formatTokensPerSecond(undefined, 100)).toBe("0 t/s")
-      expect(formatTokensPerSecond(100, undefined)).toBe("0 t/s")
+      expect(formatTokensPerSecond(undefined, 100)).toBe("—")
+      expect(formatTokensPerSecond(100, undefined)).toBe("—")
+    })
+
+    it("should hide bogus tiny-duration speeds", () => {
+      expect(formatTokensPerSecond(100, 100_000)).toBe("—")
     })
   })
 })

--- a/src/lib/__tests__/model-config-utils.test.ts
+++ b/src/lib/__tests__/model-config-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_MODEL_CONFIG } from "@/lib/constants"
+import { resolveModelConfig } from "@/lib/model-config-utils"
+
+describe("resolveModelConfig", () => {
+  it("uses 64k context when no stored config exists", () => {
+    expect(resolveModelConfig().num_ctx).toBe(DEFAULT_MODEL_CONFIG.num_ctx)
+  })
+
+  it("upgrades old 6144 context default", () => {
+    expect(resolveModelConfig({ num_ctx: 6144 }).num_ctx).toBe(
+      DEFAULT_MODEL_CONFIG.num_ctx
+    )
+  })
+
+  it("preserves custom context size", () => {
+    expect(resolveModelConfig({ num_ctx: 32768 }).num_ctx).toBe(32768)
+  })
+})

--- a/src/lib/__tests__/transcript-extractor.test.ts
+++ b/src/lib/__tests__/transcript-extractor.test.ts
@@ -99,8 +99,11 @@ describe("Transcript Extractor", () => {
             text: vi.fn().mockResolvedValue(
               JSON.stringify({
                 events: [
-                  { segs: [{ utf8: "Hello " }, { utf8: "world" }] },
-                  { segs: [{ utf8: "Next line" }] }
+                  {
+                    tStartMs: 0,
+                    segs: [{ utf8: "Hello " }, { utf8: "world" }]
+                  },
+                  { tStartMs: 7000, segs: [{ utf8: "Next line" }] }
                 ]
               })
             )
@@ -108,7 +111,40 @@ describe("Transcript Extractor", () => {
         )
 
         const result = await getTranscript()
-        expect(result).toBe("Hello world\nNext line")
+        expect(result).toBe("0:00 Hello world\n0:07 Next line")
+      })
+
+      it("should keep timestamps from XML caption tracks", async () => {
+        const script = document.createElement("script")
+        script.textContent = `var ytInitialPlayerResponse = ${JSON.stringify({
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                {
+                  baseUrl: "https://www.youtube.com/api/timedtext?v=123",
+                  languageCode: "en",
+                  name: { simpleText: "English" }
+                }
+              ]
+            }
+          }
+        })};`
+        document.head.appendChild(script)
+
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue({
+            ok: true,
+            text: vi
+              .fn()
+              .mockResolvedValue(
+                `<transcript><text start="65">Late line</text></transcript>`
+              )
+          })
+        )
+
+        const result = await getTranscript()
+        expect(result).toBe("1:05 Late line")
       })
 
       it("should extract transcript from modern YouTube transcript panel", async () => {
@@ -131,7 +167,9 @@ describe("Transcript Extractor", () => {
         document.body.appendChild(panel)
 
         const result = await getTranscript()
-        expect(result).toBe("First transcript line.\nSecond transcript line.")
+        expect(result).toBe(
+          "0:00 First transcript line.\n0:07 Second transcript line."
+        )
       })
 
       it("should handle empty transcript", async () => {

--- a/src/lib/__tests__/transcript-extractor.test.ts
+++ b/src/lib/__tests__/transcript-extractor.test.ts
@@ -147,6 +147,39 @@ describe("Transcript Extractor", () => {
         expect(result).toBe("1:05 Late line")
       })
 
+      it("should not add 0:00 for XML caption nodes without start", async () => {
+        const script = document.createElement("script")
+        script.textContent = `var ytInitialPlayerResponse = ${JSON.stringify({
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                {
+                  baseUrl: "https://www.youtube.com/api/timedtext?v=123",
+                  languageCode: "en",
+                  name: { simpleText: "English" }
+                }
+              ]
+            }
+          }
+        })};`
+        document.head.appendChild(script)
+
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue({
+            ok: true,
+            text: vi
+              .fn()
+              .mockResolvedValue(
+                `<transcript><text>Untimed line</text></transcript>`
+              )
+          })
+        )
+
+        const result = await getTranscript()
+        expect(result).toBe("Untimed line")
+      })
+
       it("should extract transcript from modern YouTube transcript panel", async () => {
         const panel = document.createElement("yt-section-list-renderer")
         panel.setAttribute("data-target-id", "PAmodern_transcript_view")
@@ -170,6 +203,22 @@ describe("Transcript Extractor", () => {
         expect(result).toBe(
           "0:00 First transcript line.\n0:07 Second transcript line."
         )
+      })
+
+      it("should not infer timestamp from transcript text content", async () => {
+        const panel = document.createElement("yt-section-list-renderer")
+        panel.setAttribute("data-target-id", "PAmodern_transcript_view")
+        panel.innerHTML = `
+          <transcript-segment-view-model>
+            <span class="ytAttributedStringHost" role="text">
+              Finished in 1:30 after launch.
+            </span>
+          </transcript-segment-view-model>
+        `
+        document.body.appendChild(panel)
+
+        const result = await getTranscript()
+        expect(result).toBe("Finished in 1:30 after launch.")
       })
 
       it("should handle empty transcript", async () => {

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -186,6 +186,8 @@ export const DEFAULT_FILE_UPLOAD_CONFIG: FileUploadConfig = {
 export const CHAT_PAGINATION_LIMIT = 50
 export const DEFAULT_MAX_TAB_CONTEXT_CHARS = 12000
 export const DEFAULT_MAX_RAG_CONTEXT_CHARS = 16000
+export const MIN_EVAL_DURATION_FOR_SPEED_NS = 10_000_000
+export const MAX_REASONABLE_TOKENS_PER_SECOND = 2_000
 
 // ── Timeouts / Intervals ─────────────────────────────────────────
 /** How long (ms) to wait for first stream chunk before aborting */

--- a/src/lib/constants/defaults.ts
+++ b/src/lib/constants/defaults.ts
@@ -27,6 +27,8 @@ export const RECOMMENDED_EMBEDDING_MODELS = [DEFAULT_EMBEDDING_MODEL] as const
 
 export const LEGACY_CONTEXT_MENU_ID = "add-to-ollama-client"
 export const DEFAULT_CONTEXT_MENU_ID = "add-to-local-llm-client"
+export const LEGACY_DEFAULT_MODEL_CONTEXT_SIZE = 6144
+export const DEFAULT_MODEL_CONTEXT_SIZE = 65536
 
 export const DEFAULT_EXCLUDE_URLS = [
   "^chrome://",
@@ -52,7 +54,7 @@ export const DEFAULT_MODEL_CONFIG: ModelConfig = {
 - If unsure about something, say so rather than making up facts.
 - Avoid repeating yourself unless it helps clarity.
 - Format responses with markdown for readability when appropriate.`,
-  num_ctx: 6144,
+  num_ctx: DEFAULT_MODEL_CONTEXT_SIZE,
   repeat_last_n: 64,
   seed: 0,
   num_predict: -1,

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -1,3 +1,8 @@
+import {
+  MAX_REASONABLE_TOKENS_PER_SECOND,
+  MIN_EVAL_DURATION_FOR_SPEED_NS
+} from "@/lib/constants"
+
 export const formatDuration = (nanoseconds?: number): string => {
   if (!nanoseconds) return "0ms"
 
@@ -19,10 +24,13 @@ export const formatTokensPerSecond = (
   tokens?: number,
   duration?: number
 ): string => {
-  if (!tokens || !duration) return "0 t/s"
+  if (!tokens || !duration || duration < MIN_EVAL_DURATION_FOR_SPEED_NS) {
+    return "—"
+  }
 
   const seconds = duration / 1_000_000_000
   const tokensPerSecond = tokens / seconds
+  if (tokensPerSecond > MAX_REASONABLE_TOKENS_PER_SECOND) return "—"
 
   return `${Math.round(tokensPerSecond)} t/s`
 }

--- a/src/lib/model-config-utils.ts
+++ b/src/lib/model-config-utils.ts
@@ -1,0 +1,27 @@
+import {
+  DEFAULT_MODEL_CONFIG,
+  LEGACY_DEFAULT_MODEL_CONTEXT_SIZE
+} from "@/lib/constants"
+import type { ModelConfig } from "@/types"
+
+export const normalizeStoredModelConfig = (
+  stored?: Partial<ModelConfig>
+): Partial<ModelConfig> | undefined => {
+  if (!stored) return undefined
+
+  if (stored.num_ctx === LEGACY_DEFAULT_MODEL_CONTEXT_SIZE) {
+    return {
+      ...stored,
+      num_ctx: DEFAULT_MODEL_CONFIG.num_ctx
+    }
+  }
+
+  return stored
+}
+
+export const resolveModelConfig = (
+  stored?: Partial<ModelConfig>
+): ModelConfig => ({
+  ...DEFAULT_MODEL_CONFIG,
+  ...(normalizeStoredModelConfig(stored) ?? {})
+})

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -546,7 +546,6 @@ const parseJson3Transcript = (payload: unknown): string | null => {
           : ""
       return withTranscriptTimestamp(timestamp, line)
     })
-    .map(normalizeTranscriptLine)
     .filter(Boolean)
     .join("\n")
 
@@ -557,10 +556,12 @@ const parseXmlTranscript = (payload: string): string | null => {
   const doc = new DOMParser().parseFromString(payload, "text/xml")
   const transcript = Array.from(doc.querySelectorAll("text"))
     .map((node) => {
-      const seconds = Number(node.getAttribute("start"))
-      const timestamp = Number.isFinite(seconds)
-        ? formatTranscriptTimestamp(seconds * 1000)
-        : ""
+      const startAttr = node.getAttribute("start")
+      const seconds = startAttr !== null ? Number(startAttr) : null
+      const timestamp =
+        seconds !== null && Number.isFinite(seconds)
+          ? formatTranscriptTimestamp(seconds * 1000)
+          : ""
       return withTranscriptTimestamp(timestamp, node.textContent || "")
     })
     .filter(Boolean)
@@ -626,12 +627,11 @@ const fetchYouTubeCaptionTranscript = async (): Promise<string | null> => {
 }
 
 const extractTextFromYouTubeSegment = (segment: Element): string => {
-  const timestamp =
-    normalizeTranscriptTimestamp(
-      segment.querySelector<HTMLElement>(
-        ".ytwTranscriptSegmentViewModelTimestamp, .timestamp, [aria-hidden='true']"
-      )?.textContent
-    ) || normalizeTranscriptTimestamp(segment.textContent)
+  const timestamp = normalizeTranscriptTimestamp(
+    segment.querySelector<HTMLElement>(
+      ".ytwTranscriptSegmentViewModelTimestamp, .timestamp, [aria-hidden='true']"
+    )?.textContent
+  )
 
   const modernText = segment.querySelector<HTMLElement>(
     '.ytAttributedStringHost[role="text"], span[role="text"]'

--- a/src/lib/transcript-extractor.ts
+++ b/src/lib/transcript-extractor.ts
@@ -474,6 +474,32 @@ const getYouTubePlayerResponse = (): YouTubePlayerResponse | null => {
 const normalizeTranscriptLine = (text: string): string =>
   text.replace(/\s+/g, " ").trim()
 
+const formatTranscriptTimestamp = (milliseconds: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, "0")}`
+}
+
+const normalizeTranscriptTimestamp = (text?: string | null): string => {
+  const normalized = normalizeTranscriptLine(text || "")
+  const match = normalized.match(/\b\d{1,2}:\d{2}(?::\d{2})?\b/)
+  return match?.[0] ?? ""
+}
+
+const withTranscriptTimestamp = (timestamp: string, text: string): string => {
+  const normalizedText = normalizeTranscriptLine(text)
+  if (!normalizedText) return ""
+  if (!timestamp || normalizedText.startsWith(timestamp)) return normalizedText
+  return `${timestamp} ${normalizedText}`
+}
+
 const getCaptionTrackLabel = (track: YouTubeCaptionTrack): string => {
   return (
     track.name?.simpleText ||
@@ -508,11 +534,17 @@ const parseJson3Transcript = (payload: unknown): string | null => {
   const transcript = events
     .map((event) => {
       const segs = (event as { segs?: unknown }).segs
+      const timestampMs = (event as { tStartMs?: unknown }).tStartMs
       if (!Array.isArray(segs)) return ""
-      return segs
+      const line = segs
         .map((seg) => (seg as { utf8?: unknown }).utf8)
         .filter((text): text is string => typeof text === "string")
         .join("")
+      const timestamp =
+        typeof timestampMs === "number"
+          ? formatTranscriptTimestamp(timestampMs)
+          : ""
+      return withTranscriptTimestamp(timestamp, line)
     })
     .map(normalizeTranscriptLine)
     .filter(Boolean)
@@ -524,7 +556,13 @@ const parseJson3Transcript = (payload: unknown): string | null => {
 const parseXmlTranscript = (payload: string): string | null => {
   const doc = new DOMParser().parseFromString(payload, "text/xml")
   const transcript = Array.from(doc.querySelectorAll("text"))
-    .map((node) => normalizeTranscriptLine(node.textContent || ""))
+    .map((node) => {
+      const seconds = Number(node.getAttribute("start"))
+      const timestamp = Number.isFinite(seconds)
+        ? formatTranscriptTimestamp(seconds * 1000)
+        : ""
+      return withTranscriptTimestamp(timestamp, node.textContent || "")
+    })
     .filter(Boolean)
     .join("\n")
 
@@ -588,17 +626,24 @@ const fetchYouTubeCaptionTranscript = async (): Promise<string | null> => {
 }
 
 const extractTextFromYouTubeSegment = (segment: Element): string => {
+  const timestamp =
+    normalizeTranscriptTimestamp(
+      segment.querySelector<HTMLElement>(
+        ".ytwTranscriptSegmentViewModelTimestamp, .timestamp, [aria-hidden='true']"
+      )?.textContent
+    ) || normalizeTranscriptTimestamp(segment.textContent)
+
   const modernText = segment.querySelector<HTMLElement>(
     '.ytAttributedStringHost[role="text"], span[role="text"]'
   )
   if (modernText?.textContent)
-    return normalizeTranscriptLine(modernText.textContent)
+    return withTranscriptTimestamp(timestamp, modernText.textContent)
 
   const legacyText = segment.querySelector<HTMLElement>(
     ".cue, .segment-text, yt-formatted-string"
   )
   if (legacyText?.textContent)
-    return normalizeTranscriptLine(legacyText.textContent)
+    return withTranscriptTimestamp(timestamp, legacyText.textContent)
 
   const clone = segment.cloneNode(true) as Element
   clone
@@ -609,7 +654,7 @@ const extractTextFromYouTubeSegment = (segment: Element): string => {
       node.remove()
     })
 
-  return normalizeTranscriptLine(clone.textContent || "")
+  return withTranscriptTimestamp(timestamp, clone.textContent || "")
 }
 
 const extractYouTubePanelTranscript = (): string | null => {


### PR DESCRIPTION
## Summary
YT transcript fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the default model context window from 6 144 to 65 536 tokens, adds a migration path that silently upgrades stored legacy configs on next use, and hardens the session-speed metric against bogus tiny `eval_duration` values (sub-10 ms) and unreasonably high token-per-second readings. It also adds timestamps to YouTube transcript extraction across JSON3, XML, and panel-based code paths.

- **Context migration**: `resolveModelConfig` / `normalizeStoredModelConfig` in the new `model-config-utils.ts` upgrade any stored `num_ctx === 6144` to 65 536 before use; all three background handlers and the `useModelConfig` hook now go through this path.
- **Speed metric hardening**: `session-metrics-utils.ts` and `format-utils.ts` both guard against sub-threshold `eval_duration` and a new `MAX_REASONABLE_TOKENS_PER_SECOND = 2000` cap; `SessionMetricsBar` falls back to showing token count with its own icon when speed data is unavailable.
- **Transcript timestamps**: `formatTranscriptTimestamp` and `withTranscriptTimestamp` helpers are added; `parseJson3Transcript` uses `tStartMs`, `parseXmlTranscript` uses the `start` attribute, and `extractTextFromYouTubeSegment` reads dedicated timestamp elements rather than scanning full segment text.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three changed subsystems (context migration, speed-metric hardening, transcript timestamps) are well-tested and the code paths are logically straightforward.

The context-size migration is a clean one-way upgrade guarded by an exact equality check, with no data loss risk. The speed-metric guards correctly suppress bogus values in the common single-message and all-bogus-duration cases. The only edge cases found are a potential numerator/denominator mismatch in rare mixed-duration sessions and a spurious 0:00 when an XML start attribute is present but empty — both are cosmetic inaccuracies, not data-loss or breakage scenarios.

session-metrics-utils.ts (token accumulation for filtered-duration messages) and transcript-extractor.ts (empty start= attribute handling)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/model-config-utils.ts | New utility: upgrades stored legacy num_ctx=6144 to the new 65536 default; resolveModelConfig merges defaults cleanly |
| src/lib/constants/defaults.ts | Bumps DEFAULT_MODEL_CONTEXT_SIZE from 6144 to 65536; adds LEGACY_DEFAULT_MODEL_CONTEXT_SIZE constant for migration guard |
| src/features/chat/lib/session-metrics-utils.ts | Filters bogus tiny eval_durations and unreasonably high speeds; token accumulation still happens for filtered messages, causing numerator/denominator mismatch in mixed sessions |
| src/lib/transcript-extractor.ts | Adds timestamp extraction (JSON3 tStartMs + XML start attr) and withTranscriptTimestamp prefix helper; empty start= edge case can still produce spurious 0:00 |
| src/lib/format-utils.ts | formatTokensPerSecond now returns — for bogus tiny durations and speeds above 2000 t/s instead of 0 t/s |
| src/features/chat/components/session-metrics-bar.tsx | Falls back to token count when speed is unavailable; dynamic icon and improved aria-label using summaryItem values |
| src/background/handlers/handle-chat-with-model.ts | Replaces DEFAULT_MODEL_CONFIG fallback with resolveModelConfig, enabling legacy context-size upgrade on every chat invocation |
| src/features/model/hooks/use-model-config.ts | Wraps stored config reads with normalizeStoredModelConfig so the UI also reflects the upgraded context size |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stored ModelConfig] --> B{num_ctx === 6144?}
    B -- yes --> C[Upgrade to 65536]
    B -- no --> D[Keep as-is]
    C --> E[Merge with DEFAULT_MODEL_CONFIG]
    D --> E
    E --> F[resolveModelConfig result]
    F --> G[handleChatWithModel]
    F --> H[handleSelectionAction]
    F --> I[handleWarmupModel]
    F --> J[useModelConfig hook]
    K[ChatMessage metrics] --> L{eval_duration >= 10ms?}
    L -- no --> M[Skip duration but still count tokens]
    L -- yes --> N[Accumulate totalEvalDuration]
    N --> O{rawSpeed <= 2000 t/s?}
    O -- yes --> P[averageSpeed = rawSpeed]
    O -- no --> Q[averageSpeed = 0]
    S[averageSpeed > 0?] -- yes --> T[Show Zap icon + speed]
    S -- no --> U[Fall back to tokens count]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Ffeatures%2Fchat%2Flib%2Fsession-metrics-utils.ts%3A50-67%0A**Speed%20numerator%2Fdenominator%20mismatch%20with%20mixed%20eval_durations**%0A%0AWhen%20a%20session%20contains%20messages%20where%20some%20have%20%60eval_duration%20%3C%20MIN_EVAL_DURATION_FOR_SPEED_NS%60%2C%20those%20messages'%20%60eval_count%60%20is%20added%20to%20%60generatedTokens%60%20%28lines%2051%E2%80%9353%29%20but%20their%20duration%20is%20excluded%20from%20%60totalEvalDuration%60%20%28line%2055%29.%20In%20a%20mixed%20session%20%28e.g.%20one%20bogus%20100%C2%B5s%20message%20%2B%20one%20valid%201s%20message%2C%20each%20with%20100%20tokens%29%2C%20%60rawAverageSpeed%60%20computes%20as%20%60200%20%2F%201%20%3D%20200%20t%2Fs%60%20instead%20of%20the%20correct%20%60100%20%2F%201%20%3D%20100%20t%2Fs%60.%20The%20%60MAX_REASONABLE_TOKENS_PER_SECOND%60%20cap%20won't%20catch%20moderate%20inflation%20like%20this.%20A%20consistent%20fix%20is%20to%20skip%20the%20%60eval_count%60%20accumulation%20for%20the%20same%20messages%20whose%20%60eval_duration%60%20is%20discarded.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A558-564%0A**Empty%20%60start%3D%22%22%60%20attribute%20produces%20spurious%20%220%3A00%22%20timestamp**%0A%0AWhen%20an%20XML%20%60%3Ctext%3E%60%20node%20has%20a%20%60start%60%20attribute%20present%20but%20empty%20%28e.g.%20%60%3Ctext%20start%3D%22%22%3E%E2%80%A6%3C%2Ftext%3E%60%29%2C%20%60startAttr%60%20is%20%60%22%22%60%20rather%20than%20%60null%60%2C%20so%20it%20passes%20the%20%60!%3D%3D%20null%60%20guard.%20%60Number%28%22%22%29%60%20is%20%600%60%20and%20%60Number.isFinite%280%29%60%20is%20%60true%60%2C%20so%20the%20node%20gets%20a%20%220%3A00%22%20prefix%20even%20though%20no%20timing%20information%20was%20provided.%20Guarding%20against%20empty%2Fwhitespace-only%20strings%20%28e.g.%20%60startAttr.trim%28%29%20!%3D%3D%20%22%22%60%29%20alongside%20the%20%60null%60%20check%20would%20close%20this%20gap.%0A%0A&repo=shishir435%2Follama-client&pr=123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2Fcontext-metrics-transcript-tuning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fcontext-metrics-transcript-tuning%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Ffeatures%2Fchat%2Flib%2Fsession-metrics-utils.ts%3A50-67%0A**Speed%20numerator%2Fdenominator%20mismatch%20with%20mixed%20eval_durations**%0A%0AWhen%20a%20session%20contains%20messages%20where%20some%20have%20%60eval_duration%20%3C%20MIN_EVAL_DURATION_FOR_SPEED_NS%60%2C%20those%20messages'%20%60eval_count%60%20is%20added%20to%20%60generatedTokens%60%20%28lines%2051%E2%80%9353%29%20but%20their%20duration%20is%20excluded%20from%20%60totalEvalDuration%60%20%28line%2055%29.%20In%20a%20mixed%20session%20%28e.g.%20one%20bogus%20100%C2%B5s%20message%20%2B%20one%20valid%201s%20message%2C%20each%20with%20100%20tokens%29%2C%20%60rawAverageSpeed%60%20computes%20as%20%60200%20%2F%201%20%3D%20200%20t%2Fs%60%20instead%20of%20the%20correct%20%60100%20%2F%201%20%3D%20100%20t%2Fs%60.%20The%20%60MAX_REASONABLE_TOKENS_PER_SECOND%60%20cap%20won't%20catch%20moderate%20inflation%20like%20this.%20A%20consistent%20fix%20is%20to%20skip%20the%20%60eval_count%60%20accumulation%20for%20the%20same%20messages%20whose%20%60eval_duration%60%20is%20discarded.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Ftranscript-extractor.ts%3A558-564%0A**Empty%20%60start%3D%22%22%60%20attribute%20produces%20spurious%20%220%3A00%22%20timestamp**%0A%0AWhen%20an%20XML%20%60%3Ctext%3E%60%20node%20has%20a%20%60start%60%20attribute%20present%20but%20empty%20%28e.g.%20%60%3Ctext%20start%3D%22%22%3E%E2%80%A6%3C%2Ftext%3E%60%29%2C%20%60startAttr%60%20is%20%60%22%22%60%20rather%20than%20%60null%60%2C%20so%20it%20passes%20the%20%60!%3D%3D%20null%60%20guard.%20%60Number%28%22%22%29%60%20is%20%600%60%20and%20%60Number.isFinite%280%29%60%20is%20%60true%60%2C%20so%20the%20node%20gets%20a%20%220%3A00%22%20prefix%20even%20though%20no%20timing%20information%20was%20provided.%20Guarding%20against%20empty%2Fwhitespace-only%20strings%20%28e.g.%20%60startAttr.trim%28%29%20!%3D%3D%20%22%22%60%29%20alongside%20the%20%60null%60%20check%20would%20close%20this%20gap.%0A%0A&repo=shishir435%2Follama-client&pr=123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: harden transcript timestamps"](https://github.com/shishir435/ollama-client/commit/29dc1b077c003181112402dbe70f36da123d5d7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37235254)</sub>

<!-- /greptile_comment -->