### PR TITLE
0.11.4: cap background memory context to the RAG char budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -74,15 +74,22 @@ describe("handleChatWithModel", () => {
   let mockPort: ReturnType<typeof createMockPort>
   let mockIsPortClosed: ReturnType<typeof createMockIsPortClosed>
 
-  beforeEach(() => {
+  beforeEach(async () => {
     clearHandlerMocks()
     setupHandlerMocks()
     mockPort = createMockPort("chat-port")
     mockIsPortClosed = createMockIsPortClosed(false)
     vi.clearAllMocks()
 
-    // Reset mockProvider to its hoisted state if needed,
-    // but vi.clearAllMocks should handle the internal mock functions.
+    // clearAllMocks resets calls but not implementations, so restore the RAG
+    // mock defaults here. This makes every test start with empty memory and
+    // removes the need for per-test teardown (which leaks if an assert throws).
+    const rag = await import("@/features/chat/rag/rag-pipeline")
+    vi.mocked(rag.retrieveContextEnhanced).mockResolvedValue([])
+    vi.mocked(rag.formatEnhancedResults).mockReturnValue({
+      formattedContext: "",
+      sources: []
+    } as never)
   })
 
   describe("successful chat requests", () => {
@@ -247,13 +254,7 @@ describe("handleChatWithModel", () => {
       )
       expect(systemMsg.content).toContain("[Context truncated due to length]")
       expect(systemMsg.content).not.toContain(longContext)
-
-      // Restore rag mocks so later tests see the empty default.
-      vi.mocked(rag.retrieveContextEnhanced).mockResolvedValue([])
-      vi.mocked(rag.formatEnhancedResults).mockReturnValue({
-        formattedContext: "",
-        sources: []
-      } as never)
+      // No manual teardown needed — beforeEach restores the RAG mock defaults.
     })
 
     it("should include keep_alive and runtime options from model config", async () => {

--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { STORAGE_KEYS } from "@/lib/constants"
-import type { ChatWithModelMessage } from "@/types"
+import type { ChatMessage, ChatWithModelMessage } from "@/types"
 import { handleChatWithModel } from "../handle-chat-with-model"
 import {
   clearHandlerMocks,
@@ -210,6 +210,50 @@ describe("handleChatWithModel", () => {
         expect.any(Function),
         expect.any(AbortSignal)
       )
+    })
+
+    it("caps injected memory context to the RAG char budget", async () => {
+      const { plasmoGlobalStorage } = await import(
+        "@/lib/plasmo-global-storage"
+      )
+      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+        if (key === STORAGE_KEYS.MEMORY.ENABLED) return true
+        if (key === STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS) return 20
+        return undefined
+      })
+      const rag = await import("@/features/chat/rag/rag-pipeline")
+      vi.mocked(rag.retrieveContextEnhanced).mockResolvedValue([
+        { score: 1 }
+      ] as never)
+      const longContext = "X".repeat(100)
+      vi.mocked(rag.formatEnhancedResults).mockReturnValue({
+        formattedContext: longContext,
+        sources: []
+      } as never)
+
+      const message: ChatWithModelMessage = {
+        type: "CHAT_WITH_MODEL",
+        payload: {
+          model: "llama3:latest",
+          messages: [{ role: "user", content: "hi" }]
+        }
+      }
+
+      await handleChatWithModel(message, mockPort, mockIsPortClosed)
+
+      const request = mockStreamChat.mock.calls[0][0]
+      const systemMsg = request.messages.find(
+        (m: ChatMessage) => m.role === "system"
+      )
+      expect(systemMsg.content).toContain("[Context truncated due to length]")
+      expect(systemMsg.content).not.toContain(longContext)
+
+      // Restore rag mocks so later tests see the empty default.
+      vi.mocked(rag.retrieveContextEnhanced).mockResolvedValue([])
+      vi.mocked(rag.formatEnhancedResults).mockReturnValue({
+        formattedContext: "",
+        sources: []
+      } as never)
     })
 
     it("should include keep_alive and runtime options from model config", async () => {

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -93,9 +93,13 @@ export const handleChatWithModel = withErrorContext(
             (await plasmoGlobalStorage.get<number>(
               STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS
             )) ?? DEFAULT_MAX_RAG_CONTEXT_CHARS
+          const truncationMarker = "\n\n[Context truncated due to length]"
           const cappedContext =
             maxRagChars > 0 && formattedContext.length > maxRagChars
-              ? `${formattedContext.slice(0, maxRagChars)}\n\n[Context truncated due to length]`
+              ? `${formattedContext.slice(
+                  0,
+                  Math.max(0, maxRagChars - truncationMarker.length)
+                )}${truncationMarker}`
               : formattedContext
 
           logger.info(

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -4,7 +4,7 @@ import { withErrorContext } from "@/background/lib/error-handler"
 import { resolveModelTools } from "@/background/lib/resolve-model-tools"
 import { streamChatWithTools } from "@/background/lib/stream-chat-with-tools"
 import { safePostMessage } from "@/background/lib/utils"
-import { STORAGE_KEYS } from "@/lib/constants"
+import { DEFAULT_MAX_RAG_CONTEXT_CHARS, STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { resolveModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
@@ -85,9 +85,26 @@ export const handleChatWithModel = withErrorContext(
         if (enhancedResults.length > 0) {
           const { formattedContext, sources } =
             formatEnhancedResults(enhancedResults)
+
+          // Enforce the prompt-budget ceiling (same setting the client RAG path
+          // uses) so a large set of recalled memories can't blow the model's
+          // context window. `<= 0` means unlimited.
+          const maxRagChars =
+            (await plasmoGlobalStorage.get<number>(
+              STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS
+            )) ?? DEFAULT_MAX_RAG_CONTEXT_CHARS
+          const cappedContext =
+            maxRagChars > 0 && formattedContext.length > maxRagChars
+              ? `${formattedContext.slice(0, maxRagChars)}\n\n[Context truncated due to length]`
+              : formattedContext
+
           logger.info(
             `Injected ${enhancedResults.length} past context items`,
-            "handleChatWithModel"
+            "handleChatWithModel",
+            {
+              contextChars: cappedContext.length,
+              truncated: cappedContext.length < formattedContext.length
+            }
           )
 
           try {
@@ -100,7 +117,7 @@ export const handleChatWithModel = withErrorContext(
               error: e
             })
           }
-          contextHeader = `\n\nIMPORTANT: You have access to context from previous conversations:\n${formattedContext}\n\nUse this context to provide personalized responses.`
+          contextHeader = `\n\nIMPORTANT: You have access to context from previous conversations:\n${cappedContext}\n\nUse this context to provide personalized responses.`
         }
       }
     }


### PR DESCRIPTION
## Summary

Wires the prompt-budget ceiling into the background memory-injection path (0.11.4 / F4).

**Trace result:** `MAX_RAG_CONTEXT_CHARS` / `MAX_TAB_CONTEXT_CHARS` are enforced on the **client** RAG path (`build-rag-context.ts`, `use-chat-turn-controller.ts`), and `MAX_TOOL_RESULT_CHARS` is applied in the chat handler. But the **background memory injection** in `handle-chat-with-model.ts` (`retrieveContextEnhanced` → `formatEnhancedResults` → `contextHeader`) injected the result into the system prompt with **no char cap** — a large set of recalled past-conversation items could blow the model's context window.

## Change

- In `handle-chat-with-model.ts`, read `STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS` (default `16000`; `<= 0` = unlimited) and truncate the formatted memory context before it goes into the system prompt, using the same `[Context truncated due to length]` marker the client path uses. Logs `contextChars` + `truncated`.
- Test: a 100-char context with a 20-char budget is truncated and the full text never reaches the model.

## Testing

`pnpm typecheck`, `pnpm lint:check`, `pnpm test:run` green; pre-push i18n gate passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the existing `MAX_RAG_CONTEXT_CHARS` prompt-budget setting into the background memory-injection path, which previously had no cap and could overflow the model's context window with large recalled histories.

- **`handle-chat-with-model.ts`**: After `formatEnhancedResults`, reads `STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS` (defaulting to `DEFAULT_MAX_RAG_CONTEXT_CHARS = 16_000`; `<= 0` = unlimited) and slices `formattedContext` to fit, appending the standard `[Context truncated due to length]` marker. Logs `contextChars` and `truncated` for observability.
- **`handle-chat-with-model.test.ts`**: Converts `beforeEach` to `async` so it can restore RAG mock defaults via dynamic import after `vi.clearAllMocks()`, eliminating the prior implicit dependency on mock state surviving across tests. Adds a new test case that verifies truncation fires and the full overlong context never reaches the model.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped additive guard with a matching test, and it leaves all existing code paths untouched when memory is disabled or no past context items are recalled.

The truncation logic is straightforward, all three changed files pass typecheck/lint/tests per the PR description, and the new behaviour only activates inside the pre-existing `enhancedResults.length > 0` branch. No existing tests were broken and a new test directly exercises the capping path.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/background/handlers/handle-chat-with-model.ts | Reads MAX_RAG_CONTEXT_CHARS from storage and truncates the background memory context before system-prompt injection; logic and guard conditions are correct. |
| src/background/handlers/__tests__/handle-chat-with-model.test.ts | Adds a truncation test and converts beforeEach to async to restore RAG mock defaults; the new test correctly validates that the truncation marker appears and the original long context does not. |
| package.json | Version bump from 0.11.3 to 0.11.4; no other changes. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleChatWithModel] --> B{isMemoryEnabled?}
    B -- No --> G[Skip memory injection]
    B -- Yes --> C[retrieveContextEnhanced]
    C --> D{enhancedResults.length > 0?}
    D -- No --> G
    D -- Yes --> E[formatEnhancedResults]
    E --> F[Read MAX_RAG_CONTEXT_CHARS from storage]
    F --> H{maxRagChars > 0 AND formattedContext.length > maxRagChars?}
    H -- No --> I[cappedContext = formattedContext]
    H -- Yes --> J[cappedContext = slice to budget + truncationMarker]
    I --> K[Build contextHeader with cappedContext]
    J --> K
    K --> L[Assemble system message]
    L --> M[streamChat / streamChatWithTools]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handleChatWithModel] --> B{isMemoryEnabled?}
    B -- No --> G[Skip memory injection]
    B -- Yes --> C[retrieveContextEnhanced]
    C --> D{enhancedResults.length > 0?}
    D -- No --> G
    D -- Yes --> E[formatEnhancedResults]
    E --> F[Read MAX_RAG_CONTEXT_CHARS from storage]
    F --> H{maxRagChars > 0 AND formattedContext.length > maxRagChars?}
    H -- No --> I[cappedContext = formattedContext]
    H -- Yes --> J[cappedContext = slice to budget + truncationMarker]
    I --> K[Build contextHeader with cappedContext]
    J --> K
    K --> L[Assemble system message]
    L --> M[streamChat / streamChatWithTools]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/background/handlers/handle-chat-with-model.ts`, line 111-114 ([link](https://github.com/shishir435/ollama-client/blob/9812b4a54cd3bbc36cfce51b5a60d2b985641b95/src/background/handlers/handle-chat-with-model.ts#L111-L114)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`sources` sent reflects full retrieval, not the truncated slice**

   `sources` is populated from `formatEnhancedResults(enhancedResults)` and includes metadata for every recalled item. After truncation, entries near the tail of `formattedContext` may be completely absent from `cappedContext`, yet the UI receives all of them via the `rag_sources` port message. This means users could see attributed sources that the model never actually read. The client-side path (`build-rag-context.ts`) has the same characteristic, so this is consistent for now — but once the cap is applied here, it would be worth filtering `sources` to only those whose content survived the slice.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fbackground%2Fhandlers%2Fhandle-chat-with-model.ts%0ALine%3A%20111-114%0A%0AComment%3A%0A**%60sources%60%20sent%20reflects%20full%20retrieval%2C%20not%20the%20truncated%20slice**%0A%0A%60sources%60%20is%20populated%20from%20%60formatEnhancedResults%28enhancedResults%29%60%20and%20includes%20metadata%20for%20every%20recalled%20item.%20After%20truncation%2C%20entries%20near%20the%20tail%20of%20%60formattedContext%60%20may%20be%20completely%20absent%20from%20%60cappedContext%60%2C%20yet%20the%20UI%20receives%20all%20of%20them%20via%20the%20%60rag_sources%60%20port%20message.%20This%20means%20users%20could%20see%20attributed%20sources%20that%20the%20model%20never%20actually%20read.%20The%20client-side%20path%20%28%60build-rag-context.ts%60%29%20has%20the%20same%20characteristic%2C%20so%20this%20is%20consistent%20for%20now%20%E2%80%94%20but%20once%20the%20cap%20is%20applied%20here%2C%20it%20would%20be%20worth%20filtering%20%60sources%60%20to%20only%20those%20whose%20content%20survived%20the%20slice.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=135&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2F0-11-4-rag-cap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2F0-11-4-rag-cap%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fbackground%2Fhandlers%2Fhandle-chat-with-model.ts%0ALine%3A%20111-114%0A%0AComment%3A%0A**%60sources%60%20sent%20reflects%20full%20retrieval%2C%20not%20the%20truncated%20slice**%0A%0A%60sources%60%20is%20populated%20from%20%60formatEnhancedResults%28enhancedResults%29%60%20and%20includes%20metadata%20for%20every%20recalled%20item.%20After%20truncation%2C%20entries%20near%20the%20tail%20of%20%60formattedContext%60%20may%20be%20completely%20absent%20from%20%60cappedContext%60%2C%20yet%20the%20UI%20receives%20all%20of%20them%20via%20the%20%60rag_sources%60%20port%20message.%20This%20means%20users%20could%20see%20attributed%20sources%20that%20the%20model%20never%20actually%20read.%20The%20client-side%20path%20%28%60build-rag-context.ts%60%29%20has%20the%20same%20characteristic%2C%20so%20this%20is%20consistent%20for%20now%20%E2%80%94%20but%20once%20the%20cap%20is%20applied%20here%2C%20it%20would%20be%20worth%20filtering%20%60sources%60%20to%20only%20those%20whose%20content%20survived%20the%20slice.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=135&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test: restore RAG mock defaults in befor..."](https://github.com/shishir435/ollama-client/commit/015c5cdfa83447252982e6e05f2190dba0360c96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38814464)</sub>

<!-- /greptile_comment -->