### PR TITLE
perf(chat): lazy-load highlight.js + export pipeline; graceful Mermaid fallback

### DIFF
--- a/src/features/chat/components/artifact-preview.tsx
+++ b/src/features/chat/components/artifact-preview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { ChatArtifact } from "@/lib/artifacts"
+import { TriangleAlert } from "@/lib/lucide-icon"
 import { PreviewTextBlock } from "./preview-sheet"
 
 const PREVIEW_RESET_STYLE =
@@ -111,11 +112,32 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
   if (error) {
     return (
       <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
-        <PreviewTextBlock
-          text={`Mermaid render failed:\n\n${error}\n\nSource:\n${artifact.content}`}
-          emptyText="No Mermaid content"
-          className="font-mono text-2xs"
-        />
+        <div className="space-y-3 p-4">
+          <div className="flex items-start gap-2 rounded-control border border-status-warning/40 bg-status-warning/10 p-3">
+            <TriangleAlert className="icon-sm mt-0.5 shrink-0 text-status-warning" />
+            <div className="min-w-0 text-xs">
+              <p className="font-medium text-status-warning">
+                Couldn't render this diagram
+              </p>
+              <p className="mt-0.5 text-muted-foreground">
+                The Mermaid syntax is invalid — the raw source is shown below.
+              </p>
+            </div>
+          </div>
+          <PreviewTextBlock
+            text={artifact.content}
+            emptyText="No Mermaid content"
+            className="rounded-control bg-muted/40 font-mono text-2xs"
+          />
+          <details className="px-1 text-2xs text-muted-foreground">
+            <summary className="cursor-pointer select-none">
+              Error details
+            </summary>
+            <pre className="mt-1 whitespace-pre-wrap wrap-anywhere">
+              {error}
+            </pre>
+          </details>
+        </div>
       </ScrollArea>
     )
   }

--- a/src/features/chat/components/artifact-preview.tsx
+++ b/src/features/chat/components/artifact-preview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { ChatArtifact } from "@/lib/artifacts"
 import { TriangleAlert } from "@/lib/lucide-icon"
@@ -60,6 +61,7 @@ const svgPreviewSrcDoc = (svg: string): string => {
 }
 
 const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
