### PR TITLE
[codex] Improve settings search quality

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Setup help and docs
-    url: https://ollama-client.shishirchaurasiya.in/ollama-setup-guide
+    url: https://www.ollamaclient.in/guides/provider-setup/
     about: How to install and configure providers (Ollama, LM Studio, llama.cpp, etc.)
   - name: Security vulnerabilities
     url: https://github.com/Shishir435/ollama-client/blob/main/SECURITY.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Each feature folder should own its UI, hooks, and (if needed) its Zustand store:
 - `model/` — model management UI, provider/embedding settings screens
 - `file-upload/` — file ingestion for RAG, per-format processors under `processors/`
 - `prompt/` — prompt templates
+- `settings/` — settings registry, i18n-backed settings search index, and search/deep-link tests
 - `memory/`, `knowledge/`, `context/`, `tabs/` — auxiliary chat-context features
 
 Cross-feature concerns (theme, shortcuts, search dialog) live in `src/stores/`. **Feature-scoped stores live under `features/<x>/stores/`, never in `src/stores/`.**
@@ -167,6 +168,16 @@ Uses Biome (not ESLint/Prettier):
 
 When binding form fields to React Hook Form, use the app-owned `Controlled*` wrappers in `src/components/forms/` (`ControlledTextInput`, `ControlledTextarea`, `ControlledNumberInput`, `ControlledSelect`, `ControlledSlider`, `ControlledSwitch`). Do **not** spread `register(...)` into `src/components/ui/*` primitives. Several UI primitives are controlled Base UI wrappers; spread-register can make the DOM look updated while RHF state still holds the old value. The contract test in `src/components/forms/__tests__/react-hook-form-contract.test.ts` enforces this for production TSX.
 
+### Settings search and deep links
+
+`src/features/settings/settings-registry.ts` is the source of truth for options-page settings search and deep-link focus. When adding or moving a setting:
+
+- Add or update a registry entry with the real tab, section, label i18n key, description key, and any visible child strings in `searchKeys`.
+- Prefer i18n keys over plain keywords. Use `aliases` only for technical synonyms, provider names, or common typos that are not visible UI copy.
+- Every registry `id` or `focusId` should resolve to a mounted element via `focusId`, `id`, or `data-settings-focus-id`. Use `SettingsCard`, `SettingsFormField`, `SettingsSliderField`, or `SettingsSwitch` focus props where available; otherwise add `data-settings-focus="true"` and `data-settings-focus-id="..."`.
+- Avoid duplicate focus IDs across tabs. Duplicate IDs make search highlights land on the wrong control after tab navigation.
+- Update `src/features/settings/__tests__/settings-registry.test.ts`, `settings-search-index.test.ts`, or the relevant component test when adding search coverage.
+
 ### i18n build pipeline
 
 `src/i18n/resources.ts` and Chrome Web Store locale metadata under `public/_locales/<lang>/messages.json` are **generated** from `src/locales/<lang>/translation.json` by `tools/generate-i18n-resources.ts`. The typed resources file is `.gitignored`; `_locales` is committed because extension packages need it.
@@ -213,9 +224,10 @@ If you change anything under `src/locales/`, run `pnpm generate:resources` manua
 
 If you're touching one of these, expect to refactor as you go:
 
-- `src/features/chat/hooks/use-chat.ts` (~271 LOC; still the busiest hook — split further along stream / abort / thinking / attachments seams if you touch it)
+- `src/features/chat/hooks/use-chat-turn-controller.ts` owns turn lifecycle, streaming, abort, thinking, and attachment handoff. Keep `use-chat.ts` as wiring only.
+- `src/features/file-upload/hooks/use-file-upload.ts` still owns UI state around ingestion; pipeline helpers live in `file-upload-pipeline.ts`. Continue moving validation, registration, and embedding enqueue logic out of the hook when touching it.
 - `src/features/sessions/stores/chat-session-store.ts` is now a thin barrel (~19 LOC) over extracted store slices/actions; persistence reads via `src/lib/repositories/chat-history.ts`. The earlier ~485-LOC god-store has been split — don't go looking for it.
-- `src/features/model/components/provider-settings.tsx` (large, no direct tests; split per provider section)
+- `src/features/model/components/provider-settings.tsx` delegates provider connection details and custom model editing to small components; keep new provider settings slices similarly scoped and covered by component tests.
 - `src/contents/index.ts` is now a thin entry (~38 LOC); selection-capture / dom-observer / messaging have been pulled into siblings.
 - `src/types/index.ts` is now a 14-line re-export barrel over six domain files (`chat`, `model`, `messaging`, `errors`, `content-extraction`, `ui-state`). New code should prefer importing from the per-domain path (`@/types/chat`) over the barrel.
 - Dexie chat-history paths are retired. Vector storage and knowledge sets still use Dexie; chat history stays SQLite-only through the facade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-06-20
+
+### Added
+- i18n-backed settings search index that searches translated labels, descriptions, and visible child strings instead of only hand-written headings.
+- Ranked settings search with case/diacritic/punctuation normalization, partial-token matching, and typo-tolerant fuzzy matching for common misses like `provder`, `ollma`, and partial queries like `prese`.
+- Search coverage for provider controls, prompt templates, keyboard shortcuts, guides, reset modules, reset danger zone, embedding storage stats, semantic search, cache, ANN, and advanced embedding search controls.
+- Cmd/Ctrl+K shortcut on the options page to focus settings search, plus compact placeholder-based search hints for smaller screens.
+
+### Changed
+- Settings search results now show the matching translated child text with parent context, then deep-link to the owning tab and focus/highlight the concrete control where possible.
+- `useChat` now delegates turn lifecycle work to `useChatTurnController`, keeping the public hook focused on wiring state into the chat UI.
+- Chat composer attachment handling, file-upload pipeline work, and provider settings panels were split into smaller focused modules without changing storage keys or public behavior.
+
+### Fixed
+- Settings search now finds presets, browser settings, base URL/API key provider controls, prompt/shortcut/guide text, and embedding search internals that were previously missed.
+- Search deep links no longer stop at the right tab for many controls; focus IDs were added across settings cards, fields, reset rows, guide rows, shortcut rows, and provider controls.
+- Duplicate `search-limit-topk` focus targets between Context and Embeddings were separated so highlights land on the intended control.
+
 ## [0.10.2] - 2026-06-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,1 +1,1 @@
-PUBLIC_SITE_URL=https://ollama-client.shishirchaurasiya.in
+PUBLIC_SITE_URL=https://www.ollamaclient.in

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/components/forms/controlled-number-input.tsx
+++ b/src/components/forms/controlled-number-input.tsx
@@ -31,6 +31,7 @@ export interface ControlledNumberInputProps
   commitMode?: "change" | "blur"
   label?: string
   icon?: LucideIcon
+  focusId?: string
 }
 
 /**
@@ -49,6 +50,7 @@ export const ControlledNumberInput = ({
   className,
   label,
   icon: Icon,
+  focusId,
   ...props
 }: ControlledNumberInputProps) => {
   const { control, getFieldState } = useFormContext()
@@ -111,6 +113,7 @@ export const ControlledNumberInput = ({
   return (
     <SettingsFormField
       htmlFor={inputId}
+      focusId={focusId}
       label={
         Icon ? (
           <div className="flex items-center gap-2">

--- a/src/components/forms/controlled-slider.tsx
+++ b/src/components/forms/controlled-slider.tsx
@@ -20,6 +20,7 @@ export interface ControlledSliderProps
   icon?: LucideIcon
   leftLabel?: string
   rightLabel?: string
+  focusId?: string
 }
 
 const toNumber = (value: unknown, fallback: number): number =>
@@ -40,6 +41,7 @@ export const ControlledSlider = ({
   icon: Icon,
   leftLabel,
   rightLabel,
+  focusId,
   ...props
 }: ControlledSliderProps) => {
   const { control } = useFormContext()
@@ -66,6 +68,7 @@ export const ControlledSlider = ({
   return (
     <SettingsFormField
       htmlFor={name}
+      focusId={focusId}
       label={
         Icon ? (
           <div className="flex items-center gap-2">

--- a/src/components/settings/__tests__/settings-search.test.tsx
+++ b/src/components/settings/__tests__/settings-search.test.tsx
@@ -2,9 +2,30 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { SettingsSearch } from "../settings-search"
 
-// t returns the key so we can assert on label keys directly.
+const messages: Record<string, string> = {
+  "settings.tabs.general": "General",
+  "settings.tabs.providers": "Providers",
+  "settings.tabs.context": "Context",
+  "settings.tabs.extraction": "Extraction",
+  "settings.search.placeholder": "Search settings…",
+  "settings.prompt_context_limits.max_tool_result_chars":
+    "Max tool result chars",
+  "settings.grounding_mode.label": "Answer only from selected page context",
+  "settings.content_extraction.selection_actions.label": "Selection actions",
+  "settings.presets.title": "Presets",
+  "settings.presets.description": "Apply a tuned combination in one click.",
+  "settings.presets.balanced.label": "Balanced",
+  "settings.providers.base_url": "Base URL",
+  "settings.providers.base_url_default": "Default",
+  "settings.reset.modules.browser.title": "Browser Settings",
+  "settings.reset.modules.browser.description": "Tab access & URL patterns"
+}
+
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key })
+  useTranslation: () => ({
+    i18n: { language: "en" },
+    t: (key: string) => messages[key] ?? key
+  })
 }))
 
 describe("SettingsSearch", () => {
@@ -12,19 +33,60 @@ describe("SettingsSearch", () => {
     render(<SettingsSearch onSelect={() => {}} />)
     const input = screen.getByRole("combobox")
     fireEvent.change(input, { target: { value: "tool result" } })
-    expect(
-      screen.getByText("settings.prompt_context_limits.max_tool_result_chars")
-    ).toBeInTheDocument()
+    expect(screen.getByText("Max tool result chars")).toBeInTheDocument()
   })
 
-  it("calls onSelect with the chosen entry and clears the query", () => {
+  it("shows fuzzy provider matches", () => {
+    render(<SettingsSearch onSelect={() => {}} />)
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "provder" } })
+    expect(screen.getAllByText("Providers").length).toBeGreaterThan(0)
+  })
+
+  it("shows presets for partial preset queries", () => {
+    render(<SettingsSearch onSelect={() => {}} />)
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "prese" } })
+    expect(screen.getByText("Presets")).toBeInTheDocument()
+  })
+
+  it("shows matched child values with parent context", () => {
+    render(<SettingsSearch onSelect={() => {}} />)
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "balanced" } })
+    expect(screen.getByText("Balanced")).toBeInTheDocument()
+    expect(screen.getByText("Presets")).toBeInTheDocument()
+  })
+
+  it("shows reset module rows", () => {
+    render(<SettingsSearch onSelect={() => {}} />)
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "browser settings" } })
+    expect(screen.getByText("Browser Settings")).toBeInTheDocument()
+  })
+
+  it("can show the mobile shortcut hint", () => {
+    render(<SettingsSearch onSelect={() => {}} showShortcutHint />)
+    expect(
+      screen.getByLabelText("Search settings shortcut")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Search settings")).toBeNull()
+  })
+
+  it("calls onSelect with the chosen record and clears the query", () => {
     const onSelect = vi.fn()
     render(<SettingsSearch onSelect={onSelect} />)
     const input = screen.getByRole("combobox") as HTMLInputElement
-    fireEvent.change(input, { target: { value: "grounded only" } })
-    fireEvent.mouseDown(screen.getByText("settings.grounding_mode.label"))
+    fireEvent.change(input, { target: { value: "answer only" } })
+    fireEvent.mouseDown(
+      screen.getByText("Answer only from selected page context")
+    )
     expect(onSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "grounded-only-mode", tab: "context" })
+      expect.objectContaining({
+        entryId: "grounded-only-mode",
+        focusId: "grounded-only-mode",
+        tab: "context"
+      })
     )
     expect(input.value).toBe("")
   })
@@ -36,7 +98,10 @@ describe("SettingsSearch", () => {
     fireEvent.change(input, { target: { value: "selection actions" } })
     fireEvent.keyDown(input, { key: "Enter" })
     expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(onSelect.mock.calls[0][0].tab).toBe("contentExtraction")
+    expect(onSelect.mock.calls[0][0]).toMatchObject({
+      entryId: "selection-actions-enabled",
+      tab: "contentExtraction"
+    })
   })
 
   it("shows nothing for an empty query", () => {

--- a/src/components/settings/preset-picker.tsx
+++ b/src/components/settings/preset-picker.tsx
@@ -71,6 +71,7 @@ export const PresetPicker = () => {
   return (
     <SettingsCard
       icon={Sparkles}
+      focusId="settings-presets"
       title={t("settings.presets.title")}
       description={t("settings.presets.description")}>
       <div className="grid gap-2 sm:grid-cols-2">

--- a/src/components/settings/settings-card.tsx
+++ b/src/components/settings/settings-card.tsx
@@ -22,6 +22,7 @@ export interface SettingsCardProps {
   badgeTooltip?: React.ReactNode
   children: React.ReactNode
   className?: string
+  focusId?: string
   headerClassName?: string
   contentClassName?: string
   headerActions?: React.ReactNode
@@ -54,12 +55,13 @@ export const SettingsCard = ({
   badgeTooltip,
   children,
   className,
+  focusId,
   headerClassName,
   contentClassName,
   headerActions
 }: SettingsCardProps) => {
   return (
-    <Card className={className}>
+    <Card className={className} data-settings-focus-id={focusId}>
       <CardHeader className={headerClassName || "pb-4"}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/src/components/settings/settings-search.tsx
+++ b/src/components/settings/settings-search.tsx
@@ -1,4 +1,4 @@
-import { type Ref, useId, useMemo, useRef, useState } from "react"
+import { type Ref, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Kbd, KbdGroup } from "@/components/ui/kbd"
 import { MiniBadge } from "@/components/ui/mini-badge"
@@ -76,6 +76,13 @@ export const SettingsSearch = ({
     setQuery("")
     setOpen(false)
   }
+
+  useEffect(
+    () => () => {
+      if (blurTimer.current) window.clearTimeout(blurTimer.current)
+    },
+    []
+  )
 
   return (
     <div className={cn("relative", className)}>

--- a/src/components/settings/settings-search.tsx
+++ b/src/components/settings/settings-search.tsx
@@ -1,11 +1,13 @@
-import { useId, useMemo, useRef, useState } from "react"
+import { type Ref, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
 import { MiniBadge } from "@/components/ui/mini-badge"
+import type { SettingsTab } from "@/features/settings/settings-registry"
 import {
-  type SettingsEntry,
-  searchSettings
-} from "@/features/settings/settings-registry"
+  buildSettingsSearchRecords,
+  rankSettingsSearchRecords,
+  type SettingsSearchRecord
+} from "@/features/settings/settings-search-index"
 import { Search } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
@@ -28,27 +30,49 @@ const MAX_RESULTS = 8
 
 interface SettingsSearchProps {
   /** Navigate to and highlight the chosen setting (sets tab + focus). */
-  onSelect: (entry: SettingsEntry) => void
+  onSelect: (record: SettingsSearchRecord) => void
+  activeTab?: SettingsTab
   className?: string
