### PR TITLE
0.11.2: centralize message-router payload parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/background/lib/__tests__/message-payloads.test.ts
+++ b/src/background/lib/__tests__/message-payloads.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest"
 import {
   parseModelRef,
   parseProviderIdPayload,
-  parseStringPayload
+  parseStringPayload,
+  parseWarmupPayload
 } from "@/background/lib/message-payloads"
 
 describe("parseModelRef", () => {
@@ -19,6 +20,41 @@ describe("parseModelRef", () => {
 
   it("drops a non-string providerId", () => {
     expect(parseModelRef({ model: "m", providerId: 5 })).toEqual({ model: "m" })
+  })
+
+  it("trims the model name in both string and object paths", () => {
+    expect(parseModelRef("  m  ")).toEqual({ model: "m" })
+    expect(parseModelRef({ model: "  m  " })).toEqual({ model: "m" })
+  })
+})
+
+describe("parseWarmupPayload", () => {
+  it("carries through previousModel/previousProviderId (unload-on-switch)", () => {
+    expect(
+      parseWarmupPayload({
+        model: "b",
+        providerId: "ollama",
+        previousModel: "a",
+        previousProviderId: "ollama"
+      })
+    ).toEqual({
+      model: "b",
+      providerId: "ollama",
+      previousModel: "a",
+      previousProviderId: "ollama"
+    })
+  })
+
+  it("returns null when the model is missing", () => {
+    expect(parseWarmupPayload({})).toBeNull()
+  })
+
+  it("works for a bare string (no previous model)", () => {
+    expect(parseWarmupPayload("b")).toEqual({
+      model: "b",
+      previousModel: undefined,
+      previousProviderId: undefined
+    })
   })
 
   it("returns null for empty, missing, or non-model payloads", () => {

--- a/src/background/lib/__tests__/message-payloads.test.ts
+++ b/src/background/lib/__tests__/message-payloads.test.ts
@@ -26,6 +26,16 @@ describe("parseModelRef", () => {
     expect(parseModelRef("  m  ")).toEqual({ model: "m" })
     expect(parseModelRef({ model: "  m  " })).toEqual({ model: "m" })
   })
+
+  it("returns null for empty, missing, or non-model payloads", () => {
+    expect(parseModelRef("")).toBeNull()
+    expect(parseModelRef("   ")).toBeNull()
+    expect(parseModelRef({})).toBeNull()
+    expect(parseModelRef({ model: "" })).toBeNull()
+    expect(parseModelRef({ model: 1 })).toBeNull()
+    expect(parseModelRef(undefined)).toBeNull()
+    expect(parseModelRef(null)).toBeNull()
+  })
 })
 
 describe("parseWarmupPayload", () => {
@@ -45,10 +55,6 @@ describe("parseWarmupPayload", () => {
     })
   })
 
-  it("returns null when the model is missing", () => {
-    expect(parseWarmupPayload({})).toBeNull()
-  })
-
   it("works for a bare string (no previous model)", () => {
     expect(parseWarmupPayload("b")).toEqual({
       model: "b",
@@ -57,22 +63,34 @@ describe("parseWarmupPayload", () => {
     })
   })
 
-  it("returns null for empty, missing, or non-model payloads", () => {
-    expect(parseModelRef("")).toBeNull()
-    expect(parseModelRef("   ")).toBeNull()
-    expect(parseModelRef({})).toBeNull()
-    expect(parseModelRef({ model: "" })).toBeNull()
-    expect(parseModelRef({ model: 1 })).toBeNull()
-    expect(parseModelRef(undefined)).toBeNull()
-    expect(parseModelRef(null)).toBeNull()
+  it("drops non-string previous* fields", () => {
+    expect(
+      parseWarmupPayload({
+        model: "b",
+        previousModel: 1,
+        previousProviderId: {}
+      })
+    ).toEqual({
+      model: "b",
+      previousModel: undefined,
+      previousProviderId: undefined
+    })
+  })
+
+  it("returns null when no usable model is present", () => {
+    expect(parseWarmupPayload({})).toBeNull()
+    expect(parseWarmupPayload({ model: "" })).toBeNull()
+    expect(parseWarmupPayload(undefined)).toBeNull()
+    expect(parseWarmupPayload({ previousModel: "a" })).toBeNull()
   })
 })
 
 describe("parseStringPayload", () => {
-  it("returns non-empty strings", () => {
+  it("returns non-empty strings, trimmed", () => {
     expect(parseStringPayload("http://localhost:11434")).toBe(
       "http://localhost:11434"
     )
+    expect(parseStringPayload("  spaced  ")).toBe("spaced")
   })
   it("returns null for empty or non-strings", () => {
     expect(parseStringPayload("  ")).toBeNull()

--- a/src/background/lib/__tests__/message-payloads.test.ts
+++ b/src/background/lib/__tests__/message-payloads.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import {
+  parseModelRef,
+  parseProviderIdPayload,
+  parseStringPayload
+} from "@/background/lib/message-payloads"
+
+describe("parseModelRef", () => {
+  it("normalizes a bare string to { model }", () => {
+    expect(parseModelRef("llama3")).toEqual({ model: "llama3" })
+  })
+
+  it("keeps model + providerId from an object", () => {
+    expect(parseModelRef({ model: "llama3", providerId: "ollama" })).toEqual({
+      model: "llama3",
+      providerId: "ollama"
+    })
+  })
+
+  it("drops a non-string providerId", () => {
+    expect(parseModelRef({ model: "m", providerId: 5 })).toEqual({ model: "m" })
+  })
+
+  it("returns null for empty, missing, or non-model payloads", () => {
+    expect(parseModelRef("")).toBeNull()
+    expect(parseModelRef("   ")).toBeNull()
+    expect(parseModelRef({})).toBeNull()
+    expect(parseModelRef({ model: "" })).toBeNull()
+    expect(parseModelRef({ model: 1 })).toBeNull()
+    expect(parseModelRef(undefined)).toBeNull()
+    expect(parseModelRef(null)).toBeNull()
+  })
+})
+
+describe("parseStringPayload", () => {
+  it("returns non-empty strings", () => {
+    expect(parseStringPayload("http://localhost:11434")).toBe(
+      "http://localhost:11434"
+    )
+  })
+  it("returns null for empty or non-strings", () => {
+    expect(parseStringPayload("  ")).toBeNull()
+    expect(parseStringPayload(42)).toBeNull()
+    expect(parseStringPayload(undefined)).toBeNull()
+  })
+})
+
+describe("parseProviderIdPayload", () => {
+  it("extracts a string providerId", () => {
+    expect(parseProviderIdPayload({ providerId: "ollama" })).toEqual({
+      providerId: "ollama"
+    })
+  })
+  it("returns {} when absent or wrong type", () => {
+    expect(parseProviderIdPayload(undefined)).toEqual({})
+    expect(parseProviderIdPayload({})).toEqual({})
+    expect(parseProviderIdPayload({ providerId: 3 })).toEqual({})
+  })
+})

--- a/src/background/lib/message-payloads.ts
+++ b/src/background/lib/message-payloads.ts
@@ -26,12 +26,43 @@ export const parseModelRef = (payload: unknown): ModelRef | null => {
     const obj = payload as { model?: unknown; providerId?: unknown }
     if (typeof obj.model !== "string" || !obj.model.trim()) return null
     return {
-      model: obj.model,
+      model: obj.model.trim(),
       providerId:
         typeof obj.providerId === "string" ? obj.providerId : undefined
     }
   }
   return null
+}
+
+/** A warmup ref: a {@link ModelRef} plus the previously-active model to unload. */
+export interface WarmupRef extends ModelRef {
+  previousModel?: string
+  previousProviderId?: string
+}
+
+/**
+ * Parse a WARMUP_MODEL payload, carrying through the `previous*` fields the
+ * unload-on-switch path depends on (a plain `parseModelRef` would drop them).
+ */
+export const parseWarmupPayload = (payload: unknown): WarmupRef | null => {
+  const ref = parseModelRef(payload)
+  if (!ref) return null
+  if (payload && typeof payload === "object") {
+    const obj = payload as {
+      previousModel?: unknown
+      previousProviderId?: unknown
+    }
+    return {
+      ...ref,
+      previousModel:
+        typeof obj.previousModel === "string" ? obj.previousModel : undefined,
+      previousProviderId:
+        typeof obj.previousProviderId === "string"
+          ? obj.previousProviderId
+          : undefined
+    }
+  }
+  return ref
 }
 
 /** Extract a non-empty string payload, or `null`. */

--- a/src/background/lib/message-payloads.ts
+++ b/src/background/lib/message-payloads.ts
@@ -1,0 +1,50 @@
+/**
+ * Single parse boundary for runtime-message payloads (v0.11.2 / F3).
+ *
+ * The message router previously narrowed payloads with scattered inline guards
+ * and `as` casts. These typed parsers centralize that: each returns a validated,
+ * normalized shape or `null`, so the router never casts and invalid payloads are
+ * rejected in one place.
+ */
+
+/** A model reference: either a bare model name or `{ model, providerId? }`. */
+export interface ModelRef {
+  model: string
+  providerId?: string
+}
+
+/**
+ * Normalize a model-ref payload (`string` or `{ model, providerId? }`) to a
+ * `ModelRef`, or `null` when the payload has no usable model name.
+ */
+export const parseModelRef = (payload: unknown): ModelRef | null => {
+  if (typeof payload === "string") {
+    const model = payload.trim()
+    return model ? { model } : null
+  }
+  if (payload && typeof payload === "object" && "model" in payload) {
+    const obj = payload as { model?: unknown; providerId?: unknown }
+    if (typeof obj.model !== "string" || !obj.model.trim()) return null
+    return {
+      model: obj.model,
+      providerId:
+        typeof obj.providerId === "string" ? obj.providerId : undefined
+    }
+  }
+  return null
+}
+
+/** Extract a non-empty string payload, or `null`. */
+export const parseStringPayload = (payload: unknown): string | null =>
+  typeof payload === "string" && payload.trim() ? payload : null
+
+/** Optional `{ providerId? }` payload (always returns an object). */
+export const parseProviderIdPayload = (
+  payload: unknown
+): { providerId?: string } => {
+  if (payload && typeof payload === "object" && "providerId" in payload) {
+    const providerId = (payload as { providerId?: unknown }).providerId
+    if (typeof providerId === "string") return { providerId }
+  }
+  return {}
+}

--- a/src/background/lib/message-payloads.ts
+++ b/src/background/lib/message-payloads.ts
@@ -65,9 +65,12 @@ export const parseWarmupPayload = (payload: unknown): WarmupRef | null => {
   return ref
 }
 
-/** Extract a non-empty string payload, or `null`. */
-export const parseStringPayload = (payload: unknown): string | null =>
-  typeof payload === "string" && payload.trim() ? payload : null
+/** Extract a non-empty, trimmed string payload, or `null`. */
+export const parseStringPayload = (payload: unknown): string | null => {
+  if (typeof payload !== "string") return null
+  const trimmed = payload.trim()
+  return trimmed || null
+}
 
 /** Optional `{ providerId? }` payload (always returns an object). */
 export const parseProviderIdPayload = (

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -13,6 +13,11 @@ import { handleShowModelDetails } from "@/background/handlers/handle-show-model-
 import { handleUnloadModel } from "@/background/handlers/handle-unload-model"
 import { handleUpdateBaseUrl } from "@/background/handlers/handle-update-base-url"
 import { handleWarmupModel } from "@/background/handlers/handle-warmup-model"
+import {
+  parseModelRef,
+  parseProviderIdPayload,
+  parseStringPayload
+} from "@/background/lib/message-payloads"
 import { postSelectionToSidePanels } from "@/background/lib/selection-bridge"
 import { safeSendResponse } from "@/background/lib/utils"
 import { browser, isChromiumBased } from "@/lib/browser-api"
@@ -26,26 +31,11 @@ import type {
   SendResponseFunction
 } from "@/types"
 
-const isModelPayload = (
-  payload: unknown
-): payload is string | { model: string; providerId?: string } =>
-  typeof payload === "string" ||
-  (typeof payload === "object" && payload !== null && "model" in payload)
-
-const parseEmbeddingModelPayload = (payload: unknown) => {
-  const modelName =
-    typeof payload === "string"
-      ? payload
-      : payload && typeof payload === "object" && "model" in payload
-        ? (payload as { model: string }).model
-        : null
-  const providerId =
-    payload && typeof payload === "object" && "providerId" in payload
-      ? (payload as { providerId?: string }).providerId
-      : undefined
-
-  return { modelName, providerId }
-}
+const respondInvalidPayload = (sendResponse: SendResponseFunction) =>
+  safeSendResponse(sendResponse, {
+    success: false,
+    error: { status: 400, message: "Invalid message payload" }
+  })
 
 const openSidePanelForSelection = (tab?: {
   windowId?: number
@@ -134,10 +124,11 @@ const handleSelectionMessage = (
 
 export const registerMessageRouter = () => {
   browser.runtime.onMessage.addListener(
-    (message, sender, sendResponse): true | undefined => {
+    (rawMessage, sender, sendResponse): true | undefined => {
       const response = sendResponse as SendResponseFunction
+      const message = rawMessage as ChromeMessage
 
-      switch ((message as ChromeMessage).type) {
+      switch (message.type) {
         case MESSAGE_KEYS.PROVIDER.GET_MODELS:
         case MESSAGE_KEYS.OLLAMA.GET_MODELS: {
           handleGetModels(response)
@@ -145,10 +136,8 @@ export const registerMessageRouter = () => {
         }
 
         case MESSAGE_KEYS.PROVIDER.SHOW_MODEL_DETAILS: {
-          const payload = (message as ChromeMessage).payload
-          if (isModelPayload(payload)) {
-            handleShowModelDetails(payload, response)
-          }
+          const ref = parseModelRef(message.payload)
+          if (ref) handleShowModelDetails(ref, response)
           return true
         }
 
@@ -181,8 +170,8 @@ export const registerMessageRouter = () => {
 
         case MESSAGE_KEYS.PROVIDER.SCRAPE_MODEL:
         case MESSAGE_KEYS.OLLAMA.SCRAPE_MODEL: {
-          const query = (message as ChromeMessage).query
-          if (query && typeof query === "string") {
+          const query = parseStringPayload(message.query)
+          if (query) {
             handleScrapeModel(query, response)
             return true
           }
@@ -191,8 +180,8 @@ export const registerMessageRouter = () => {
 
         case MESSAGE_KEYS.PROVIDER.SCRAPE_MODEL_VARIANTS:
         case MESSAGE_KEYS.OLLAMA.SCRAPE_MODEL_VARIANTS: {
-          const name = (message as ChromeMessage).name
-          if (name && typeof name === "string") {
+          const name = parseStringPayload(message.name)
+          if (name) {
             handleScrapeModelVariants(name, response)
             return true
           }
@@ -201,44 +190,36 @@ export const registerMessageRouter = () => {
 
         case MESSAGE_KEYS.PROVIDER.UPDATE_BASE_URL:
         case MESSAGE_KEYS.OLLAMA.UPDATE_BASE_URL: {
-          const payload = (message as ChromeMessage).payload
-          if (typeof payload === "string")
-            handleUpdateBaseUrl(payload, response)
+          const baseUrl = parseStringPayload(message.payload)
+          if (baseUrl) handleUpdateBaseUrl(baseUrl, response)
           return true
         }
 
         case MESSAGE_KEYS.PROVIDER.GET_LOADED_MODELS:
         case MESSAGE_KEYS.OLLAMA.GET_LOADED_MODELS: {
           handleGetLoadedModels(
-            (message as ChromeMessage).payload as
-              | { providerId?: string }
-              | undefined,
+            parseProviderIdPayload(message.payload),
             response
           )
           return true
         }
 
         case MESSAGE_KEYS.PROVIDER.UNLOAD_MODEL: {
-          const payload = (message as ChromeMessage).payload
-          if (isModelPayload(payload)) {
-            handleUnloadModel(payload, response)
-          }
+          const ref = parseModelRef(message.payload)
+          if (ref) handleUnloadModel(ref, response)
           return true
         }
 
         case MESSAGE_KEYS.PROVIDER.WARMUP_MODEL: {
-          handleWarmupModel(
-            (message as ChromeMessage).payload as { model: string },
-            response
-          )
+          const ref = parseModelRef(message.payload)
+          if (ref) handleWarmupModel(ref, response)
+          else respondInvalidPayload(response)
           return true
         }
 
         case MESSAGE_KEYS.PROVIDER.DELETE_MODEL: {
-          const payload = (message as ChromeMessage).payload
-          if (typeof payload === "string") {
-            handleDeleteModel(payload, response)
-          }
+          const modelName = parseStringPayload(message.payload)
+          if (modelName) handleDeleteModel(modelName, response)
           return true
         }
 
@@ -249,11 +230,9 @@ export const registerMessageRouter = () => {
         }
 
         case MESSAGE_KEYS.PROVIDER.CHECK_EMBEDDING_MODEL: {
-          const { modelName, providerId } = parseEmbeddingModelPayload(
-            (message as ChromeMessage).payload
-          )
+          const ref = parseModelRef(message.payload)
 
-          if (typeof modelName !== "string") {
+          if (!ref) {
             safeSendResponse(response, {
               success: false,
               error: { status: 400, message: "Invalid embedding model request" }
@@ -261,7 +240,7 @@ export const registerMessageRouter = () => {
             return true
           }
 
-          checkEmbeddingModelExists(modelName, providerId)
+          checkEmbeddingModelExists(ref.model, ref.providerId)
             .then((result) => {
               safeSendResponse(response, {
                 success: true,
@@ -281,34 +260,25 @@ export const registerMessageRouter = () => {
         }
 
         case MESSAGE_KEYS.PROVIDER.PREPARE_EMBEDDING_MODEL: {
-          handlePrepareEmbeddingModel(
-            (message as ChromeMessage).payload,
-            response
-          )
+          handlePrepareEmbeddingModel(message.payload, response)
           return true
         }
 
         case MESSAGE_KEYS.PROVIDER.EMBED_FILE_CHUNKS: {
-          handleEmbedFileChunks(message as ChromeMessage, response).catch(
-            (err) => {
-              safeSendResponse(response, {
-                success: false,
-                error: {
-                  status: 0,
-                  message: err instanceof Error ? err.message : String(err)
-                }
-              })
-            }
-          )
+          handleEmbedFileChunks(message, response).catch((err) => {
+            safeSendResponse(response, {
+              success: false,
+              error: {
+                status: 0,
+                message: err instanceof Error ? err.message : String(err)
+              }
+            })
+          })
           return true
         }
 
         case MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT: {
-          return handleSelectionMessage(
-            message as ChromeMessage,
-            sender.tab,
-            response
-          )
+          return handleSelectionMessage(message, sender.tab, response)
         }
       }
     }

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -16,7 +16,8 @@ import { handleWarmupModel } from "@/background/handlers/handle-warmup-model"
 import {
   parseModelRef,
   parseProviderIdPayload,
-  parseStringPayload
+  parseStringPayload,
+  parseWarmupPayload
 } from "@/background/lib/message-payloads"
 import { postSelectionToSidePanels } from "@/background/lib/selection-bridge"
 import { safeSendResponse } from "@/background/lib/utils"
@@ -211,7 +212,7 @@ export const registerMessageRouter = () => {
         }
 
         case MESSAGE_KEYS.PROVIDER.WARMUP_MODEL: {
-          const ref = parseModelRef(message.payload)
+          const ref = parseWarmupPayload(message.payload)
           if (ref) handleWarmupModel(ref, response)
           else respondInvalidPayload(response)
           return true

--- a/src/lib/runtime-messages.ts
+++ b/src/lib/runtime-messages.ts
@@ -73,6 +73,38 @@ export interface RuntimeMessageMap {
     }
     response: RuntimeResponse
   }
+  [MESSAGE_KEYS.PROVIDER.WARMUP_MODEL]: {
+    request: {
+      type: typeof MESSAGE_KEYS.PROVIDER.WARMUP_MODEL
+      payload: { model: string; providerId?: string }
+    }
+    response: RuntimeResponse
+  }
+  [MESSAGE_KEYS.PROVIDER.DELETE_MODEL]: {
+    request: {
+      type: typeof MESSAGE_KEYS.PROVIDER.DELETE_MODEL
+      payload: string
+    }
+    response: RuntimeResponse
+  }
+  [MESSAGE_KEYS.PROVIDER.GET_PROVIDER_VERSION]: {
+    request: { type: typeof MESSAGE_KEYS.PROVIDER.GET_PROVIDER_VERSION }
+    response: RuntimeResponse<{ data?: { version?: string } }>
+  }
+  [MESSAGE_KEYS.PROVIDER.PREPARE_EMBEDDING_MODEL]: {
+    request: {
+      type: typeof MESSAGE_KEYS.PROVIDER.PREPARE_EMBEDDING_MODEL
+      payload: { model: string; providerId?: string }
+    }
+    response: RuntimeResponse
+  }
+  [MESSAGE_KEYS.PROVIDER.EMBED_FILE_CHUNKS]: {
+    request: {
+      type: typeof MESSAGE_KEYS.PROVIDER.EMBED_FILE_CHUNKS
+      payload?: unknown
+    }
+    response: RuntimeResponse
+  }
   [MESSAGE_KEYS.PROVIDER.UPDATE_BASE_URL]: {
     request: {
       type: typeof MESSAGE_KEYS.PROVIDER.UPDATE_BASE_URL

--- a/src/lib/runtime-messages.ts
+++ b/src/lib/runtime-messages.ts
@@ -76,7 +76,12 @@ export interface RuntimeMessageMap {
   [MESSAGE_KEYS.PROVIDER.WARMUP_MODEL]: {
     request: {
       type: typeof MESSAGE_KEYS.PROVIDER.WARMUP_MODEL
-      payload: { model: string; providerId?: string }
+      payload: {
+        model: string
+        providerId?: string
+        previousModel?: string
+        previousProviderId?: string
+      }
     }
     response: RuntimeResponse
   }


### PR DESCRIPTION
## Summary

First slice of the typed-message foundation (0.11.2 / F3). The send side already had a typed `RuntimeMessageMap` + `sendRuntimeMessage`; this hardens the **background router**, which previously narrowed payloads with scattered inline guards and `as unknown as` / `as {...}` casts.

## Changes

- **`src/background/lib/message-payloads.ts`** — single parse boundary: `parseModelRef`, `parseStringPayload`, `parseProviderIdPayload`. Each returns a validated, normalized shape or `null`.
- **`message-router.ts`** — `message` typed once (`ChromeMessage`); every case uses a parser instead of a cast. Removed `isModelPayload` / `parseEmbeddingModelPayload` and all per-case `as` casts.
- **`RuntimeMessageMap`** — completed with the 5 runtime types it was missing: `WARMUP_MODEL`, `DELETE_MODEL`, `GET_PROVIDER_VERSION`, `PREPARE_EMBEDDING_MODEL`, `EMBED_FILE_CHUNKS`.
- Parser unit tests; existing router dispatch tests still pass.

## Behavior

Preserved. One intentional tightening: `WARMUP_MODEL` with an invalid payload now returns a 400 instead of forwarding an empty `{model}` to the handler (the handler errored anyway). Cases that previously no-op'd on invalid payloads still no-op.

## Testing

`pnpm typecheck`, `pnpm lint:check`, `pnpm test:run` green; pre-push i18n gate passes (all locales 100%).

## Scope note

This is phase 1 — it removes the unsafe casts and centralizes parsing. A fuller discriminated-union dispatch (incl. the legacy `OLLAMA.*` aliases and port-stream typing) can follow if wanted, but this delivers the core safety win with no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes runtime-message payload parsing for the background service worker by introducing a typed parse-boundary module (`message-payloads.ts`) and threading its parsers through `message-router.ts`, replacing scattered inline guards and `as` casts throughout.

- **New parse boundary** (`message-payloads.ts`): `parseModelRef`, `parseWarmupPayload`, `parseStringPayload`, and `parseProviderIdPayload` each return a validated, normalized shape or `null`; the router never casts.
- **Router hardened**: `message` is cast once to `ChromeMessage`; every case delegates to a parser, and `WARMUP_MODEL` now correctly carries `previousModel`/`previousProviderId` via `parseWarmupPayload` rather than dropping those fields.
- **`RuntimeMessageMap` completed**: five previously-missing runtime types (`WARMUP_MODEL`, `DELETE_MODEL`, `GET_PROVIDER_VERSION`, `PREPARE_EMBEDDING_MODEL`, `EMBED_FILE_CHUNKS`) are now declared, with `WARMUP_MODEL` including the full `WarmupPayload` shape.

<h3>Confidence Score: 5/5</h3>

Safe to merge — previously-flagged issues (dropped warmup fields, incomplete RuntimeMessageMap, model-name trim inconsistency) have all been addressed, and no new regressions are introduced.

The refactor is narrowly scoped: it replaces scattered inline casts with four well-tested parser functions. All three issues raised in the prior review round have been resolved — `parseWarmupPayload` now carries `previousModel`/`previousProviderId` through to the handler, `RuntimeMessageMap` declares the full warmup payload shape, and the model-name trimming is consistent across both the string and object paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/background/lib/message-payloads.ts | New parse-boundary module; `parseWarmupPayload` correctly preserves `previousModel`/`previousProviderId`, model trimming is consistent across both the string and object paths, and all four parsers are unit-tested. |
| src/background/message-router.ts | Router now casts `rawMessage` once to `ChromeMessage` and delegates every case to a typed parser; `WARMUP_MODEL` uses `parseWarmupPayload` so `previousModel`/`previousProviderId` are preserved and an invalid payload returns 400 instead of silently forwarding garbage. |
| src/lib/runtime-messages.ts | Five missing `RuntimeMessageMap` entries added; `WARMUP_MODEL` now declares the full payload shape including `previousModel?` and `previousProviderId?`, matching the handler and the existing call-site in `model-menu.tsx`. |
| src/background/lib/__tests__/message-payloads.test.ts | New unit test file covering all four parsers, including the unload-on-switch path for `parseWarmupPayload`, null/empty inputs, type coercions, and the string/object trimming edge cases. |
| package.json | Version bump from 0.11.1 to 0.11.2. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test/fix: correct parser test structure ..."](https://github.com/shishir435/ollama-client/commit/d30567e3c241bea5d8ad8b7e18b23fac49e3f0d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38811475)</sub>

<!-- /greptile_comment -->