### PR TITLE
0.11.3: timeouts on long-running model fetches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/background/handlers/handle-embedding-download.ts
+++ b/src/background/handlers/handle-embedding-download.ts
@@ -1,4 +1,8 @@
 import { createErrorResponse } from "@/background/lib/error-handler"
+import {
+  createAbortTimeout,
+  EMBEDDING_DOWNLOAD_TIMEOUT_MS
+} from "@/background/lib/fetch-timeout"
 import { getBaseUrl } from "@/background/lib/utils"
 import {
   DEFAULT_EMBEDDING_MODEL,
@@ -325,11 +329,24 @@ export const downloadEmbeddingModelSilently = async (
       stream: false // Don't stream for silent download
     }
 
-    const res = await fetch(`${baseUrl}/api/pull`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(requestBody)
-    })
+    // Non-streaming pull holds the connection until the whole model downloads;
+    // cap it so a hung provider can't keep the request (and SW) alive forever.
+    const controller = new AbortController()
+    const downloadTimeout = createAbortTimeout(
+      controller,
+      EMBEDDING_DOWNLOAD_TIMEOUT_MS
+    )
+    let res: Response
+    try {
+      res = await fetch(`${baseUrl}/api/pull`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal
+      })
+    } finally {
+      downloadTimeout.clear()
+    }
 
     if (!res.ok) {
       const errorText = await res.text()

--- a/src/background/handlers/handle-embedding-download.ts
+++ b/src/background/handlers/handle-embedding-download.ts
@@ -1,5 +1,6 @@
 import { createErrorResponse } from "@/background/lib/error-handler"
 import {
+  type AbortTimeout,
   createAbortTimeout,
   EMBEDDING_DOWNLOAD_TIMEOUT_MS
 } from "@/background/lib/fetch-timeout"
@@ -309,6 +310,9 @@ export const checkEmbeddingModelExists = async (
 export const downloadEmbeddingModelSilently = async (
   modelName: string = DEFAULT_EMBEDDING_MODEL
 ): Promise<{ success: boolean; error?: string }> => {
+  // Declared here (armed only around the fetch below) so the catch can tell a
+  // timeout from other errors without leaving a timer running on early returns.
+  let downloadTimeout: AbortTimeout | undefined
   try {
     const normalizedModelName = normalizeEmbeddingModelName(modelName)
     // Check if model already exists
@@ -332,21 +336,17 @@ export const downloadEmbeddingModelSilently = async (
     // Non-streaming pull holds the connection until the whole model downloads;
     // cap it so a hung provider can't keep the request (and SW) alive forever.
     const controller = new AbortController()
-    const downloadTimeout = createAbortTimeout(
+    downloadTimeout = createAbortTimeout(
       controller,
       EMBEDDING_DOWNLOAD_TIMEOUT_MS
     )
-    let res: Response
-    try {
-      res = await fetch(`${baseUrl}/api/pull`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-        signal: controller.signal
-      })
-    } finally {
-      downloadTimeout.clear()
-    }
+    const res = await fetch(`${baseUrl}/api/pull`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal
+    })
+    downloadTimeout.clear()
 
     if (!res.ok) {
       const errorText = await res.text()
@@ -378,6 +378,14 @@ export const downloadEmbeddingModelSilently = async (
     )
     return { success: true }
   } catch (error) {
+    downloadTimeout?.clear()
+    if (downloadTimeout?.timedOut()) {
+      const message = `Embedding model download timed out after ${
+        EMBEDDING_DOWNLOAD_TIMEOUT_MS / 60_000
+      } minutes.`
+      logger.error(message, "downloadEmbeddingModelSilently")
+      return { success: false, error: message }
+    }
     const errorMessage = getErrorMessage(error)
     logger.error(
       "Error downloading embedding model",

--- a/src/background/handlers/handle-model-pull.ts
+++ b/src/background/handlers/handle-model-pull.ts
@@ -6,6 +6,10 @@ import {
 } from "@/background/lib/abort-controller-registry"
 import { normalizeError } from "@/background/lib/error-handler"
 import {
+  createAbortTimeout,
+  PULL_CONNECT_TIMEOUT_MS
+} from "@/background/lib/fetch-timeout"
+import {
   getBaseUrl,
   getPullAbortControllerKey,
   safePostMessage
@@ -56,6 +60,10 @@ export const handleModelPull = async (
   const controllerKey = getPullAbortControllerKey(port.name, modelName)
   setAbortController(controllerKey, controller)
 
+  // Cap the initial connection only — once headers arrive the download stream
+  // may legitimately run for minutes, so the timer is cleared before streaming.
+  const connectTimeout = createAbortTimeout(controller, PULL_CONNECT_TIMEOUT_MS)
+
   try {
     const requestBody: DefaultProviderPullRequest = { name: modelName }
     const isLmStudio = provider.id === ProviderId.LM_STUDIO
@@ -72,6 +80,7 @@ export const handleModelPull = async (
       body,
       signal: controller.signal
     })
+    connectTimeout.clear()
 
     if (!res.ok) {
       safePostMessage(port, {
@@ -95,7 +104,17 @@ export const handleModelPull = async (
 
     await handlePullStream(res, port, isPortClosed, modelName)
   } catch (err) {
-    if (isAbortError(err)) {
+    connectTimeout.clear()
+    if (connectTimeout.timedOut()) {
+      safePostMessage(port, {
+        error: {
+          status: 408,
+          message: `Connection timed out after ${
+            PULL_CONNECT_TIMEOUT_MS / 1000
+          }s. Is the provider running and reachable?`
+        }
+      })
+    } else if (isAbortError(err)) {
       safePostMessage(port, { error: "Download cancelled" })
     } else {
       safePostMessage(port, {

--- a/src/background/lib/__tests__/fetch-timeout.test.ts
+++ b/src/background/lib/__tests__/fetch-timeout.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createAbortTimeout } from "@/background/lib/fetch-timeout"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("createAbortTimeout", () => {
+  it("aborts the controller once the timeout elapses", () => {
+    const controller = new AbortController()
+    const t = createAbortTimeout(controller, 1000)
+
+    expect(controller.signal.aborted).toBe(false)
+    expect(t.timedOut()).toBe(false)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(controller.signal.aborted).toBe(true)
+    expect(t.timedOut()).toBe(true)
+  })
+
+  it("does not abort when cleared before the timeout", () => {
+    const controller = new AbortController()
+    const t = createAbortTimeout(controller, 1000)
+
+    t.clear()
+    vi.advanceTimersByTime(5000)
+
+    expect(controller.signal.aborted).toBe(false)
+    expect(t.timedOut()).toBe(false)
+  })
+
+  it("timedOut() stays false for an external abort (user cancel)", () => {
+    const controller = new AbortController()
+    const t = createAbortTimeout(controller, 1000)
+
+    controller.abort() // e.g. user-initiated cancel
+    expect(controller.signal.aborted).toBe(true)
+    expect(t.timedOut()).toBe(false)
+
+    t.clear()
+  })
+})

--- a/src/background/lib/fetch-timeout.ts
+++ b/src/background/lib/fetch-timeout.ts
@@ -1,0 +1,48 @@
+/**
+ * Abort-timer for long-running fetches (v0.11.3 / F1 — lifecycle hardening).
+ *
+ * MV3 background fetches with no timeout can hang indefinitely (a provider that
+ * never responds keeps the request — and any awaiting job — alive forever). This
+ * arms a timer that calls `controller.abort()` after `ms` unless cleared first.
+ *
+ * `timedOut()` distinguishes a timeout-driven abort from a user-initiated cancel
+ * so callers can surface the right message instead of "cancelled".
+ *
+ * Usage — connect timeout for a stream (clear once headers arrive, then stream
+ * uncapped):
+ *   const t = createAbortTimeout(controller, 60_000)
+ *   const res = await fetch(url, { signal: controller.signal })
+ *   t.clear()
+ *
+ * Usage — overall cap for a non-streaming request (clear in finally):
+ *   const t = createAbortTimeout(controller, 900_000)
+ *   try { return await fetch(url, { signal: controller.signal }) }
+ *   finally { t.clear() }
+ */
+export interface AbortTimeout {
+  /** Cancel the pending abort timer. Safe to call multiple times. */
+  clear: () => void
+  /** True once the timer fired and aborted (vs. an external cancel). */
+  timedOut: () => boolean
+}
+
+export const createAbortTimeout = (
+  controller: AbortController,
+  ms: number
+): AbortTimeout => {
+  let didTimeout = false
+  const id = setTimeout(() => {
+    didTimeout = true
+    controller.abort()
+  }, ms)
+  return {
+    clear: () => clearTimeout(id),
+    timedOut: () => didTimeout
+  }
+}
+
+/** Initial-connection cap for a streaming model pull. */
+export const PULL_CONNECT_TIMEOUT_MS = 60_000
+
+/** Overall cap for the silent, non-streaming embedding-model download. */
+export const EMBEDDING_DOWNLOAD_TIMEOUT_MS = 15 * 60_000


### PR DESCRIPTION
## Summary

First slice of MV3 lifecycle hardening (0.11.3 / F1). MV3 background `fetch`es with no timeout can hang the service worker indefinitely when a provider never responds — the audit flagged model pull and the install-time embedding download as having no timeout at all. This adds bounded timeouts to both.

## Changes

- **`src/background/lib/fetch-timeout.ts`** — `createAbortTimeout(controller, ms)`: arms a timer that aborts the controller after `ms` unless cleared; `timedOut()` distinguishes a timeout from a user-initiated cancel so callers show the right message.
- **Model pull** (`handle-model-pull.ts`) — 60s cap on the **initial connection only**, cleared once response headers arrive so the (legitimately long) download stream stays uncapped. A timeout now reports `408 connection timed out` instead of hanging or being mislabeled "Download cancelled".
- **Silent embedding download** (`handle-embedding-download.ts`) — the non-streaming `/api/pull` holds the connection until the whole model downloads; wrapped in a 15-minute overall cap so a hung provider can't keep the request (and worker) alive forever.
- Unit tests for the timer (fires / cleared / external-abort cases).

## Behavior

User-initiated cancel still works unchanged (the existing AbortController is reused; `timedOut()` is false for an external abort). Only genuinely hung connections are now bounded.

## Testing

`pnpm typecheck`, `pnpm lint:check`, `pnpm test:run` green; pre-push i18n gate passes.

## Scope note

Phase 1 of F1 — the concrete "no timeout" bug. The larger pieces (alarms for jobs that must survive suspension, resumable job state) are separate follow-ups; `offscreen` stays parked (CSP). This delivers the hang fix on its own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bounded timeouts to two previously unguarded MV3 background fetches: a 60-second connection-only cap on interactive model pulls (streaming continues uncapped once headers arrive) and a 15-minute overall cap on the silent, non-streaming embedding model download. A new `createAbortTimeout` utility in `fetch-timeout.ts` centralises the timer logic and lets callers distinguish a timeout-driven abort from a user cancel.

- **`fetch-timeout.ts`** — New `createAbortTimeout(controller, ms)` helper with `clear()` / `timedOut()` interface; constants `PULL_CONNECT_TIMEOUT_MS` (60 s) and `EMBEDDING_DOWNLOAD_TIMEOUT_MS` (15 min) exported alongside it.
- **`handle-model-pull.ts`** — `connectTimeout` declared before `try`, cleared immediately after headers arrive, checked in `catch` to return a 408 message instead of \"Download cancelled\" on a hung connection.
- **`handle-embedding-download.ts`** — `downloadTimeout` declared before `try` (so it is in scope in `catch`), armed around the single blocking `fetch`, and checked in `catch` to surface a human-readable timeout message rather than a generic `AbortError` string.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, all three timeout-state paths are exercised by unit tests, and the scoping fix for `downloadTimeout` ensures the catch handler always sees the timer state correctly.

Both handlers declare their timeout handles before the `try` block so `catch` can distinguish a timeout from a user cancel or a network error. `clear()` is idempotent and correctly does not reset `didTimeout`, so the `timedOut()` check after `clear()` remains accurate whether the timer fired or not. The stream for interactive model pulls remains uncapped once headers arrive, preserving large-model download behaviour. No existing logic paths were restructured — only the catch branches gained a new leading guard.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/background/lib/fetch-timeout.ts | New utility — clean implementation; `clear()` correctly uses `clearTimeout` without resetting `didTimeout`, so `timedOut()` is accurate even after `clear()` is called post-fire. Tests cover all three meaningful states. |
| src/background/handlers/handle-model-pull.ts | Timeout correctly scoped outside `try`; cleared on connection success, cleared again (idempotent) in `catch` before the `timedOut()` guard — the 408 message is shown only for genuine hangs; user cancels still map to "Download cancelled". |
| src/background/handlers/handle-embedding-download.ts | `downloadTimeout` declared before the `try` block, making it accessible in `catch`; `clear()` + `timedOut()` pattern mirrors handle-model-pull.ts; all early-return paths before the fetch correctly leave `downloadTimeout` undefined, so the `?.` guards are safe. |
| src/background/lib/__tests__/fetch-timeout.test.ts | Three focused tests with fake timers cover fire/abort, clear-prevents-abort, and external-cancel-does-not-set-timedOut — all three meaningful states of the helper. |
| package.json | Version bump only (0.11.2 → 0.11.3). |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI / Port
    participant H as handleModelPull
    participant T as createAbortTimeout
    participant F as fetch (provider)

    UI->>H: pull request
    H->>T: createAbortTimeout(controller, 60s)
    T-->>H: "connectTimeout { clear, timedOut }"
    H->>F: "fetch(endpoint, { signal })"

    alt Provider responds within 60 s
        F-->>H: response headers
        H->>T: connectTimeout.clear()
        H->>F: stream body (uncapped)
        F-->>H: done
        H-->>UI: progress / done
    else Provider hangs → timer fires
        T->>F: controller.abort()
        F-->>H: AbortError
        H->>T: connectTimeout.clear() (no-op)
        Note over H,T: connectTimeout.timedOut() → true
        H-->>UI: 408 Connection timed out
    else User cancels
        UI->>H: cancel message → controller.abort()
        F-->>H: AbortError
        H->>T: connectTimeout.clear() (cancels timer)
        Note over H,T: connectTimeout.timedOut() → false
        H-->>UI: Download cancelled
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI / Port
    participant H as handleModelPull
    participant T as createAbortTimeout
    participant F as fetch (provider)

    UI->>H: pull request
    H->>T: createAbortTimeout(controller, 60s)
    T-->>H: "connectTimeout { clear, timedOut }"
    H->>F: "fetch(endpoint, { signal })"

    alt Provider responds within 60 s
        F-->>H: response headers
        H->>T: connectTimeout.clear()
        H->>F: stream body (uncapped)
        F-->>H: done
        H-->>UI: progress / done
    else Provider hangs → timer fires
        T->>F: controller.abort()
        F-->>H: AbortError
        H->>T: connectTimeout.clear() (no-op)
        Note over H,T: connectTimeout.timedOut() → true
        H-->>UI: 408 Connection timed out
    else User cancels
        UI->>H: cancel message → controller.abort()
        F-->>H: AbortError
        H->>T: connectTimeout.clear() (cancels timer)
        Note over H,T: connectTimeout.timedOut() → false
        H-->>UI: Download cancelled
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: report embedding-download timeout d..."](https://github.com/shishir435/ollama-client/commit/17a25409110e3116bebbd2362434222c7a59e580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38812984)</sub>

<!-- /greptile_comment -->