+  inputRef?: Ref<HTMLInputElement>
+  showShortcutHint?: boolean
 }
 
 export const SettingsSearch = ({
   onSelect,
-  className
+  activeTab,
+  className,
+  inputRef,
+  showShortcutHint = false
 }: SettingsSearchProps) => {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
+  const language = i18n.language
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
   const blurTimer = useRef<number | null>(null)
   const listId = useId()
+  const modKey =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().includes("MAC")
+      ? "⌘"
+      : "Ctrl"
+
+  const records = useMemo(() => {
+    void language
+    return buildSettingsSearchRecords(undefined, t)
+  }, [language, t])
 
   const results = useMemo(
-    () => (query.trim() ? searchSettings(query, t).slice(0, MAX_RESULTS) : []),
-    [query, t]
+    () =>
+      query.trim()
+        ? rankSettingsSearchRecords(query, records, activeTab)
+            .slice(0, MAX_RESULTS)
+            .map((result) => result.record)
+        : [],
+    [activeTab, query, records]
   )
 
-  const choose = (entry: SettingsEntry) => {
-    onSelect(entry)
+  const choose = (record: SettingsSearchRecord) => {
+    onSelect(record)
     setQuery("")
     setOpen(false)
   }
@@ -58,6 +82,7 @@ export const SettingsSearch = ({
       <div className="relative">
         <Search className="icon-sm pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
         <input
+          ref={inputRef}
           type="search"
           role="combobox"
           aria-expanded={open && results.length > 0}
@@ -81,30 +106,47 @@ export const SettingsSearch = ({
               choose(results[0])
             }
           }}
-          className="h-9 w-full rounded-control border border-input bg-background pl-8 pr-3 text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40"
+          className={cn(
+            "h-9 w-full rounded-control border border-input bg-background pl-8 text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40",
+            showShortcutHint ? "pr-20" : "pr-3"
+          )}
         />
+        {showShortcutHint && (
+          <KbdGroup
+            aria-label="Search settings shortcut"
+            className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+            <Kbd>{modKey}</Kbd>
+            <Kbd>K</Kbd>
+          </KbdGroup>
+        )}
       </div>
 
       {open && results.length > 0 && (
         <ul
           id={listId}
           className="absolute z-50 mt-1 max-h-80 w-full overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md">
-          {results.map((entry) => (
-            <li key={entry.id}>
+          {results.map((record) => (
+            <li
+              key={`${record.entryId}:${record.sourceType}:${record.sourceOrder}`}>
               <button
                 type="button"
                 // mousedown fires before input blur, so the click survives.
                 onMouseDown={(e) => {
                   e.preventDefault()
                   if (blurTimer.current) window.clearTimeout(blurTimer.current)
-                  choose(entry)
+                  choose(record)
                 }}
-                className="flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent">
-                <span className="truncate">{t(entry.labelKey)}</span>
+                className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent">
+                <span className="truncate">{record.displayLabel}</span>
                 <MiniBadge
-                  text={t(TAB_LABEL_KEYS[entry.tab] ?? entry.tab)}
-                  className="shrink-0"
+                  text={t(TAB_LABEL_KEYS[record.tab] ?? record.tab)}
+                  className="row-span-2 shrink-0"
                 />
+                {record.displayContext && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {record.displayContext}
+                  </span>
+                )}
               </button>
             </li>
           ))}

--- a/src/components/settings/settings-search.tsx
+++ b/src/components/settings/settings-search.tsx
@@ -44,8 +44,7 @@ export const SettingsSearch = ({
   inputRef,
   showShortcutHint = false
 }: SettingsSearchProps) => {
-  const { i18n, t } = useTranslation()
-  const language = i18n.language
+  const { t } = useTranslation()
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
   const blurTimer = useRef<number | null>(null)
@@ -57,9 +56,8 @@ export const SettingsSearch = ({
       : "Ctrl"
 
   const records = useMemo(() => {
-    void language
     return buildSettingsSearchRecords(undefined, t)
-  }, [language, t])
+  }, [t])
 
   const results = useMemo(
     () =>

--- a/src/features/chat/components/chat-backfill-panel.tsx
+++ b/src/features/chat/components/chat-backfill-panel.tsx
@@ -67,6 +67,7 @@ export const ChatBackfillPanel = () => {
   return (
     <SettingsCard
       icon={Sparkles}
+      focusId="backfill-embeddings"
       title={t("chat.backfill.title")}
       description={t("chat.backfill.description")}
       contentClassName="space-y-4">

--- a/src/features/chat/components/chat-input-box.tsx
+++ b/src/features/chat/components/chat-input-box.tsx
@@ -2,15 +2,10 @@ import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Textarea } from "@/components/ui/textarea"
-import {
-  type ImageRejectReason,
-  useImageAttachments
-} from "@/features/chat/hooks/use-image-attachments"
+import { useChatInputAttachments } from "@/features/chat/hooks/use-chat-input-attachments"
 import { useSessionMetricsPreference } from "@/features/chat/hooks/use-session-metrics-preference"
 import { useChatInput } from "@/features/chat/stores/chat-input-store"
 import { useLoadStream } from "@/features/chat/stores/load-stream-store"
-import { useFileUpload } from "@/features/file-upload/hooks/use-file-upload"
-import { useSelectedModelCapabilities } from "@/features/model/hooks/use-selected-model-capabilities"
 import { PromptSelectorSheet } from "@/features/prompt/components/prompt-selector-sheet"
 import { useTabContents } from "@/features/tabs/hooks/use-tab-contents"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
@@ -18,13 +13,11 @@ import { useAutoResizeTextarea } from "@/hooks/use-auto-resize-textarea"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 import { useToast } from "@/hooks/use-toast"
 import {
-  DEFAULT_MAX_IMAGE_SIZE_MB,
   DEFAULT_TABS_ACCESS,
   MESSAGE_KEYS,
   STORAGE_KEYS
 } from "@/lib/constants"
 import type { ProcessedFile } from "@/lib/file-processors/types"
-import { logger } from "@/lib/logger"
 import {
   getPlasmoStorageForKey,
   plasmoGlobalStorage
@@ -79,78 +72,15 @@ export const ChatInputBox = ({
   const {
     processFiles,
     processingStates,
+    successfulFiles,
     clearProcessingState,
-    clearAllProcessingStates
-  } = useFileUpload({
-    onError: (error) => {
-      logger.error("File processing error", "ChatInputBox", { error })
-      toast({
-        variant: "destructive",
-        title: "File Upload Failed",
-        description: error.message || "Failed to process file"
-      })
-    }
-  })
-
-  const { capabilities, isResolving: capabilitiesResolving } =
-    useSelectedModelCapabilities()
-  const visionSupported = capabilities?.vision ?? false
-  // Confirmed-unsupported only once detection has finished. While it's still
-  // resolving we don't block — otherwise the first attach (before /api/show
-  // returns) would be wrongly rejected on a vision model.
-  const visionUnsupported = !visionSupported && !capabilitiesResolving
-
-  const [maxImageSizeMb] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.IMAGES.MAX_SIZE_MB,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_IMAGE_SIZE_MB
-  )
-
-  // Stable reference so useImageAttachments' addFiles isn't recreated each render.
-  const handleImageReject = useCallback(
-    (reason: ImageRejectReason, file: File) => {
-      const description =
-        reason === "size"
-          ? t("chat.input.images.too_large", {
-              name: file.name,
-              max: maxImageSizeMb || DEFAULT_MAX_IMAGE_SIZE_MB
-            })
-          : reason === "heic"
-            ? t("chat.input.images.heic_unsupported", { name: file.name })
-            : t("chat.input.images.unsupported_type", { name: file.name })
-      toast({ variant: "destructive", description })
-    },
-    [t, toast, maxImageSizeMb]
-  )
-
-  const {
+    clearAllProcessingStates,
     images,
-    addFiles: addImageFiles,
-    remove: removeImage,
-    clear: clearImages
-  } = useImageAttachments({
-    maxSizeBytes: (maxImageSizeMb || DEFAULT_MAX_IMAGE_SIZE_MB) * 1024 * 1024,
-    onReject: handleImageReject
-  })
-
-  // Route image files to the image pipeline when the model supports vision,
-  // otherwise reject with a clear, capability-aware message.
-  const handleImageFiles = useCallback(
-    (imageFiles: File[]) => {
-      if (imageFiles.length === 0) return
-      if (visionUnsupported) {
-        toast({
-          variant: "destructive",
-          description: t("chat.input.images.model_unsupported")
-        })
-        return
-      }
-      void addImageFiles(imageFiles)
-    },
-    [visionUnsupported, addImageFiles, toast, t]
-  )
+    handleImageFiles,
+    visionUnsupported,
+    removeImage,
+    clearImages
+  } = useChatInputAttachments()
 
   const [useRAG, setUseRAG] = useStorage<boolean>(
     {
@@ -216,13 +146,6 @@ export const ChatInputBox = ({
       handleSend()
     }
   }
-
-  const successfulFiles = processingStates
-    .filter(
-      (s): s is typeof s & { status: "success"; result: ProcessedFile } =>
-        s.status === "success" && s.result !== undefined
-    )
-    .map((s) => s.result)
 
   const handleSend = () => {
     // Don't start a new turn while one is in flight (the action button is a

--- a/src/features/chat/components/speech-settings.tsx
+++ b/src/features/chat/components/speech-settings.tsx
@@ -71,7 +71,10 @@ export const SpeechSettings = () => {
         description={t("settings.speech.description")}
         contentClassName="space-y-5">
         {/* Voice Selection */}
-        <div className="space-y-3">
+        <div
+          className="space-y-3"
+          data-settings-focus="true"
+          data-settings-focus-id="voice-selection">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Mic className="icon-md text-muted-foreground" />
@@ -95,6 +98,7 @@ export const SpeechSettings = () => {
 
         {/* Rate Control */}
         <SettingsSliderField
+          focusId="speech-rate"
           label={t("settings.speech.rate_label")}
           value={rate}
           valueLabel={
@@ -115,6 +119,7 @@ export const SpeechSettings = () => {
 
         {/* Pitch Control */}
         <SettingsSliderField
+          focusId="speech-pitch"
           label={t("settings.speech.pitch_label")}
           value={pitch}
           valueLabel={

--- a/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { loadStreamStore } from "@/features/chat/stores/load-stream-store"
+import type { ChatMessage } from "@/types"
+import { useChatTurnController } from "../use-chat-turn-controller"
+
+const rag = vi.hoisted(() => ({
+  buildRagContext: vi.fn()
+}))
+
+vi.mock("@/features/chat/hooks/build-rag-context", () => rag)
+
+const baseConfig = {
+  selectedModel: "llama3",
+  selectedModelRef: { providerId: "ollama", modelId: "llama3" },
+  selectionConflictModel: null,
+  memoryEnabled: true,
+  maxTabContextChars: 4000,
+  maxRagContextChars: 4000,
+  groundedOnlyMode: false
+}
+
+describe("useChatTurnController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    loadStreamStore.setState({ isLoading: false, isStreaming: false })
+    rag.buildRagContext.mockResolvedValue({
+      contentWithRAG: "question\n\ncontext",
+      ragSources: null,
+      pageContextAdded: false,
+      promptContextStats: {
+        promptInputLength: 8,
+        promptAugmentedLength: 18,
+        tabContextLength: 0,
+        ragContextLength: 10,
+        tabContextTruncated: false,
+        groundedOnlyMode: false,
+        insufficientContext: false,
+        usedContextChunks: [],
+        activityEvents: []
+      }
+    })
+  })
+
+  it("persists the user turn, builds context, and starts response generation", async () => {
+    const addMessage = vi.fn().mockResolvedValue(1)
+    const autoRenameSession = vi.fn().mockResolvedValue(undefined)
+    const generateResponse = vi.fn().mockResolvedValue(undefined)
+    const setNextResponseMetrics = vi.fn()
+
+    const { result } = renderHook(() =>
+      useChatTurnController({
+        config: baseConfig as any,
+        input: "question",
+        setInput: vi.fn(),
+        selectedTabIds: [],
+        contextText: "",
+        tabDocuments: [],
+        messages: [] as ChatMessage[],
+        setIsLoading: vi.fn(),
+        setIsStreaming: vi.fn(),
+        ensureSessionId: vi.fn().mockResolvedValue("session-1"),
+        autoRenameSession,
+        addMessage,
+        setNextResponseMetrics,
+        clearNextResponseMetrics: vi.fn(),
+        generateResponse,
+        toast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      await result.current.sendMessage()
+    })
+
+    expect(addMessage).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ role: "user", content: "question" })
+    )
+    expect(rag.buildRagContext).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "question" })
+    )
+    expect(setNextResponseMetrics).toHaveBeenCalled()
+    expect(generateResponse).toHaveBeenCalledWith(undefined, "session-1", [
+      expect.objectContaining({ role: "user", content: "question\n\ncontext" })
+    ])
+  })
+})

--- a/src/features/chat/hooks/use-chat-input-attachments.ts
+++ b/src/features/chat/hooks/use-chat-input-attachments.ts
@@ -1,0 +1,109 @@
+import { useStorage } from "@plasmohq/storage/hook"
+import { useCallback } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  type ImageRejectReason,
+  useImageAttachments
+} from "@/features/chat/hooks/use-image-attachments"
+import { useFileUpload } from "@/features/file-upload/hooks/use-file-upload"
+import { useSelectedModelCapabilities } from "@/features/model/hooks/use-selected-model-capabilities"
+import { useToast } from "@/hooks/use-toast"
+import { DEFAULT_MAX_IMAGE_SIZE_MB, STORAGE_KEYS } from "@/lib/constants"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+import { logger } from "@/lib/logger"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+
+export const useChatInputAttachments = () => {
+  const { t } = useTranslation()
+  const { toast } = useToast()
+
+  const {
+    processFiles,
+    processingStates,
+    clearProcessingState,
+    clearAllProcessingStates
+  } = useFileUpload({
+    onError: (error) => {
+      logger.error("File processing error", "ChatInputBox", { error })
+      toast({
+        variant: "destructive",
+        title: "File Upload Failed",
+        description: error.message || "Failed to process file"
+      })
+    }
+  })
+
+  const { capabilities, isResolving: capabilitiesResolving } =
+    useSelectedModelCapabilities()
+  const visionSupported = capabilities?.vision ?? false
+  const visionUnsupported = !visionSupported && !capabilitiesResolving
+
+  const [maxImageSizeMb] = useStorage<number>(
+    {
+      key: STORAGE_KEYS.IMAGES.MAX_SIZE_MB,
+      instance: plasmoGlobalStorage
+    },
+    DEFAULT_MAX_IMAGE_SIZE_MB
+  )
+
+  const handleImageReject = useCallback(
+    (reason: ImageRejectReason, file: File) => {
+      const description =
+        reason === "size"
+          ? t("chat.input.images.too_large", {
+              name: file.name,
+              max: maxImageSizeMb || DEFAULT_MAX_IMAGE_SIZE_MB
+            })
+          : reason === "heic"
+            ? t("chat.input.images.heic_unsupported", { name: file.name })
+            : t("chat.input.images.unsupported_type", { name: file.name })
+      toast({ variant: "destructive", description })
+    },
+    [t, toast, maxImageSizeMb]
+  )
+
+  const {
+    images,
+    addFiles: addImageFiles,
+    remove: removeImage,
+    clear: clearImages
+  } = useImageAttachments({
+    maxSizeBytes: (maxImageSizeMb || DEFAULT_MAX_IMAGE_SIZE_MB) * 1024 * 1024,
+    onReject: handleImageReject
+  })
+
+  const handleImageFiles = useCallback(
+    (imageFiles: File[]) => {
+      if (imageFiles.length === 0) return
+      if (visionUnsupported) {
+        toast({
+          variant: "destructive",
+          description: t("chat.input.images.model_unsupported")
+        })
+        return
+      }
+      void addImageFiles(imageFiles)
+    },
+    [visionUnsupported, addImageFiles, toast, t]
+  )
+
+  const successfulFiles = processingStates
+    .filter(
+      (state): state is typeof state & { result: ProcessedFile } =>
+        state.status === "success" && state.result !== undefined
+    )
+    .map((state) => state.result)
+
+  return {
+    processFiles,
+    processingStates,
+    successfulFiles,
+    clearProcessingState,
+    clearAllProcessingStates,
+    images,
+    handleImageFiles,
+    visionUnsupported,
+    removeImage,
+    clearImages
+  }
+}

--- a/src/features/chat/hooks/use-chat-turn-controller.ts
+++ b/src/features/chat/hooks/use-chat-turn-controller.ts
@@ -1,0 +1,315 @@
+import { useState } from "react"
+import { buildRagContext } from "@/features/chat/hooks/build-rag-context"
+import type { useChatConfig } from "@/features/chat/hooks/use-chat-config"
+import { loadStreamStore } from "@/features/chat/stores/load-stream-store"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+import { logger } from "@/lib/logger"
+import type {
+  ActivityEvent,
+  ChatMessage,
+  FileAttachment,
+  ImageAttachment,
+  RagSources,
+  SelectedModelRef
+} from "@/types"
+
+type ToastFn = (input: {
+  variant?: "default" | "destructive"
+  title: string
+  description?: string
+}) => void
+
+interface UseChatTurnControllerOptions {
+  config: ReturnType<typeof useChatConfig>
+  input: string
+  setInput: (value: string) => void
+  selectedTabIds: string[]
+  contextText: string | undefined
+  tabDocuments: Array<{ id: string; title: string; content: string }>
+  messages: ChatMessage[]
+  setIsLoading: (value: boolean) => void
+  setIsStreaming: (value: boolean) => void
+  ensureSessionId: () => Promise<string | null>
+  autoRenameSession: (sessionId: string, content: string) => Promise<void>
+  addMessage: (sessionId: string, message: ChatMessage) => Promise<unknown>
+  setNextResponseMetrics: (
+    ragSources: RagSources | null,
+    promptContextStats: Awaited<
+      ReturnType<typeof buildRagContext>
+    >["promptContextStats"]
+  ) => void
+  clearNextResponseMetrics: () => void
+  generateResponse: (
+    customModel?: string,
+    sessionId?: string,
+    overrideMessages?: ChatMessage[]
+  ) => Promise<void>
+  toast: ToastFn
+}
+
+const buildFileAttachments = (
+  files: ProcessedFile[] | undefined
+): FileAttachment[] | undefined =>
+  files && files.length > 0
+    ? files.map((file) => ({
+        fileId: file.metadata.fileId || `file-${Date.now()}-${Math.random()}`,
+        fileName: file.metadata.fileName,
+        fileType: file.metadata.fileType,
+        fileSize: file.metadata.fileSize,
+        textPreview: file.text.slice(0, 200),
+        processedAt: file.metadata.processedAt
+      }))
+    : undefined
+
+const modelForAssistantFallback = (
+  customModel: string | undefined,
+  selectedModelRef: SelectedModelRef | null,
+  selectedModel: string
+) => customModel || selectedModelRef?.modelId || selectedModel
+
+export const useChatTurnController = ({
+  config,
+  input,
+  setInput,
+  selectedTabIds,
+  contextText,
+  tabDocuments,
+  messages,
+  setIsLoading,
+  setIsStreaming,
+  ensureSessionId,
+  autoRenameSession,
+  addMessage,
+  setNextResponseMetrics,
+  clearNextResponseMetrics,
+  generateResponse,
+  toast
+}: UseChatTurnControllerOptions) => {
+  const [pendingActivityEvents, setPendingActivityEvents] = useState<
+    ActivityEvent[]
+  >([])
+
+  const sendMessage = async (
+    customInput?: string,
+    customModel?: string,
+    files?: ProcessedFile[],
+    images?: ImageAttachment[]
+  ) => {
+    const live = loadStreamStore.getState()
+    if (live.isLoading || live.isStreaming) return
+
+    const rawInput = customInput?.trim() ?? input.trim()
+
+    if (config.selectionConflictModel) {
+      toast({
+        variant: "destructive",
+        title: "Model provider selection required",
+        description: `Select a provider for "${config.selectionConflictModel}" in the model menu before sending a message.`
+      })
+      return
+    }
+
+    const hasImages = !!images && images.length > 0
+    if (!rawInput && (!files || files.length === 0) && !hasImages) return
+
+    setIsLoading(true)
+    const preparingEvent: ActivityEvent = {
+      id: "preparing-context",
+      kind: "preparing_context",
+      label: "Preparing context",
+      status: "running",
+      startedAt: Date.now(),
+      inputPreview: rawInput || files?.[0]?.metadata.fileName
+    }
+    setPendingActivityEvents([preparingEvent])
+
+    const sessionId = await ensureSessionId()
+    if (!sessionId) {
+      setPendingActivityEvents([])
+      setIsLoading(false)
+      return
+    }
+
+    const includeContext = selectedTabIds.length > 0 && !!contextText?.trim()
+    const userContent = rawInput || ""
+    const hasTabContext = includeContext && tabDocuments.length > 0
+    const userMessage: ChatMessage = {
+      role: "user",
+      content: userContent,
+      attachments: buildFileAttachments(files),
+      images: hasImages ? images : undefined
+    }
+
+    try {
+      await addMessage(sessionId, userMessage)
+
+      if (!customInput) setInput("")
+
+      const titleContent = rawInput || files?.[0]?.metadata.fileName || ""
+      await autoRenameSession(sessionId, titleContent)
+    } catch (error) {
+      logger.error("Failed to persist user message", "useChat", { error })
+      setPendingActivityEvents([])
+      setIsLoading(false)
+      toast({
+        variant: "destructive",
+        title: "Couldn't send message",
+        description: "Saving the message failed. Please try again."
+      })
+      return
+    }
+
+    let ragResult: Awaited<ReturnType<typeof buildRagContext>>
+    try {
+      ragResult = await buildRagContext({
+        rawInput: userContent,
+        files,
+        messages,
+        hasTabContext,
+        contextText: contextText || "",
+        tabDocuments,
+        memoryEnabled: config.memoryEnabled,
+        maxTabContextChars: config.maxTabContextChars,
+        maxRagContextChars: config.maxRagContextChars,
+        groundedOnlyMode: config.groundedOnlyMode,
+        selectedModel: config.selectedModel,
+        selectedModelRef: config.selectedModelRef,
+        customModel,
+        onActivityEvent: (events) => {
+          setPendingActivityEvents([
+            {
+              ...preparingEvent,
+              status: "done",
+              finishedAt: Date.now()
+            },
+            ...events
+          ])
+        },
+        toast
+      })
+    } catch (error) {
+      logger.error("Failed to build chat context", "useChat", { error })
+      clearNextResponseMetrics()
+      setPendingActivityEvents([])
+      setIsLoading(false)
+      setIsStreaming(false)
+
+      try {
+        await addMessage(sessionId, {
+          role: "assistant",
+          content:
+            "I couldn't prepare the context for this message. Please try again, or reduce the selected context/files if this keeps happening.",
+          done: true,
+          model: modelForAssistantFallback(
+            customModel,
+            config.selectedModelRef,
+            config.selectedModel
+          ),
+          metrics: {
+            contextBuildFailed: true
+          }
+        })
+      } catch (messageError) {
+        logger.error(
+          "Failed to persist context preparation error message",
+          "useChat",
+          { error: messageError }
+        )
+      }
+
+      toast({
+        variant: "destructive",
+        title: "Context preparation failed",
+        description:
+          "The message was saved, but the assistant could not start because context preparation failed."
+      })
+      return
+    }
+
+    let { contentWithRAG } = ragResult
+    const { ragSources, promptContextStats } = ragResult
+
+    const hasRelevantPageContext = promptContextStats.tabContextLength > 0
+    if (config.groundedOnlyMode) {
+      const strictGroundingInstruction =
+        'You must answer only from the supplied selected-page context. If context is insufficient, respond with: "Insufficient page context."'
+      contentWithRAG = `${strictGroundingInstruction}\n\n${contentWithRAG}`
+      promptContextStats.promptAugmentedLength = contentWithRAG.length
+    }
+
+    if (config.groundedOnlyMode && !hasRelevantPageContext) {
+      setIsLoading(false)
+      setPendingActivityEvents([])
+      const settingsDeepLink =
+        "/options.html?tab=context&focus=grounded-only-mode"
+
+      await addMessage(sessionId, {
+        role: "assistant",
+        content: `Insufficient page context. Select at least one tab with relevant extracted content and try again.\n\nIf you want to disable this behavior, go to [Settings > Context > Answer only from selected page context](${settingsDeepLink}).`,
+        done: true,
+        model: modelForAssistantFallback(
+          customModel,
+          config.selectedModelRef,
+          config.selectedModel
+        ),
+        metrics: {
+          groundedOnlyMode: true,
+          insufficientContext: true,
+          promptInputLength: userContent.length,
+          promptAugmentedLength: contentWithRAG.length,
+          tabContextLength: promptContextStats.tabContextLength,
+          ragContextLength: promptContextStats.ragContextLength,
+          tabContextTruncated: promptContextStats.tabContextTruncated,
+          usedContextChunks: promptContextStats.usedContextChunks
+        }
+      })
+      return
+    }
+
+    const messagesForLLM = [
+      ...messages,
+      { ...userMessage, content: contentWithRAG }
+    ]
+
+    setNextResponseMetrics(ragSources, promptContextStats)
+    setPendingActivityEvents([
+      {
+        ...preparingEvent,
+        status: "done",
+        finishedAt: Date.now()
+      },
+      ...promptContextStats.activityEvents,
+      {
+        id: "generating-answer",
+        kind: "generating_answer",
+        label: "Generating answer",
+        status: "running",
+        startedAt: Date.now()
+      }
+    ])
+
+    logger.info("Prompt context stats", "useChat", {
+      sessionId,
+      promptInputLength: promptContextStats.promptInputLength,
+      promptAugmentedLength: promptContextStats.promptAugmentedLength,
+      tabContextLength: promptContextStats.tabContextLength,
+      ragContextLength: promptContextStats.ragContextLength,
+      tabContextTruncated: promptContextStats.tabContextTruncated,
+      groundedOnlyMode: config.groundedOnlyMode,
+      usedContextChunkCount: promptContextStats.usedContextChunks.length
+    })
+
+    if (promptContextStats.tabContextTruncated) {
+      toast({
+        title: "Context trimmed",
+        description:
+          "Extracted tab context exceeded your limit and was trimmed before sending."
+      })
+    }
+
+    await generateResponse(customModel, sessionId, messagesForLLM)
+    setPendingActivityEvents([])
+  }
+
+  return { pendingActivityEvents, sendMessage }
+}

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -1,26 +1,15 @@
-import { useEffect, useRef, useState } from "react"
-import { buildRagContext } from "@/features/chat/hooks/build-rag-context"
+import { useEffect, useRef } from "react"
 import { useChatConfig } from "@/features/chat/hooks/use-chat-config"
 import { useChatResponse } from "@/features/chat/hooks/use-chat-response"
 import { useChatSessionLifecycle } from "@/features/chat/hooks/use-chat-session-lifecycle"
 import { useChatStreaming } from "@/features/chat/hooks/use-chat-streaming"
+import { useChatTurnController } from "@/features/chat/hooks/use-chat-turn-controller"
 import { useChatInput } from "@/features/chat/stores/chat-input-store"
-import {
-  loadStreamStore,
-  useLoadStream
-} from "@/features/chat/stores/load-stream-store"
+import { useLoadStream } from "@/features/chat/stores/load-stream-store"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
 import { useTabContent } from "@/features/tabs/stores/tab-content-store"
 import { useToast } from "@/hooks/use-toast"
-import type { ProcessedFile } from "@/lib/file-processors/types"
-import { logger } from "@/lib/logger"
-import type {
-  ActivityEvent,
-  ChatMessage,
-  FileAttachment,
-  ImageAttachment
-} from "@/types"
 
 export const useChat = () => {
   const config = useChatConfig()
@@ -46,9 +35,6 @@ export const useChat = () => {
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const previousSessionIdRef = useRef<string | null>(null)
-  const [pendingActivityEvents, setPendingActivityEvents] = useState<
-    ActivityEvent[]
-  >([])
 
   const currentSession = sessions.find((s) => s.id === currentSessionId)
   const messages = currentSession?.messages ?? []
@@ -95,254 +81,24 @@ export const useChat = () => {
       currentStreamingMessageIdRef
     })
 
-  const sendMessage = async (
-    customInput?: string,
-    customModel?: string,
-    files?: ProcessedFile[],
-    images?: ImageAttachment[]
-  ) => {
-    // Block re-entrancy: ignore a send while a generation is already in flight
-    // so a slow turn can't have a second query queued behind it. Read live
-    // store state, not the render-time closure — setIsLoading(true) below
-    // updates the store synchronously but the closed-over value lags a render,
-    // so two sends in the same frame would both slip past a closure check.
-    const live = loadStreamStore.getState()
-    if (live.isLoading || live.isStreaming) return
-
-    const rawInput = customInput?.trim() ?? input.trim()
-
-    if (config.selectionConflictModel) {
-      toast({
-        variant: "destructive",
-        title: "Model provider selection required",
-        description: `Select a provider for "${config.selectionConflictModel}" in the model menu before sending a message.`
-      })
-      return
-    }
-
-    const hasImages = !!images && images.length > 0
-    if (!rawInput && (!files || files.length === 0) && !hasImages) return
-
-    // Show the thinking state immediately, before any await — session
-    // creation, context building (RAG embedding, vector search) all run before
-    // the stream starts, and without this the user gets no feedback for that
-    // whole window, assumes nothing happened, and re-sends.
-    setIsLoading(true)
-    const preparingEvent: ActivityEvent = {
-      id: "preparing-context",
-      kind: "preparing_context",
-      label: "Preparing context",
-      status: "running",
-      startedAt: Date.now(),
-      inputPreview: rawInput || files?.[0]?.metadata.fileName
-    }
-    setPendingActivityEvents([preparingEvent])
-
-    const sessionId = await ensureSessionId()
-    if (!sessionId) {
-      setPendingActivityEvents([])
-      setIsLoading(false)
-      return
-    }
-
-    const includeContext = selectedTabIds.length > 0 && !!contextText?.trim()
-    const userContent = rawInput || ""
-    const hasTabContext = includeContext && tabDocuments.length > 0
-
-    const attachments: FileAttachment[] | undefined =
-      files && files.length > 0
-        ? files.map((file) => ({
-            fileId:
-              file.metadata.fileId || `file-${Date.now()}-${Math.random()}`,
-            fileName: file.metadata.fileName,
-            fileType: file.metadata.fileType,
-            fileSize: file.metadata.fileSize,
-            textPreview: file.text.slice(0, 200),
-            processedAt: file.metadata.processedAt
-          }))
-        : undefined
-
-    // Display user message immediately (instant feedback).
-    const userMessage: ChatMessage = {
-      role: "user",
-      content: userContent,
-      attachments,
-      images: hasImages ? images : undefined
-    }
-
-    // addMessage/autoRenameSession are async SQLite writes running inside the
-    // loading window. A failure here must clear isLoading, or the session is
-    // wedged — every later send hits the re-entrancy guard and silently bails.
-    try {
-      await addMessage(sessionId, userMessage)
-
-      if (!customInput) setInput("")
-
-      const titleContent = rawInput || files?.[0]?.metadata.fileName || ""
-      await autoRenameSession(sessionId, titleContent)
-    } catch (error) {
-      logger.error("Failed to persist user message", "useChat", { error })
-      setPendingActivityEvents([])
-      setIsLoading(false)
-      toast({
-        variant: "destructive",
-        title: "Couldn't send message",
-        description: "Saving the message failed. Please try again."
-      })
-      return
-    }
-
-    let ragResult: Awaited<ReturnType<typeof buildRagContext>>
-    try {
-      // Build the RAG-augmented body in the background.
-      ragResult = await buildRagContext({
-        rawInput: userContent,
-        files,
-        messages,
-        hasTabContext,
-        contextText: contextText || "",
-        tabDocuments,
-        memoryEnabled: config.memoryEnabled,
-        maxTabContextChars: config.maxTabContextChars,
-        maxRagContextChars: config.maxRagContextChars,
-        groundedOnlyMode: config.groundedOnlyMode,
-        selectedModel: config.selectedModel,
-        selectedModelRef: config.selectedModelRef,
-        customModel,
-        onActivityEvent: (events) => {
-          setPendingActivityEvents([
-            {
-              ...preparingEvent,
-              status: "done",
-              finishedAt: Date.now()
-            },
-            ...events
-          ])
-        },
-        toast
-      })
-    } catch (error) {
-      logger.error("Failed to build chat context", "useChat", { error })
-      clearNextResponseMetrics()
-      setPendingActivityEvents([])
-      setIsLoading(false)
-      setIsStreaming(false)
-
-      try {
-        await addMessage(sessionId, {
-          role: "assistant",
-          content:
-            "I couldn't prepare the context for this message. Please try again, or reduce the selected context/files if this keeps happening.",
-          done: true,
-          model:
-            customModel ||
-            config.selectedModelRef?.modelId ||
-            config.selectedModel,
-          metrics: {
-            contextBuildFailed: true
-          }
-        })
-      } catch (messageError) {
-        logger.error(
-          "Failed to persist context preparation error message",
-          "useChat",
-          { error: messageError }
-        )
-      }
-
-      toast({
-        variant: "destructive",
-        title: "Context preparation failed",
-        description:
-          "The message was saved, but the assistant could not start because context preparation failed."
-      })
-      return
-    }
-
-    let { contentWithRAG } = ragResult
-    const { ragSources, promptContextStats } = ragResult
-
-    const hasRelevantPageContext = promptContextStats.tabContextLength > 0
-    if (config.groundedOnlyMode) {
-      const strictGroundingInstruction =
-        'You must answer only from the supplied selected-page context. If context is insufficient, respond with: "Insufficient page context."'
-      contentWithRAG = `${strictGroundingInstruction}\n\n${contentWithRAG}`
-      promptContextStats.promptAugmentedLength = contentWithRAG.length
-    }
-
-    if (config.groundedOnlyMode && !hasRelevantPageContext) {
-      // Early exit without streaming — clear the thinking state we set above.
-      setIsLoading(false)
-      setPendingActivityEvents([])
-      const settingsDeepLink =
-        "/options.html?tab=context&focus=grounded-only-mode"
-
-      await addMessage(sessionId, {
-        role: "assistant",
-        content: `Insufficient page context. Select at least one tab with relevant extracted content and try again.\n\nIf you want to disable this behavior, go to [Settings > Context > Answer only from selected page context](${settingsDeepLink}).`,
-        done: true,
-        model:
-          customModel ||
-          config.selectedModelRef?.modelId ||
-          config.selectedModel,
-        metrics: {
-          groundedOnlyMode: true,
-          insufficientContext: true,
-          promptInputLength: userContent.length,
-          promptAugmentedLength: contentWithRAG.length,
-          tabContextLength: promptContextStats.tabContextLength,
-          ragContextLength: promptContextStats.ragContextLength,
-          tabContextTruncated: promptContextStats.tabContextTruncated,
-          usedContextChunks: promptContextStats.usedContextChunks
-        }
-      })
-      return
-    }
-
-    const messagesForLLM = [
-      ...messages,
-      { ...userMessage, content: contentWithRAG }
-    ]
-
-    setNextResponseMetrics(ragSources, promptContextStats)
-    setPendingActivityEvents([
-      {
-        ...preparingEvent,
-        status: "done",
-        finishedAt: Date.now()
-      },
-      ...promptContextStats.activityEvents,
-      {
-        id: "generating-answer",
-        kind: "generating_answer",
-        label: "Generating answer",
-        status: "running",
-        startedAt: Date.now()
-      }
-    ])
-
-    logger.info("Prompt context stats", "useChat", {
-      sessionId,
-      promptInputLength: promptContextStats.promptInputLength,
-      promptAugmentedLength: promptContextStats.promptAugmentedLength,
-      tabContextLength: promptContextStats.tabContextLength,
-      ragContextLength: promptContextStats.ragContextLength,
-      tabContextTruncated: promptContextStats.tabContextTruncated,
-      groundedOnlyMode: config.groundedOnlyMode,
-      usedContextChunkCount: promptContextStats.usedContextChunks.length
-    })
-
-    if (promptContextStats.tabContextTruncated) {
-      toast({
-        title: "Context trimmed",
-        description:
-          "Extracted tab context exceeded your limit and was trimmed before sending."
-      })
-    }
-
-    await generateResponse(customModel, sessionId, messagesForLLM)
-    setPendingActivityEvents([])
-  }
+  const { pendingActivityEvents, sendMessage } = useChatTurnController({
+    config,
+    input,
+    setInput,
+    selectedTabIds,
+    contextText,
+    tabDocuments,
+    messages,
+    setIsLoading,
+    setIsStreaming,
+    ensureSessionId,
+    autoRenameSession,
+    addMessage,
+    setNextResponseMetrics,
+    clearNextResponseMetrics,
+    generateResponse,
+    toast
+  })
 
   return {
     messages,

--- a/src/features/context/components/prompt-context-limits-settings.tsx
+++ b/src/features/context/components/prompt-context-limits-settings.tsx
@@ -63,6 +63,7 @@ export const PromptContextLimitsSettings = () => {
       <FormGrid>
         <SettingsFormField
           htmlFor="max-tab-context-chars"
+          focusId="max-tab-context-chars"
           label={t("settings.prompt_context_limits.max_tab_context_chars")}>
           <Input
             id="max-tab-context-chars"
@@ -82,6 +83,7 @@ export const PromptContextLimitsSettings = () => {
 
         <SettingsFormField
           htmlFor="max-rag-context-chars"
+          focusId="max-rag-context-chars"
           label={t("settings.prompt_context_limits.max_rag_context_chars")}>
           <Input
             id="max-rag-context-chars"

--- a/src/features/file-upload/components/file-upload-settings.tsx
+++ b/src/features/file-upload/components/file-upload-settings.tsx
@@ -56,6 +56,7 @@ export const FileUploadSettings = () => {
       <FieldStack>
         <SettingsFormField
           htmlFor="max-file-size"
+          focusId="max-file-size-mb"
           label={t("file_upload.settings.max_file_size_label")}
           description={t("file_upload.settings.max_file_size_description")}>
           <div className="flex items-center gap-2">
@@ -73,6 +74,7 @@ export const FileUploadSettings = () => {
 
         <SettingsFormField
           htmlFor="max-image-size"
+          focusId="max-image-size-mb"
           label={t("file_upload.settings.max_image_size_label")}
           description={t("file_upload.settings.max_image_size_description")}>
           <div className="flex items-center gap-2">

--- a/src/features/file-upload/hooks/__tests__/file-upload-pipeline.test.ts
+++ b/src/features/file-upload/hooks/__tests__/file-upload-pipeline.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+import {
+  ensureProcessedFileId,
+  registerKnowledgeFile,
+  validateFileForUpload
+} from "../file-upload-pipeline"
+
+const knowledge = vi.hoisted(() => ({
+  addFileToKnowledgeSet: vi.fn(),
+  getActiveKnowledgeSetId: vi.fn()
+}))
+
+vi.mock("@/lib/knowledge/knowledge-sets", () => knowledge)
+
+describe("file-upload-pipeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    knowledge.getActiveKnowledgeSetId.mockResolvedValue("knowledge-default")
+  })
+
+  it("rejects files above the configured size", () => {
+    const file = new File(["hello"], "note.txt", { type: "text/plain" })
+
+    const error = validateFileForUpload(file, 1)
+
+    expect(error?.message).toContain("exceeds maximum size")
+  })
+
+  it("keeps existing processed file ids", () => {
+    const result = {
+      text: "hello",
+      metadata: {
+        fileId: "existing-id",
+        fileName: "note.txt",
+        fileType: "text/plain",
+        fileSize: 5,
+        processedAt: 1
+      }
+    } as ProcessedFile
+
+    expect(ensureProcessedFileId(result)).toBe("existing-id")
+    expect(result.metadata.fileId).toBe("existing-id")
+  })
+
+  it("registers processed files with the active knowledge set", async () => {
+    const result = {
+      text: "hello",
+      metadata: {
+        fileName: "note.txt",
+        fileType: "text/plain",
+        fileSize: 5,
+        processedAt: 123
+      }
+    } as ProcessedFile
+
+    await registerKnowledgeFile(result, "file-1")
+
+    expect(result.metadata.knowledgeSetId).toBe("knowledge-default")
+    expect(knowledge.addFileToKnowledgeSet).toHaveBeenCalledWith({
+      id: "file-1",
+      knowledgeSetId: "knowledge-default",
+      fileName: "note.txt",
+      fileType: "text/plain",
+      fileSize: 5,
+      createdAt: 123
+    })
+  })
+})

--- a/src/features/file-upload/hooks/file-upload-pipeline.ts
+++ b/src/features/file-upload/hooks/file-upload-pipeline.ts
@@ -1,0 +1,51 @@
+import { isFileTypeSupported } from "@/lib/file-processors"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+import {
+  addFileToKnowledgeSet,
+  getActiveKnowledgeSetId
+} from "@/lib/knowledge/knowledge-sets"
+
+export const validateFileForUpload = (
+  file: File,
+  maxFileSize: number
+): Error | null => {
+  if (!isFileTypeSupported(file)) {
+    return new Error(
+      `Unsupported file type: "${file.name}". Supported formats: Text files (.txt, .md, .js, .ts, etc.), PDF (.pdf), DOCX (.docx), CSV/TSV (.csv, .tsv), and HTML (.html).`
+    )
+  }
+
+  if (file.size > maxFileSize) {
+    return new Error(
+      `File "${file.name}" exceeds maximum size of ${(maxFileSize / 1024 / 1024).toFixed(0)}MB`
+    )
+  }
+
+  return null
+}
+
+export const ensureProcessedFileId = (result: ProcessedFile): string => {
+  const fallbackId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? `file-${crypto.randomUUID()}`
+      : `file-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const fileId = result.metadata.fileId || fallbackId
+  result.metadata.fileId = fileId
+  return fileId
+}
+
+export const registerKnowledgeFile = async (
+  result: ProcessedFile,
+  fileId: string
+): Promise<void> => {
+  const knowledgeSetId = await getActiveKnowledgeSetId()
+  result.metadata.knowledgeSetId = knowledgeSetId
+  await addFileToKnowledgeSet({
+    id: fileId,
+    knowledgeSetId,
+    fileName: result.metadata.fileName,
+    fileType: result.metadata.fileType,
+    fileSize: result.metadata.fileSize,
+    createdAt: result.metadata.processedAt || Date.now()
+  })
+}

--- a/src/features/file-upload/hooks/use-file-upload.ts
+++ b/src/features/file-upload/hooks/use-file-upload.ts
@@ -9,17 +9,13 @@ import {
 } from "@/lib/constants"
 import { chunkTextAsync } from "@/lib/embeddings/chunker"
 import { getDisplayErrorMessage } from "@/lib/error-display"
-import { isFileTypeSupported, processFile } from "@/lib/file-processors"
+import { processFile } from "@/lib/file-processors"
 import type {
   FileProcessingState,
   ProcessedFile
 } from "@/lib/file-processors/types"
 import { processKnowledge } from "@/lib/knowledge"
-import {
-  addFileToKnowledgeSet,
-  getActiveKnowledgeSetId,
-  markKnowledgeFileEmbedded
-} from "@/lib/knowledge/knowledge-sets"
+import { markKnowledgeFileEmbedded } from "@/lib/knowledge/knowledge-sets"
 import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type {
@@ -27,6 +23,11 @@ import type {
   EmbeddingStatusMessage,
   FileUploadConfig
 } from "@/types"
+import {
+  ensureProcessedFileId,
+  registerKnowledgeFile,
+  validateFileForUpload
+} from "./file-upload-pipeline"
 
 export interface UseFileUploadOptions {
   onFileProcessed?: (file: ProcessedFile) => void
@@ -69,25 +70,8 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
 
       // Initialize processing states
       for (const file of fileArray) {
-        // Check if file type is supported
-        if (!isFileTypeSupported(file)) {
-          const error = new Error(
-            `Unsupported file type: "${file.name}". Supported formats: Text files (.txt, .md, .js, .ts, etc.), PDF (.pdf), DOCX (.docx), CSV/TSV (.csv, .tsv), and HTML (.html).`
-          )
-          newStates.set(file, {
-            file,
-            status: "error",
-            error: error.message
-          })
-          if (onError) onError(error)
-          continue
-        }
-
-        // Check file size
-        if (file.size > maxFileSize) {
-          const error = new Error(
-            `File "${file.name}" exceeds maximum size of ${(maxFileSize / 1024 / 1024).toFixed(0)}MB`
-          )
+        const error = validateFileForUpload(file, maxFileSize)
+        if (error) {
           newStates.set(file, {
             file,
             status: "error",
@@ -113,24 +97,10 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
 
         try {
           const result = await processFile(file)
-          const fallbackId =
-            typeof crypto !== "undefined" && "randomUUID" in crypto
-              ? `file-${crypto.randomUUID()}`
-              : `file-${Date.now()}-${Math.random().toString(16).slice(2)}`
-          const fileId = result.metadata.fileId || fallbackId
-          result.metadata.fileId = fileId
+          const fileId = ensureProcessedFileId(result)
 
           try {
-            const knowledgeSetId = await getActiveKnowledgeSetId()
-            result.metadata.knowledgeSetId = knowledgeSetId
-            await addFileToKnowledgeSet({
-              id: fileId,
-              knowledgeSetId,
-              fileName: result.metadata.fileName,
-              fileType: result.metadata.fileType,
-              fileSize: result.metadata.fileSize,
-              createdAt: result.metadata.processedAt || Date.now()
-            })
+            await registerKnowledgeFile(result, fileId)
           } catch (err) {
             logger.warn("Failed to register knowledge file", "useFileUpload", {
               error: err

--- a/src/features/knowledge/components/data-migration-settings.tsx
+++ b/src/features/knowledge/components/data-migration-settings.tsx
@@ -145,6 +145,7 @@ export const DataMigrationSettings = () => {
       description={t("settings.migration.description")}>
       <div className="space-y-4">
         <SettingsFormField
+          focusId="data-migration-export"
           label={t("settings.migration.export.label")}
           description={t("settings.migration.export.description")}>
           <Button
@@ -161,6 +162,7 @@ export const DataMigrationSettings = () => {
         </SettingsFormField>
 
         <SettingsFormField
+          focusId="data-migration-import"
           label={t("settings.migration.import.label")}
           description={t("settings.migration.import.description")}>
           <Button

--- a/src/features/knowledge/components/feedback-settings.tsx
+++ b/src/features/knowledge/components/feedback-settings.tsx
@@ -153,7 +153,7 @@ export function FeedbackSettings() {
       description={t("model.embedding_config.feedback_learning_description")}
       contentClassName="space-y-6">
       <SettingsSwitch
-        id="feedback-enabled"
+        id="embeddings-feedback-enabled"
         label={t("model.embedding_config.feedback_enable_label")}
         description={t("model.embedding_config.feedback_enable_description")}
         checked={feedbackEnabled}
@@ -161,7 +161,7 @@ export function FeedbackSettings() {
       />
 
       <SettingsSwitch
-        id="feedback-show-chunks"
+        id="embeddings-show-retrieved-chunks"
         label={t("model.embedding_config.feedback_show_chunks_label")}
         description={t(
           "model.embedding_config.feedback_show_chunks_description"
@@ -225,6 +225,7 @@ export function FeedbackSettings() {
 
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <SettingsFormField
+          focusId="embeddings-feedback-clear"
           label={t("model.embedding_config.feedback_privacy_title")}
           description={t("model.embedding_config.feedback_privacy_note")}
         />

--- a/src/features/knowledge/components/rag-settings.tsx
+++ b/src/features/knowledge/components/rag-settings.tsx
@@ -218,6 +218,7 @@ export const RAGSettings = () => {
     <div className="space-y-6">
       <div className="space-y-4">
         <SettingsSwitch
+          id="rag-enabled"
           label={t("model.embedding_config.rag_enable_label")}
           description={t("model.embedding_config.rag_enable_description")}
           checked={useRAG}
@@ -225,6 +226,7 @@ export const RAGSettings = () => {
         />
 
         <SettingsSwitch
+          id="use-reranking"
           label={t("model.embedding_config.reranking_label")}
           description={t("model.embedding_config.reranking_description")}
           checked={config.useReranking ?? false}
@@ -239,6 +241,7 @@ export const RAGSettings = () => {
       </div>
 
       <SettingsSliderField
+        focusId="search-limit-topk"
         label={t("model.embedding_config.search_limit_label")}
         valueLabel={`Top-K: ${topK}`}
         description={t("model.embedding_config.search_limit_description")}
@@ -250,6 +253,7 @@ export const RAGSettings = () => {
       />
 
       <SettingsSliderField
+        focusId="min-rerank-score"
         label={t("knowledge_sets.min_rerank_label")}
         valueLabel={minRerankScore.toFixed(2)}
         description={t("knowledge_sets.min_rerank_description")}
@@ -271,6 +275,7 @@ export const RAGSettings = () => {
           <AccordionTrigger>{t("knowledge_sets.title")}</AccordionTrigger>
           <AccordionContent className="space-y-6 pt-4">
             <SettingsFormField
+              focusId="active-knowledge-set"
               label={t("knowledge_sets.active_label")}
               description={t("knowledge_sets.active_description")}>
               <Select

--- a/src/features/knowledge/components/text-splitting-settings.tsx
+++ b/src/features/knowledge/components/text-splitting-settings.tsx
@@ -81,6 +81,7 @@ export const TextSplittingSettings = () => {
     <div className="space-y-6">
       <div className="space-y-4">
         <SettingsSwitch
+          id="enhanced-chunking"
           label={t("model.embedding_config.enhanced_chunking_label")}
           description={t(
             "model.embedding_config.enhanced_chunking_description"
@@ -97,6 +98,7 @@ export const TextSplittingSettings = () => {
       </div>
 
       <SettingsSliderField
+        focusId="chunk-size"
         label={t("model.embedding_config.chunk_size_label")}
         valueLabel={`${chunkSize} tokens`}
         description={t("model.embedding_config.chunk_size_description")}
@@ -108,6 +110,7 @@ export const TextSplittingSettings = () => {
       />
 
       <SettingsSliderField
+        focusId="chunk-overlap"
         label={t("model.embedding_config.chunk_overlap_label")}
         valueLabel={`${chunkOverlap} tokens`}
         description={t("model.embedding_config.chunk_overlap_description")}
@@ -120,6 +123,7 @@ export const TextSplittingSettings = () => {
 
       {!config.useEnhancedChunking && (
         <SettingsFormField
+          focusId="chunking-strategy"
           label={t("model.embedding_config.chunking_strategy_label")}>
           <Select
             value={config.chunkingStrategy}

--- a/src/features/memory/components/memory-settings.tsx
+++ b/src/features/memory/components/memory-settings.tsx
@@ -78,7 +78,7 @@ export const MemorySettings = () => {
       badge={t("settings.memory.beta_badge")}
       contentClassName="space-y-6">
       <SettingsSwitch
-        id="memory-toggle"
+        id="memory-enabled"
         label={t("settings.memory.enable.label")}
         description={t("settings.memory.enable.description")}
         checked={isEnabled}
@@ -88,6 +88,7 @@ export const MemorySettings = () => {
       <div className="border-t pt-4">
         <div className="flex items-center justify-between">
           <SettingsFormField
+            focusId="clear-memory"
             label={t("settings.memory.clear.label")}
             description={
               <>

--- a/src/features/model/components/__tests__/provider-settings.test.tsx
+++ b/src/features/model/components/__tests__/provider-settings.test.tsx
@@ -100,11 +100,25 @@ describe("ProviderSettings", () => {
   it("renders selected provider controls and delegates primary actions", () => {
     const actions = mockProviderState({ hasUnsavedChanges: true })
 
-    renderProviderSettings()
+    const { container } = renderProviderSettings()
 
     expect(screen.getAllByText("Ollama")).toHaveLength(2)
     expect(
       screen.getByText("settings.providers.not_tested")
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-settings-focus-id="provider-picker"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-settings-focus-id="provider-base-url"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-settings-focus-id="provider-enabled"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-settings-focus-id="provider-test-connection"]'
+      )
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "OpenAI Compatible" }))
@@ -134,11 +148,19 @@ describe("ProviderSettings", () => {
       headerStatus: { dot: "bg-status-success", label: "connected" }
     })
 
-    renderProviderSettings()
+    const { container } = renderProviderSettings()
 
     expect(screen.getByDisplayValue("secret")).toBeInTheDocument()
     expect(screen.getByText(/This endpoint is remote/)).toBeInTheDocument()
     expect(screen.getByText("CSP hint")).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-settings-focus-id="provider-api-key"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-settings-focus-id="provider-custom-models"]'
+      )
+    ).toBeInTheDocument()
 
     const customModelInput = screen.getByPlaceholderText(
       "e.g. google/gemini-pro"

--- a/src/features/model/components/content-extraction-settings.tsx
+++ b/src/features/model/components/content-extraction-settings.tsx
@@ -159,6 +159,7 @@ const ContentExtractionSettingsForm = ({
     <SettingsFormField
       key={field.id}
       htmlFor={field.id}
+      focusId={field.id}
       label={
         <>
           <field.icon className="icon-xs" />
@@ -203,6 +204,7 @@ const ContentExtractionSettingsForm = ({
   ) => (
     <div className="space-y-3">
       <SettingsFormField
+        focusId="content-scraper"
         label={
           <>
             <FileText className="icon-md" />
@@ -284,6 +286,7 @@ const ContentExtractionSettingsForm = ({
   ) => (
     <SettingsFormField
       htmlFor={id || "scroll-strategy"}
+      focusId="scroll-strategy"
       label={
         <>
           <Target className="icon-md" />
@@ -317,6 +320,7 @@ const ContentExtractionSettingsForm = ({
     const depthPercent = Math.round(depth * 100)
     return (
       <SettingsSliderField
+        focusId="scroll-depth"
         label={
           <>
             <Zap className="icon-md" />
@@ -344,7 +348,7 @@ const ContentExtractionSettingsForm = ({
       badge="Beta">
       {/* Enable/Disable Toggle */}
       <SettingsSwitch
-        id="enabled"
+        id="content-extraction-enabled"
         label={t("settings.content_extraction.enable.label")}
         description={t("settings.content_extraction.enable.description")}
         checked={config.enabled}

--- a/src/features/model/components/embedding-config/database-management-card.tsx
+++ b/src/features/model/components/embedding-config/database-management-card.tsx
@@ -29,6 +29,8 @@ export const DatabaseManagementCard = ({
       description={t("model.embedding_config.database_management_description")}
       contentClassName="space-y-3">
       <SettingsRow
+        data-settings-focus="true"
+        data-settings-focus-id="remove-duplicate-vectors"
         label={t("model.embedding_config.remove_duplicates_button")}
         description={t("model.embedding_config.remove_duplicates_description")}
         control={
@@ -42,6 +44,8 @@ export const DatabaseManagementCard = ({
       />
 
       <SettingsRow
+        data-settings-focus="true"
+        data-settings-focus-id="clear-chat-vectors"
         label={t("model.embedding_config.clear_chat_button")}
         description={t("model.embedding_config.clear_chat_description")}
         control={
@@ -55,6 +59,8 @@ export const DatabaseManagementCard = ({
       />
 
       <SettingsRow
+        data-settings-focus="true"
+        data-settings-focus-id="clear-all-vectors"
         label={t("model.embedding_config.clear_all_button")}
         description={t("model.embedding_config.clear_all_description")}
         control={

--- a/src/features/model/components/embedding-config/embedding-generation-config.tsx
+++ b/src/features/model/components/embedding-config/embedding-generation-config.tsx
@@ -27,6 +27,7 @@ export const EmbeddingGenerationConfig = ({
       <div className="space-y-4">
         <SettingsFormField
           htmlFor="batchSize"
+          focusId="embeddings-batch-size"
           label={t("model.embedding_config.batch_size_label")}
           description={t("model.embedding_config.batch_size_description")}>
           <Input
@@ -45,7 +46,7 @@ export const EmbeddingGenerationConfig = ({
         </SettingsFormField>
 
         <SettingsSwitch
-          id="enableCaching"
+          id="embeddings-enable-caching"
           label={t("model.embedding_config.enable_caching_label")}
           description={t("model.embedding_config.enable_caching_description")}
           checked={config.enableCaching}

--- a/src/features/model/components/embedding-config/embedding-health-alert.tsx
+++ b/src/features/model/components/embedding-config/embedding-health-alert.tsx
@@ -61,7 +61,10 @@ export const EmbeddingHealthAlert = ({
       : 0
 
   return (
-    <div className="space-y-3">
+    <div
+      className="space-y-3"
+      data-settings-focus="true"
+      data-settings-focus-id="rebuild-embeddings">
       <StatusAlert
         variant="warning"
         icon={AlertTriangle}

--- a/src/features/model/components/embedding-config/embedding-model-selector.tsx
+++ b/src/features/model/components/embedding-config/embedding-model-selector.tsx
@@ -105,6 +105,7 @@ export const EmbeddingModelSelector = ({
   return (
     <SettingsCard
       icon={Brain}
+      focusId="embeddings-model-select"
       title={t("settings.embeddings.title")}
       description={t("settings.embeddings.description")}
       badge="Beta">
@@ -192,6 +193,7 @@ export const EmbeddingModelSelector = ({
 
           {hasAdvancedModels && (
             <SettingsSwitch
+              id="embeddings-show-advanced-models"
               label={t("settings.embeddings.model_select.show_advanced_label")}
               description={t(
                 "settings.embeddings.model_select.show_advanced_description"

--- a/src/features/model/components/embedding-config/embedding-search-config.tsx
+++ b/src/features/model/components/embedding-config/embedding-search-config.tsx
@@ -36,6 +36,7 @@ export const EmbeddingSearchConfig = ({
       <div className="space-y-4">
         <SettingsFormField
           htmlFor="defaultSearchLimit"
+          focusId="embeddings-search-limit-topk"
           label={t("model.embedding_config.search_limit_label")}
           description={t("model.embedding_config.search_limit_description")}>
           <Input
@@ -56,6 +57,7 @@ export const EmbeddingSearchConfig = ({
         </SettingsFormField>
 
         <SettingsSliderField
+          focusId="embeddings-min-similarity"
           label={t("model.embedding_config.min_similarity_label")}
           valueLabel={config.defaultMinSimilarity.toFixed(2)}
           description={t("model.embedding_config.min_similarity_description")}
@@ -72,6 +74,7 @@ export const EmbeddingSearchConfig = ({
 
         <SettingsFormField
           htmlFor="searchCacheTTL"
+          focusId="embeddings-cache-ttl"
           label={t("model.embedding_config.cache_ttl_label")}
           description={t("model.embedding_config.cache_ttl_description")}
           className="pt-2 border-t">
@@ -94,6 +97,7 @@ export const EmbeddingSearchConfig = ({
 
         <SettingsFormField
           htmlFor="searchCacheMaxSize"
+          focusId="embeddings-cache-max-size"
           label={t("model.embedding_config.cache_max_size_label")}
           description={t("model.embedding_config.cache_max_size_description")}>
           <Input
@@ -114,6 +118,7 @@ export const EmbeddingSearchConfig = ({
         </SettingsFormField>
 
         <SettingsFormField
+          focusId="embeddings-ann-backend"
           label={t("model.embedding_config.ann_backend_label")}
           description={t("model.embedding_config.ann_backend_description")}
           className="pt-2 border-t">
@@ -149,6 +154,7 @@ export const EmbeddingSearchConfig = ({
 
         <SettingsFormField
           htmlFor="annMinVectors"
+          focusId="embeddings-ann-min-vectors"
           label={t("model.embedding_config.ann_min_vectors_label")}
           description={t("model.embedding_config.ann_min_vectors_description")}>
           <Input

--- a/src/features/model/components/embedding-config/embedding-test-generation.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-generation.tsx
@@ -46,6 +46,7 @@ export const EmbeddingTestGeneration = ({
   return (
     <SettingsCard
       icon={Sparkles}
+      focusId="embeddings-test-generation"
       title={t("settings.embeddings.test_generation.title")}
       description={t("settings.embeddings.test_generation.description")}
       headerActions={

--- a/src/features/model/components/embedding-config/embedding-test-search.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-search.tsx
@@ -56,6 +56,7 @@ export const EmbeddingTestSearch = ({
   return (
     <SettingsCard
       icon={Search}
+      focusId="embeddings-test-search"
       title={t("settings.embeddings.test_search.title")}
       description={t("settings.embeddings.test_search.description")}>
       <div className="flex gap-2 mb-3">

--- a/src/features/model/components/embedding-config/storage-stats-card.tsx
+++ b/src/features/model/components/embedding-config/storage-stats-card.tsx
@@ -26,6 +26,7 @@ export const StorageStatsCard = ({
   return (
     <SettingsCard
       icon={Database}
+      focusId="embeddings-storage-stats"
       title={t("model.embedding_config.storage_stats_title")}
       description={t(
         "model.embedding_config.storage_stats_description",

--- a/src/features/model/components/embedding-index-controls.tsx
+++ b/src/features/model/components/embedding-index-controls.tsx
@@ -54,6 +54,7 @@ export const EmbeddingIndexControls = () => {
   return (
     <SettingsCard
       icon={Database}
+      focusId="rebuild-keyword-index"
       title={t("settings.embeddings.rebuild_index.title")}
       description={t("settings.embeddings.rebuild_index.description")}
       headerActions={

--- a/src/features/model/components/model-performance-section.tsx
+++ b/src/features/model/components/model-performance-section.tsx
@@ -73,6 +73,7 @@ export const ModelPerformanceSection = ({
       contentClassName="space-y-5">
       <SettingsFormField
         htmlFor="keep-alive"
+        focusId="keep-alive"
         label={t("settings.model.runtime.keep_alive_label")}
         description={t("settings.model.runtime.keep_alive_description")}>
         <Input
@@ -86,6 +87,7 @@ export const ModelPerformanceSection = ({
 
       <FormGrid>
         <SettingsSwitch
+          id="warm-on-select"
           label={t("settings.model.runtime.warm_on_select_label")}
           description={t("settings.model.runtime.warm_on_select_description")}
           checked={config.warm_on_select ?? false}
@@ -94,6 +96,7 @@ export const ModelPerformanceSection = ({
           }
         />
         <SettingsSwitch
+          id="unload-on-switch"
           label={t("settings.model.runtime.unload_on_switch_label")}
           description={t("settings.model.runtime.unload_on_switch_description")}
           checked={config.unload_on_switch ?? false}

--- a/src/features/model/components/model-system-section.tsx
+++ b/src/features/model/components/model-system-section.tsx
@@ -48,6 +48,7 @@ export const ModelSystemSection = ({
       contentClassName="space-y-6">
       <SettingsFormField
         htmlFor="system"
+        focusId="system-prompt"
         label={t("settings.model.system.prompt_label")}
         className="space-y-3">
         <ControlledTextarea
@@ -67,6 +68,7 @@ export const ModelSystemSection = ({
       <Separator />
       <SettingsFormField
         htmlFor="stop-sequences"
+        focusId="stop-sequences"
         label={
           <div className="flex items-center gap-2">
             <StopCircle className="icon-md" />

--- a/src/features/model/components/provider-connection-panel.tsx
+++ b/src/features/model/components/provider-connection-panel.tsx
@@ -1,0 +1,82 @@
+import { Save } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { SettingsActionRow, SettingsFormField } from "@/components/settings"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { DEFAULT_PROVIDERS } from "@/lib/providers/manager"
+import type { ProviderConfig } from "@/lib/providers/types"
+
+interface ProviderConnectionPanelProps {
+  activeConfig: ProviderConfig
+  cspCompatibilityHint: string | null
+  isLocalProvider: boolean
+  isRemoteEndpoint: boolean
+  hasUnsavedChanges: boolean
+  onSave: (config: ProviderConfig) => void
+  updateConfig: (updates: Partial<ProviderConfig>) => void
+}
+
+export const ProviderConnectionPanel = ({
+  activeConfig,
+  cspCompatibilityHint,
+  isLocalProvider,
+  isRemoteEndpoint,
+  hasUnsavedChanges,
+  onSave,
+  updateConfig
+}: ProviderConnectionPanelProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <SettingsFormField
+        focusId="provider-base-url"
+        label={t("settings.providers.base_url")}
+        description={
+          <>
+            {t("settings.providers.base_url_default")}:{" "}
+            {DEFAULT_PROVIDERS.find((p) => p.id === activeConfig.id)?.baseUrl}
+          </>
+        }>
+        <SettingsActionRow>
+          <Input
+            value={activeConfig.baseUrl || ""}
+            onChange={(e) => updateConfig({ baseUrl: e.target.value })}
+            placeholder="https://api.example.com/v1"
+            className="flex-1"
+          />
+          <Button
+            onClick={() => onSave(activeConfig)}
+            disabled={!hasUnsavedChanges}>
+            <Save className="icon-md mr-2" />
+            {t("settings.providers.save")}
+          </Button>
+        </SettingsActionRow>
+        {isRemoteEndpoint && (
+          <p className="mt-2 text-xs text-status-warning">
+            This endpoint is remote. Prompts and responses will be sent outside
+            your local machine.
+          </p>
+        )}
+        {cspCompatibilityHint && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {cspCompatibilityHint}
+          </p>
+        )}
+      </SettingsFormField>
+
+      {!isLocalProvider && (
+        <SettingsFormField
+          focusId="provider-api-key"
+          label={t("settings.providers.api_key")}>
+          <Input
+            type="password"
+            value={activeConfig.apiKey || ""}
+            onChange={(e) => updateConfig({ apiKey: e.target.value })}
+            placeholder="sk-..."
+          />
+        </SettingsFormField>
+      )}
+    </>
+  )
+}

--- a/src/features/model/components/provider-custom-models.tsx
+++ b/src/features/model/components/provider-custom-models.tsx
@@ -1,0 +1,89 @@
+import { Plus, Trash2 } from "lucide-react"
+import { useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { TooltipActionButton } from "@/components/actions"
+import { FieldStack } from "@/components/layout"
+import { SettingsActionRow, SettingsFormField } from "@/components/settings"
+import { Input } from "@/components/ui/input"
+import type { ProviderConfig } from "@/lib/providers/types"
+
+interface ProviderCustomModelsProps {
+  activeConfig: ProviderConfig
+  updateConfig: (updates: Partial<ProviderConfig>) => void
+}
+
+export const ProviderCustomModels = ({
+  activeConfig,
+  updateConfig
+}: ProviderCustomModelsProps) => {
+  const { t } = useTranslation()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const addCustomModel = () => {
+    const input = inputRef.current
+    const value = input?.value.trim()
+    if (!input || !value || activeConfig.customModels?.includes(value)) return
+
+    updateConfig({
+      customModels: [...(activeConfig.customModels || []), value]
+    })
+    input.value = ""
+  }
+
+  const removeCustomModel = (model: string) => {
+    updateConfig({
+      customModels: activeConfig.customModels?.filter((item) => item !== model)
+    })
+  }
+
+  return (
+    <SettingsFormField
+      focusId="provider-custom-models"
+      label={t("settings.providers.custom_models")}
+      description={t("settings.providers.custom_models_description")}>
+      <FieldStack className="space-y-3">
+        <SettingsActionRow>
+          <Input
+            ref={inputRef}
+            placeholder="e.g. google/gemini-pro"
+            id="custom-model-input"
+            onKeyDown={(event) => {
+              if (event.key === "Enter") addCustomModel()
+            }}
+          />
+          <TooltipActionButton
+            variant="outline"
+            size="icon"
+            onClick={addCustomModel}
+            icon={Plus}
+            iconClassName="icon-md"
+            label={t("settings.model.system.add_button")}
+          />
+        </SettingsActionRow>
+
+        {activeConfig.customModels && activeConfig.customModels.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {activeConfig.customModels.map((model) => (
+              <div
+                key={model}
+                className="flex items-center gap-2 bg-secondary text-secondary-foreground px-3 py-1.5 rounded-md text-sm">
+                <span>{model}</span>
+                <TooltipActionButton
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="size-5 hover:text-destructive"
+                  onClick={() => removeCustomModel(model)}
+                  icon={Trash2}
+                  iconClassName="icon-sm"
+                  label={t("common.close")}
+                  ariaLabel={`${t("common.close")} ${model}`}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </FieldStack>
+    </SettingsFormField>
+  )
+}

--- a/src/features/model/components/provider-settings.tsx
+++ b/src/features/model/components/provider-settings.tsx
@@ -1,18 +1,8 @@
-import {
-  CheckCircle2,
-  Info,
-  Loader2,
-  Plus,
-  Save,
-  Trash2,
-  XCircle,
-  Zap
-} from "lucide-react"
+import { CheckCircle2, Info, Loader2, XCircle, Zap } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { TooltipActionButton } from "@/components/actions"
 import { StatusCallout } from "@/components/feedback"
 import { FieldStack, InlineActions, SectionStack } from "@/components/layout"
-import { SettingsActionRow, SettingsFormField } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -21,13 +11,13 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { MiniBadge } from "@/components/ui/mini-badge"
 import { Switch } from "@/components/ui/switch"
+import { ProviderConnectionPanel } from "@/features/model/components/provider-connection-panel"
+import { ProviderCustomModels } from "@/features/model/components/provider-custom-models"
 import { ProviderGrid } from "@/features/model/components/provider-grid"
 import { useProviderSettingsState } from "@/features/model/hooks/use-provider-settings-state"
-import { DEFAULT_PROVIDERS } from "@/lib/providers/manager"
 import { isBetaProvider } from "@/lib/providers/registry"
 import { cn } from "@/lib/utils"
 
@@ -63,13 +53,15 @@ export const ProviderSettings = () => {
 
   return (
     <SectionStack>
-      <ProviderGrid
-        providers={providers}
-        selectedId={selectedId}
-        providerHealth={providerHealth}
-        manualTestStatus={connectionStatus}
-        onSelect={setSelectedId}
-      />
+      <div data-settings-focus="true" data-settings-focus-id="provider-picker">
+        <ProviderGrid
+          providers={providers}
+          selectedId={selectedId}
+          providerHealth={providerHealth}
+          manualTestStatus={connectionStatus}
+          onSelect={setSelectedId}
+        />
+      </div>
 
       {/* Configuration Panel */}
       {activeConfig && (
@@ -107,7 +99,10 @@ export const ProviderSettings = () => {
             </div>
 
             <InlineActions className="gap-4">
-              <div className="flex items-center gap-2">
+              <div
+                className="flex items-center gap-2"
+                data-settings-focus="true"
+                data-settings-focus-id="provider-enabled">
                 <Label htmlFor="enabled-switch" className="text-sm font-medium">
                   {activeConfig.enabled
                     ? t("settings.providers.enabled")
@@ -121,6 +116,8 @@ export const ProviderSettings = () => {
               </div>
 
               <Button
+                data-settings-focus="true"
+                data-settings-focus-id="provider-test-connection"
                 variant="outline"
                 size="sm"
                 onClick={handleTestConnection}
@@ -152,144 +149,21 @@ export const ProviderSettings = () => {
 
           <CardContent>
             <FieldStack>
-              <SettingsFormField
-                label={t("settings.providers.base_url")}
-                description={
-                  <>
-                    {t("settings.providers.base_url_default")}:{" "}
-                    {
-                      DEFAULT_PROVIDERS.find((p) => p.id === activeConfig.id)
-                        ?.baseUrl
-                    }
-                  </>
-                }>
-                <SettingsActionRow>
-                  <Input
-                    value={activeConfig.baseUrl || ""}
-                    onChange={(e) => updateConfig({ baseUrl: e.target.value })}
-                    placeholder="https://api.example.com/v1"
-                    className="flex-1"
-                  />
-                  <Button
-                    onClick={() => handleSave(activeConfig)}
-                    disabled={!hasUnsavedChanges}>
-                    <Save className="icon-md mr-2" />
-                    {t("settings.providers.save")}
-                  </Button>
-                </SettingsActionRow>
-                {isRemoteEndpoint && (
-                  <p className="mt-2 text-xs text-status-warning">
-                    This endpoint is remote. Prompts and responses will be sent
-                    outside your local machine.
-                  </p>
-                )}
-                {cspCompatibilityHint && (
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    {cspCompatibilityHint}
-                  </p>
-                )}
-              </SettingsFormField>
+              <ProviderConnectionPanel
+                activeConfig={activeConfig}
+                cspCompatibilityHint={cspCompatibilityHint}
+                isLocalProvider={isLocalProvider}
+                isRemoteEndpoint={isRemoteEndpoint}
+                hasUnsavedChanges={hasUnsavedChanges}
+                onSave={handleSave}
+                updateConfig={updateConfig}
+              />
 
               {!isLocalProvider && (
-                <SettingsFormField label={t("settings.providers.api_key")}>
-                  <Input
-                    type="password"
-                    value={activeConfig.apiKey || ""}
-                    onChange={(e) => updateConfig({ apiKey: e.target.value })}
-                    placeholder="sk-..."
-                  />
-                </SettingsFormField>
-              )}
-
-              {!isLocalProvider && (
-                <SettingsFormField
-                  label={t("settings.providers.custom_models")}
-                  description={t(
-                    "settings.providers.custom_models_description"
-                  )}>
-                  <FieldStack className="space-y-3">
-                    <SettingsActionRow>
-                      <Input
-                        placeholder="e.g. google/gemini-pro"
-                        id="custom-model-input"
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            const input = e.currentTarget
-                            const val = input.value.trim()
-                            if (
-                              val &&
-                              !activeConfig.customModels?.includes(val)
-                            ) {
-                              updateConfig({
-                                customModels: [
-                                  ...(activeConfig.customModels || []),
-                                  val
-                                ]
-                              })
-                              input.value = ""
-                            }
-                          }
-                        }}
-                      />
-                      <TooltipActionButton
-                        variant="outline"
-                        size="icon"
-                        onClick={() => {
-                          const input = document.getElementById(
-                            "custom-model-input"
-                          ) as HTMLInputElement
-                          const val = input.value.trim()
-                          if (
-                            val &&
-                            !activeConfig.customModels?.includes(val)
-                          ) {
-                            updateConfig({
-                              customModels: [
-                                ...(activeConfig.customModels || []),
-                                val
-                              ]
-                            })
-                            input.value = ""
-                          }
-                        }}
-                        icon={Plus}
-                        iconClassName="icon-md"
-                        label={t("settings.model.system.add_button")}
-                      />
-                    </SettingsActionRow>
-
-                    {activeConfig.customModels &&
-                      activeConfig.customModels.length > 0 && (
-                        <div className="flex flex-wrap gap-2">
-                          {activeConfig.customModels.map((m) => (
-                            <div
-                              key={m}
-                              className="flex items-center gap-2 bg-secondary text-secondary-foreground px-3 py-1.5 rounded-md text-sm">
-                              <span>{m}</span>
-                              <TooltipActionButton
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                className="size-5 hover:text-destructive"
-                                onClick={() => {
-                                  updateConfig({
-                                    customModels:
-                                      activeConfig.customModels?.filter(
-                                        (cm) => cm !== m
-                                      )
-                                  })
-                                }}
-                                icon={Trash2}
-                                iconClassName="icon-sm"
-                                label={t("common.close")}
-                                ariaLabel={`${t("common.close")} ${m}`}
-                              />
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                  </FieldStack>
-                </SettingsFormField>
+                <ProviderCustomModels
+                  activeConfig={activeConfig}
+                  updateConfig={updateConfig}
+                />
               )}
             </FieldStack>
           </CardContent>

--- a/src/features/model/lib/model-form-config.ts
+++ b/src/features/model/lib/model-form-config.ts
@@ -19,6 +19,7 @@ export type FormValues = {
 export type NumberInputConfig = {
   name: keyof FormValues
   label: string
+  focusId?: string
   icon?: LucideIcon
   min?: number
   max?: number
@@ -30,6 +31,7 @@ export type NumberInputConfig = {
 export type SliderConfig = {
   name: keyof FormValues
   label: string
+  focusId?: string
   icon?: LucideIcon
   min: number
   max: number
@@ -57,6 +59,7 @@ export const fieldValidations: Record<
 export const getSliderConfigs = (t: TFunction): SliderConfig[] => [
   {
     name: "temperature",
+    focusId: "temperature",
     label: t("settings.model.parameters.temperature.label"),
     icon: Thermometer,
     min: 0,
@@ -67,6 +70,7 @@ export const getSliderConfigs = (t: TFunction): SliderConfig[] => [
   },
   {
     name: "top_p",
+    focusId: "top-p",
     label: t("settings.model.parameters.top_p.label"),
     icon: Eye,
     min: 0,
@@ -80,6 +84,7 @@ export const getSliderConfigs = (t: TFunction): SliderConfig[] => [
 export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   {
     name: "top_k",
+    focusId: "top-k",
     label: t("settings.model.parameters.top_k.label"),
     icon: Hash,
     min: 1,
@@ -95,6 +100,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "min_p",
+    focusId: "min-p",
     label: t("settings.model.parameters.min_p.label"),
     icon: Layers,
     step: 0.01,
@@ -118,6 +124,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "seed",
+    focusId: "seed",
     label: t("settings.model.parameters.seed.label"),
     min: 0,
     group: "context-row1",
@@ -132,6 +139,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "num_ctx",
+    focusId: "num-ctx",
     label: t("settings.model.parameters.num_ctx.label"),
     min: 128,
     group: "context-row1",
@@ -146,6 +154,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "num_predict",
+    focusId: "num-predict",
     label: t("settings.model.parameters.num_predict.label"),
     group: "context-row2",
     validation: {
@@ -159,6 +168,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "repeat_penalty",
+    focusId: "repeat-penalty",
     label: t("settings.model.parameters.repeat_penalty.label"),
     step: 0.1,
     min: 0.1,
@@ -174,6 +184,7 @@ export const getNumberInputConfigs = (t: TFunction): NumberInputConfig[] => [
   },
   {
     name: "repeat_last_n",
+    focusId: "repeat-last-n",
     label: t("settings.model.parameters.repeat_last_n.label"),
     min: -1,
     group: "context-row3",

--- a/src/features/prompt/components/prompt-template-manager.tsx
+++ b/src/features/prompt/components/prompt-template-manager.tsx
@@ -113,6 +113,7 @@ export const PromptTemplateManager = () => {
     <SectionStack>
       <SettingsCard
         icon={FileText}
+        focusId="prompt-templates"
         title={t("settings.prompts.title")}
         description={t("settings.prompts.description", {
           count: templates?.length || 0

--- a/src/features/settings/__tests__/settings-registry.test.ts
+++ b/src/features/settings/__tests__/settings-registry.test.ts
@@ -4,6 +4,7 @@ import {
   getSettingsEntry,
   getSettingsForTab,
   isSettingsTab,
+  rankSettings,
   SETTINGS_REGISTRY,
   SETTINGS_TABS,
   searchSettings
@@ -83,12 +84,57 @@ describe("settings-registry", () => {
       expect(hit?.tab).toBe("contentExtraction")
     })
 
-    it("requires all tokens (AND semantics)", () => {
-      // 'temperature' exists; 'temperature voice' should not match it.
+    it("matches reset module rows", () => {
+      const results = searchSettings("browser settings")
+      const hit = results.find((e) => e.id === "reset-browser")
+      expect(hit?.tab).toBe("reset")
+    })
+
+    it("matches non-model tabs that were easy to miss", () => {
+      expect(searchSettings("prompt templates").map((e) => e.id)).toContain(
+        "prompt-templates"
+      )
+      expect(searchSettings("keyboard shortcuts").map((e) => e.id)).toContain(
+        "keyboard-shortcuts"
+      )
+      expect(searchSettings("setup guide").map((e) => e.id)).toContain(
+        "guide-setup"
+      )
+    })
+
+    it("matches embedding search internals on the embeddings tab", () => {
+      expect(searchSettings("semantic search").map((e) => e.id)).toContain(
+        "embeddings-test-search"
+      )
+      expect(searchSettings("search cache ttl").map((e) => e.id)).toContain(
+        "embeddings-cache-ttl"
+      )
+      expect(searchSettings("ann backend").map((e) => e.id)).toContain(
+        "embeddings-ann-backend"
+      )
+    })
+
+    it("matches reset danger zone separately from module rows", () => {
+      const hit = searchSettings("danger zone").find(
+        (e) => e.id === "reset-danger-zone"
+      )
+      expect(hit?.tab).toBe("reset")
+      expect(hit?.destructive).toBe(true)
+    })
+
+    it("keeps useful partial matches instead of strict AND misses", () => {
       expect(searchSettings("temperature").map((e) => e.id)).toContain(
         "temperature"
       )
-      expect(searchSettings("temperature voice")).toEqual([])
+      expect(searchSettings("temperature voice").map((e) => e.id)).toContain(
+        "temperature"
+      )
+      expect(searchSettings("prese").map((e) => e.id)).toContain(
+        "settings-presets"
+      )
+      expect(searchSettings("preset").map((e) => e.id)).toContain(
+        "settings-presets"
+      )
     })
 
     it("can match resolved label text via a translator", () => {
@@ -96,6 +142,31 @@ describe("settings-registry", () => {
         key === "settings.grounding_mode.label" ? "Answer only from page" : key
       const results = searchSettings("answer only from page", translate)
       expect(results.map((e) => e.id)).toContain("grounded-only-mode")
+    })
+
+    it("matches fuzzy provider and settings queries", () => {
+      expect(searchSettings("provder").map((e) => e.id)).toContain(
+        "provider-picker"
+      )
+      expect(searchSettings("ollma").map((e) => e.id)).toContain(
+        "provider-picker"
+      )
+      expect(searchSettings("base url").map((e) => e.id)).toContain(
+        "provider-base-url"
+      )
+      expect(searchSettings("api").map((e) => e.id)).toContain(
+        "provider-api-key"
+      )
+    })
+
+    it("ranks exact phrase matches above loose partial matches", () => {
+      const results = rankSettings("base url")
+      expect(results[0].entry.id).toBe("provider-base-url")
+      expect(results[0].score).toBeGreaterThan(0)
+    })
+
+    it("returns [] for unrelated queries", () => {
+      expect(searchSettings("zzzzqqqq nowhere")).toEqual([])
     })
   })
 })

--- a/src/features/settings/__tests__/settings-registry.test.ts
+++ b/src/features/settings/__tests__/settings-registry.test.ts
@@ -78,6 +78,12 @@ describe("settings-registry", () => {
       expect(results.map((e) => e.id)).toContain("grounded-only-mode")
     })
 
+    it("uses prefix matching in the compatibility wrapper", () => {
+      expect(searchSettings("pres").map((e) => e.id)).toContain(
+        "settings-presets"
+      )
+    })
+
     it("matches selection actions to the content extraction tab", () => {
       const results = searchSettings("selection actions")
       const hit = results.find((e) => e.id === "selection-actions-enabled")

--- a/src/features/settings/__tests__/settings-search-index.test.ts
+++ b/src/features/settings/__tests__/settings-search-index.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import type { SettingsEntry } from "../settings-registry"
+import {
+  buildSettingsSearchRecords,
+  rankSettingsSearchRecords
+} from "../settings-search-index"
+
+const messages: Record<string, string> = {
+  "settings.presets.title": "Presets",
+  "settings.presets.description": "Apply a tuned combination in one click.",
+  "settings.presets.fast.label": "Fast",
+  "settings.presets.fast.description": "Quicker, lighter responses.",
+  "settings.presets.balanced.label": "Balanced",
+  "settings.presets.large_context.label": "Large context",
+  "settings.presets.privacy_strict.label": "Privacy strict",
+  "settings.providers.base_url": "Base URL",
+  "settings.providers.base_url_default": "Default",
+  "settings.base_url.label": "Provider API Server Endpoint",
+  "settings.prompt_context_limits.max_tab_context_chars":
+    "Max tab context chars"
+}
+
+const t = (key: string) => messages[key] ?? key
+
+const entries: SettingsEntry[] = [
+  {
+    id: "settings-presets",
+    tab: "general",
+    sectionId: "presets",
+    labelKey: "settings.presets.title",
+    descriptionKey: "settings.presets.description",
+    searchKeys: [
+      "settings.presets.fast.label",
+      "settings.presets.fast.description",
+      "settings.presets.balanced.label",
+      "settings.presets.large_context.label",
+      "settings.presets.privacy_strict.label",
+      "settings.presets.applied"
+    ],
+    aliases: ["preset", "provder"]
+  },
+  {
+    id: "provider-base-url",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.base_url",
+    descriptionKey: "settings.providers.base_url_default",
+    searchKeys: ["settings.base_url.label"],
+    aliases: ["base url", "endpoint"]
+  },
+  {
+    id: "max-tab-context-chars",
+    tab: "context",
+    sectionId: "prompt-budget",
+    labelKey: "settings.prompt_context_limits.max_tab_context_chars",
+    aliases: ["character budget"]
+  }
+]
+
+describe("settings-search-index", () => {
+  it("builds visible child records from explicit search keys", () => {
+    const records = buildSettingsSearchRecords(entries, t)
+    expect(records.map((record) => record.displayLabel)).toEqual(
+      expect.arrayContaining([
+        "Fast",
+        "Balanced",
+        "Large context",
+        "Privacy strict"
+      ])
+    )
+    expect(
+      records.find((record) => record.displayLabel === "Balanced")
+    ).toMatchObject({
+      entryId: "settings-presets",
+      focusId: "settings-presets",
+      tab: "general",
+      displayContext: "Presets"
+    })
+  })
+
+  it("skips unresolved and interpolation keys", () => {
+    const records = buildSettingsSearchRecords(entries, t)
+    expect(
+      records.some((record) => record.sourceKey === "settings.presets.applied")
+    ).toBe(false)
+  })
+
+  it("returns matched child text instead of only the parent heading", () => {
+    const records = buildSettingsSearchRecords(entries, t)
+    const [hit] = rankSettingsSearchRecords("balanced", records)
+    expect(hit.record.displayLabel).toBe("Balanced")
+    expect(hit.record.entryId).toBe("settings-presets")
+  })
+
+  it("maps canonical control concepts to their real control, not preset mirrors", () => {
+    const records = buildSettingsSearchRecords(entries, t)
+    const [hit] = rankSettingsSearchRecords("character budget", records)
+    expect(hit.record.entryId).toBe("max-tab-context-chars")
+    expect(hit.record.tab).toBe("context")
+  })
+
+  it("caps crowded records per focus id", () => {
+    const records = buildSettingsSearchRecords(entries, t)
+    const hits = rankSettingsSearchRecords("preset response context", records)
+    const presetHits = hits.filter(
+      (hit) => hit.record.focusId === "settings-presets"
+    )
+    expect(presetHits.length).toBeLessThanOrEqual(2)
+  })
+
+  it("supports active-language text from the injected translator", () => {
+    const localeT = (key: string) =>
+      key === "settings.presets.balanced.label" ? "Equilibrado" : t(key)
+    const records = buildSettingsSearchRecords(entries, localeT)
+    const [hit] = rankSettingsSearchRecords("equilibrado", records)
+    expect(hit.record.displayLabel).toBe("Equilibrado")
+  })
+})

--- a/src/features/settings/settings-registry.ts
+++ b/src/features/settings/settings-registry.ts
@@ -41,8 +41,14 @@ export interface SettingsEntry {
   labelKey: string
   /** i18n key for the control's description, when it has one. */
   descriptionKey?: string
+  /** Additional visible i18n strings that should route to this setting. */
+  searchKeys?: string[]
+  /** Focus target override for search records; defaults to `id`. */
+  focusId?: string
   /** Extra search terms (plain words, not i18n keys) for fuzzy matching. */
   keywords?: string[]
+  /** Non-i18n search aliases, typos, and technical synonyms. */
+  aliases?: string[]
   /** Power-user tuning control — eligible for "Advanced" grouping (item 10). */
   advanced?: boolean
   /** Deletes/clears data — never auto-collapsed, flagged in danger zones. */
@@ -65,7 +71,7 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     tab: "general",
     sectionId: "general",
     labelKey: "common.language.select_label",
-    keywords: ["language", "locale", "translation"]
+    aliases: ["language", "locale", "translation"]
   },
   {
     id: "show-session-metrics",
@@ -73,7 +79,25 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     sectionId: "general",
     labelKey: "settings.chat_display.session_metrics_label",
     descriptionKey: "settings.chat_display.session_metrics_description",
-    keywords: ["metrics", "tokens", "performance", "stats"]
+    aliases: ["metrics", "tokens", "performance", "stats"]
+  },
+  {
+    id: "settings-presets",
+    tab: "general",
+    sectionId: "presets",
+    labelKey: "settings.presets.title",
+    descriptionKey: "settings.presets.description",
+    searchKeys: [
+      "settings.presets.fast.label",
+      "settings.presets.fast.description",
+      "settings.presets.balanced.label",
+      "settings.presets.balanced.description",
+      "settings.presets.large_context.label",
+      "settings.presets.large_context.description",
+      "settings.presets.privacy_strict.label",
+      "settings.presets.privacy_strict.description"
+    ],
+    aliases: ["preset", "presets", "profiles", "quick setup"]
   },
 
   // ---- Models: system ----------------------------------------------------
@@ -190,6 +214,81 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     labelKey: "settings.model.runtime.unload_on_switch_label",
     descriptionKey: "settings.model.runtime.unload_on_switch_description",
     keywords: ["unload", "memory", "switch"]
+  },
+
+  // ---- Providers ---------------------------------------------------------
+  {
+    id: "provider-picker",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.tabs.providers",
+    searchKeys: [
+      "settings.providers.default",
+      "settings.providers.beta_badge",
+      "settings.providers.enabled",
+      "settings.providers.disabled",
+      "settings.providers.inactive",
+      "settings.providers.connected",
+      "settings.providers.connection_failed",
+      "settings.providers.not_tested"
+    ],
+    aliases: [
+      "provider",
+      "providers",
+      "ollama",
+      "lm studio",
+      "llama.cpp",
+      "vllm",
+      "koboldcpp",
+      "localai",
+      "openai compatible",
+      "localhost",
+      "remote"
+    ]
+  },
+  {
+    id: "provider-enabled",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.enabled",
+    searchKeys: ["settings.providers.disabled"],
+    aliases: ["provider", "enable", "disable", "toggle"]
+  },
+  {
+    id: "provider-test-connection",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.test",
+    searchKeys: [
+      "settings.providers.connected",
+      "settings.providers.connection_failed",
+      "settings.providers.not_tested"
+    ],
+    aliases: ["provider", "test", "connection", "health", "localhost"]
+  },
+  {
+    id: "provider-base-url",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.base_url",
+    descriptionKey: "settings.providers.base_url_default",
+    searchKeys: ["settings.base_url.title", "settings.base_url.label"],
+    aliases: ["provider", "base url", "endpoint", "localhost", "remote"]
+  },
+  {
+    id: "provider-api-key",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.api_key",
+    aliases: ["provider", "api key", "token", "secret", "remote"]
+  },
+  {
+    id: "provider-custom-models",
+    tab: "providers",
+    sectionId: "providers",
+    labelKey: "settings.providers.custom_models",
+    descriptionKey: "settings.providers.custom_models_description",
+    aliases: ["provider", "custom models", "manual models", "openai compatible"]
   },
 
   // ---- Context: Conversation Context -------------------------------------
@@ -477,6 +576,7 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
   },
   {
     id: "rebuild-embeddings",
+    focusId: "embeddings-model-select",
     tab: "embeddings",
     sectionId: "vector-db",
     labelKey: "settings.context.embedding_health.action",
@@ -490,6 +590,18 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     descriptionKey: "settings.embeddings.rebuild_index.description",
     advanced: true,
     keywords: ["rebuild", "keyword", "index"]
+  },
+  {
+    id: "embeddings-storage-stats",
+    tab: "embeddings",
+    sectionId: "vector-db",
+    labelKey: "model.embedding_config.storage_stats_title",
+    searchKeys: [
+      "model.embedding_config.total_vectors",
+      "model.embedding_config.storage_used",
+      "model.embedding_config.cache"
+    ],
+    keywords: ["storage statistics", "vectors", "cache", "usage"]
   },
 
   // ---- Embeddings: model selection ---------------------------------------
@@ -564,6 +676,76 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     labelKey: "settings.embeddings.test_generation.button",
     descriptionKey: "settings.embeddings.test_generation.description",
     keywords: ["test", "generation", "diagnostic"]
+  },
+  {
+    id: "embeddings-test-search",
+    tab: "embeddings",
+    sectionId: "embeddings-test",
+    labelKey: "settings.embeddings.test_search.title",
+    descriptionKey: "settings.embeddings.test_search.description",
+    searchKeys: ["settings.embeddings.test_search.placeholder"],
+    aliases: ["semantic search", "test search", "search files"],
+    keywords: ["search", "semantic", "uploaded files", "query"]
+  },
+  {
+    id: "embeddings-search-limit-topk",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.search_limit_label",
+    descriptionKey: "model.embedding_config.search_limit_description",
+    advanced: true,
+    keywords: ["search limit", "top k", "semantic search", "retrieval"]
+  },
+  {
+    id: "embeddings-min-similarity",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.min_similarity_label",
+    descriptionKey: "model.embedding_config.min_similarity_description",
+    advanced: true,
+    keywords: ["similarity", "threshold", "semantic search", "cosine"]
+  },
+  {
+    id: "embeddings-cache-ttl",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.cache_ttl_label",
+    descriptionKey: "model.embedding_config.cache_ttl_description",
+    advanced: true,
+    keywords: ["cache", "ttl", "minutes", "search cache"]
+  },
+  {
+    id: "embeddings-cache-max-size",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.cache_max_size_label",
+    descriptionKey: "model.embedding_config.cache_max_size_description",
+    advanced: true,
+    keywords: ["cache", "cached queries", "search cache"]
+  },
+  {
+    id: "embeddings-ann-backend",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.ann_backend_label",
+    descriptionKey: "model.embedding_config.ann_backend_description",
+    searchKeys: [
+      "model.embedding_config.ann_backend_placeholder",
+      "model.embedding_config.ann_backend_group",
+      "model.embedding_config.ann_backend_ts",
+      "model.embedding_config.ann_backend_bruteforce"
+    ],
+    advanced: true,
+    keywords: ["ann", "hnsw", "brute force", "vector search"]
+  },
+  {
+    id: "embeddings-ann-min-vectors",
+    tab: "embeddings",
+    sectionId: "embeddings-search",
+    labelKey: "model.embedding_config.ann_min_vectors_label",
+    descriptionKey: "model.embedding_config.ann_min_vectors_description",
+    advanced: true,
+    keywords: ["ann", "min vectors", "threshold", "vector search"]
   },
   {
     id: "data-migration-export",
@@ -686,6 +868,343 @@ export const SETTINGS_REGISTRY: SettingsEntry[] = [
     sectionId: "voices",
     labelKey: "settings.speech.pitch_label",
     keywords: ["pitch", "tone", "tts", "speech"]
+  },
+
+  // ---- Prompts -----------------------------------------------------------
+  {
+    id: "prompt-templates",
+    tab: "prompts",
+    sectionId: "prompts",
+    labelKey: "settings.prompts.title",
+    searchKeys: [
+      "settings.prompts.new_template",
+      "settings.prompts.search_placeholder",
+      "settings.prompts.category_placeholder",
+      "settings.prompts.all_categories",
+      "settings.prompts.sort.recent",
+      "settings.prompts.sort.popular",
+      "settings.prompts.sort.alphabetical",
+      "settings.prompts.empty_state.title",
+      "settings.prompts.empty_state.description",
+      "settings.prompts.export",
+      "settings.prompts.import",
+      "settings.prompts.reset",
+      "settings.prompts.form.title",
+      "settings.prompts.form.category",
+      "settings.prompts.form.description",
+      "settings.prompts.form.tags",
+      "settings.prompts.form.system_prompt",
+      "settings.prompts.form.user_prompt",
+      "settings.prompts.form.create_button"
+    ],
+    aliases: ["prompt templates", "templates", "system prompt template"]
+  },
+
+  // ---- Shortcuts ---------------------------------------------------------
+  {
+    id: "keyboard-shortcuts",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.title",
+    descriptionKey: "settings.shortcuts.description",
+    searchKeys: [
+      "settings.shortcuts.recording",
+      "settings.shortcuts.reset_all",
+      "settings.shortcuts.new_chat",
+      "settings.shortcuts.new_chat_desc",
+      "settings.shortcuts.focus_input",
+      "settings.shortcuts.focus_input_desc",
+      "settings.shortcuts.toggle_sidebar",
+      "settings.shortcuts.toggle_sidebar_desc",
+      "settings.shortcuts.stop_generation",
+      "settings.shortcuts.stop_generation_desc",
+      "settings.shortcuts.open_settings",
+      "settings.shortcuts.open_settings_desc",
+      "settings.shortcuts.toggle_theme",
+      "settings.shortcuts.toggle_theme_desc",
+      "settings.shortcuts.toggle_rag",
+      "settings.shortcuts.toggle_rag_desc",
+      "settings.shortcuts.toggle_speech",
+      "settings.shortcuts.toggle_speech_desc",
+      "settings.shortcuts.toggle_tabs",
+      "settings.shortcuts.toggle_tabs_desc",
+      "settings.shortcuts.search_messages",
+      "settings.shortcuts.search_messages_desc",
+      "settings.shortcuts.clear_chat",
+      "settings.shortcuts.clear_chat_desc",
+      "settings.shortcuts.copy_last_response",
+      "settings.shortcuts.copy_last_response_desc",
+      "settings.shortcuts.toggle_session_metrics",
+      "settings.shortcuts.toggle_session_metrics_desc",
+      "settings.shortcuts.export_json",
+      "settings.shortcuts.export_json_desc",
+      "settings.shortcuts.export_markdown",
+      "settings.shortcuts.export_markdown_desc",
+      "settings.shortcuts.export_pdf",
+      "settings.shortcuts.export_pdf_desc",
+      "settings.shortcuts.export_text",
+      "settings.shortcuts.export_text_desc"
+    ],
+    aliases: ["shortcuts", "keyboard", "hotkeys", "keybindings"]
+  },
+  {
+    id: "shortcut-focus-input",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.focus_input",
+    descriptionKey: "settings.shortcuts.focus_input_desc",
+    aliases: ["input shortcut", "focus chat input"]
+  },
+  {
+    id: "shortcut-close-sidebar",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_sidebar",
+    descriptionKey: "settings.shortcuts.toggle_sidebar_desc",
+    aliases: ["sidebar shortcut", "close sidebar"]
+  },
+  {
+    id: "shortcut-settings",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.open_settings",
+    descriptionKey: "settings.shortcuts.open_settings_desc",
+    aliases: ["settings shortcut", "open settings"]
+  },
+  {
+    id: "shortcut-search-messages",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.search_messages",
+    descriptionKey: "settings.shortcuts.search_messages_desc",
+    aliases: ["message search shortcut", "semantic chat search"]
+  },
+  {
+    id: "shortcut-new-chat",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.new_chat",
+    descriptionKey: "settings.shortcuts.new_chat_desc",
+    aliases: ["new chat shortcut"]
+  },
+  {
+    id: "shortcut-stop-generation",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.stop_generation",
+    descriptionKey: "settings.shortcuts.stop_generation_desc",
+    aliases: ["stop response shortcut"]
+  },
+  {
+    id: "shortcut-clear-chat",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.clear_chat",
+    descriptionKey: "settings.shortcuts.clear_chat_desc",
+    aliases: ["clear chat shortcut"]
+  },
+  {
+    id: "shortcut-copy-last-response",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.copy_last_response",
+    descriptionKey: "settings.shortcuts.copy_last_response_desc",
+    aliases: ["copy response shortcut"]
+  },
+  {
+    id: "shortcut-export-json",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.export_json",
+    descriptionKey: "settings.shortcuts.export_json_desc",
+    aliases: ["json export shortcut"]
+  },
+  {
+    id: "shortcut-export-markdown",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.export_markdown",
+    descriptionKey: "settings.shortcuts.export_markdown_desc",
+    aliases: ["markdown export shortcut"]
+  },
+  {
+    id: "shortcut-export-pdf",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.export_pdf",
+    descriptionKey: "settings.shortcuts.export_pdf_desc",
+    aliases: ["pdf export shortcut"]
+  },
+  {
+    id: "shortcut-export-text",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.export_text",
+    descriptionKey: "settings.shortcuts.export_text_desc",
+    aliases: ["text export shortcut"]
+  },
+  {
+    id: "shortcut-toggle-theme",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_theme",
+    descriptionKey: "settings.shortcuts.toggle_theme_desc",
+    aliases: ["theme shortcut"]
+  },
+  {
+    id: "shortcut-toggle-rag",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_rag",
+    descriptionKey: "settings.shortcuts.toggle_rag_desc",
+    aliases: ["rag shortcut", "context retrieval shortcut"]
+  },
+  {
+    id: "shortcut-toggle-speech",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_speech",
+    descriptionKey: "settings.shortcuts.toggle_speech_desc",
+    aliases: ["speech shortcut", "tts shortcut"]
+  },
+  {
+    id: "shortcut-toggle-tabs",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_tabs",
+    descriptionKey: "settings.shortcuts.toggle_tabs_desc",
+    aliases: ["tabs shortcut", "tab access shortcut"]
+  },
+  {
+    id: "shortcut-toggle-session-metrics",
+    tab: "shortcuts",
+    sectionId: "shortcuts",
+    labelKey: "settings.shortcuts.toggle_session_metrics",
+    descriptionKey: "settings.shortcuts.toggle_session_metrics_desc",
+    aliases: ["metrics shortcut", "session metrics shortcut"]
+  },
+
+  // ---- Reset -------------------------------------------------------------
+  {
+    id: "reset-settings",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.title",
+    descriptionKey: "settings.reset.description",
+    aliases: ["reset settings", "clear data"]
+  },
+  {
+    id: "reset-provider",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.provider.title",
+    descriptionKey: "settings.reset.modules.provider.description",
+    aliases: ["provider settings", "models", "configuration"]
+  },
+  {
+    id: "reset-theme",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.theme.title",
+    descriptionKey: "settings.reset.modules.theme.description",
+    aliases: ["theme", "ui", "appearance"]
+  },
+  {
+    id: "reset-browser",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.browser.title",
+    descriptionKey: "settings.reset.modules.browser.description",
+    aliases: ["browser settings", "tab access", "url patterns"]
+  },
+  {
+    id: "reset-tts",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.tts.title",
+    descriptionKey: "settings.reset.modules.tts.description",
+    aliases: ["text to speech", "tts", "speech"]
+  },
+  {
+    id: "reset-chat-sessions",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.chat_sessions.title",
+    descriptionKey: "settings.reset.modules.chat_sessions.description",
+    aliases: ["chat history", "conversation history"]
+  },
+  {
+    id: "reset-feedback",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.modules.feedback.title",
+    descriptionKey: "settings.reset.modules.feedback.description",
+    aliases: ["user feedback", "learning feedback"]
+  },
+  {
+    id: "reset-danger-zone",
+    tab: "reset",
+    sectionId: "reset-modules",
+    labelKey: "settings.reset.danger_zone.title",
+    descriptionKey: "settings.reset.danger_zone.description",
+    searchKeys: ["settings.reset.danger_zone.button"],
+    aliases: ["reset all", "clear all", "danger zone", "factory reset"],
+    destructive: true
+  },
+
+  // ---- Guides ------------------------------------------------------------
+  {
+    id: "guides-overview",
+    focusId: "guides-card",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.title",
+    descriptionKey: "guides.description",
+    aliases: ["documentation", "docs", "help"]
+  },
+  {
+    id: "guide-setup",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.items.setup.label",
+    descriptionKey: "guides.items.setup.description",
+    searchKeys: ["guides.items.setup.badge"],
+    aliases: ["setup guide", "install guide"]
+  },
+  {
+    id: "guide-library",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.items.library.label",
+    descriptionKey: "guides.items.library.description",
+    searchKeys: ["guides.items.library.badge"],
+    aliases: ["model library", "ollama library"]
+  },
+  {
+    id: "guide-github",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.items.github.label",
+    descriptionKey: "guides.items.github.description",
+    searchKeys: ["guides.items.github.badge"],
+    aliases: ["github", "repo", "source code", "releases"]
+  },
+  {
+    id: "guide-faq",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.items.faq.label",
+    descriptionKey: "guides.items.faq.description",
+    searchKeys: ["guides.items.faq.badge"],
+    aliases: ["faq", "troubleshooting", "support"]
+  },
+  {
+    id: "guide-support",
+    tab: "guides",
+    sectionId: "guides",
+    labelKey: "guides.support.title",
+    descriptionKey: "guides.support.description",
+    aliases: ["product hunt", "support project"]
   }
 ]
 
@@ -705,7 +1224,7 @@ export const getSectionEntries = (sectionId: string): SettingsEntry[] =>
 
 /** Look up a single entry by its focus id. */
 export const getSettingsEntry = (id: string): SettingsEntry | undefined =>
-  SETTINGS_REGISTRY.find((entry) => entry.id === id)
+  SETTINGS_REGISTRY.find((entry) => entry.id === id || entry.focusId === id)
 
 /**
  * Optional translator: resolves an i18n key to display text. When supplied,
@@ -715,33 +1234,125 @@ export const getSettingsEntry = (id: string): SettingsEntry | undefined =>
  */
 export type Translate = (key: string) => string
 
+export interface RankedSettingsEntry {
+  entry: SettingsEntry
+  score: number
+}
+
+const normalizeSearchText = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+
+const getSearchParts = (entry: SettingsEntry, translate?: Translate) => {
+  const parts = [
+    entry.id.replace(/-/g, " "),
+    entry.id,
+    entry.labelKey,
+    entry.descriptionKey ?? "",
+    ...(entry.searchKeys ?? []),
+    ...(entry.aliases ?? []),
+    ...(entry.keywords ?? [])
+  ]
+  if (translate) {
+    parts.push(translate(entry.labelKey))
+    if (entry.descriptionKey) parts.push(translate(entry.descriptionKey))
+  }
+  return parts
+}
+
+const levenshteinDistance = (a: string, b: string): number => {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let current = Array.from({ length: b.length + 1 }, () => 0)
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + substitutionCost
+      )
+    }
+    ;[previous, current] = [current, previous]
+  }
+
+  return previous[b.length]
+}
+
+const fuzzyThreshold = (token: string): number => {
+  if (token.length < 3) return 0
+  if (token.length <= 5) return 1
+  return 2
+}
+
+const scoreToken = (
+  token: string,
+  haystack: string,
+  words: string[]
+): number => {
+  if (words.includes(token)) return 40
+  if (haystack.includes(token)) return 20
+
+  const threshold = fuzzyThreshold(token)
+  if (threshold === 0) return 0
+
+  const hasFuzzyWord = words.some(
+    (word) =>
+      Math.abs(word.length - token.length) <= threshold &&
+      levenshteinDistance(token, word) <= threshold
+  )
+
+  return hasFuzzyWord ? 8 : 0
+}
+
 /**
- * Search the registry. Matches every whitespace-separated token in `query`
- * (AND semantics) against the entry's id, keyword list, label/description i18n
- * keys, and — when `translate` is given — the resolved label/description text.
+ * Search the registry. Ranks exact phrases, exact words, substrings, and small
+ * typos against the entry's id, keywords, label/description i18n keys, and —
+ * when `translate` is given — the resolved label/description text.
  *
- * Returns matches in registry order. An empty/whitespace query returns [].
+ * Returns ranked matches. An empty/whitespace query returns [].
  */
 export const searchSettings = (
   query: string,
   translate?: Translate
 ): SettingsEntry[] => {
-  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean)
+  return rankSettings(query, translate).map((result) => result.entry)
+}
+
+export const rankSettings = (
+  query: string,
+  translate?: Translate
+): RankedSettingsEntry[] => {
+  const normalizedQuery = normalizeSearchText(query)
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean)
   if (tokens.length === 0) return []
 
-  return SETTINGS_REGISTRY.filter((entry) => {
-    const parts = [
-      entry.id.replace(/-/g, " "),
-      entry.id,
-      entry.labelKey,
-      entry.descriptionKey ?? "",
-      ...(entry.keywords ?? [])
-    ]
-    if (translate) {
-      parts.push(translate(entry.labelKey))
-      if (entry.descriptionKey) parts.push(translate(entry.descriptionKey))
+  return SETTINGS_REGISTRY.map((entry, index) => {
+    const haystack = normalizeSearchText(
+      getSearchParts(entry, translate).join(" ")
+    )
+    const words = haystack.split(/\s+/).filter(Boolean)
+    const phraseScore = haystack.includes(normalizedQuery) ? 100 : 0
+    const tokenScore = tokens.reduce(
+      (total, token) => total + scoreToken(token, haystack, words),
+      0
+    )
+    return {
+      entry,
+      score: phraseScore + tokenScore,
+      index
     }
-    const haystack = parts.join(" ").toLowerCase()
-    return tokens.every((token) => haystack.includes(token))
   })
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map(({ entry, score }) => ({ entry, score }))
 }

--- a/src/features/settings/settings-registry.ts
+++ b/src/features/settings/settings-registry.ts
@@ -1,3 +1,8 @@
+import {
+  normalizeSettingsSearchText,
+  scoreSettingsSearchToken
+} from "@/features/settings/settings-search-scoring"
+
 /**
  * Settings registry — the single source of truth for "what settings exist,
  * where they live, and what they're called."
@@ -1239,14 +1244,6 @@ export interface RankedSettingsEntry {
   score: number
 }
 
-const normalizeSearchText = (value: string): string =>
-  value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim()
-
 const getSearchParts = (entry: SettingsEntry, translate?: Translate) => {
   const parts = [
     entry.id.replace(/-/g, " "),
@@ -1262,56 +1259,6 @@ const getSearchParts = (entry: SettingsEntry, translate?: Translate) => {
     if (entry.descriptionKey) parts.push(translate(entry.descriptionKey))
   }
   return parts
-}
-
-const levenshteinDistance = (a: string, b: string): number => {
-  if (a === b) return 0
-  if (a.length === 0) return b.length
-  if (b.length === 0) return a.length
-
-  let previous = Array.from({ length: b.length + 1 }, (_, i) => i)
-  let current = Array.from({ length: b.length + 1 }, () => 0)
-
-  for (let i = 1; i <= a.length; i++) {
-    current[0] = i
-    for (let j = 1; j <= b.length; j++) {
-      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
-      current[j] = Math.min(
-        current[j - 1] + 1,
-        previous[j] + 1,
-        previous[j - 1] + substitutionCost
-      )
-    }
-    ;[previous, current] = [current, previous]
-  }
-
-  return previous[b.length]
-}
-
-const fuzzyThreshold = (token: string): number => {
-  if (token.length < 3) return 0
-  if (token.length <= 5) return 1
-  return 2
-}
-
-const scoreToken = (
-  token: string,
-  haystack: string,
-  words: string[]
-): number => {
-  if (words.includes(token)) return 40
-  if (haystack.includes(token)) return 20
-
-  const threshold = fuzzyThreshold(token)
-  if (threshold === 0) return 0
-
-  const hasFuzzyWord = words.some(
-    (word) =>
-      Math.abs(word.length - token.length) <= threshold &&
-      levenshteinDistance(token, word) <= threshold
-  )
-
-  return hasFuzzyWord ? 8 : 0
 }
 
 /**
@@ -1332,18 +1279,19 @@ export const rankSettings = (
   query: string,
   translate?: Translate
 ): RankedSettingsEntry[] => {
-  const normalizedQuery = normalizeSearchText(query)
+  const normalizedQuery = normalizeSettingsSearchText(query)
   const tokens = normalizedQuery.split(/\s+/).filter(Boolean)
   if (tokens.length === 0) return []
 
   return SETTINGS_REGISTRY.map((entry, index) => {
-    const haystack = normalizeSearchText(
+    const haystack = normalizeSettingsSearchText(
       getSearchParts(entry, translate).join(" ")
     )
     const words = haystack.split(/\s+/).filter(Boolean)
     const phraseScore = haystack.includes(normalizedQuery) ? 100 : 0
     const tokenScore = tokens.reduce(
-      (total, token) => total + scoreToken(token, haystack, words),
+      (total, token) =>
+        total + scoreSettingsSearchToken(token, haystack, words),
       0
     )
     return {

--- a/src/features/settings/settings-search-index.ts
+++ b/src/features/settings/settings-search-index.ts
@@ -1,0 +1,277 @@
+import {
+  SETTINGS_REGISTRY,
+  type SettingsEntry,
+  type SettingsTab
+} from "@/features/settings/settings-registry"
+
+export type SearchTranslate = (key: string) => unknown
+
+export type SettingsSearchSourceType =
+  | "label"
+  | "description"
+  | "field"
+  | "alias"
+
+export interface SettingsSearchRecord {
+  entry: SettingsEntry
+  entryId: string
+  focusId: string
+  tab: SettingsTab
+  sectionId: string
+  sourceKey?: string
+  sourceText: string
+  displayLabel: string
+  displayContext?: string
+  sourceType: SettingsSearchSourceType
+  registryOrder: number
+  sourceOrder: number
+}
+
+export interface RankedSettingsSearchRecord {
+  record: SettingsSearchRecord
+  score: number
+}
+
+const SOURCE_TYPE_ORDER: Record<SettingsSearchSourceType, number> = {
+  label: 0,
+  field: 1,
+  description: 2,
+  alias: 3
+}
+
+const MAX_RECORDS_PER_FOCUS_ID = 2
+
+export const normalizeSettingsSearchText = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+
+const isResolvedText = (key: string, value: unknown): value is string => {
+  if (typeof value !== "string") return false
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  if (trimmed === key) return false
+  if (trimmed.includes("{{")) return false
+  return true
+}
+
+const resolveText = (key: string, translate?: SearchTranslate) => {
+  if (!translate) return key
+  const value = translate(key)
+  return isResolvedText(key, value) ? value.trim() : undefined
+}
+
+const makeRecord = ({
+  entry,
+  registryOrder,
+  sourceOrder,
+  sourceType,
+  sourceText,
+  sourceKey,
+  parentLabel
+}: {
+  entry: SettingsEntry
+  registryOrder: number
+  sourceOrder: number
+  sourceType: SettingsSearchSourceType
+  sourceText: string
+  sourceKey?: string
+  parentLabel: string
+}): SettingsSearchRecord => {
+  const displayLabel = sourceType === "alias" ? parentLabel : sourceText
+  const displayContext = sourceType === "label" ? undefined : parentLabel
+  return {
+    entry,
+    entryId: entry.id,
+    focusId: entry.focusId ?? entry.id,
+    tab: entry.tab,
+    sectionId: entry.sectionId,
+    sourceKey,
+    sourceText,
+    displayLabel,
+    displayContext,
+    sourceType,
+    registryOrder,
+    sourceOrder
+  }
+}
+
+export const buildSettingsSearchRecords = (
+  entries: SettingsEntry[] = SETTINGS_REGISTRY,
+  translate?: SearchTranslate
+): SettingsSearchRecord[] => {
+  const records: SettingsSearchRecord[] = []
+
+  entries.forEach((entry, registryOrder) => {
+    const parentLabel = resolveText(entry.labelKey, translate) ?? entry.labelKey
+    let sourceOrder = 0
+
+    const addKey = (
+      key: string | undefined,
+      sourceType: SettingsSearchSourceType
+    ) => {
+      if (!key) return
+      const sourceText = resolveText(key, translate)
+      if (!sourceText) return
+      records.push(
+        makeRecord({
+          entry,
+          registryOrder,
+          sourceOrder,
+          sourceType,
+          sourceText,
+          sourceKey: key,
+          parentLabel
+        })
+      )
+      sourceOrder += 1
+    }
+
+    addKey(entry.labelKey, "label")
+    addKey(entry.descriptionKey, "description")
+    for (const key of entry.searchKeys ?? []) addKey(key, "field")
+
+    const aliases = [...(entry.aliases ?? []), ...(entry.keywords ?? [])]
+    for (const alias of aliases) {
+      const sourceText = alias.trim()
+      if (!sourceText || sourceText.includes("{{")) continue
+      records.push(
+        makeRecord({
+          entry,
+          registryOrder,
+          sourceOrder,
+          sourceType: "alias",
+          sourceText,
+          parentLabel
+        })
+      )
+      sourceOrder += 1
+    }
+  })
+
+  return records
+}
+
+const levenshteinDistance = (a: string, b: string): number => {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let current = Array.from({ length: b.length + 1 }, () => 0)
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + substitutionCost
+      )
+    }
+    ;[previous, current] = [current, previous]
+  }
+
+  return previous[b.length]
+}
+
+const fuzzyThreshold = (token: string): number => {
+  if (token.length < 3) return 0
+  if (token.length <= 5) return 1
+  return 2
+}
+
+const scoreToken = (
+  token: string,
+  haystack: string,
+  words: string[]
+): number => {
+  if (words.includes(token)) return 40
+  if (words.some((word) => word.startsWith(token))) return 28
+  if (haystack.includes(token)) return 20
+
+  const threshold = fuzzyThreshold(token)
+  if (threshold === 0) return 0
+
+  const hasFuzzyWord = words.some(
+    (word) =>
+      Math.abs(word.length - token.length) <= threshold &&
+      levenshteinDistance(token, word) <= threshold
+  )
+
+  return hasFuzzyWord ? 8 : 0
+}
+
+const getRecordHaystack = (record: SettingsSearchRecord) =>
+  normalizeSettingsSearchText(
+    [record.sourceText, record.displayLabel].join(" ")
+  )
+
+const rankRecord = (
+  record: SettingsSearchRecord,
+  normalizedQuery: string,
+  tokens: string[],
+  activeTab?: SettingsTab
+) => {
+  const haystack = getRecordHaystack(record)
+  const words = haystack.split(/\s+/).filter(Boolean)
+  const phraseScore = haystack.includes(normalizedQuery) ? 100 : 0
+  const tokenScore = tokens.reduce(
+    (total, token) => total + scoreToken(token, haystack, words),
+    0
+  )
+  const activeTabScore = activeTab && activeTab === record.tab ? 3 : 0
+  const aliasPenalty = record.sourceType === "alias" ? -2 : 0
+  return phraseScore + tokenScore + activeTabScore + aliasPenalty
+}
+
+const capRecordsPerFocusId = (
+  ranked: RankedSettingsSearchRecord[]
+): RankedSettingsSearchRecord[] => {
+  const counts = new Map<string, number>()
+  const labels = new Map<string, Set<string>>()
+  return ranked.filter(({ record }) => {
+    const normalizedLabel = normalizeSettingsSearchText(record.displayLabel)
+    const focusLabels = labels.get(record.focusId) ?? new Set<string>()
+    if (focusLabels.has(normalizedLabel)) return false
+
+    const count = counts.get(record.focusId) ?? 0
+    if (count >= MAX_RECORDS_PER_FOCUS_ID) return false
+
+    focusLabels.add(normalizedLabel)
+    labels.set(record.focusId, focusLabels)
+    counts.set(record.focusId, count + 1)
+    return true
+  })
+}
+
+export const rankSettingsSearchRecords = (
+  query: string,
+  records: SettingsSearchRecord[],
+  activeTab?: SettingsTab
+): RankedSettingsSearchRecord[] => {
+  const normalizedQuery = normalizeSettingsSearchText(query)
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return []
+
+  const ranked = records
+    .map((record) => ({
+      record,
+      score: rankRecord(record, normalizedQuery, tokens, activeTab)
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        SOURCE_TYPE_ORDER[a.record.sourceType] -
+          SOURCE_TYPE_ORDER[b.record.sourceType] ||
+        a.record.registryOrder - b.record.registryOrder ||
+        a.record.sourceOrder - b.record.sourceOrder
+    )
+
+  return capRecordsPerFocusId(ranked)
+}

--- a/src/features/settings/settings-search-index.ts
+++ b/src/features/settings/settings-search-index.ts
@@ -3,6 +3,10 @@ import {
   type SettingsEntry,
   type SettingsTab
 } from "@/features/settings/settings-registry"
+import {
+  normalizeSettingsSearchText,
+  scoreSettingsSearchToken
+} from "@/features/settings/settings-search-scoring"
 
 export type SearchTranslate = (key: string) => unknown
 
@@ -40,14 +44,6 @@ const SOURCE_TYPE_ORDER: Record<SettingsSearchSourceType, number> = {
 }
 
 const MAX_RECORDS_PER_FOCUS_ID = 2
-
-export const normalizeSettingsSearchText = (value: string): string =>
-  value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim()
 
 const isResolvedText = (key: string, value: unknown): value is string => {
   if (typeof value !== "string") return false
@@ -155,57 +151,6 @@ export const buildSettingsSearchRecords = (
   return records
 }
 
-const levenshteinDistance = (a: string, b: string): number => {
-  if (a === b) return 0
-  if (a.length === 0) return b.length
-  if (b.length === 0) return a.length
-
-  let previous = Array.from({ length: b.length + 1 }, (_, i) => i)
-  let current = Array.from({ length: b.length + 1 }, () => 0)
-
-  for (let i = 1; i <= a.length; i++) {
-    current[0] = i
-    for (let j = 1; j <= b.length; j++) {
-      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
-      current[j] = Math.min(
-        current[j - 1] + 1,
-        previous[j] + 1,
-        previous[j - 1] + substitutionCost
-      )
-    }
-    ;[previous, current] = [current, previous]
-  }
-
-  return previous[b.length]
-}
-
-const fuzzyThreshold = (token: string): number => {
-  if (token.length < 3) return 0
-  if (token.length <= 5) return 1
-  return 2
-}
-
-const scoreToken = (
-  token: string,
-  haystack: string,
-  words: string[]
-): number => {
-  if (words.includes(token)) return 40
-  if (words.some((word) => word.startsWith(token))) return 28
-  if (haystack.includes(token)) return 20
-
-  const threshold = fuzzyThreshold(token)
-  if (threshold === 0) return 0
-
-  const hasFuzzyWord = words.some(
-    (word) =>
-      Math.abs(word.length - token.length) <= threshold &&
-      levenshteinDistance(token, word) <= threshold
-  )
-
-  return hasFuzzyWord ? 8 : 0
-}
-
 const getRecordHaystack = (record: SettingsSearchRecord) =>
   normalizeSettingsSearchText(
     [record.sourceText, record.displayLabel].join(" ")
@@ -221,7 +166,7 @@ const rankRecord = (
   const words = haystack.split(/\s+/).filter(Boolean)
   const phraseScore = haystack.includes(normalizedQuery) ? 100 : 0
   const tokenScore = tokens.reduce(
-    (total, token) => total + scoreToken(token, haystack, words),
+    (total, token) => total + scoreSettingsSearchToken(token, haystack, words),
     0
   )
   const activeTabScore = activeTab && activeTab === record.tab ? 3 : 0

--- a/src/features/settings/settings-search-scoring.ts
+++ b/src/features/settings/settings-search-scoring.ts
@@ -1,0 +1,58 @@
+export const normalizeSettingsSearchText = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+
+const levenshteinDistance = (a: string, b: string): number => {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let current = Array.from({ length: b.length + 1 }, () => 0)
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + substitutionCost
+      )
+    }
+    ;[previous, current] = [current, previous]
+  }
+
+  return previous[b.length]
+}
+
+const fuzzyThreshold = (token: string): number => {
+  if (token.length < 3) return 0
+  if (token.length <= 5) return 1
+  return 2
+}
+
+export const scoreSettingsSearchToken = (
+  token: string,
+  haystack: string,
+  words: string[]
+): number => {
+  if (words.includes(token)) return 40
+  if (words.some((word) => word.startsWith(token))) return 28
+  if (haystack.includes(token)) return 20
+
+  const threshold = fuzzyThreshold(token)
+  if (threshold === 0) return 0
+
+  const hasFuzzyWord = words.some(
+    (word) =>
+      Math.abs(word.length - token.length) <= threshold &&
+      levenshteinDistance(token, word) <= threshold
+  )
+
+  return hasFuzzyWord ? 8 : 0
+}

--- a/src/features/web-search/components/web-search-settings.tsx
+++ b/src/features/web-search/components/web-search-settings.tsx
@@ -139,7 +139,7 @@ export const WebSearchSettings = () => {
           label={t("settings.web_search.provider.label")}
           description={t("settings.web_search.provider.description")}
           className="min-w-0"
-          data-settings-focus-id="web-search-provider">
+          focusId="web-search-provider">
           <Select
             value={config.provider}
             onValueChange={(provider) =>
@@ -165,7 +165,7 @@ export const WebSearchSettings = () => {
           label={t("settings.web_search.safe_search.label")}
           description={t("settings.web_search.safe_search.description")}
           className="min-w-0"
-          data-settings-focus-id="web-search-safe-search">
+          focusId="web-search-safe-search">
           <Select
             value={config.safeSearch}
             onValueChange={(safeSearch) =>
@@ -192,7 +192,7 @@ export const WebSearchSettings = () => {
           htmlFor="web-search-endpoint"
           label={t("settings.web_search.endpoint.label")}
           description={t("settings.web_search.endpoint.description")}
-          data-settings-focus-id="web-search-endpoint">
+          focusId="web-search-endpoint">
           <Input
             id="web-search-endpoint"
             type="url"
@@ -218,7 +218,7 @@ export const WebSearchSettings = () => {
           htmlFor="web-search-api-key"
           label={t("settings.web_search.api_key.label")}
           description={t("settings.web_search.api_key.description")}
-          data-settings-focus-id="web-search-api-key">
+          focusId="web-search-api-key">
           <Input
             id="web-search-api-key"
             type="password"
@@ -231,6 +231,7 @@ export const WebSearchSettings = () => {
 
       {config.provider === "searxng" && (
         <SettingsSliderField
+          focusId="web-search-result-count"
           label={t("settings.web_search.searxng_pages.label")}
           description={t("settings.web_search.searxng_pages.description")}
           value={config.searxngPages ?? 1}

--- a/src/features/web-search/components/web-search-settings.tsx
+++ b/src/features/web-search/components/web-search-settings.tsx
@@ -231,7 +231,6 @@ export const WebSearchSettings = () => {
 
       {config.provider === "searxng" && (
         <SettingsSliderField
-          focusId="web-search-result-count"
           label={t("settings.web_search.searxng_pages.label")}
           description={t("settings.web_search.searxng_pages.description")}
           value={config.searxngPages ?? 1}
@@ -246,6 +245,7 @@ export const WebSearchSettings = () => {
       )}
 
       <SettingsSliderField
+        focusId="web-search-result-count"
         label={t("settings.web_search.result_count.label")}
         description={t("settings.web_search.result_count.description")}
         value={config.count ?? 5}

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -292,6 +292,60 @@ describe("messages", () => {
     expect(msg.thinking).toBe("reasoning...")
   })
 
+  it("messageFromRow preserves persisted web-search tool sources", async () => {
+    mockedQuery.mockResolvedValueOnce([
+      {
+        id: 1,
+        sessionId: "s1",
+        role: "assistant",
+        content: "Answer with citations",
+        model: "m",
+        timestamp: 5,
+        parentId: null,
+        done: 1,
+        metrics: JSON.stringify({
+          toolRuns: [
+            {
+              toolId: "web_search",
+              label: "web_search",
+              category: "web",
+              status: "done",
+              startedAt: 1,
+              completedAt: 2,
+              sources: [
+                {
+                  id: "call-1:web-0",
+                  title: "Example",
+                  url: "https://example.com",
+                  excerpt: "snippet",
+                  score: null,
+                  used: true
+                }
+              ]
+            }
+          ]
+        }),
+        thinking: null
+      }
+    ])
+
+    const [msg] = await repo.getAllMessages()
+
+    expect(msg.metrics?.toolRuns?.[0]).toMatchObject({
+      toolId: "web_search",
+      status: "done",
+      sources: [
+        {
+          id: "call-1:web-0",
+          title: "Example",
+          url: "https://example.com",
+          excerpt: "snippet",
+          used: true
+        }
+      ]
+    })
+  })
+
   it("messageFromRow tolerates malformed JSON in metrics", async () => {
     mockedQuery.mockResolvedValueOnce([
       {

--- a/src/options/components/__tests__/settings-page.test.tsx
+++ b/src/options/components/__tests__/settings-page.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { SettingsPage } from "../settings-page"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ i18n: { language: "en" }, t: (key: string) => key })
+}))
+
+vi.mock("@/components/language-selector", () => ({
+  LanguageSelector: () => <div>language</div>
+}))
+vi.mock("@/components/performance-warning", () => ({
+  PerformanceWarning: () => <div>performance</div>
+}))
+vi.mock("@/components/social-handles", () => ({
+  SocialHandles: () => <div>social handles</div>
+}))
+vi.mock("@/components/social-link-button", () => ({
+  SocialLinkButton: () => <a href="https://example.com">social</a>
+}))
+vi.mock("@/components/theme-toggle", () => ({
+  ThemeToggle: () => <button type="button">theme</button>
+}))
+vi.mock("@/features/chat/components", () => ({
+  ChatDisplaySettings: () => <div>chat display</div>,
+  SpeechSettings: () => <div>speech</div>
+}))
+vi.mock("@/features/context/components/context-settings", () => ({
+  ContextSettings: () => <div>context</div>
+}))
+vi.mock("@/features/model/components/content-extraction-settings", () => ({
+  ContentExtractionSettings: () => <div>extraction</div>
+}))
+vi.mock("@/features/model/components/embedding-settings", () => ({
+  EmbeddingSettings: () => <div>embeddings</div>
+}))
+vi.mock("@/features/model/components/model-settings-form", () => ({
+  ModelSettingsForm: () => <div>models</div>
+}))
+vi.mock("@/features/model/components/provider-settings", () => ({
+  ProviderSettings: () => (
+    <div data-settings-focus-id="provider-base-url">providers</div>
+  )
+}))
+vi.mock("@/features/prompt/components/prompt-template-manager", () => ({
+  PromptTemplateManager: () => <div>prompts</div>
+}))
+vi.mock("@/options/components/guides", () => ({
+  Guides: () => <div>guides</div>
+}))
+vi.mock("@/options/components/reset-storage", () => ({
+  ResetStorage: () => <div>reset</div>
+}))
+vi.mock("@/options/components/shortcuts-settings", () => ({
+  ShortcutsSettings: () => <div>shortcuts</div>
+}))
+
+describe("SettingsPage", () => {
+  afterEach(() => {
+    window.history.replaceState({}, "", "/")
+  })
+
+  it("focuses settings search with Ctrl+K", () => {
+    render(<SettingsPage />)
+    const searches = screen.getAllByRole("combobox")
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true })
+
+    expect(searches.some((search) => search === document.activeElement)).toBe(
+      true
+    )
+  })
+
+  it("renders mobile search before mobile navigation", () => {
+    render(<SettingsPage />)
+
+    const mobileSearch = screen.getAllByRole("combobox")[1]
+    const nav = screen.getAllByRole("navigation", {
+      name: "Settings navigation"
+    })[1]
+
+    expect(
+      mobileSearch.compareDocumentPosition(nav) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("writes the selected record focus id into the URL", () => {
+    render(<SettingsPage />)
+    const search = screen.getAllByRole("combobox")[0]
+
+    fireEvent.change(search, { target: { value: "base url" } })
+    fireEvent.mouseDown(screen.getAllByText("settings.providers.base_url")[0])
+
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get("tab")).toBe("providers")
+    expect(params.get("focus")).toBe("provider-base-url")
+  })
+})

--- a/src/options/components/guides.tsx
+++ b/src/options/components/guides.tsx
@@ -9,6 +9,9 @@ import { GUIDES } from "@/lib/constants-ui"
 import { ExternalLink, Notebook } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
+const guideFocusId = (labelKey: string) =>
+  `guide-${labelKey.split(".")[labelKey.split(".").length - 2] ?? "item"}`
+
 export const Guides = () => {
   const { t } = useTranslation()
 
@@ -16,6 +19,7 @@ export const Guides = () => {
     <SectionStack>
       <SettingsCard
         icon={Notebook}
+        focusId="guides-card"
         title={t("guides.title")}
         description={t("guides.description")}>
         <div className="grid gap-3">
@@ -23,6 +27,8 @@ export const Guides = () => {
             ({ labelKey, href, descriptionKey, badgeKey, icon: Icon }) => (
               <Card
                 key={href}
+                data-settings-focus="true"
+                data-settings-focus-id={guideFocusId(labelKey)}
                 className="group transition-all hover:border-primary/20 hover:shadow-xs">
                 <CardContent className="flex items-center justify-between">
                   <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -60,7 +66,10 @@ export const Guides = () => {
         </div>
 
         <div className="border-t pt-4">
-          <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+          <div
+            data-settings-focus="true"
+            data-settings-focus-id="guide-support"
+            className="flex flex-col items-center justify-between gap-4 sm:flex-row">
             <div className="text-center sm:text-left">
               <h4 className="mb-1 text-sm font-medium">
                 {t("guides.support.title")}

--- a/src/options/components/reset-storage.tsx
+++ b/src/options/components/reset-storage.tsx
@@ -102,6 +102,7 @@ export const ResetStorage = () => {
     <SectionStack>
       <SettingsCard
         icon={RefreshCcw}
+        focusId="reset-settings"
         title={t("settings.reset.title")}
         description={t("settings.reset.description")}>
         <div className="grid gap-3">
@@ -120,38 +121,47 @@ export const ResetStorage = () => {
 
         <Separator />
 
-        <StatusAlert
-          variant="destructive"
-          icon={RefreshCcw}
-          title={t("settings.reset.danger_zone.title")}
-          description={t("settings.reset.danger_zone.description")}
-          actions={
-            <Dialog open={open} onOpenChange={setOpen}>
-              <DialogTrigger
-                render={
-                  <Button variant="destructive" className="w-full sm:w-auto" />
-                }>
-                {t("settings.reset.danger_zone.button")}
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>{t("settings.reset.dialog.title")}</DialogTitle>
-                  <DialogDescription>
-                    {t("settings.reset.dialog.description")}
-                  </DialogDescription>
-                </DialogHeader>
-                <DialogFooter className="flex flex-col gap-4">
-                  <Button variant="destructive" onClick={handleResetAll}>
-                    {t("settings.reset.dialog.confirm")}
-                  </Button>
-                  <Button variant="secondary" onClick={() => setOpen(false)}>
-                    {t("settings.reset.dialog.cancel")}
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          }
-        />
+        <div
+          data-settings-focus="true"
+          data-settings-focus-id="reset-danger-zone">
+          <StatusAlert
+            variant="destructive"
+            icon={RefreshCcw}
+            title={t("settings.reset.danger_zone.title")}
+            description={t("settings.reset.danger_zone.description")}
+            actions={
+              <Dialog open={open} onOpenChange={setOpen}>
+                <DialogTrigger
+                  render={
+                    <Button
+                      variant="destructive"
+                      className="w-full sm:w-auto"
+                    />
+                  }>
+                  {t("settings.reset.danger_zone.button")}
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>
+                      {t("settings.reset.dialog.title")}
+                    </DialogTitle>
+                    <DialogDescription>
+                      {t("settings.reset.dialog.description")}
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter className="flex flex-col gap-4">
+                    <Button variant="destructive" onClick={handleResetAll}>
+                      {t("settings.reset.dialog.confirm")}
+                    </Button>
+                    <Button variant="secondary" onClick={() => setOpen(false)}>
+                      {t("settings.reset.dialog.cancel")}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            }
+          />
+        </div>
       </SettingsCard>
     </SectionStack>
   )
@@ -175,9 +185,13 @@ const ModuleResetItem = ({
   const { t } = useTranslation()
   const [resetting, setResetting] = useState(false)
   const ModuleIcon = getModuleIcon(module)
+  const focusId = `reset-${module.toLowerCase().replace(/_/g, "-")}`
 
   return (
-    <Card className="flex-row items-center justify-between gap-3 bg-sidebar-accent ring-0 p-3 transition-colors hover:bg-accent/50">
+    <Card
+      data-settings-focus="true"
+      data-settings-focus-id={focusId}
+      className="flex-row items-center justify-between gap-3 bg-sidebar-accent ring-0 p-3 transition-colors hover:bg-accent/50">
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <ModuleIcon className="icon-md shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">

--- a/src/options/components/settings-page.tsx
+++ b/src/options/components/settings-page.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from "react"
 import { useTranslation } from "react-i18next"
@@ -36,8 +37,10 @@ import { ProviderSettings } from "@/features/model/components/provider-settings"
 import { PromptTemplateManager } from "@/features/prompt/components/prompt-template-manager"
 import {
   getSettingsEntry,
-  type SettingsEntry
+  isSettingsTab,
+  type SettingsTab
 } from "@/features/settings/settings-registry"
+import type { SettingsSearchRecord } from "@/features/settings/settings-search-index"
 import { HIGHLIGHT_FOCUS_DELAY_MS } from "@/lib/constants"
 import { SOCIAL_LINKS } from "@/lib/constants-ui"
 import {
@@ -59,16 +62,17 @@ import { ShortcutsSettings } from "@/options/components/shortcuts-settings"
 
 export const SettingsPage = () => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState(() => {
+  const desktopSearchRef = useRef<HTMLInputElement>(null)
+  const mobileSearchRef = useRef<HTMLInputElement>(null)
+  const [activeTab, setActiveTab] = useState<SettingsTab>(() => {
     if (typeof window === "undefined") return "general"
     const params = new URLSearchParams(window.location.search)
     const requestedTab = params.get("tab")?.replace(/^"+|"+$/g, "")
     // Honor the registry's tab for a deep-linked focus id so links survive a
-    // control moving tabs (e.g. vector-DB controls relocated Context →
-    // Embeddings in 0.10.2). The focus id's home tab wins over a stale `tab`.
+    // control moving tabs. The focus id's home tab wins over a stale `tab`.
     const focusId = params.get("focus")?.replace(/^"+|"+$/g, "")
     const entryTab = focusId ? getSettingsEntry(focusId)?.tab : undefined
-    return entryTab || requestedTab || "general"
+    return entryTab || (requestedTab as SettingsTab) || "general"
   })
 
   const navSections: NavSection[] = [
@@ -266,25 +270,51 @@ export const SettingsPage = () => {
   // effect above run the highlight; if we're already on the target tab the
   // effect won't re-fire, so highlight directly.
   const navigateToSetting = useCallback(
-    (entry: SettingsEntry) => {
+    (record: SettingsSearchRecord) => {
       if (typeof window !== "undefined") {
         const url = new URL(window.location.href)
-        url.searchParams.set("tab", entry.tab)
-        url.searchParams.set("focus", entry.id)
+        url.searchParams.set("tab", record.tab)
+        url.searchParams.set("focus", record.focusId)
         window.history.replaceState({}, "", url.toString())
       }
-      if (entry.tab !== activeTab) {
-        setActiveTab(entry.tab)
+      if (record.tab !== activeTab) {
+        setActiveTab(record.tab)
       } else {
-        highlightFocus(entry.id)
+        highlightFocus(record.focusId)
       }
     },
     [activeTab, highlightFocus]
   )
 
+  const handleTabChange = useCallback((key: string) => {
+    if (isSettingsTab(key)) setActiveTab(key)
+  }, [])
+
   const githubLink =
     SOCIAL_LINKS.find((link) => link.id === "github")?.href ||
     "https://github.com/Shishir435/ollama-client"
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().includes("MAC")
+      const pressedMod = isMac ? event.metaKey : event.ctrlKey
+      if (!pressedMod || event.shiftKey || event.altKey) return
+      if (event.key.toLowerCase() !== "k") return
+
+      event.preventDefault()
+      const refs = [mobileSearchRef, desktopSearchRef]
+      const visibleSearch =
+        refs.find((ref) => ref.current && ref.current.offsetParent !== null)
+          ?.current ??
+        desktopSearchRef.current ??
+        mobileSearchRef.current
+      visibleSearch?.focus()
+      visibleSearch?.select()
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [])
 
   return (
     <AppShell>
@@ -320,23 +350,32 @@ export const SettingsPage = () => {
       <div className="flex flex-1 overflow-hidden">
         <div className="hidden w-64 flex-none flex-col border-r border-sidebar-border bg-surface-sidebar lg:flex">
           <div className="p-4 pb-2">
-            <SettingsSearch onSelect={navigateToSetting} />
+            <SettingsSearch
+              activeTab={activeTab}
+              inputRef={desktopSearchRef}
+              onSelect={navigateToSetting}
+            />
           </div>
           <SettingsSidebar
             sections={navSections}
             activeTab={activeTab}
-            onTabChange={setActiveTab}
+            onTabChange={handleTabChange}
             className="w-full p-4 pt-2"
           />
         </div>
         <div className="flex flex-col flex-1 overflow-hidden">
           <div className="px-4 pt-4 sm:px-6 lg:hidden">
-            <SettingsSearch onSelect={navigateToSetting} />
+            <SettingsSearch
+              activeTab={activeTab}
+              inputRef={mobileSearchRef}
+              onSelect={navigateToSetting}
+              showShortcutHint
+            />
           </div>
           <SettingsMobileNav
             items={allNavItems}
             activeTab={activeTab}
-            onTabChange={setActiveTab}
+            onTabChange={handleTabChange}
             className="flex-none px-4 pt-4 sm:px-6"
           />
           <main className="min-w-0 flex-1 overflow-y-auto">

--- a/src/options/components/settings-page.tsx
+++ b/src/options/components/settings-page.tsx
@@ -64,6 +64,7 @@ export const SettingsPage = () => {
   const { t } = useTranslation()
   const desktopSearchRef = useRef<HTMLInputElement>(null)
   const mobileSearchRef = useRef<HTMLInputElement>(null)
+  const highlightTimersRef = useRef<Set<number>>(new Set())
   const [activeTab, setActiveTab] = useState<SettingsTab>(() => {
     if (typeof window === "undefined") return "general"
     const params = new URLSearchParams(window.location.search)
@@ -209,6 +210,13 @@ export const SettingsPage = () => {
 
     let attempts = 0
     const maxAttempts = 40
+    const scheduleHighlightTimer = (callback: () => void, delay: number) => {
+      const timerId = window.setTimeout(() => {
+        highlightTimersRef.current.delete(timerId)
+        callback()
+      }, delay)
+      highlightTimersRef.current.add(timerId)
+    }
 
     const highlightWhenReady = () => {
       attempts += 1
@@ -219,7 +227,7 @@ export const SettingsPage = () => {
 
       if (!focusTarget) {
         if (attempts < maxAttempts) {
-          window.setTimeout(highlightWhenReady, 50)
+          scheduleHighlightTimer(highlightWhenReady, 50)
         }
         return
       }
@@ -236,7 +244,7 @@ export const SettingsPage = () => {
         "ring-offset-background"
       )
 
-      window.setTimeout(() => {
+      scheduleHighlightTimer(() => {
         focusContainer.classList.remove(
           "ring-2",
           "ring-primary",
@@ -250,8 +258,18 @@ export const SettingsPage = () => {
       }
     }
 
-    window.setTimeout(highlightWhenReady, 0)
+    scheduleHighlightTimer(highlightWhenReady, 0)
   }, [])
+
+  useEffect(
+    () => () => {
+      for (const timerId of highlightTimersRef.current) {
+        window.clearTimeout(timerId)
+      }
+      highlightTimersRef.current.clear()
+    },
+    []
+  )
 
   // Sync the tab into the URL and, when a `?focus` id is present, highlight it
   // once the tab's content mounts.
@@ -354,6 +372,7 @@ export const SettingsPage = () => {
               activeTab={activeTab}
               inputRef={desktopSearchRef}
               onSelect={navigateToSetting}
+              showShortcutHint
             />
           </div>
           <SettingsSidebar

--- a/src/options/components/shortcuts-settings.tsx
+++ b/src/options/components/shortcuts-settings.tsx
@@ -20,6 +20,9 @@ const CATEGORY_LABELS = {
   toggles: "Toggles"
 } as const
 
+const shortcutFocusId = (id: ShortcutAction) =>
+  `shortcut-${id.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()}`
+
 export const ShortcutsSettings = () => {
   const { t } = useTranslation()
   const {
@@ -173,6 +176,7 @@ export const ShortcutsSettings = () => {
   return (
     <SettingsCard
       icon={Keyboard}
+      focusId="keyboard-shortcuts"
       title={t("settings.shortcuts.title")}
       description={t("settings.shortcuts.description")}>
       {/* Search */}
@@ -214,6 +218,8 @@ export const ShortcutsSettings = () => {
                     <button
                       type="button"
                       key={shortcut.id}
+                      data-settings-focus="true"
+                      data-settings-focus-id={shortcutFocusId(shortcut.id)}
                       className={cn(
                         "group flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left transition-colors hover:bg-accent/50",
                         isRecording && "bg-accent ring-2 ring-primary"

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -165,6 +165,41 @@ describe("ChatMessageMetricsSchema", () => {
     expect(result.success).toBe(true)
   })
 
+  it("accepts persisted web-search sources with nullable optional fields", () => {
+    const result = ChatMessageMetricsSchema.safeParse({
+      toolRuns: [
+        {
+          toolId: "web_search",
+          label: "web_search",
+          category: "web",
+          status: "done",
+          startedAt: 1,
+          sources: [
+            {
+              title: "Example",
+              url: "https://example.com",
+              excerpt: null,
+              publishedAt: null,
+              source: null,
+              score: null,
+              category: null,
+              used: true
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.toolRuns?.[0].sources?.[0]).toEqual({
+        title: "Example",
+        url: "https://example.com",
+        used: true
+      })
+    }
+  })
+
   it("accepts activity event metadata", () => {
     const result = ChatMessageMetricsSchema.safeParse({
       activityEvents: [

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -1,5 +1,20 @@
 import { z } from "zod"
 
+const optionalString = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.string().optional()
+)
+
+const optionalNumber = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.number().optional()
+)
+
+const optionalBoolean = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.boolean().optional()
+)
+
 // ---- Metrics (used inside messages and for SQLite parseMetrics) ----
 
 const RagSourceSchema = z.object({
@@ -48,13 +63,13 @@ const ToolRunSchema = z.object({
       z.object({
         id: z.union([z.string(), z.number()]).optional(),
         title: z.string(),
-        url: z.string().optional(),
-        excerpt: z.string().optional(),
-        publishedAt: z.string().optional(),
-        source: z.string().optional(),
-        score: z.number().optional(),
-        category: z.string().optional(),
-        used: z.boolean().optional()
+        url: optionalString,
+        excerpt: optionalString,
+        publishedAt: optionalString,
+        source: optionalString,
+        score: optionalNumber,
+        category: optionalString,
+        used: optionalBoolean
       })
     )
     .optional(),


### PR DESCRIPTION
Fixes settings search polish and preserves persisted web-search sources after reload.

Checks: typecheck, lint, related tests, full test suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors settings search into a two-layer architecture (`settings-search-scoring.ts` shared scoring module → `settings-search-index.ts` per-record index) and expands the registry with ~340 new entries covering providers, shortcuts, prompts, reset, and guides tabs. It also fixes a data-persistence bug where SQLite NULL values in stored web-search tool results caused Zod parse failures on reload.

- **Search quality**: `SettingsSearch` now builds per-source-string records (label, description, child `searchKeys`, aliases), ranks with active-tab boosting and Levenshtein fuzzy matching, shows a `displayContext` sub-label under each result, and adds a Cmd/Ctrl+K shortcut to focus the search input.
- **Registry expansion**: New entries for every settings tab (providers, shortcuts, prompts, reset, guides, embedding internals) so search reaches every visible control; `getSettingsEntry` extended to match by `focusId` as well as `id` for deep-link stability.
- **Schema fix**: Optional fields in `ToolRunSchema` now preprocess `null → undefined` before Zod validation, preserving persisted web-search sources after a browser reload.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are additive or tightly scoped fixes with no regressions observed.

The core search refactor extracts shared logic into a dedicated scoring module (resolving a previous divergence), and the per-record index correctly resolves all i18n keys through the injected translator. The Zod schema fix for null web-search fields is minimal and isolated. Timer-cleanup and deep-link changes are defensive improvements. All paths are covered by the updated test suite.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/features/settings/settings-search-index.ts | New file: builds per-source-string search records from the registry and ranks them with active-tab boosting, source-type ordering, and per-focusId capping. |
| src/features/settings/settings-search-scoring.ts | New shared scoring module; extracts levenshteinDistance, fuzzyThreshold, normalizeSettingsSearchText, and scoreSettingsSearchToken so both settings-registry.ts and settings-search-index.ts use identical logic. |
| src/features/settings/settings-registry.ts | Major expansion: adds ~340 new registry entries (providers, shortcuts, prompts, reset, guides, embeddings internals); introduces searchKeys/aliases/focusId fields; replaces AND-filter with ranked scoring via shared scoring module; getSettingsEntry now matches by focusId as well as id. |
| src/components/settings/settings-search.tsx | Migrated from searchSettings to buildSettingsSearchRecords + rankSettingsSearchRecords; adds activeTab prop for tab-boosted results, inputRef forwarding, Cmd/Ctrl+K hint badge, displayContext sub-label in results, and proper blurTimer cleanup on unmount. |
| src/options/components/settings-page.tsx | Adds Cmd/Ctrl+K shortcut to focus the visible search input; registers both search refs (desktop/mobile) and finds the visible one; wraps all highlightFocus timers in a tracked ref for clean unmount teardown; upgrades tab change to validated isSettingsTab guard. |
| src/features/web-search/components/web-search-settings.tsx | Migrates four SettingsCard/SettingsFormField anchors from data-settings-focus-id attributes to focusId prop; correctly places focusId='web-search-result-count' on the always-visible general result count slider. |
| src/types/chat.schemas.ts | Adds null→undefined preprocessors for optional string/number/boolean fields in ToolRunSchema so SQLite NULL values round-trip correctly through Zod validation, fixing lost web-search sources after reload. |
| src/features/chat/hooks/use-chat-turn-controller.ts | New file: turn lifecycle (sendMessage, RAG context build, activity events, toast, error handling) extracted from use-chat.ts as directed by AGENTS.md; use-chat.ts now acts as wiring only. |
| src/options/components/reset-storage.tsx | Adds focusId='reset-settings' to the outer SettingsCard and dynamically generates data-settings-focus-id on each ModuleResetItem so deep-links from settings search land on the correct reset card. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types query] --> B[SettingsSearch component]
    B --> C[buildSettingsSearchRecords]
    C --> D[SETTINGS_REGISTRY entries]
    D --> E[SettingsSearchRecord array per source string]
    E --> F[rankSettingsSearchRecords with activeTab]
    F --> G[normalizeSettingsSearchText]
    G --> H[scoreSettingsSearchToken]
    H --> I[phraseScore + tokenScore + activeTabScore + aliasPenalty]
    I --> J[sort by score then capRecordsPerFocusId max 2]
    J --> K[slice 0 to 8 results with displayLabel and displayContext]
    K --> L{User selects result}
    L -->|different tab| M[setActiveTab and URL focus param]
    L -->|same tab| N[highlightFocus with tracked timer]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User types query] --> B[SettingsSearch component]
    B --> C[buildSettingsSearchRecords]
    C --> D[SETTINGS_REGISTRY entries]
    D --> E[SettingsSearchRecord array per source string]
    E --> F[rankSettingsSearchRecords with activeTab]
    F --> G[normalizeSettingsSearchText]
    G --> H[scoreSettingsSearchToken]
    H --> I[phraseScore + tokenScore + activeTabScore + aliasPenalty]
    I --> J[sort by score then capRecordsPerFocusId max 2]
    J --> K[slice 0 to 8 results with displayLabel and displayContext]
    K --> L{User selects result}
    L -->|different tab| M[setActiveTab and URL focus param]
    L -->|same tab| N[highlightFocus with tracked timer]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/features/web-search/components/web-search-settings.tsx`, line 232-259 ([link](https://github.com/shishir435/ollama-client/blob/461bc56d449f44f7e30cec01b0cd784bcb6e1d5d/src/features/web-search/components/web-search-settings.tsx#L232-L259)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`focusId` placed on the wrong slider**

   `focusId="web-search-result-count"` was added to the conditionally-rendered SearXNG pages slider, but the registry entry for `web-search-result-count` maps to `settings.web_search.result_count.label` — the always-visible general result count slider below it. For any user whose active provider is Brave or Tavily, the SearXNG slider never mounts, so clicking "result count" from the settings search bar exhausts all 40 `highlightWhenReady` retries (≈2 s) and then silently does nothing. The general result count slider is what should carry the `focusId`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fweb-search%2Fcomponents%2Fweb-search-settings.tsx%0ALine%3A%20232-259%0A%0AComment%3A%0A**%60focusId%60%20placed%20on%20the%20wrong%20slider**%0A%0A%60focusId%3D%22web-search-result-count%22%60%20was%20added%20to%20the%20conditionally-rendered%20SearXNG%20pages%20slider%2C%20but%20the%20registry%20entry%20for%20%60web-search-result-count%60%20maps%20to%20%60settings.web_search.result_count.label%60%20%E2%80%94%20the%20always-visible%20general%20result%20count%20slider%20below%20it.%20For%20any%20user%20whose%20active%20provider%20is%20Brave%20or%20Tavily%2C%20the%20SearXNG%20slider%20never%20mounts%2C%20so%20clicking%20%22result%20count%22%20from%20the%20settings%20search%20bar%20exhausts%20all%2040%20%60highlightWhenReady%60%20retries%20%28%E2%89%882%20s%29%20and%20then%20silently%20does%20nothing.%20The%20general%20result%20count%20slider%20is%20what%20should%20carry%20the%20%60focusId%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2Fsettings-search-quality-0-10-3%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fsettings-search-quality-0-10-3%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffeatures%2Fweb-search%2Fcomponents%2Fweb-search-settings.tsx%0ALine%3A%20232-259%0A%0AComment%3A%0A**%60focusId%60%20placed%20on%20the%20wrong%20slider**%0A%0A%60focusId%3D%22web-search-result-count%22%60%20was%20added%20to%20the%20conditionally-rendered%20SearXNG%20pages%20slider%2C%20but%20the%20registry%20entry%20for%20%60web-search-result-count%60%20maps%20to%20%60settings.web_search.result_count.label%60%20%E2%80%94%20the%20always-visible%20general%20result%20count%20slider%20below%20it.%20For%20any%20user%20whose%20active%20provider%20is%20Brave%20or%20Tavily%2C%20the%20SearXNG%20slider%20never%20mounts%2C%20so%20clicking%20%22result%20count%22%20from%20the%20settings%20search%20bar%20exhausts%20all%2040%20%60highlightWhenReady%60%20retries%20%28%E2%89%882%20s%29%20and%20then%20silently%20does%20nothing.%20The%20general%20result%20count%20slider%20is%20what%20should%20carry%20the%20%60focusId%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(settings): address search review"](https://github.com/shishir435/ollama-client/commit/73e9b546257b7a860cef72d8e705b5f8f7492f79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38793305)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->