### PR TITLE
Add artifact previews

### DIFF
--- a/FEATURE_ROADMAP.md
+++ b/FEATURE_ROADMAP.md
@@ -352,7 +352,7 @@ only after the keyword; no passive capture.
 - Code: `src/background/lib/omnibox.ts`,
   `src/features/chat/hooks/use-omnibox-query.ts`.
 
-### E7. Artifacts / Output Canvas — 🟢 `v0.11.11`
+### E7. Artifacts / Output Canvas — 🟡 `v0.11.11` 🚧 in progress
 
 **What:** When the model outputs runnable/renderable content (HTML, SVG, mermaid,
 a code block), render it in a sandboxed preview pane alongside the chat instead of
@@ -366,6 +366,29 @@ safety).
 back a rebuilt component, preview it).
 
 **Privacy:** 🟢 — sandboxed, no network egress (CSP blocks it).
+
+**Implementation plan review (pre-build):**
+
+1. **Artifact detection.** Parse assistant markdown for fenced code blocks that
+   are directly renderable (`html`, `svg`, `mermaid`) or useful as source/code
+   artifacts (`js`, `ts`, `tsx`, `css`, `json`, etc.). Keep raw chat markdown
+   unchanged.
+2. **Canvas surface.** Add a compact artifact launcher on assistant messages,
+   opening a right-side preview sheet. Use a sandboxed iframe for HTML/SVG
+   previews and a source preview for non-renderable code.
+3. **Safety.** No network enablement, no extension privileges, no top-navigation.
+   Generated HTML runs inside `sandbox="allow-scripts"` only; external requests
+   remain blocked by extension CSP and sandbox origin isolation.
+4. **Visible by default.** Show the launcher before long code blocks so users can
+   preview generated artifacts without scrolling to the bottom of the answer.
+5. **Tests.** Cover markdown extraction, preview `srcDoc`, disabled canvas
+   rendering, and assistant-only rendering.
+
+**Implementation status:** v0.11.11 starts with always-on artifact detection and
+a sandboxed preview sheet for HTML/SVG/code blocks inside assistant messages.
+Downloads and richer Mermaid rendering remain follow-ups for E9 / later E7
+polish.
+
 **Effort:** M.
 
 ### E8. Prompt Template Variables & Chaining — 🟢 `v0.11.12`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [
@@ -97,6 +97,7 @@
     "markdown-it-sub": "^2.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-lists": "^2.1.1",
+    "mermaid": "^11.15.0",
     "minisearch": "^7.2.0",
     "next-themes": "^0.4.6",
     "pdfjs-dist": "^4.10.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       markdown-it-task-lists:
         specifier: ^2.1.1
         version: 2.1.1
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0