+  const { t } = useTranslation()
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const renderId = useMemo(
@@ -117,21 +119,21 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
             <TriangleAlert className="icon-sm mt-0.5 shrink-0 text-status-warning" />
             <div className="min-w-0 text-xs">
               <p className="font-medium text-status-warning">
-                Couldn't render this diagram
+                {t("chat.artifacts.render_failed_title")}
               </p>
               <p className="mt-0.5 text-muted-foreground">
-                The raw source is shown below — expand details for the error.
+                {t("chat.artifacts.render_failed_desc")}
               </p>
             </div>
           </div>
           <PreviewTextBlock
             text={artifact.content}
-            emptyText="No Mermaid content"
+            emptyText={t("chat.artifacts.mermaid_empty")}
             className="rounded-control bg-muted/40 font-mono text-2xs"
           />
           <details className="px-1 text-2xs text-muted-foreground">
             <summary className="cursor-pointer select-none">
-              Error details
+              {t("chat.artifacts.error_details")}
             </summary>
             <pre className="mt-1 whitespace-pre-wrap wrap-anywhere">
               {error}
@@ -145,7 +147,7 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
   if (!svg) {
     return (
       <div className="grid min-h-96 flex-1 place-items-center text-sm text-muted-foreground">
-        Rendering Mermaid diagram...
+        {t("chat.artifacts.rendering_mermaid")}
       </div>
     )
   }
@@ -162,6 +164,8 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
 }
 
 export const ArtifactPreview = ({ artifact }: { artifact: ChatArtifact }) => {
+  const { t } = useTranslation()
+
   if (artifact.kind === "mermaid") {
     return <MermaidPreview artifact={artifact} />
   }
@@ -181,7 +185,7 @@ export const ArtifactPreview = ({ artifact }: { artifact: ChatArtifact }) => {
     <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
       <PreviewTextBlock
         text={artifact.content}
-        emptyText="No artifact content"
+        emptyText={t("chat.artifacts.empty")}
         className="font-mono text-2xs"
       />
     </ScrollArea>

--- a/src/features/chat/components/artifact-preview.tsx
+++ b/src/features/chat/components/artifact-preview.tsx
@@ -120,7 +120,7 @@ const MermaidPreview = ({ artifact }: { artifact: ChatArtifact }) => {
                 Couldn't render this diagram
               </p>
               <p className="mt-0.5 text-muted-foreground">
-                The Mermaid syntax is invalid — the raw source is shown below.
+                The raw source is shown below — expand details for the error.
               </p>
             </div>
           </div>

--- a/src/features/chat/hooks/use-message-export.ts
+++ b/src/features/chat/hooks/use-message-export.ts
@@ -1,4 +1,6 @@
 import { useTranslation } from "react-i18next"
+import { toast } from "@/hooks/use-toast"
+import { logger } from "@/lib/logger"
 import type { ChatMessage } from "@/types"
 
 // Exporters pull in heavy deps (markdown-it + highlight.js, jsPDF, jszip).
@@ -6,39 +8,45 @@ import type { ChatMessage } from "@/types"
 export const useMessageExport = () => {
   const { t } = useTranslation()
 
-  const exportMessageAsJson = async (
-    message: ChatMessage,
-    fileName?: string
-  ) => {
-    const { jsonExporter } = await import("@/lib/exporters/json-exporter")
-    jsonExporter.exportMessage(message, t, { fileName })
+  // Exporters load lazily, so a chunk-load failure would otherwise be swallowed
+  // by the fire-and-forget call sites. Surface it instead of failing silently.
+  const guard = async (run: () => Promise<void>) => {
+    try {
+      await run()
+    } catch (error) {
+      logger.error("Message export failed", "useMessageExport", { error })
+      toast({
+        variant: "destructive",
+        title: t("settings.migration.export.error_title")
+      })
+    }
   }
 
-  const exportMessageAsPdf = async (
-    message: ChatMessage,
-    fileName?: string
-  ) => {
-    const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
-    pdfExporter.exportMessage(message, t, { fileName })
-  }
+  const exportMessageAsJson = (message: ChatMessage, fileName?: string) =>
+    guard(async () => {
+      const { jsonExporter } = await import("@/lib/exporters/json-exporter")
+      jsonExporter.exportMessage(message, t, { fileName })
+    })
 
-  const exportMessageAsMarkdown = async (
-    message: ChatMessage,
-    fileName?: string
-  ) => {
-    const { markdownExporter } = await import(
-      "@/lib/exporters/markdown-exporter"
-    )
-    markdownExporter.exportMessage(message, t, { fileName })
-  }
+  const exportMessageAsPdf = (message: ChatMessage, fileName?: string) =>
+    guard(async () => {
+      const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
+      pdfExporter.exportMessage(message, t, { fileName })
+    })
 
-  const exportMessageAsText = async (
-    message: ChatMessage,
-    fileName?: string
-  ) => {
-    const { textExporter } = await import("@/lib/exporters/text-exporter")
-    textExporter.exportMessage(message, t, { fileName })
-  }
+  const exportMessageAsMarkdown = (message: ChatMessage, fileName?: string) =>
+    guard(async () => {
+      const { markdownExporter } = await import(
+        "@/lib/exporters/markdown-exporter"
+      )
+      markdownExporter.exportMessage(message, t, { fileName })
+    })
+
+  const exportMessageAsText = (message: ChatMessage, fileName?: string) =>
+    guard(async () => {
+      const { textExporter } = await import("@/lib/exporters/text-exporter")
+      textExporter.exportMessage(message, t, { fileName })
+    })
 
   return {
     exportMessageAsJson,

--- a/src/features/chat/hooks/use-message-export.ts
+++ b/src/features/chat/hooks/use-message-export.ts
@@ -1,26 +1,42 @@
 import { useTranslation } from "react-i18next"
-import { jsonExporter } from "@/lib/exporters/json-exporter"
-import { markdownExporter } from "@/lib/exporters/markdown-exporter"
-import { pdfExporter } from "@/lib/exporters/pdf-exporter"
-import { textExporter } from "@/lib/exporters/text-exporter"
 import type { ChatMessage } from "@/types"
 
+// Exporters pull in heavy deps (markdown-it + highlight.js, jsPDF, jszip).
+// Load them on demand so they stay out of the eager side-panel bundle.
 export const useMessageExport = () => {
   const { t } = useTranslation()
 
-  const exportMessageAsJson = (message: ChatMessage, fileName?: string) => {
+  const exportMessageAsJson = async (
+    message: ChatMessage,
+    fileName?: string
+  ) => {
+    const { jsonExporter } = await import("@/lib/exporters/json-exporter")
     jsonExporter.exportMessage(message, t, { fileName })
   }
 
-  const exportMessageAsPdf = (message: ChatMessage, fileName?: string) => {
+  const exportMessageAsPdf = async (
+    message: ChatMessage,
+    fileName?: string
+  ) => {
+    const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
     pdfExporter.exportMessage(message, t, { fileName })
   }
 
-  const exportMessageAsMarkdown = (message: ChatMessage, fileName?: string) => {
+  const exportMessageAsMarkdown = async (
+    message: ChatMessage,
+    fileName?: string
+  ) => {
+    const { markdownExporter } = await import(
+      "@/lib/exporters/markdown-exporter"
+    )
     markdownExporter.exportMessage(message, t, { fileName })
   }
 
-  const exportMessageAsText = (message: ChatMessage, fileName?: string) => {
+  const exportMessageAsText = async (
+    message: ChatMessage,
+    fileName?: string
+  ) => {
+    const { textExporter } = await import("@/lib/exporters/text-exporter")
     textExporter.exportMessage(message, t, { fileName })
   }
 

--- a/src/features/sessions/hooks/use-export-chat.ts
+++ b/src/features/sessions/hooks/use-export-chat.ts
@@ -1,9 +1,5 @@
 import { useTranslation } from "react-i18next"
 import { splitStoredFiles } from "@/features/sessions/lib/message-tree"
-import { jsonExporter } from "@/lib/exporters/json-exporter"
-import { markdownExporter } from "@/lib/exporters/markdown-exporter"
-import { pdfExporter } from "@/lib/exporters/pdf-exporter"
-import { textExporter } from "@/lib/exporters/text-exporter"
 import {
   getFilesByMessageIds,
   getMessagesBySessionOrderedByTimestamp
@@ -45,6 +41,7 @@ export const useChatExport = () => {
     fileName?: string
   ) => {
     const fullSession = await getFullSession(session)
+    const { jsonExporter } = await import("@/lib/exporters/json-exporter")
     jsonExporter.exportSession(fullSession, t, { fileName })
   }
 
@@ -53,6 +50,7 @@ export const useChatExport = () => {
     fileName?: string
   ) => {
     const fullSession = await getFullSession(session)
+    const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
     pdfExporter.exportSession(fullSession, t, { fileName })
   }
 
@@ -61,6 +59,9 @@ export const useChatExport = () => {
     fileName?: string
   ) => {
     const fullSession = await getFullSession(session)
+    const { markdownExporter } = await import(
+      "@/lib/exporters/markdown-exporter"
+    )
     markdownExporter.exportSession(fullSession, t, { fileName })
   }
 
@@ -69,6 +70,7 @@ export const useChatExport = () => {
     fileName?: string
   ) => {
     const fullSession = await getFullSession(session)
+    const { textExporter } = await import("@/lib/exporters/text-exporter")
     textExporter.exportSession(fullSession, t, { fileName })
   }
 

--- a/src/features/sessions/hooks/use-export-chat.ts
+++ b/src/features/sessions/hooks/use-export-chat.ts
@@ -1,5 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { splitStoredFiles } from "@/features/sessions/lib/message-tree"
+import { toast } from "@/hooks/use-toast"
+import { logger } from "@/lib/logger"
 import {
   getFilesByMessageIds,
   getMessagesBySessionOrderedByTimestamp
@@ -8,6 +10,20 @@ import type { ChatSession } from "@/types"
 
 export const useChatExport = () => {
   const { t } = useTranslation()
+
+  // Exporters load lazily; surface chunk-load/export failures instead of
+  // letting the unawaited call sites swallow them.
+  const guard = async (run: () => Promise<void>) => {
+    try {
+      await run()
+    } catch (error) {
+      logger.error("Session export failed", "useChatExport", { error })
+      toast({
+        variant: "destructive",
+        title: t("settings.migration.export.error_title")
+      })
+    }
+  }
 
   // Helper to ensure we have all messages
   const getFullSession = async (session: ChatSession): Promise<ChatSession> => {
@@ -36,43 +52,35 @@ export const useChatExport = () => {
     return { ...session, messages: messagesWithFiles }
   }
 
-  const exportSessionAsJson = async (
-    session: ChatSession,
-    fileName?: string
-  ) => {
-    const fullSession = await getFullSession(session)
-    const { jsonExporter } = await import("@/lib/exporters/json-exporter")
-    jsonExporter.exportSession(fullSession, t, { fileName })
-  }
+  const exportSessionAsJson = (session: ChatSession, fileName?: string) =>
+    guard(async () => {
+      const fullSession = await getFullSession(session)
+      const { jsonExporter } = await import("@/lib/exporters/json-exporter")
+      jsonExporter.exportSession(fullSession, t, { fileName })
+    })
 
-  const exportSessionAsPdf = async (
-    session: ChatSession,
-    fileName?: string
-  ) => {
-    const fullSession = await getFullSession(session)
-    const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
-    pdfExporter.exportSession(fullSession, t, { fileName })
-  }
+  const exportSessionAsPdf = (session: ChatSession, fileName?: string) =>
+    guard(async () => {
+      const fullSession = await getFullSession(session)
+      const { pdfExporter } = await import("@/lib/exporters/pdf-exporter")
+      pdfExporter.exportSession(fullSession, t, { fileName })
+    })
 
-  const exportSessionAsMarkdown = async (
-    session: ChatSession,
-    fileName?: string
-  ) => {
-    const fullSession = await getFullSession(session)
-    const { markdownExporter } = await import(
-      "@/lib/exporters/markdown-exporter"
-    )
-    markdownExporter.exportSession(fullSession, t, { fileName })
-  }
+  const exportSessionAsMarkdown = (session: ChatSession, fileName?: string) =>
+    guard(async () => {
+      const fullSession = await getFullSession(session)
+      const { markdownExporter } = await import(
+        "@/lib/exporters/markdown-exporter"
+      )
+      markdownExporter.exportSession(fullSession, t, { fileName })
+    })
 
-  const exportSessionAsText = async (
-    session: ChatSession,
-    fileName?: string
-  ) => {
-    const fullSession = await getFullSession(session)
-    const { textExporter } = await import("@/lib/exporters/text-exporter")
-    textExporter.exportSession(fullSession, t, { fileName })
-  }
+  const exportSessionAsText = (session: ChatSession, fileName?: string) =>
+    guard(async () => {
+      const fullSession = await getFullSession(session)
+      const { textExporter } = await import("@/lib/exporters/text-exporter")
+      textExporter.exportSession(fullSession, t, { fileName })
+    })
 
   return {
     exportSessionAsJson,

--- a/src/hooks/use-markdown-parser.ts
+++ b/src/hooks/use-markdown-parser.ts
@@ -10,7 +10,22 @@ import sup from "markdown-it-sup"
 import taskLists from "markdown-it-task-lists"
 import { useEffect, useMemo, useState } from "react"
 
-import { hljs } from "@/lib/hljs"
+// highlight.js (core + ~20 languages) is heavy; keep it out of the eager
+// side-panel bundle. Load it on demand the first time a code fence appears,
+// then re-render to colorise. Until then code blocks render escaped + plain.
+let hljsModule: typeof import("@/lib/hljs") | null = null
+let hljsLoading: Promise<void> | null = null
+const ensureHljs = (): Promise<void> => {
+  if (hljsModule) return Promise.resolve()
+  if (!hljsLoading) {
+    hljsLoading = import("@/lib/hljs").then((mod) => {
+      hljsModule = mod
+    })
+  }
+  return hljsLoading
+}
+
+const CODE_FENCE = /(^|\n)\s*(```|~~~)/
 
 export const useMarkdownParser = (markdown: string) => {
   const md = useMemo(() => {
@@ -21,7 +36,8 @@ export const useMarkdownParser = (markdown: string) => {
       highlight(str, lang) {
         const safeLang = instance.utils.escapeHtml(lang || "")
         const langAttrs = safeLang ? ` data-code-language="${safeLang}"` : ""
-        if (lang && hljs.getLanguage(lang)) {
+        const hljs = hljsModule?.hljs
+        if (hljs && lang && hljs.getLanguage(lang)) {
           try {
             return `<pre class="hljs"${langAttrs}><code class="language-${safeLang}">${
               hljs.highlight(str, {
@@ -49,11 +65,14 @@ export const useMarkdownParser = (markdown: string) => {
     return instance
   }, [])
 
+  const [hljsReady, setHljsReady] = useState(() => hljsModule !== null)
   const [html, setHtml] = useState(() => {
     const rawHtml = md.render(markdown)
     return DOMPurify.sanitize(rawHtml)
   })
 
+  // Re-render on content change and once highlight.js has loaded.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hljsReady is a deliberate re-render trigger (highlight after lazy load)
   useEffect(() => {
     const rafId = requestAnimationFrame(() => {
       const rawHtml = md.render(markdown)
@@ -62,7 +81,19 @@ export const useMarkdownParser = (markdown: string) => {
     })
 
     return () => cancelAnimationFrame(rafId)
-  }, [markdown, md])
+  }, [markdown, md, hljsReady])
+
+  // Lazy-load highlight.js the first time the content has a code fence.
+  useEffect(() => {
+    if (hljsReady || !CODE_FENCE.test(markdown)) return
+    let cancelled = false
+    ensureHljs().then(() => {
+      if (!cancelled) setHljsReady(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [markdown, hljsReady])
 
   return html
 }

--- a/src/hooks/use-markdown-parser.ts
+++ b/src/hooks/use-markdown-parser.ts
@@ -18,9 +18,15 @@ let hljsLoading: Promise<void> | null = null
 const ensureHljs = (): Promise<void> => {
   if (hljsModule) return Promise.resolve()
   if (!hljsLoading) {
-    hljsLoading = import("@/lib/hljs").then((mod) => {
-      hljsModule = mod
-    })
+    hljsLoading = import("@/lib/hljs")
+      .then((mod) => {
+        hljsModule = mod
+      })
+      .catch((error) => {
+        // Let a later code-fence render retry instead of caching the rejection.
+        hljsLoading = null
+        throw error
+      })
   }
   return hljsLoading
 }
@@ -87,9 +93,13 @@ export const useMarkdownParser = (markdown: string) => {
   useEffect(() => {
     if (hljsReady || !CODE_FENCE.test(markdown)) return
     let cancelled = false
-    ensureHljs().then(() => {
-      if (!cancelled) setHljsReady(true)
-    })
+    ensureHljs()
+      .then(() => {
+        if (!cancelled) setHljsReady(true)
+      })
+      .catch(() => {
+        // Highlighting stays off; a later render can retry.
+      })
     return () => {
       cancelled = true
     }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} Dateien",
       "knowledge": "Wissen",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "Dieses Diagramm konnte nicht gerendert werden",
+      "render_failed_desc": "Der Quelltext wird unten angezeigt – Details für den Fehler aufklappen.",
+      "error_details": "Fehlerdetails",
+      "mermaid_empty": "Kein Mermaid-Inhalt",
+      "rendering_mermaid": "Mermaid-Diagramm wird gerendert …",
+      "empty": "Kein Artefakt-Inhalt"
     }
   },
   "file_upload": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} files",
       "knowledge": "Knowledge",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "Couldn't render this diagram",
+      "render_failed_desc": "The raw source is shown below — expand details for the error.",
+      "error_details": "Error details",
+      "mermaid_empty": "No Mermaid content",
+      "rendering_mermaid": "Rendering Mermaid diagram…",
+      "empty": "No artifact content"
     }
   },
   "file_upload": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} archivos",
       "knowledge": "Conocimiento",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "No se pudo renderizar este diagrama",
+      "render_failed_desc": "El código fuente se muestra abajo; despliega los detalles para ver el error.",
+      "error_details": "Detalles del error",
+      "mermaid_empty": "Sin contenido Mermaid",
+      "rendering_mermaid": "Renderizando diagrama Mermaid…",
+      "empty": "Sin contenido de artefacto"
     }
   },
   "file_upload": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} fichiers",
       "knowledge": "Connaissances",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "Impossible d'afficher ce diagramme",
+      "render_failed_desc": "Le code source est affiché ci-dessous — développez les détails pour voir l'erreur.",
+      "error_details": "Détails de l'erreur",
+      "mermaid_empty": "Aucun contenu Mermaid",
+      "rendering_mermaid": "Rendu du diagramme Mermaid…",
+      "empty": "Aucun contenu d'artefact"
     }
   },
   "file_upload": {

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} फ़ाइलें",
       "knowledge": "ज्ञान",
       "web": "वेब"
+    },
+    "artifacts": {
+      "render_failed_title": "यह आरेख रेंडर नहीं हो सका",
+      "render_failed_desc": "कच्चा स्रोत नीचे दिखाया गया है — त्रुटि के लिए विवरण खोलें।",
+      "error_details": "त्रुटि विवरण",
+      "mermaid_empty": "कोई Mermaid सामग्री नहीं",
+      "rendering_mermaid": "Mermaid आरेख रेंडर हो रहा है…",
+      "empty": "कोई आर्टिफ़ैक्ट सामग्री नहीं"
     }
   },
   "file_upload": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} file",
       "knowledge": "Conoscenza",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "Impossibile renderizzare questo diagramma",
+      "render_failed_desc": "Il codice sorgente è mostrato sotto — espandi i dettagli per vedere l'errore.",
+      "error_details": "Dettagli dell'errore",
+      "mermaid_empty": "Nessun contenuto Mermaid",
+      "rendering_mermaid": "Rendering del diagramma Mermaid…",
+      "empty": "Nessun contenuto dell'artefatto"
     }
   },
   "file_upload": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} 個のファイル",
       "knowledge": "ナレッジ",
       "web": "Web"
+    },
+    "artifacts": {
+      "render_failed_title": "この図を表示できませんでした",
+      "render_failed_desc": "ソースを以下に表示しています。詳細を開いてエラーを確認してください。",
+      "error_details": "エラーの詳細",
+      "mermaid_empty": "Mermaid コンテンツがありません",
+      "rendering_mermaid": "Mermaid 図をレンダリング中…",
+      "empty": "アーティファクトの内容がありません"
     }
   },
   "file_upload": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} файлов",
       "knowledge": "Знания",
       "web": "Веб"
+    },
+    "artifacts": {
+      "render_failed_title": "Не удалось отобразить эту диаграмму",
+      "render_failed_desc": "Исходный код показан ниже — разверните подробности, чтобы увидеть ошибку.",
+      "error_details": "Подробности ошибки",
+      "mermaid_empty": "Нет содержимого Mermaid",
+      "rendering_mermaid": "Отрисовка диаграммы Mermaid…",
+      "empty": "Нет содержимого артефакта"
     }
   },
   "file_upload": {

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -407,6 +407,14 @@
       "files": "{{count}} 个文件",
       "knowledge": "知识",
       "web": "网页"
+    },
+    "artifacts": {
+      "render_failed_title": "无法渲染此图表",
+      "render_failed_desc": "下方显示原始源代码——展开详情查看错误。",
+      "error_details": "错误详情",
+      "mermaid_empty": "没有 Mermaid 内容",
+      "rendering_mermaid": "正在渲染 Mermaid 图表…",
+      "empty": "没有工件内容"
     }
   },
   "file_upload": {


### PR DESCRIPTION
## Summary
Two changes.

### Graceful Mermaid fallback
Model output sometimes emits invalid Mermaid syntax. Instead of dumping the raw
parser error, the preview now shows a friendly notice, the raw source (so
nothing is lost), and tucks the parser message into a collapsible "Error
details".

### Lazy-load heavy, non-critical deps
Keep heavy libs out of the eager side-panel bundle:
- **highlight.js** (core + ~20 languages) loads on demand the first time a code
  fence appears; code renders escaped/plain until it arrives, then re-highlights.
- **Export pipeline** (jsPDF / jszip / markdown-utils) is dynamic-imported only
  when the user actually exports a message/session.

**Measured:** side-panel entry chunk **636 kB → 520 kB**; highlight.js is now a
106 kB lazy chunk. (mermaid, pdfjs, katex, cytoscape were already lazy.)

The remaining large `query-client` chunk is the core app vendor (react-query +
the eager dependency graph shared by both entries) — not a lazy-load target.

## Testing
typecheck · lint · `test:run` (1774) · Chrome MV3 + Firefox MV2 builds · docs build — all pass (via the pre-push gate).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two performance and UX improvements: lazy-loading of highlight.js and the export pipeline (jsPDF/jszip/markdown-utils) so they no longer inflate the eager side-panel bundle, and a graceful Mermaid render-failure UI that preserves the raw source and tucks the parser error into a collapsible `<details>` block instead of dumping it as raw text.

- **Lazy highlight.js** (`use-markdown-parser.ts`): a module-level singleton (`hljsModule` / `hljsLoading`) loads the library on first code-fence encounter; subsequent renders re-highlight once the promise resolves. The `.catch()` correctly resets `hljsLoading = null` so a failed load can be retried on the next render.
- **Lazy export pipeline** (`use-message-export.ts`, `use-export-chat.ts`): all four export functions now dynamic-import their exporter inside a shared `guard()` wrapper that catches chunk-load failures and surfaces them as a toast, addressing the previously identified fire-and-forget problem.
- **Mermaid fallback UI** (`artifact-preview.tsx`): replaces the monolithic `PreviewTextBlock` error dump with a structured warning banner, the raw source, and a collapsible error block; all copy is i18n-keyed and added across all 9 supported locales.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both lazy-load paths handle failures gracefully and all previously identified gaps have been addressed.

The retry logic for a failed hljs chunk load is correctly implemented by resetting hljsLoading to null in the catch block. Export failures are surfaced via a toast through the guard() wrapper rather than swallowed silently. The Mermaid fallback renders error content as React text nodes (auto-escaped). All 9 locale files are updated consistently.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/hooks/use-markdown-parser.ts | Lazy-loads highlight.js via a module-level singleton; correctly resets hljsLoading on rejection to allow retries; per-component hljsReady state coordinates re-render after load. |
| src/features/chat/hooks/use-message-export.ts | Converts all four message-export functions to dynamic-import with a shared guard() wrapper that catches chunk-load failures and shows a destructive toast; cleanly addresses the previous fire-and-forget concern. |
| src/features/sessions/hooks/use-export-chat.ts | Mirrors the same guard() pattern as use-message-export.ts for session-level exports; getFullSession is correctly inside the guard closure so DB errors are also caught. |
| src/features/chat/components/artifact-preview.tsx | Replaces raw error dump with a structured warning banner + collapsible error details; error content rendered as React text (auto-escaped); all strings i18n-keyed. |
| src/locales/en/translation.json | Adds 6 new keys under chat.artifacts for the Mermaid fallback UI; consistent across all 9 supported locales. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Component (useMarkdownParser)
    participant E as ensureHljs()
    participant M as hljsModule (singleton)
    participant D as Dynamic import(@/lib/hljs)

    C->>E: first code-fence detected
    E->>M: "hljsModule === null?"
    M-->>E: null
    E->>D: "import("@/lib/hljs")"
    Note over E: hljsLoading = Promise
    D-->>E: module resolved
    E->>M: "hljsModule = mod"
    E-->>C: Promise.resolve()
    C->>C: setHljsReady(true)
    C->>C: useEffect re-runs → re-render with syntax highlighting

    Note over C,D: Subsequent calls
    C->>E: ensureHljs()
    E->>M: "hljsModule !== null"
    E-->>C: Promise.resolve() immediately

    Note over C,D: On chunk-load failure
    D-->>E: rejection
    E->>E: "hljsLoading = null (retry allowed)"
    E-->>C: throw error
    C->>C: .catch() — highlighting stays off, next render can retry
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Component (useMarkdownParser)
    participant E as ensureHljs()
    participant M as hljsModule (singleton)
    participant D as Dynamic import(@/lib/hljs)

    C->>E: first code-fence detected
    E->>M: "hljsModule === null?"
    M-->>E: null
    E->>D: "import("@/lib/hljs")"
    Note over E: hljsLoading = Promise
    D-->>E: module resolved
    E->>M: "hljsModule = mod"
    E-->>C: Promise.resolve()
    C->>C: setHljsReady(true)
    C->>C: useEffect re-runs → re-render with syntax highlighting

    Note over C,D: Subsequent calls
    C->>E: ensureHljs()
    E->>M: "hljsModule !== null"
    E-->>C: Promise.resolve() immediately

    Note over C,D: On chunk-load failure
    D-->>E: rejection
    E->>E: "hljsLoading = null (retry allowed)"
    E-->>C: throw error
    C->>C: .catch() — highlighting stays off, next render can retry
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["i18n(chat): translate artifact-preview s..."](https://github.com/shishir435/ollama-client/commit/0c1f390ad057a88c99d307fbcd0df601644abd6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40569369)</sub>

<!-- /greptile_comment -->