### PR TITLE
feat: per-artifact downloads (E9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/components/__tests__/markdown-renderer.test.tsx
+++ b/src/components/__tests__/markdown-renderer.test.tsx
@@ -8,7 +8,8 @@ vi.mock("react-i18next", () => ({
       ({
         "chat.actions.copy": "Copy",
         "chat.actions.copied": "Copied",
-        "chat.actions.preview": "Preview"
+        "chat.actions.preview": "Preview",
+        "chat.actions.download": "Download"
       })[key] ?? key
   })
 }))
@@ -44,6 +45,17 @@ describe("MarkdownRenderer", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
     })
+    expect(
+      screen.queryByRole("button", { name: /Preview/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("adds a download control to code artifacts (no preview required)", async () => {
+    render(<MarkdownRenderer content={"```ts\nconst a = 1\n```"} />)
+
+    expect(
+      await screen.findByRole("button", { name: /Download/ })
+    ).toBeInTheDocument()
     expect(
       screen.queryByRole("button", { name: /Preview/ })
     ).not.toBeInTheDocument()

--- a/src/components/markdown-code-block-actions.tsx
+++ b/src/components/markdown-code-block-actions.tsx
@@ -2,14 +2,44 @@ import type { RefObject } from "react"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { TooltipActionButton } from "@/components/actions"
 import { ArtifactPreview } from "@/features/chat/components/artifact-preview"
 import { CopyButton } from "@/features/chat/components/copy-button"
 import { PreviewSheet } from "@/features/chat/components/preview-sheet"
+import { chatIconBtnCls } from "@/features/chat/lib/chat-styles"
+import { downloadArtifact } from "@/lib/artifact-download"
 import type { ChatArtifact } from "@/lib/artifacts"
 import { createChatArtifactFromCodeBlock } from "@/lib/artifacts"
+import { Download } from "@/lib/lucide-icon"
 
 const codeActionButtonClass =
-  "rounded border border-border/50 bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
+  "inline-flex items-center justify-center rounded border border-border/50 bg-background/90 p-1 text-muted-foreground shadow-xs backdrop-blur hover:text-foreground"
+
+/**
+ * Inline Lucide icon paths (the markdown toolbar is built with raw DOM, not
+ * React, so we inject SVG markup rather than render icon components). Kept in
+ * sync with the `lucide-react` icons of the same name.
+ */
+const ICON_PATHS = {
+  copy: '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  eye: '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>',
+  download:
+    '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/>'
+} as const
+
+const iconSvg = (paths: string): string =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`
+
+/** Build an icon-only toolbar button (icons are self-explanatory; aria-label only). */
+const createIconButton = (paths: string, label: string): HTMLButtonElement => {
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = codeActionButtonClass
+  button.innerHTML = iconSvg(paths)
+  button.setAttribute("aria-label", label)
+  return button
+}
 
 export const MarkdownCodeBlockActions = ({
   containerRef,
@@ -50,34 +80,37 @@ export const MarkdownCodeBlockActions = ({
       toolbar.className =
         "not-prose absolute right-1 top-1 z-10 flex items-center gap-1 opacity-80 transition-opacity group-hover/code:opacity-100"
 
-      const copyButton = document.createElement("button")
-      copyButton.type = "button"
-      copyButton.className = codeActionButtonClass
-      copyButton.textContent = t("chat.actions.copy")
-      copyButton.setAttribute("aria-label", t("chat.actions.copy"))
+      const copyLabel = t("chat.actions.copy")
+      const copyButton = createIconButton(ICON_PATHS.copy, copyLabel)
       copyButton.addEventListener("click", () => {
         void navigator.clipboard.writeText(rawCode)
-        copyButton.textContent = t("chat.actions.copied")
+        copyButton.innerHTML = iconSvg(ICON_PATHS.check)
         window.setTimeout(() => {
-          copyButton.textContent = t("chat.actions.copy")
+          copyButton.innerHTML = iconSvg(ICON_PATHS.copy)
         }, 1500)
       })
       toolbar.appendChild(copyButton)
 
       if (artifact?.renderable) {
-        const previewLabel = t("chat.actions.preview")
-        const previewButton = document.createElement("button")
-        previewButton.type = "button"
-        previewButton.className = codeActionButtonClass
-        previewButton.textContent = previewLabel
-        previewButton.setAttribute(
-          "aria-label",
-          `${previewLabel} ${artifact.title}`
+        const previewButton = createIconButton(
+          ICON_PATHS.eye,
+          `${t("chat.actions.preview")} ${artifact.title}`
         )
         previewButton.addEventListener("click", () => {
           setActiveArtifact(artifact)
         })
         toolbar.appendChild(previewButton)
+      }
+
+      if (artifact) {
+        const downloadButton = createIconButton(
+          ICON_PATHS.download,
+          `${t("chat.actions.download")} ${artifact.title}`
+        )
+        downloadButton.addEventListener("click", () => {
+          void downloadArtifact(artifact)
+        })
+        toolbar.appendChild(downloadButton)
       }
 
       pre.replaceWith(shell)
@@ -99,7 +132,22 @@ export const MarkdownCodeBlockActions = ({
           : undefined
       }
       actions={
-        activeArtifact ? <CopyButton text={activeArtifact.content} /> : null
+        activeArtifact ? (
+          <div className="flex items-center gap-1">
+            <CopyButton text={activeArtifact.content} />
+            <TooltipActionButton
+              ariaLabel={t("chat.actions.download")}
+              tooltip={t("chat.actions.download")}
+              size="icon"
+              variant="ghost"
+              className={chatIconBtnCls}
+              icon={<Download className="icon-xs" />}
+              onClick={() => {
+                void downloadArtifact(activeArtifact)
+              }}
+            />
+          </div>
+        ) : null
       }
       className="w-[min(56rem,calc(100vw-1rem))] sm:max-w-4xl">
       {activeArtifact ? <ArtifactPreview artifact={activeArtifact} /> : null}

--- a/src/components/markdown-code-block-actions.tsx
+++ b/src/components/markdown-code-block-actions.tsx
@@ -85,8 +85,10 @@ export const MarkdownCodeBlockActions = ({
       copyButton.addEventListener("click", () => {
         void navigator.clipboard.writeText(rawCode)
         copyButton.innerHTML = iconSvg(ICON_PATHS.check)
+        copyButton.setAttribute("aria-label", t("chat.actions.copied"))
         window.setTimeout(() => {
           copyButton.innerHTML = iconSvg(ICON_PATHS.copy)
+          copyButton.setAttribute("aria-label", copyLabel)
         }, 1500)
       })
       toolbar.appendChild(copyButton)

--- a/src/lib/__tests__/artifact-download.test.ts
+++ b/src/lib/__tests__/artifact-download.test.ts
@@ -73,6 +73,14 @@ describe("artifactFileName", () => {
     ).toBe("etc-passwd.ts")
     expect(artifactFileName(makeArtifact({ title: "   " }))).toBe("artifact.ts")
   })
+
+  it("does not leave a trailing dash when the 64-char slice lands on one", () => {
+    const name = artifactFileName(
+      makeArtifact({ title: `${"a".repeat(63)} tail` })
+    )
+    expect(name).toBe(`${"a".repeat(63)}.ts`)
+    expect(name).not.toContain("-.")
+  })
 })
 
 describe("downloadArtifact", () => {

--- a/src/lib/__tests__/artifact-download.test.ts
+++ b/src/lib/__tests__/artifact-download.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { artifactFileName, downloadArtifact } from "@/lib/artifact-download"
+import type { ChatArtifact } from "@/lib/artifacts"
+
+const download = vi.fn()
+const hasPermission = vi.fn()
+const requestPermission = vi.fn()
+const downloadFile = vi.fn()
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: {
+    downloads: {
+      download: (...args: unknown[]) => download(...args)
+    }
+  }
+}))
+
+vi.mock("@/lib/permissions", () => ({
+  hasPermission: (...args: unknown[]) => hasPermission(...args),
+  requestPermission: (...args: unknown[]) => requestPermission(...args)
+}))
+
+vi.mock("@/lib/exporters/utils", () => ({
+  downloadFile: (...args: unknown[]) => downloadFile(...args)
+}))
+
+const makeArtifact = (over: Partial<ChatArtifact> = {}): ChatArtifact => ({
+  id: "code-1",
+  kind: "code",
+  language: "ts",
+  title: "TS artifact 1",
+  content: "const a = 1",
+  renderable: false,
+  ...over
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.URL.createObjectURL = vi.fn(() => "blob:fake")
+  global.URL.revokeObjectURL = vi.fn()
+})
+
+describe("artifactFileName", () => {
+  it("uses the kind extension for renderable artifacts", () => {
+    expect(
+      artifactFileName(makeArtifact({ kind: "html", title: "HTML artifact 2" }))
+    ).toBe("html-artifact-2.html")
+    expect(
+      artifactFileName(makeArtifact({ kind: "svg", title: "SVG artifact 1" }))
+    ).toBe("svg-artifact-1.svg")
+    expect(
+      artifactFileName(
+        makeArtifact({ kind: "mermaid", title: "Mermaid diagram 1" })
+      )
+    ).toBe("mermaid-diagram-1.mmd")
+  })
+
+  it("maps code language to its file extension, falling back to txt", () => {
+    expect(artifactFileName(makeArtifact({ language: "ts" }))).toBe(
+      "ts-artifact-1.ts"
+    )
+    expect(
+      artifactFileName(makeArtifact({ language: "python", title: "script" }))
+    ).toBe("script.py")
+    expect(
+      artifactFileName(makeArtifact({ language: "brainfuck", title: "weird" }))
+    ).toBe("weird.txt")
+  })
+
+  it("sanitizes the title into a safe base name", () => {
+    expect(
+      artifactFileName(makeArtifact({ title: "../../etc/passwd!!" }))
+    ).toBe("etc-passwd.ts")
+    expect(artifactFileName(makeArtifact({ title: "   " }))).toBe("artifact.ts")
+  })
+})
+
+describe("downloadArtifact", () => {
+  it("uses the downloads API when the permission is already granted", async () => {
+    hasPermission.mockResolvedValue(true)
+    download.mockResolvedValue(1)
+
+    await downloadArtifact(makeArtifact())
+
+    expect(requestPermission).not.toHaveBeenCalled()
+    expect(download).toHaveBeenCalledWith({
+      url: "blob:fake",
+      filename: "ts-artifact-1.ts",
+      saveAs: true
+    })
+    expect(downloadFile).not.toHaveBeenCalled()
+  })
+
+  it("requests the permission when it is not yet granted, then downloads", async () => {
+    hasPermission.mockResolvedValue(false)
+    requestPermission.mockResolvedValue(true)
+    download.mockResolvedValue(1)
+
+    await downloadArtifact(makeArtifact())
+
+    expect(requestPermission).toHaveBeenCalledWith("downloads")
+    expect(download).toHaveBeenCalledTimes(1)
+    expect(downloadFile).not.toHaveBeenCalled()
+  })
+
+  it("falls back to anchor download when the permission is denied", async () => {
+    hasPermission.mockResolvedValue(false)
+    requestPermission.mockResolvedValue(false)
+
+    await downloadArtifact(makeArtifact())
+
+    expect(download).not.toHaveBeenCalled()
+    expect(downloadFile).toHaveBeenCalledTimes(1)
+    expect(downloadFile).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "ts-artifact-1.ts"
+    )
+  })
+
+  it("falls back to anchor download when the downloads API throws", async () => {
+    hasPermission.mockResolvedValue(true)
+    download.mockRejectedValue(new Error("disk full"))
+
+    await downloadArtifact(makeArtifact())
+
+    expect(downloadFile).toHaveBeenCalledTimes(1)
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake")
+  })
+})

--- a/src/lib/artifact-download.ts
+++ b/src/lib/artifact-download.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-artifact download (E9 — FEATURE_ROADMAP §3). Distinct from whole-session
+ * export (`use-export-chat.ts`): this saves one generated artifact (HTML, SVG,
+ * Mermaid, or a code block) to its own file.
+ *
+ * Save path, in order of preference:
+ *   1. `browser.downloads` (optional `downloads` permission) — a real entry in
+ *      the browser download manager with a Save-As dialog. Requested on the
+ *      click (a user gesture), per the privacy stance (FEATURE_ROADMAP §0.4).
+ *   2. Anchor `<a download>` fallback (`downloadFile`) — no permission needed, so
+ *      the action still works if the user declines `downloads`.
+ */
+
+import type { ChatArtifact } from "@/lib/artifacts"
+import { browser } from "@/lib/browser-api"
+import { downloadFile } from "@/lib/exporters/utils"
+import { hasPermission, requestPermission } from "@/lib/permissions"
+
+/** File extension per code language; falls back to `.txt` for unknown code. */
+const CODE_EXTENSIONS: Record<string, string> = {
+  css: "css",
+  js: "js",
+  jsx: "jsx",
+  ts: "ts",
+  tsx: "tsx",
+  json: "json",
+  python: "py",
+  py: "py",
+  bash: "sh",
+  sh: "sh",
+  sql: "sql",
+  rust: "rs",
+  go: "go",
+  java: "java",
+  kotlin: "kt",
+  swift: "swift",
+  php: "php",
+  ruby: "rb",
+  yaml: "yaml",
+  yml: "yaml"
+}
+
+const extensionFor = (artifact: ChatArtifact): string => {
+  if (artifact.kind === "html") return "html"
+  if (artifact.kind === "svg") return "svg"
+  if (artifact.kind === "mermaid") return "mmd"
+  return CODE_EXTENSIONS[artifact.language] ?? "txt"
+}
+
+const mimeFor = (artifact: ChatArtifact): string => {
+  if (artifact.kind === "html") return "text/html"
+  if (artifact.kind === "svg") return "image/svg+xml"
+  if (artifact.kind === "code" && artifact.language === "json") {
+    return "application/json"
+  }
+  return "text/plain"
+}
+
+/**
+ * Derive a safe, kind-appropriate filename from the artifact title. Strips path
+ * separators and characters the download APIs reject, collapses whitespace, and
+ * always appends the correct extension.
+ */
+export const artifactFileName = (artifact: ChatArtifact): string => {
+  const base =
+    artifact.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 64) || "artifact"
+  return `${base}.${extensionFor(artifact)}`
+}
+
+/**
+ * Save a single artifact to a file. Prefers the `downloads` API (requesting the
+ * optional permission on this user gesture); falls back to an anchor download if
+ * the permission is unavailable or denied so the action never silently no-ops.
+ */
+export const downloadArtifact = async (
+  artifact: ChatArtifact
+): Promise<void> => {
+  const filename = artifactFileName(artifact)
+  const blob = new Blob([artifact.content], { type: mimeFor(artifact) })
+
+  const granted =
+    (await hasPermission("downloads")) || (await requestPermission("downloads"))
+
+  if (granted && typeof browser.downloads?.download === "function") {
+    const url = URL.createObjectURL(blob)
+    try {
+      await browser.downloads.download({ url, filename, saveAs: true })
+      // Revoke once the download has had time to start reading the blob; revoking
+      // synchronously can abort the transfer in some browsers.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
+      return
+    } catch {
+      URL.revokeObjectURL(url)
+      // fall through to the anchor fallback below
+    }
+  }
+
+  downloadFile(blob, filename)
+}

--- a/src/lib/artifact-download.ts
+++ b/src/lib/artifact-download.ts
@@ -14,6 +14,7 @@
 import type { ChatArtifact } from "@/lib/artifacts"
 import { browser } from "@/lib/browser-api"
 import { downloadFile } from "@/lib/exporters/utils"
+import { logger } from "@/lib/logger"
 import { hasPermission, requestPermission } from "@/lib/permissions"
 
 /** File extension per code language; falls back to `.txt` for unknown code. */
@@ -62,12 +63,14 @@ const mimeFor = (artifact: ChatArtifact): string => {
  * always appends the correct extension.
  */
 export const artifactFileName = (artifact: ChatArtifact): string => {
+  // Trim after slicing too: a 64-char cut can land inside a dash run.
   const base =
     artifact.title
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "")
-      .slice(0, 64) || "artifact"
+      .slice(0, 64)
+      .replace(/-+$/, "") || "artifact"
   return `${base}.${extensionFor(artifact)}`
 }
 
@@ -82,22 +85,30 @@ export const downloadArtifact = async (
   const filename = artifactFileName(artifact)
   const blob = new Blob([artifact.content], { type: mimeFor(artifact) })
 
-  const granted =
-    (await hasPermission("downloads")) || (await requestPermission("downloads"))
+  // Top-level guard: call sites invoke this as `void downloadArtifact(...)`, so a
+  // rejection from the permission calls or the anchor fallback would otherwise be
+  // swallowed. Log it instead of failing silently.
+  try {
+    const granted =
+      (await hasPermission("downloads")) ||
+      (await requestPermission("downloads"))
 
-  if (granted && typeof browser.downloads?.download === "function") {
-    const url = URL.createObjectURL(blob)
-    try {
-      await browser.downloads.download({ url, filename, saveAs: true })
-      // Revoke once the download has had time to start reading the blob; revoking
-      // synchronously can abort the transfer in some browsers.
-      setTimeout(() => URL.revokeObjectURL(url), 60_000)
-      return
-    } catch {
-      URL.revokeObjectURL(url)
-      // fall through to the anchor fallback below
+    if (granted && typeof browser.downloads?.download === "function") {
+      const url = URL.createObjectURL(blob)
+      try {
+        await browser.downloads.download({ url, filename, saveAs: true })
+        // Revoke once the download has had time to start reading the blob;
+        // revoking synchronously can abort the transfer in some browsers.
+        setTimeout(() => URL.revokeObjectURL(url), 60_000)
+        return
+      } catch {
+        URL.revokeObjectURL(url)
+        // fall through to the anchor fallback below
+      }
     }
-  }
 
-  downloadFile(blob, filename)
+    downloadFile(blob, filename)
+  } catch (error) {
+    logger.error("Artifact download failed", "downloadArtifact", { error })
+  }
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Text",
       "previous_branch": "Vorheriger Zweig",
       "next_branch": "Nächster Zweig",
-      "preview": "Vorschau"
+      "preview": "Vorschau",
+      "download": "Herunterladen"
     },
     "metrics": {
       "total_time": "Gesamtzeit",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Text",
       "previous_branch": "Previous branch",
       "next_branch": "Next branch",
-      "preview": "Preview"
+      "preview": "Preview",
+      "download": "Download"
     },
     "metrics": {
       "total_time": "Total Time",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Texto",
       "previous_branch": "Rama Anterior",
       "next_branch": "Rama Siguiente",
-      "preview": "Vista previa"
+      "preview": "Vista previa",
+      "download": "Descargar"
     },
     "metrics": {
       "total_time": "Tiempo total",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Texte",
       "previous_branch": "Branche précédente",
       "next_branch": "Branche suivante",
-      "preview": "Aperçu"
+      "preview": "Aperçu",
+      "download": "Télécharger"
     },
     "metrics": {
       "total_time": "Temps total",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "पाठ",
       "previous_branch": "पिछली शाखा",
       "next_branch": "अगली शाखा",
-      "preview": "पूर्वावलोकन"
+      "preview": "पूर्वावलोकन",
+      "download": "डाउनलोड"
     },
     "metrics": {
       "total_time": "कुल समय",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Testo",
       "previous_branch": "Branch Precedente",
       "next_branch": "Branch Successivo",
-      "preview": "Anteprima"
+      "preview": "Anteprima",
+      "download": "Scarica"
     },
     "metrics": {
       "total_time": "Tempo totale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "テキスト",
       "previous_branch": "前のブランチ",
       "next_branch": "次のブランチ",
-      "preview": "プレビュー"
+      "preview": "プレビュー",
+      "download": "ダウンロード"
     },
     "metrics": {
       "total_time": "合計時間",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "Текст",
       "previous_branch": "Предыдущая ветка",
       "next_branch": "Следующая ветка",
-      "preview": "Предпросмотр"
+      "preview": "Предпросмотр",
+      "download": "Скачать"
     },
     "metrics": {
       "total_time": "Общее время",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -211,7 +211,8 @@
       "export_format_text": "文本",
       "previous_branch": "上一个分支",
       "next_branch": "下一个分支",
-      "preview": "预览"
+      "preview": "预览",
+      "download": "下载"
     },
     "metrics": {
       "total_time": "总时间",


### PR DESCRIPTION
One-click save for generated artifacts (code/HTML/SVG/Mermaid) via the `downloads` API.

- New `src/lib/artifact-download.ts`: requests optional `downloads` permission on click (Save-As), falls back to anchor download if denied; filename from artifact title + kind/language extension.
- Download icon button on code-block toolbar + in the artifact preview sheet.
- `chat.actions.download` added to all 9 locales.
- Tests for filename derivation + download/fallback paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds one-click per-artifact downloads for code, HTML, SVG, and Mermaid blocks, using the optional `downloads` browser permission with a transparent anchor-tag fallback when the permission is unavailable or denied.

- **`src/lib/artifact-download.ts`**: New download module that requests the `downloads` permission on the user gesture, builds a slug-safe filename (extension derived from artifact kind/language), and falls back to the existing `downloadFile` anchor helper. A top-level `try/catch` prevents silent rejection swallowing, and the trailing-dash edge case at the 64-char slice boundary is handled correctly.
- **`src/components/markdown-code-block-actions.tsx`**: Adds the download icon to both the raw-DOM code-block toolbar (for all recognised artifacts) and the React preview-sheet action bar; also takes the opportunity to fix the copy-button accessible-label feedback cycle.
- **Locale files**: `chat.actions.download` added to all 9 locales; `_locales/` is auto-regenerated on build so no separate commit is needed for the UI-only key.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, the fallback path ensures the feature never silently no-ops, and all signal paths are covered by tests.

The permission flow correctly short-circuits the requestPermission call when the permission is already held, the slug-safety pipeline handles the known edge cases (trailing dash after 64-char slice, blank title), and both the toolbar and sheet download paths delegate to the same well-tested downloadArtifact function. No issues were found that affect correctness or reliability.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/artifact-download.ts | New download module: permission-guarded (downloads API → anchor fallback), correct slug/dash trim order after slicing, top-level try/catch prevents silent rejection swallowing. No issues found. |
| src/lib/__tests__/artifact-download.test.ts | Covers happy path, permission-denied fallback, API-throw fallback, and the trailing-dash-at-slice-boundary edge case. All signal paths tested with mocks. |
| src/components/markdown-code-block-actions.tsx | Adds download button to both the raw-DOM toolbar and the preview sheet; copy button aria-label feedback also fixed. Icon-path approach is consistent with the existing toolbar pattern. |
| src/components/__tests__/markdown-renderer.test.tsx | Adds test asserting Download button appears for code artifacts and Preview does not (correct: only renderable artifacts get Preview). Test mock updated for new locale key. |
| src/locales/en/translation.json | Adds chat.actions.download key to all 9 locales consistently. _locales/ is auto-regenerated on build so no manual regeneration required for this UI-only key. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Download button] --> B{hasPermission downloads?}
    B -- yes --> C[Create Blob + ObjectURL]
    B -- no --> D{requestPermission downloads?}
    D -- granted --> C
    D -- denied --> G[anchor fallback: downloadFile blob, filename]
    C --> E[browser.downloads.download saveAs: true]
    E -- success --> F[setTimeout 60s → revokeObjectURL]
    E -- throws --> H[revokeObjectURL immediately] --> G
    G --> I[Done]
    F --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Download button] --> B{hasPermission downloads?}
    B -- yes --> C[Create Blob + ObjectURL]
    B -- no --> D{requestPermission downloads?}
    D -- granted --> C
    D -- denied --> G[anchor fallback: downloadFile blob, filename]
    C --> E[browser.downloads.download saveAs: true]
    E -- success --> F[setTimeout 60s → revokeObjectURL]
    E -- throws --> H[revokeObjectURL immediately] --> G
    G --> I[Done]
    F --> I
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review on artifact download..."](https://github.com/shishir435/ollama-client/commit/11325bcbb650a92ab22d529b32e650aacbb9f0c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39366168)</sub>

<!-- /greptile_comment -->