### PR TITLE
chore(deps): migrate to Vite 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "tailwindcss": "4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
-    "vite": "^7.3.3",
+    "vite": "^8.0.0",
     "vitest": "^4.1.7",
     "wxt": "^0.20.26"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
         version: 0.12.5
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+        version: 5.2.0(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -253,14 +253,14 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.3
-        version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+        specifier: ^8.0.0
+        version: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
       wxt:
         specifier: ^0.20.26
-        version: 0.20.26(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rolldown@1.0.2)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
+        version: 0.20.26(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(rolldown@1.0.2)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
 
   docs:
     dependencies:
@@ -8531,7 +8531,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -8539,7 +8539,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8555,7 +8555,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -8566,14 +8566,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@22.19.19)(typescript@5.9.3)
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -8602,7 +8602,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -13148,23 +13148,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.4
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.19.19
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      less: 4.3.0
-      lightningcss: 1.32.0
-      sass: 1.89.0
-      yaml: 2.9.0
-
   vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
@@ -13202,10 +13185,10 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -13222,7 +13205,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
@@ -13395,7 +13378,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rolldown@1.0.2)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0):
+  wxt@0.20.26(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(rolldown@1.0.2)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.60.4)
@@ -13436,7 +13419,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.16
       unimport: 6.3.0(rolldown@1.0.2)
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
       web-ext-run: 0.2.4
     transitivePeerDependencies:
@@ -13445,7 +13428,6 @@ snapshots:
       - canvas
       - jiti
       - less
-      - lightningcss
       - oxc-parser
       - rolldown
       - rollup


### PR DESCRIPTION
## Summary
Bumps `vite` `^7.3.3` → `^8.0.0` (8.0.14).

No further changes were needed — `wxt@0.20.27`, `vitest@4.1.7`, and
`@vitejs/plugin-react@5.2` already declare `vite ^8` support, so the extension
stays on the rollup path (no rolldown / plugin-react 6 / react-compiler-peer
migration). The docs site (Astro) bundles its own vite and is unaffected.

## Verified locally (and via the pre-push gate)
- `pnpm typecheck`, `pnpm lint:check`
- `pnpm test:run` — 1774 tests pass (vitest 4 on vite 8)
- `pnpm build` (Chrome MV3) and `pnpm build:firefox` (Firefox MV2)
- `pnpm docs:build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `vite` from `^7.3.3` to `^8.0.0` (resolving to `8.0.14`) across the project. The lock file is updated consistently, with all vite-dependent packages (`@vitejs/plugin-react`, `vitest`, `wxt`) re-resolved against the new version.

- `lightningcss` is dropped as an optional peer of both `vite` and `wxt`, which reflects Vite 8's changed CSS-processing approach; since all builds were verified locally this is expected.
- `esbuild@0.27.7` (unchanged version) moves from a direct required dependency to an optional peer in Vite 8's resolution string, consistent with Vite 8 introducing Rolldown as an alternative bundler while keeping esbuild for projects that don't migrate.
- The docs site (`Astro` under `docs/`) retains its own `vite@7.3.3(@types/node@24.12.4)` snapshot and is unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a minimal dependency bump touching only package.json and the lock file, with all consumers already declaring vite 8 compatibility.

The change is a single-line specifier bump in package.json with a consistent lock file update. All vite-dependent packages were already compatible with vite 8, the docs site retains its own isolated vite 7 snapshot, and the author verified typecheck, lint, 1774 tests, and both browser builds locally.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Single-line specifier change from `^7.3.3` to `^8.0.0` — straightforward and correct. |
| pnpm-lock.yaml | Lock file updated consistently: `vite@8.0.14` resolves all dependent snapshots; old `vite@7.3.3(@types/node@22.19.19)` snapshot removed; docs-site `vite@7.3.3(@types/node@24.12.4)` snapshot correctly retained. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[vite specifier bumped to v8] --> B[vite 8.0.14 resolved]
    B --> C[plugin-react 5.2.0 peer updated]
    B --> D[vitest 4.1.7 peer updated]
    B --> E[wxt 0.20.26 peer updated]
    B --> F[esbuild 0.27.7 now optional peer]
    B --> G[lightningcss dropped as peer]
    H[docs Astro site] --> I[vite 7.3.3 snapshot retained]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[vite specifier bumped to v8] --> B[vite 8.0.14 resolved]
    B --> C[plugin-react 5.2.0 peer updated]
    B --> D[vitest 4.1.7 peer updated]
    B --> E[wxt 0.20.26 peer updated]
    B --> F[esbuild 0.27.7 now optional peer]
    B --> G[lightningcss dropped as peer]
    H[docs Astro site] --> I[vite 7.3.3 snapshot retained]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): migrate to Vite 8"](https://github.com/shishir435/ollama-client/commit/905944ef9c5726550a7c77a5bb8a6eae38ec7d10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40392172)</sub>

<!-- /greptile_comment -->