--- a/src/components/__tests__/markdown-renderer.test.tsx
+++ b/src/components/__tests__/markdown-renderer.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { MarkdownRenderer } from "../markdown-renderer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "chat.actions.copy": "Copy",
+        "chat.actions.copied": "Copied"
+      })[key] ?? key
+  })
+}))
+
+describe("MarkdownRenderer", () => {
+  it("adds copy and preview controls to renderable code blocks", async () => {
+    render(
+      <MarkdownRenderer
+        content={"```html\n<section>Hello preview</section>\n```"}
+      />
+    )
+
+    expect(
+      await screen.findByRole("button", { name: "Copy" })
+    ).toBeInTheDocument()
+    const preview = await screen.findByRole("button", {
+      name: "Preview HTML artifact 1"
+    })
+
+    fireEvent.click(preview)
+
+    const iframe = await screen.findByTitle("HTML artifact 1")
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts")
+    expect(iframe).toHaveAttribute(
+      "srcDoc",
+      expect.stringContaining("Hello preview")
+    )
+  })
+
+  it("does not add preview to plain code blocks", async () => {
+    render(<MarkdownRenderer content={"```\njust notes\n```"} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole("button", { name: /Preview/ })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/markdown-renderer.test.tsx
+++ b/src/components/__tests__/markdown-renderer.test.tsx
@@ -7,7 +7,8 @@ vi.mock("react-i18next", () => ({
     t: (key: string) =>
       ({
         "chat.actions.copy": "Copy",
-        "chat.actions.copied": "Copied"
+        "chat.actions.copied": "Copied",
+        "chat.actions.preview": "Preview"
       })[key] ?? key
   })
 }))
@@ -46,5 +47,17 @@ describe("MarkdownRenderer", () => {
     expect(
       screen.queryByRole("button", { name: /Preview/ })
     ).not.toBeInTheDocument()
+  })
+
+  it("numbers previews by artifacts, not all code blocks", async () => {
+    render(
+      <MarkdownRenderer
+        content={"```\nplain notes\n```\n\n```html\n<section>Hi</section>\n```"}
+      />
+    )
+
+    expect(
+      await screen.findByRole("button", { name: "Preview HTML artifact 1" })
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/markdown-code-block-actions.tsx
+++ b/src/components/markdown-code-block-actions.tsx
@@ -27,8 +27,9 @@ export const MarkdownCodeBlockActions = ({
     const container = containerRef.current
     if (!container || !html) return
 
+    let artifactIndex = 0
     const blocks = Array.from(container.querySelectorAll("pre"))
-    blocks.forEach((pre, index) => {
+    blocks.forEach((pre) => {
       if (pre.parentElement?.dataset.codeBlockShell === "true") return
 
       const code = pre.querySelector("code")
@@ -37,8 +38,9 @@ export const MarkdownCodeBlockActions = ({
       const artifact = createChatArtifactFromCodeBlock({
         code: rawCode,
         language,
-        index: index + 1
+        index: artifactIndex + 1
       })
+      if (artifact) artifactIndex += 1
 
       const shell = document.createElement("div")
       shell.dataset.codeBlockShell = "true"
@@ -63,11 +65,15 @@ export const MarkdownCodeBlockActions = ({
       toolbar.appendChild(copyButton)
 
       if (artifact?.renderable) {
+        const previewLabel = t("chat.actions.preview")
         const previewButton = document.createElement("button")
         previewButton.type = "button"
         previewButton.className = codeActionButtonClass
-        previewButton.textContent = "Preview"
-        previewButton.setAttribute("aria-label", `Preview ${artifact.title}`)
+        previewButton.textContent = previewLabel
+        previewButton.setAttribute(
+          "aria-label",
+          `${previewLabel} ${artifact.title}`
+        )
         previewButton.addEventListener("click", () => {
           setActiveArtifact(artifact)
         })

--- a/src/components/markdown-code-block-actions.tsx
+++ b/src/components/markdown-code-block-actions.tsx
@@ -1,0 +1,102 @@
+import type { RefObject } from "react"
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { ArtifactPreview } from "@/features/chat/components/artifact-preview"
+import { CopyButton } from "@/features/chat/components/copy-button"
+import { PreviewSheet } from "@/features/chat/components/preview-sheet"
+import type { ChatArtifact } from "@/lib/artifacts"
+import { createChatArtifactFromCodeBlock } from "@/lib/artifacts"
+
+const codeActionButtonClass =
+  "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
+
+export const MarkdownCodeBlockActions = ({
+  containerRef,
+  html
+}: {
+  containerRef: RefObject<HTMLDivElement | null>
+  html: string
+}) => {
+  const { t } = useTranslation()
+  const [activeArtifact, setActiveArtifact] = useState<ChatArtifact | null>(
+    null
+  )
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !html) return
+
+    const blocks = Array.from(container.querySelectorAll("pre"))
+    blocks.forEach((pre, index) => {
+      if (pre.parentElement?.dataset.codeBlockShell === "true") return
+
+      const code = pre.querySelector("code")
+      const rawCode = code?.textContent ?? ""
+      const language = pre.dataset.codeLanguage ?? ""
+      const artifact = createChatArtifactFromCodeBlock({
+        code: rawCode,
+        language,
+        index: index + 1
+      })
+
+      const shell = document.createElement("div")
+      shell.dataset.codeBlockShell = "true"
+      shell.className = "group/code relative"
+
+      const toolbar = document.createElement("div")
+      toolbar.className =
+        "not-prose absolute right-1 top-1 z-10 flex items-center gap-1 opacity-80 transition-opacity group-hover/code:opacity-100"
+
+      const copyButton = document.createElement("button")
+      copyButton.type = "button"
+      copyButton.className = codeActionButtonClass
+      copyButton.textContent = t("chat.actions.copy")
+      copyButton.setAttribute("aria-label", t("chat.actions.copy"))
+      copyButton.addEventListener("click", () => {
+        void navigator.clipboard.writeText(rawCode)
+        copyButton.textContent = t("chat.actions.copied")
+        window.setTimeout(() => {
+          copyButton.textContent = t("chat.actions.copy")
+        }, 1500)
+      })
+      toolbar.appendChild(copyButton)
+
+      if (artifact?.renderable) {
+        const previewButton = document.createElement("button")
+        previewButton.type = "button"
+        previewButton.className = codeActionButtonClass
+        previewButton.textContent = "Preview"
+        previewButton.setAttribute("aria-label", `Preview ${artifact.title}`)
+        previewButton.addEventListener("click", () => {
+          setActiveArtifact(artifact)
+        })
+        toolbar.appendChild(previewButton)
+      }
+
+      pre.replaceWith(shell)
+      shell.appendChild(toolbar)
+      shell.appendChild(pre)
+    })
+  }, [containerRef, html, t])
+
+  return (
+    <PreviewSheet
+      open={Boolean(activeArtifact)}
+      onOpenChange={(next) => {
+        if (!next) setActiveArtifact(null)
+      }}
+      title={activeArtifact?.title ?? "Preview"}
+      meta={
+        activeArtifact
+          ? `${activeArtifact.language.toUpperCase()} · ${activeArtifact.content.length.toLocaleString()} chars`
+          : undefined
+      }
+      actions={
+        activeArtifact ? <CopyButton text={activeArtifact.content} /> : null
+      }
+      className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
+      {activeArtifact ? <ArtifactPreview artifact={activeArtifact} /> : null}
+    </PreviewSheet>
+  )
+}

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -1,18 +1,79 @@
-import { useCopyCode as initializeCopyCode } from "markdown-it-copy-code"
-import { useEffect, useRef } from "react"
-
+import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ArtifactPreview } from "@/features/chat/components/artifact-canvas"
+import { CopyButton } from "@/features/chat/components/copy-button"
+import { PreviewSheet } from "@/features/chat/components/preview-sheet"
 import { useMarkdownParser } from "@/hooks/use-markdown-parser"
+import type { ChatArtifact } from "@/lib/artifacts"
+import { createChatArtifactFromCodeBlock } from "@/lib/artifacts"
 import { openExternalUrl, openOptionsInTab, runtime } from "@/lib/browser-api"
 
 export const MarkdownRenderer = ({ content }: { content: string }) => {
+  const { t } = useTranslation()
   const html = useMarkdownParser(content)
   const containerRef = useRef<HTMLDivElement>(null)
+  const [activeArtifact, setActiveArtifact] = useState<ChatArtifact | null>(
+    null
+  )
 
   useEffect(() => {
-    if (containerRef.current) {
-      initializeCopyCode()
-    }
-  }, [])
+    const container = containerRef.current
+    if (!container || !html) return
+
+    const blocks = Array.from(container.querySelectorAll("pre"))
+    blocks.forEach((pre, index) => {
+      if (pre.parentElement?.dataset.codeBlockShell === "true") return
+
+      const code = pre.querySelector("code")
+      const rawCode = code?.textContent ?? ""
+      const language = pre.dataset.codeLanguage ?? ""
+      const artifact = createChatArtifactFromCodeBlock({
+        code: rawCode,
+        language,
+        index: index + 1
+      })
+
+      const shell = document.createElement("div")
+      shell.dataset.codeBlockShell = "true"
+      shell.className = "group/code relative"
+
+      const toolbar = document.createElement("div")
+      toolbar.className =
+        "not-prose absolute right-1 top-1 z-10 flex items-center gap-1 opacity-80 transition-opacity group-hover/code:opacity-100"
+
+      const copyButton = document.createElement("button")
+      copyButton.type = "button"
+      copyButton.className =
+        "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
+      copyButton.textContent = t("chat.actions.copy")
+      copyButton.setAttribute("aria-label", t("chat.actions.copy"))
+      copyButton.addEventListener("click", () => {
+        void navigator.clipboard.writeText(rawCode)
+        copyButton.textContent = t("chat.actions.copied")
+        window.setTimeout(() => {
+          copyButton.textContent = t("chat.actions.copy")
+        }, 1500)
+      })
+      toolbar.appendChild(copyButton)
+
+      if (artifact?.renderable) {
+        const previewButton = document.createElement("button")
+        previewButton.type = "button"
+        previewButton.className =
+          "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
+        previewButton.textContent = "Preview"
+        previewButton.setAttribute("aria-label", `Preview ${artifact.title}`)
+        previewButton.addEventListener("click", () => {
+          setActiveArtifact(artifact)
+        })
+        toolbar.appendChild(previewButton)
+      }
+
+      pre.replaceWith(shell)
+      shell.appendChild(toolbar)
+      shell.appendChild(pre)
+    })
+  }, [html, t])
 
   useEffect(() => {
     const container = containerRef.current
@@ -46,11 +107,30 @@ export const MarkdownRenderer = ({ content }: { content: string }) => {
   }, [])
 
   return (
-    <div
-      ref={containerRef}
-      className="markdown-container prose prose-sm max-w-none wrap-break-word px-2 py-1 dark:prose-invert [&_code]:wrap-break-word [&_code]:whitespace-pre-wrap [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_pre]:text-xs [&_pre_code]:text-foreground [&_table]:block [&_table]:overflow-x-auto"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized by DOMPurify in useMarkdownParser
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <>
+      <div
+        ref={containerRef}
+        className="markdown-container prose prose-sm max-w-none wrap-break-word px-2 py-1 dark:prose-invert [&_code]:wrap-break-word [&_code]:whitespace-pre-wrap [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_pre]:text-xs [&_pre_code]:text-foreground [&_table]:block [&_table]:overflow-x-auto"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized by DOMPurify in useMarkdownParser
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <PreviewSheet
+        open={Boolean(activeArtifact)}
+        onOpenChange={(next) => {
+          if (!next) setActiveArtifact(null)
+        }}
+        title={activeArtifact?.title ?? "Preview"}
+        meta={
+          activeArtifact
+            ? `${activeArtifact.language.toUpperCase()} · ${activeArtifact.content.length.toLocaleString()} chars`
+            : undefined
+        }
+        actions={
+          activeArtifact ? <CopyButton text={activeArtifact.content} /> : null
+        }
+        className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
+        {activeArtifact ? <ArtifactPreview artifact={activeArtifact} /> : null}
+      </PreviewSheet>
+    </>
   )
 }

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -1,79 +1,11 @@
-import { useEffect, useRef, useState } from "react"
-import { useTranslation } from "react-i18next"
-import { ArtifactPreview } from "@/features/chat/components/artifact-canvas"
-import { CopyButton } from "@/features/chat/components/copy-button"
-import { PreviewSheet } from "@/features/chat/components/preview-sheet"
+import { useEffect, useRef } from "react"
 import { useMarkdownParser } from "@/hooks/use-markdown-parser"
-import type { ChatArtifact } from "@/lib/artifacts"
-import { createChatArtifactFromCodeBlock } from "@/lib/artifacts"
 import { openExternalUrl, openOptionsInTab, runtime } from "@/lib/browser-api"
+import { MarkdownCodeBlockActions } from "./markdown-code-block-actions"
 
 export const MarkdownRenderer = ({ content }: { content: string }) => {
-  const { t } = useTranslation()
   const html = useMarkdownParser(content)
   const containerRef = useRef<HTMLDivElement>(null)
-  const [activeArtifact, setActiveArtifact] = useState<ChatArtifact | null>(
-    null
-  )
-
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container || !html) return
-
-    const blocks = Array.from(container.querySelectorAll("pre"))
-    blocks.forEach((pre, index) => {
-      if (pre.parentElement?.dataset.codeBlockShell === "true") return
-
-      const code = pre.querySelector("code")
-      const rawCode = code?.textContent ?? ""
-      const language = pre.dataset.codeLanguage ?? ""
-      const artifact = createChatArtifactFromCodeBlock({
-        code: rawCode,
-        language,
-        index: index + 1
-      })
-
-      const shell = document.createElement("div")
-      shell.dataset.codeBlockShell = "true"
-      shell.className = "group/code relative"
-
-      const toolbar = document.createElement("div")
-      toolbar.className =
-        "not-prose absolute right-1 top-1 z-10 flex items-center gap-1 opacity-80 transition-opacity group-hover/code:opacity-100"
-
-      const copyButton = document.createElement("button")
-      copyButton.type = "button"
-      copyButton.className =
-        "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
-      copyButton.textContent = t("chat.actions.copy")
-      copyButton.setAttribute("aria-label", t("chat.actions.copy"))
-      copyButton.addEventListener("click", () => {
-        void navigator.clipboard.writeText(rawCode)
-        copyButton.textContent = t("chat.actions.copied")
-        window.setTimeout(() => {
-          copyButton.textContent = t("chat.actions.copy")
-        }, 1500)
-      })
-      toolbar.appendChild(copyButton)
-
-      if (artifact?.renderable) {
-        const previewButton = document.createElement("button")
-        previewButton.type = "button"
-        previewButton.className =
-          "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
-        previewButton.textContent = "Preview"
-        previewButton.setAttribute("aria-label", `Preview ${artifact.title}`)
-        previewButton.addEventListener("click", () => {
-          setActiveArtifact(artifact)
-        })
-        toolbar.appendChild(previewButton)
-      }
-
-      pre.replaceWith(shell)
-      shell.appendChild(toolbar)
-      shell.appendChild(pre)
-    })
-  }, [html, t])
 
   useEffect(() => {
     const container = containerRef.current
@@ -114,23 +46,7 @@ export const MarkdownRenderer = ({ content }: { content: string }) => {
         // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized by DOMPurify in useMarkdownParser
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      <PreviewSheet
-        open={Boolean(activeArtifact)}
-        onOpenChange={(next) => {
-          if (!next) setActiveArtifact(null)
-        }}
-        title={activeArtifact?.title ?? "Preview"}
-        meta={
-          activeArtifact
-            ? `${activeArtifact.language.toUpperCase()} · ${activeArtifact.content.length.toLocaleString()} chars`
-            : undefined
-        }
-        actions={
-          activeArtifact ? <CopyButton text={activeArtifact.content} /> : null
-        }
-        className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
-        {activeArtifact ? <ArtifactPreview artifact={activeArtifact} /> : null}
-      </PreviewSheet>
+      <MarkdownCodeBlockActions containerRef={containerRef} html={html} />
     </>
   )
 }

--- a/src/features/chat/components/__tests__/artifact-canvas.test.tsx
+++ b/src/features/chat/components/__tests__/artifact-canvas.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type { ChatArtifact } from "@/lib/artifacts"
+import { ArtifactCanvas, previewSrcDoc } from "../artifact-canvas"
+
+const mermaidMock = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn(async () => ({
+    svg: '<svg role="img"><text>Rendered Mermaid</text></svg>'
+  }))
+}))
+
+vi.mock("mermaid", () => ({
+  default: mermaidMock
+}))
+
+describe("ArtifactCanvas", () => {
+  it("renders nothing when disabled", () => {
+    const { container } = render(
+      <ArtifactCanvas
+        enabled={false}
+        content={"```html\n<h1>Hello</h1>\n```"}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("opens a sandboxed preview for renderable artifacts", () => {
+    render(
+      <ArtifactCanvas
+        enabled
+        content={"```html\n<section>Hello artifact</section>\n```"}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Preview HTML artifact 1/ })
+    )
+
+    const iframe = screen.getByTitle("HTML artifact 1")
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts")
+    expect(iframe).toHaveAttribute(
+      "srcDoc",
+      expect.stringContaining("Hello artifact")
+    )
+  })
+
+  it("shows source preview for code artifacts", () => {
+    render(<ArtifactCanvas enabled content={"```ts\nconst value = 1\n```"} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Open ts artifact 1/i }))
+
+    expect(screen.getByText("const value = 1")).toBeInTheDocument()
+  })
+
+  it("renders Mermaid artifacts as diagrams", async () => {
+    render(
+      <ArtifactCanvas
+        enabled
+        content={"```mermaid\ngraph TD\n  A --> B\n```"}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Preview Mermaid diagram 1/i })
+    )
+
+    expect(await screen.findByTestId("mermaid-preview")).toContainHTML(
+      "Rendered Mermaid"
+    )
+    expect(mermaidMock.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({ securityLevel: "strict" })
+    )
+    expect(mermaidMock.render).toHaveBeenCalledWith(
+      expect.stringContaining("artifact-mermaid-1"),
+      "graph TD\n  A --> B"
+    )
+  })
+})
+
+describe("previewSrcDoc", () => {
+  it("removes default document margin and body padding from HTML previews", () => {
+    const artifact: ChatArtifact = {
+      id: "html-1",
+      kind: "html",
+      language: "html",
+      title: "HTML artifact 1",
+      content:
+        "<!doctype html><html><head><style>body{padding:20px}</style></head><body>Hello</body></html>",
+      renderable: true
+    }
+
+    expect(previewSrcDoc(artifact)).toContain(
+      "margin:0!important;padding:0!important"
+    )
+  })
+
+  it("blocks link and form navigation inside HTML previews", () => {
+    const artifact: ChatArtifact = {
+      id: "html-1",
+      kind: "html",
+      language: "html",
+      title: "HTML artifact 1",
+      content: '<a href="/next">Next</a><form></form>',
+      renderable: true
+    }
+
+    expect(previewSrcDoc(artifact)).toContain(
+      'document.addEventListener("click"'
+    )
+    expect(previewSrcDoc(artifact)).toContain(
+      'document.addEventListener("submit"'
+    )
+  })
+
+  it("wraps SVG with a restrictive CSP document", () => {
+    const artifact: ChatArtifact = {
+      id: "svg-1",
+      kind: "svg",
+      language: "svg",
+      title: "SVG artifact 1",
+      content: "<svg></svg>",
+      renderable: true
+    }
+
+    expect(previewSrcDoc(artifact)).toContain("Content-Security-Policy")
+    expect(previewSrcDoc(artifact)).toContain("<svg></svg>")
+  })
+})

--- a/src/features/chat/components/__tests__/artifact-preview.test.tsx
+++ b/src/features/chat/components/__tests__/artifact-preview.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import type { ChatArtifact } from "@/lib/artifacts"
-import { ArtifactCanvas, previewSrcDoc } from "../artifact-canvas"
+import { ArtifactPreview, previewSrcDoc } from "../artifact-preview"
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -14,28 +14,19 @@ vi.mock("mermaid", () => ({
   default: mermaidMock
 }))
 
-describe("ArtifactCanvas", () => {
-  it("renders nothing when disabled", () => {
-    const { container } = render(
-      <ArtifactCanvas
-        enabled={false}
-        content={"```html\n<h1>Hello</h1>\n```"}
-      />
-    )
-
-    expect(container).toBeEmptyDOMElement()
-  })
-
-  it("opens a sandboxed preview for renderable artifacts", () => {
+describe("ArtifactPreview", () => {
+  it("renders a sandboxed iframe for HTML artifacts", () => {
     render(
-      <ArtifactCanvas
-        enabled
-        content={"```html\n<section>Hello artifact</section>\n```"}
+      <ArtifactPreview
+        artifact={{
+          id: "html-1",
+          kind: "html",
+          language: "html",
+          title: "HTML artifact 1",
+          content: "<section>Hello artifact</section>",
+          renderable: true
+        }}
       />
-    )
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /Preview HTML artifact 1/ })
     )
 
     const iframe = screen.getByTitle("HTML artifact 1")
@@ -47,23 +38,34 @@ describe("ArtifactCanvas", () => {
   })
 
   it("shows source preview for code artifacts", () => {
-    render(<ArtifactCanvas enabled content={"```ts\nconst value = 1\n```"} />)
-
-    fireEvent.click(screen.getByRole("button", { name: /Open ts artifact 1/i }))
+    render(
+      <ArtifactPreview
+        artifact={{
+          id: "code-1",
+          kind: "code",
+          language: "ts",
+          title: "ts artifact 1",
+          content: "const value = 1",
+          renderable: false
+        }}
+      />
+    )
 
     expect(screen.getByText("const value = 1")).toBeInTheDocument()
   })
 
   it("renders Mermaid artifacts as diagrams", async () => {
     render(
-      <ArtifactCanvas
-        enabled
-        content={"```mermaid\ngraph TD\n  A --> B\n```"}
+      <ArtifactPreview
+        artifact={{
+          id: "mermaid-1",
+          kind: "mermaid",
+          language: "mermaid",
+          title: "Mermaid diagram 1",
+          content: "graph TD\n  A --> B",
+          renderable: true
+        }}
       />
-    )
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /Preview Mermaid diagram 1/i })
     )
 
     expect(await screen.findByTestId("mermaid-preview")).toContainHTML(

--- a/src/features/chat/components/__tests__/artifact-preview.test.tsx
+++ b/src/features/chat/components/__tests__/artifact-preview.test.tsx
@@ -75,7 +75,7 @@ describe("ArtifactPreview", () => {
       expect.objectContaining({ securityLevel: "strict" })
     )
     expect(mermaidMock.render).toHaveBeenCalledWith(
-      expect.stringContaining("artifact-mermaid-1"),
+      expect.stringMatching(/^artifact-mermaid-1-[a-z0-9]+$/),
       "graph TD\n  A --> B"
     )
   })
@@ -96,6 +96,7 @@ describe("previewSrcDoc", () => {
     expect(previewSrcDoc(artifact)).toContain(
       "margin:0!important;padding:0!important"
     )
+    expect(previewSrcDoc(artifact)).toContain("Content-Security-Policy")
   })
 
   it("blocks link and form navigation inside HTML previews", () => {

--- a/src/features/chat/components/__tests__/chat-message-content.test.tsx
+++ b/src/features/chat/components/__tests__/chat-message-content.test.tsx
@@ -46,4 +46,15 @@ describe("ChatMessageContent", () => {
     )
     expect(screen.queryByText("Typing")).not.toBeInTheDocument()
   })
+
+  it("renders message markdown content", () => {
+    render(
+      <ChatMessageContent
+        msg={{ role: "assistant", content: "Hello **there**" }}
+        isUser={false}
+      />
+    )
+
+    expect(screen.getByText("Hello **there**")).toBeInTheDocument()
+  })
 })

--- a/src/features/chat/components/artifact-canvas.tsx
+++ b/src/features/chat/components/artifact-canvas.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import type { ChatArtifact } from "@/lib/artifacts"
+import { extractChatArtifacts } from "@/lib/artifacts"
+import { Code, Eye, Sparkles } from "@/lib/lucide-icon"
+import { cn } from "@/lib/utils"
+import { CopyButton } from "./copy-button"
+import { PreviewSheet, PreviewTextBlock } from "./preview-sheet"
+
+const PREVIEW_RESET_STYLE =
+  "<style>html,body{margin:0!important;padding:0!important;min-height:100%;}</style>"
+const PREVIEW_NAVIGATION_GUARD = `<script>(()=>{const scrollToHash=(hash)=>{try{const id=decodeURIComponent(hash.slice(1));const target=document.getElementById(id)||document.getElementsByName(id)[0];if(target)target.scrollIntoView({block:"start"});}catch{}};document.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target:null;const link=target?.closest("a[href]");if(!link)return;const href=link.getAttribute("href")||"";event.preventDefault();event.stopPropagation();if(href.startsWith("#")&&href.length>1)scrollToHash(href);},true);document.addEventListener("submit",(event)=>{event.preventDefault();event.stopPropagation();},true);window.open=()=>null;})();</script>`
+
+const withPreviewChrome = (html: string): string => {
+  let next = html
+  if (/<\/head>/i.test(html)) {
+    next = next.replace(/<\/head>/i, `${PREVIEW_RESET_STYLE}</head>`)
+  } else {
+    next = `${PREVIEW_RESET_STYLE}${next}`
+  }
+  if (/<\/body>/i.test(next)) {
+    return next.replace(/<\/body>/i, `${PREVIEW_NAVIGATION_GUARD}</body>`)
+  }
+  return `${next}${PREVIEW_NAVIGATION_GUARD}`
+}
+
+const previewSrcDoc = (artifact: ChatArtifact): string => {
+  const csp = [
+    "default-src 'none'",
+    "img-src data: blob:",
+    "style-src 'unsafe-inline'",
+    "script-src 'unsafe-inline'"
+  ].join("; ")
+
+  if (artifact.kind === "svg") {
+    return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{margin:0;min-height:100%;background:#fff;color:#111;display:grid;place-items:center}svg{max-width:100%;max-height:100vh}</style></head><body>${artifact.content}</body></html>`
+  }
+
+  if (/^\s*<!doctype html\b|^\s*<html[\s>]/i.test(artifact.content)) {
+    return withPreviewChrome(artifact.content)
+  }
+
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}">${PREVIEW_RESET_STYLE}</head><body>${artifact.content}${PREVIEW_NAVIGATION_GUARD}</body></html>`
+}
+
+const svgPreviewSrcDoc = (svg: string): string => {
+  const csp =
+    "default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'"
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{margin:0;min-height:100%;background:#fff;color:#0f172a;display:grid;place-items:center}svg{max-width:100%;height:auto}</style></head><body>${svg}</body></html>`
+}
+
+const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
+  const [svg, setSvg] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const renderId = useMemo(
+    () => `artifact-${artifact.id}-${artifact.content.length}`,
+    [artifact]
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    const render = async () => {
+      setSvg(null)
+      setError(null)
+
+      try {
+        const { default: mermaid } = await import("mermaid")
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: "base",
+          themeVariables: {
+            background: "#ffffff",
+            primaryColor: "#e0f2fe",
+            primaryTextColor: "#0f172a",
+            primaryBorderColor: "#0284c7",
+            lineColor: "#475569",
+            textColor: "#0f172a"
+          }
+        })
+
+        const result = await mermaid.render(renderId, artifact.content)
+        if (!cancelled) setSvg(result.svg)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      }
+    }
+
+    void render()
+
+    return () => {
+      cancelled = true
+    }
+  }, [artifact, renderId])
+
+  if (error) {
+    return (
+      <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
+        <PreviewTextBlock
+          text={`Mermaid render failed:\n\n${error}\n\nSource:\n${artifact.content}`}
+          emptyText="No Mermaid content"
+          className="font-mono text-[11px]"
+        />
+      </ScrollArea>
+    )
+  }
+
+  if (!svg) {
+    return (
+      <div className="grid min-h-96 flex-1 place-items-center text-sm text-muted-foreground">
+        Rendering Mermaid diagram...
+      </div>
+    )
+  }
+
+  return (
+    <iframe
+      title={`${artifact.title} preview`}
+      sandbox=""
+      srcDoc={svgPreviewSrcDoc(svg)}
+      className="h-full min-h-96 w-full flex-1 border-0 bg-white"
+      data-testid="mermaid-preview"
+    />
+  )
+}
+
+export const ArtifactPreview = ({ artifact }: { artifact: ChatArtifact }) => {
+  if (artifact.kind === "mermaid") {
+    return <MermaidPreview artifact={artifact} />
+  }
+
+  if (artifact.renderable) {
+    return (
+      <iframe
+        title={artifact.title}
+        sandbox="allow-scripts"
+        srcDoc={previewSrcDoc(artifact)}
+        className="h-full min-h-96 w-full flex-1 border-0 bg-white"
+      />
+    )
+  }
+
+  return (
+    <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
+      <PreviewTextBlock
+        text={artifact.content}
+        emptyText="No artifact content"
+        className="font-mono text-[11px]"
+      />
+    </ScrollArea>
+  )
+}
+
+export const ArtifactCanvas = ({
+  content,
+  enabled,
+  className
+}: {
+  content: string
+  enabled: boolean
+  className?: string
+}) => {
+  const artifacts = useMemo(() => extractChatArtifacts(content), [content])
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  if (!enabled || artifacts.length === 0) return null
+
+  const active = artifacts.find((artifact) => artifact.id === activeId) ?? null
+
+  return (
+    <div className={cn("not-prose mt-2 flex flex-wrap gap-1.5", className)}>
+      {artifacts.map((artifact) => (
+        <Button
+          key={artifact.id}
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="h-7 gap-1.5 rounded-chip px-2 text-xs"
+          onClick={() => setActiveId(artifact.id)}>
+          {artifact.renderable ? (
+            <Eye className="icon-xs" />
+          ) : (
+            <Code className="icon-xs" />
+          )}
+          <span className="max-w-44 truncate">
+            {artifact.renderable ? "Preview" : "Open"} {artifact.title}
+          </span>
+        </Button>
+      ))}
+      <PreviewSheet
+        open={Boolean(active)}
+        onOpenChange={(next) => {
+          if (!next) setActiveId(null)
+        }}
+        title={active?.title ?? "Artifact"}
+        meta={
+          active
+            ? `${active.language.toUpperCase()} · ${active.content.length.toLocaleString()} chars`
+            : undefined
+        }
+        actions={active ? <CopyButton text={active.content} /> : undefined}
+        className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
+        {active ? (
+          <ArtifactPreview artifact={active} />
+        ) : (
+          <div className="grid min-h-64 place-items-center text-muted-foreground">
+            <Sparkles className="icon-lg" />
+          </div>
+        )}
+      </PreviewSheet>
+    </div>
+  )
+}
+
+export { previewSrcDoc }

--- a/src/features/chat/components/artifact-preview.tsx
+++ b/src/features/chat/components/artifact-preview.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
-import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { ChatArtifact } from "@/lib/artifacts"
-import { extractChatArtifacts } from "@/lib/artifacts"
-import { Code, Eye, Sparkles } from "@/lib/lucide-icon"
-import { cn } from "@/lib/utils"
-import { CopyButton } from "./copy-button"
-import { PreviewSheet, PreviewTextBlock } from "./preview-sheet"
+import { PreviewTextBlock } from "./preview-sheet"
 
 const PREVIEW_RESET_STYLE =
   "<style>html,body{margin:0!important;padding:0!important;min-height:100%;}</style>"
@@ -152,67 +147,6 @@ export const ArtifactPreview = ({ artifact }: { artifact: ChatArtifact }) => {
         className="font-mono text-[11px]"
       />
     </ScrollArea>
-  )
-}
-
-export const ArtifactCanvas = ({
-  content,
-  enabled,
-  className
-}: {
-  content: string
-  enabled: boolean
-  className?: string
-}) => {
-  const artifacts = useMemo(() => extractChatArtifacts(content), [content])
-  const [activeId, setActiveId] = useState<string | null>(null)
-
-  if (!enabled || artifacts.length === 0) return null
-
-  const active = artifacts.find((artifact) => artifact.id === activeId) ?? null
-
-  return (
-    <div className={cn("not-prose mt-2 flex flex-wrap gap-1.5", className)}>
-      {artifacts.map((artifact) => (
-        <Button
-          key={artifact.id}
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="h-7 gap-1.5 rounded-chip px-2 text-xs"
-          onClick={() => setActiveId(artifact.id)}>
-          {artifact.renderable ? (
-            <Eye className="icon-xs" />
-          ) : (
-            <Code className="icon-xs" />
-          )}
-          <span className="max-w-44 truncate">
-            {artifact.renderable ? "Preview" : "Open"} {artifact.title}
-          </span>
-        </Button>
-      ))}
-      <PreviewSheet
-        open={Boolean(active)}
-        onOpenChange={(next) => {
-          if (!next) setActiveId(null)
-        }}
-        title={active?.title ?? "Artifact"}
-        meta={
-          active
-            ? `${active.language.toUpperCase()} · ${active.content.length.toLocaleString()} chars`
-            : undefined
-        }
-        actions={active ? <CopyButton text={active.content} /> : undefined}
-        className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
-        {active ? (
-          <ArtifactPreview artifact={active} />
-        ) : (
-          <div className="grid min-h-64 place-items-center text-muted-foreground">
-            <Sparkles className="icon-lg" />
-          </div>
-        )}
-      </PreviewSheet>
-    </div>
   )
 }
 

--- a/src/features/chat/components/artifact-preview.tsx
+++ b/src/features/chat/components/artifact-preview.tsx
@@ -6,13 +6,33 @@ import { PreviewTextBlock } from "./preview-sheet"
 const PREVIEW_RESET_STYLE =
   "<style>html,body{margin:0!important;padding:0!important;min-height:100%;}</style>"
 const PREVIEW_NAVIGATION_GUARD = `<script>(()=>{const scrollToHash=(hash)=>{try{const id=decodeURIComponent(hash.slice(1));const target=document.getElementById(id)||document.getElementsByName(id)[0];if(target)target.scrollIntoView({block:"start"});}catch{}};document.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target:null;const link=target?.closest("a[href]");if(!link)return;const href=link.getAttribute("href")||"";event.preventDefault();event.stopPropagation();if(href.startsWith("#")&&href.length>1)scrollToHash(href);},true);document.addEventListener("submit",(event)=>{event.preventDefault();event.stopPropagation();},true);window.open=()=>null;})();</script>`
+const PREVIEW_CSP = [
+  "default-src 'none'",
+  "img-src data: blob:",
+  "style-src 'unsafe-inline'",
+  "script-src 'unsafe-inline'"
+].join("; ")
+const PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}">`
+
+let mermaidInitialized = false
+
+const hashContent = (content: string): string => {
+  let hash = 5381
+  for (let i = 0; i < content.length; i += 1) {
+    hash = ((hash << 5) + hash) ^ content.charCodeAt(i)
+  }
+  return (hash >>> 0).toString(36)
+}
 
 const withPreviewChrome = (html: string): string => {
   let next = html
   if (/<\/head>/i.test(html)) {
-    next = next.replace(/<\/head>/i, `${PREVIEW_RESET_STYLE}</head>`)
+    next = next.replace(
+      /<\/head>/i,
+      `${PREVIEW_CSP_META}${PREVIEW_RESET_STYLE}</head>`
+    )
   } else {
-    next = `${PREVIEW_RESET_STYLE}${next}`
+    next = `${PREVIEW_CSP_META}${PREVIEW_RESET_STYLE}${next}`
   }
   if (/<\/body>/i.test(next)) {
     return next.replace(/<\/body>/i, `${PREVIEW_NAVIGATION_GUARD}</body>`)
@@ -21,22 +41,15 @@ const withPreviewChrome = (html: string): string => {
 }
 
 const previewSrcDoc = (artifact: ChatArtifact): string => {
-  const csp = [
-    "default-src 'none'",
-    "img-src data: blob:",
-    "style-src 'unsafe-inline'",
-    "script-src 'unsafe-inline'"
-  ].join("; ")
-
   if (artifact.kind === "svg") {
-    return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{margin:0;min-height:100%;background:#fff;color:#111;display:grid;place-items:center}svg{max-width:100%;max-height:100vh}</style></head><body>${artifact.content}</body></html>`
+    return `<!doctype html><html><head><meta charset="utf-8">${PREVIEW_CSP_META}<style>html,body{margin:0;min-height:100%;background:#fff;color:#111;display:grid;place-items:center}svg{max-width:100%;max-height:100vh}</style></head><body>${artifact.content}</body></html>`
   }
 
   if (/^\s*<!doctype html\b|^\s*<html[\s>]/i.test(artifact.content)) {
     return withPreviewChrome(artifact.content)
   }
 
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}">${PREVIEW_RESET_STYLE}</head><body>${artifact.content}${PREVIEW_NAVIGATION_GUARD}</body></html>`
+  return `<!doctype html><html><head><meta charset="utf-8">${PREVIEW_CSP_META}${PREVIEW_RESET_STYLE}</head><body>${artifact.content}${PREVIEW_NAVIGATION_GUARD}</body></html>`
 }
 
 const svgPreviewSrcDoc = (svg: string): string => {
@@ -49,7 +62,7 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const renderId = useMemo(
-    () => `artifact-${artifact.id}-${artifact.content.length}`,
+    () => `artifact-${artifact.id}-${hashContent(artifact.content)}`,
     [artifact]
   )
 
@@ -62,19 +75,22 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
 
       try {
         const { default: mermaid } = await import("mermaid")
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: "strict",
-          theme: "base",
-          themeVariables: {
-            background: "#ffffff",
-            primaryColor: "#e0f2fe",
-            primaryTextColor: "#0f172a",
-            primaryBorderColor: "#0284c7",
-            lineColor: "#475569",
-            textColor: "#0f172a"
-          }
-        })
+        if (!mermaidInitialized) {
+          mermaid.initialize({
+            startOnLoad: false,
+            securityLevel: "strict",
+            theme: "base",
+            themeVariables: {
+              background: "#ffffff",
+              primaryColor: "#e0f2fe",
+              primaryTextColor: "#0f172a",
+              primaryBorderColor: "#0284c7",
+              lineColor: "#475569",
+              textColor: "#0f172a"
+            }
+          })
+          mermaidInitialized = true
+        }
 
         const result = await mermaid.render(renderId, artifact.content)
         if (!cancelled) setSvg(result.svg)

--- a/src/features/permissions/components/permissions-panel.tsx
+++ b/src/features/permissions/components/permissions-panel.tsx
@@ -67,7 +67,6 @@ const FLAG_LABELS: Record<FeatureFlag, string> = {
   bookmarksHistoryRag: "Bookmarks & history knowledge",
   perSiteProfiles: "Per-site context profiles",
   tabGroups: "Tab-group workflows",
-  artifactsCanvas: "Artifacts / output canvas",
   templateChaining: "Template variables & chaining",
   downloads: "Save generated artifacts",
   browserTools: "Browser actions as tools"

--- a/src/hooks/use-markdown-parser.ts
+++ b/src/hooks/use-markdown-parser.ts
@@ -1,7 +1,6 @@
 import DOMPurify from "dompurify"
 import MarkdownIt from "markdown-it"
 import container from "markdown-it-container"
-import MarkdownItCopyCode from "markdown-it-copy-code"
 import deflist from "markdown-it-deflist"
 import { full as emoji } from "markdown-it-emoji"
 import footnote from "markdown-it-footnote"
@@ -13,9 +12,6 @@ import { useEffect, useMemo, useState } from "react"
 
 import { hljs } from "@/lib/hljs"
 
-import "markdown-it-copy-code/styles/base.css"
-import "markdown-it-copy-code/styles/small.css"
-
 export const useMarkdownParser = (markdown: string) => {
   const md = useMemo(() => {
     const instance = new MarkdownIt({
@@ -23,9 +19,11 @@ export const useMarkdownParser = (markdown: string) => {
       linkify: true,
       typographer: true,
       highlight(str, lang) {
+        const safeLang = instance.utils.escapeHtml(lang || "")
+        const langAttrs = safeLang ? ` data-code-language="${safeLang}"` : ""
         if (lang && hljs.getLanguage(lang)) {
           try {
-            return `<pre class="hljs"><code>${
+            return `<pre class="hljs"${langAttrs}><code class="language-${safeLang}">${
               hljs.highlight(str, {
                 language: lang,
                 ignoreIllegals: true
@@ -33,7 +31,7 @@ export const useMarkdownParser = (markdown: string) => {
             }</code></pre>`
           } catch {}
         }
-        return `<pre class="hljs"><code>${instance.utils.escapeHtml(str)}</code></pre>`
+        return `<pre class="hljs"${langAttrs}><code>${instance.utils.escapeHtml(str)}</code></pre>`
       }
     })
 
@@ -43,7 +41,6 @@ export const useMarkdownParser = (markdown: string) => {
       .use(container, "info")
       .use(container, "warning")
       .use(emoji)
-      .use(MarkdownItCopyCode)
       .use(markdownItMark)
       .use(deflist)
       .use(sub)

--- a/src/lib/__tests__/artifacts.test.ts
+++ b/src/lib/__tests__/artifacts.test.ts
@@ -63,4 +63,14 @@ plain
 `)
     ).toEqual([])
   })
+
+  it("does not treat generic XML as SVG", () => {
+    expect(
+      extractChatArtifacts(`
+\`\`\`xml
+<rss><channel><title>Feed</title></channel></rss>
+\`\`\`
+`)
+    ).toEqual([])
+  })
 })

--- a/src/lib/__tests__/artifacts.test.ts
+++ b/src/lib/__tests__/artifacts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import { extractChatArtifacts } from "@/lib/artifacts"
+
+describe("extractChatArtifacts", () => {
+  it("extracts renderable HTML, SVG, and Mermaid fenced blocks", () => {
+    const artifacts = extractChatArtifacts(`
+Text
+\`\`\`html
+<main><h1>Hello</h1></main>
+\`\`\`
+
+\`\`\`svg
+<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" /></svg>
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  A --> B
+\`\`\`
+`)
+
+    expect(artifacts).toHaveLength(3)
+    expect(artifacts[0]).toMatchObject({
+      kind: "html",
+      language: "html",
+      renderable: true
+    })
+    expect(artifacts[1]).toMatchObject({
+      kind: "svg",
+      language: "svg",
+      renderable: true
+    })
+    expect(artifacts[2]).toMatchObject({
+      kind: "mermaid",
+      language: "mermaid",
+      renderable: true
+    })
+  })
+
+  it("keeps non-renderable code artifacts as source previews", () => {
+    const artifacts = extractChatArtifacts(`
+\`\`\`ts
+export const value = 1
+\`\`\`
+`)
+
+    expect(artifacts).toEqual([
+      expect.objectContaining({
+        kind: "code",
+        language: "ts",
+        renderable: false,
+        content: "export const value = 1"
+      })
+    ])
+  })
+
+  it("ignores unsupported fences", () => {
+    expect(
+      extractChatArtifacts(`
+\`\`\`
+plain
+\`\`\`
+`)
+    ).toEqual([])
+  })
+})

--- a/src/lib/artifacts.ts
+++ b/src/lib/artifacts.ts
@@ -14,7 +14,6 @@ const MAX_ARTIFACT_CHARS = 120_000
 
 const LANGUAGE_ALIASES: Record<string, string> = {
   htm: "html",
-  xml: "svg",
   mmd: "mermaid",
   javascript: "js",
   typescript: "ts"

--- a/src/lib/artifacts.ts
+++ b/src/lib/artifacts.ts
@@ -1,0 +1,107 @@
+export type ArtifactKind = "html" | "svg" | "mermaid" | "code"
+
+export interface ChatArtifact {
+  id: string
+  kind: ArtifactKind
+  language: string
+  title: string
+  content: string
+  renderable: boolean
+}
+
+const FENCED_CODE_BLOCK_RE = /```([^\n`]*)\n([\s\S]*?)```/g
+const MAX_ARTIFACT_CHARS = 120_000
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  htm: "html",
+  xml: "svg",
+  mmd: "mermaid",
+  javascript: "js",
+  typescript: "ts"
+}
+
+const CODE_LANGUAGES = new Set([
+  "css",
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "json",
+  "python",
+  "py",
+  "bash",
+  "sh",
+  "sql",
+  "rust",
+  "go",
+  "java",
+  "kotlin",
+  "swift",
+  "php",
+  "ruby",
+  "yaml",
+  "yml"
+])
+
+const normalizeLanguage = (raw: string): string => {
+  const token = raw.trim().split(/\s+/)[0]?.toLowerCase() ?? ""
+  return LANGUAGE_ALIASES[token] ?? token
+}
+
+const inferKind = (language: string, content: string): ArtifactKind | null => {
+  const trimmed = content.trimStart()
+  if (language === "html" || /^<!doctype html\b|^<html[\s>]/i.test(trimmed)) {
+    return "html"
+  }
+  if (language === "svg" || /^<svg[\s>]/i.test(trimmed)) return "svg"
+  if (language === "mermaid") return "mermaid"
+  if (CODE_LANGUAGES.has(language)) return "code"
+  return null
+}
+
+const titleFor = (kind: ArtifactKind, language: string, index: number) => {
+  if (kind === "html") return `HTML artifact ${index}`
+  if (kind === "svg") return `SVG artifact ${index}`
+  if (kind === "mermaid") return `Mermaid diagram ${index}`
+  return `${language || "Code"} artifact ${index}`
+}
+
+export const createChatArtifactFromCodeBlock = ({
+  code,
+  language,
+  index
+}: {
+  code: string
+  language: string
+  index: number
+}): ChatArtifact | null => {
+  const normalizedLanguage = normalizeLanguage(language)
+  const content = code.trim()
+  if (!content) return null
+
+  const kind = inferKind(normalizedLanguage, content)
+  if (!kind) return null
+
+  return {
+    id: `${kind}-${index}`,
+    kind,
+    language: normalizedLanguage || kind,
+    title: titleFor(kind, normalizedLanguage, index),
+    content: content.slice(0, MAX_ARTIFACT_CHARS),
+    renderable: kind === "html" || kind === "svg" || kind === "mermaid"
+  }
+}
+
+export const extractChatArtifacts = (content: string): ChatArtifact[] => {
+  const artifacts: ChatArtifact[] = []
+  for (const match of content.matchAll(FENCED_CODE_BLOCK_RE)) {
+    const code = (match[2] ?? "").trim()
+    const artifact = createChatArtifactFromCodeBlock({
+      code,
+      language: match[1] ?? "",
+      index: artifacts.length + 1
+    })
+    if (artifact) artifacts.push(artifact)
+  }
+  return artifacts
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Text",
       "previous_branch": "Vorheriger Zweig",
-      "next_branch": "Nächster Zweig"
+      "next_branch": "Nächster Zweig",
+      "preview": "Vorschau"
     },
     "metrics": {
       "total_time": "Gesamtzeit",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Text",
       "previous_branch": "Previous branch",
-      "next_branch": "Next branch"
+      "next_branch": "Next branch",
+      "preview": "Preview"
     },
     "metrics": {
       "total_time": "Total Time",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Texto",
       "previous_branch": "Rama Anterior",
-      "next_branch": "Rama Siguiente"
+      "next_branch": "Rama Siguiente",
+      "preview": "Vista previa"
     },
     "metrics": {
       "total_time": "Tiempo total",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Texte",
       "previous_branch": "Branche précédente",
-      "next_branch": "Branche suivante"
+      "next_branch": "Branche suivante",
+      "preview": "Aperçu"
     },
     "metrics": {
       "total_time": "Temps total",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "पाठ",
       "previous_branch": "पिछली शाखा",
-      "next_branch": "अगली शाखा"
+      "next_branch": "अगली शाखा",
+      "preview": "पूर्वावलोकन"
     },
     "metrics": {
       "total_time": "कुल समय",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Testo",
       "previous_branch": "Branch Precedente",
-      "next_branch": "Branch Successivo"
+      "next_branch": "Branch Successivo",
+      "preview": "Anteprima"
     },
     "metrics": {
       "total_time": "Tempo totale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "テキスト",
       "previous_branch": "前のブランチ",
-      "next_branch": "次のブランチ"
+      "next_branch": "次のブランチ",
+      "preview": "プレビュー"
     },
     "metrics": {
       "total_time": "合計時間",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "Текст",
       "previous_branch": "Предыдущая ветка",
-      "next_branch": "Следующая ветка"
+      "next_branch": "Следующая ветка",
+      "preview": "Предпросмотр"
     },
     "metrics": {
       "total_time": "Общее время",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -210,7 +210,8 @@
       "export_format_markdown": "Markdown",
       "export_format_text": "文本",
       "previous_branch": "上一个分支",
-      "next_branch": "下一个分支"
+      "next_branch": "下一个分支",
+      "preview": "预览"
     },
     "metrics": {
       "total_time": "总时间",

--- a/src/stores/feature-flags.ts
+++ b/src/stores/feature-flags.ts
@@ -21,7 +21,6 @@ export const FEATURE_FLAG_DEFAULTS = {
   bookmarksHistoryRag: false, // E2 — bookmarks/history local RAG
   perSiteProfiles: false, // E3 — per-site auto-context profiles
   tabGroups: false, // E4 — tab-group / multi-tab workflows
-  artifactsCanvas: false, // E7 — artifacts / output canvas
   templateChaining: false, // E8 — prompt template variables + chaining
   downloads: false, // E9 — downloads for generated artifacts
   browserTools: false // E10 — browser actions as local tools


### PR DESCRIPTION
## Summary
- Add inline preview controls beside code-block copy buttons for HTML, SVG, and Mermaid
- Render previews in a sandboxed sheet with navigation blocked
- Bump to 0.11.11 and update the roadmap

## Tests
- pnpm lint:fix
- pnpm typecheck
- pnpm test:run src/components/__tests__/markdown-renderer.test.tsx src/features/chat/components/__tests__/artifact-canvas.test.tsx src/features/chat/components/__tests__/chat-message-content.test.tsx src/lib/__tests__/artifacts.test.ts
- pnpm build
- pre-push: pnpm test:run

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships always-on artifact previews for HTML, SVG, and Mermaid code blocks, replacing the `markdown-it-copy-code` plugin with a custom imperative toolbar injected into rendered `<pre>` elements and a sandboxed sheet renderer.

- **Artifact detection** (`src/lib/artifacts.ts`): regex-based fenced-code extraction with normalized language aliases and content-sniffing; the previous `xml → svg` alias has been removed and a dedicated test confirms generic XML is no longer misclassified as SVG.
- **Preview rendering** (`artifact-preview.tsx`): per-kind iframe CSP/sandbox split — HTML fragments and full documents use `sandbox=\"allow-scripts\"` with an inline navigation guard; Mermaid renders with the stricter `sandbox=\"\"` inside `svgPreviewSrcDoc`; a `hashContent` fingerprint prevents Mermaid ID collisions.
- **Always-on**: the `artifactsCanvas` feature flag and its permissions-panel toggle are removed; TypeScript confirms no remaining consumers.

<h3>Confidence Score: 5/5</h3>

Safe to merge; sandboxing and CSP isolation are correctly applied per artifact kind, and the previous xml→svg misclassification issue is resolved.

The core artifact detection, sandboxed iframe wrappers, and navigation guard are all well-constructed. The issues found — the module-level Mermaid initialization flag locking the theme, and imperative button text not updating on locale change — are cosmetic quality nits that don't affect correctness or security.

artifact-preview.tsx (module-level mermaidInitialized) and markdown-code-block-actions.tsx (locale-change button text staleness)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/artifacts.ts | New artifact detection layer: regex-based fenced-code extraction with normalized language aliases and content-sniffing; correctly excludes generic XML (unlike earlier draft). |
| src/features/chat/components/artifact-preview.tsx | New sandboxed preview renderer: correct per-kind iframe CSP/sandbox split; module-level mermaidInitialized flag freezes theme after first render; "Rendering Mermaid diagram..." loading text is not i18n'd. |
| src/components/markdown-code-block-actions.tsx | New imperative DOM wrapper for code-block toolbars; locale-change re-runs the effect but skips already-wrapped blocks, leaving button text in the old language. |
| src/components/markdown-renderer.tsx | Drops markdown-it-copy-code in favour of new MarkdownCodeBlockActions sibling; clean refactor. |
| src/hooks/use-markdown-parser.ts | Adds data-code-language attribute to pre elements for language-aware toolbar injection; removes MarkdownItCopyCode dependency. |
| src/stores/feature-flags.ts | Removes artifactsCanvas feature flag — artifact previews are now always on; TypeScript ensures no remaining references. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MarkdownRenderer\nrenders html via dangerouslySetInnerHTML] --> B[MarkdownCodeBlockActions\nuseEffect scans pre elements]
    B --> C{artifact\ncreated?}
    C -- No --> D[Copy button only]
    C -- Yes, renderable --> E[Copy + Preview buttons]
    C -- Yes, code only --> F[Copy button\npreview opens source]
    E --> G[Click setActiveArtifact]
    F --> G
    G --> H[PreviewSheet opens]
    H --> I{artifact.kind}
    I -- html/svg --> J[ArtifactPreview\niframe sandbox=allow-scripts\npreviewSrcDoc CSP meta]
    I -- mermaid --> K[MermaidPreview\nmermaid.render to SVG\niframe sandbox empty\nsvgPreviewSrcDoc stricter CSP]
    I -- code --> L[PreviewTextBlock\nscrolled source view]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MarkdownRenderer\nrenders html via dangerouslySetInnerHTML] --> B[MarkdownCodeBlockActions\nuseEffect scans pre elements]
    B --> C{artifact\ncreated?}
    C -- No --> D[Copy button only]
    C -- Yes, renderable --> E[Copy + Preview buttons]
    C -- Yes, code only --> F[Copy button\npreview opens source]
    E --> G[Click setActiveArtifact]
    F --> G
    G --> H[PreviewSheet opens]
    H --> I{artifact.kind}
    I -- html/svg --> J[ArtifactPreview\niframe sandbox=allow-scripts\npreviewSrcDoc CSP meta]
    I -- mermaid --> K[MermaidPreview\nmermaid.render to SVG\niframe sandbox empty\nsvgPreviewSrcDoc stricter CSP]
    I -- code --> L[PreviewTextBlock\nscrolled source view]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: harden artifact previews"](https://github.com/shishir435/ollama-client/commit/550c3b63a111c9dd46bb66580f4fe95e7f198397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39325436)</sub>

<!-- /greptile_comment -->