### PR TITLE
Prepare 0.11.24 release confidence update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.11.24] - 2026-06-29
+
+### Added
+- S3 provider round-trip smoke coverage for a mock OpenAI-compatible provider:
+  stream a response, persist the assistant reply, reload the SQLite facade, and
+  assert the reply survives.
+- SEO foundation docs: quick start, privacy, FAQ, and Ollama CORS troubleshooting
+  pages, with FAQPage structured data and higher-signal homepage retrieval copy.
+
+### Changed
+- Local OpenAI-compatible `401`/`403` failures now point users at CORS/origin
+  setup instead of misleading API-key guidance when the provider URL is local.
+- Docs site upgraded to Astro 7 and Starlight 0.41, with the Mermaid markdown
+  hook moved to Astro's current markdown processor API.
+- Bumped package version to `0.11.24`.
+
 ## [0.11.23] - 2026-06-28
 
 ### Added
@@ -381,7 +397,16 @@ Consolidated 0.11.x line: the "agent's hands" features plus a data-integrity har
 ### Documentation
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.11.24...HEAD
+[0.11.24]: https://github.com/Shishir435/ollama-client/compare/v0.11.23...v0.11.24
+[0.11.23]: https://github.com/Shishir435/ollama-client/compare/v0.11.22...v0.11.23
+[0.11.22]: https://github.com/Shishir435/ollama-client/compare/v0.11.20...v0.11.22
+[0.11.20]: https://github.com/Shishir435/ollama-client/compare/v0.10.3...v0.11.20
+[0.10.3]: https://github.com/Shishir435/ollama-client/compare/v0.10.2...v0.10.3
+[0.10.2]: https://github.com/Shishir435/ollama-client/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/Shishir435/ollama-client/compare/v0.9.1...v0.10.1
+[0.9.1]: https://github.com/Shishir435/ollama-client/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/Shishir435/ollama-client/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Shishir435/ollama-client/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/Shishir435/ollama-client/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/Shishir435/ollama-client/compare/v0.7.1...v0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.11.24] - 2026-06-29
 
 ### Added
-- S3 provider round-trip smoke coverage for a mock OpenAI-compatible provider:
+- OpenAI-compatible provider round-trip smoke coverage:
   stream a response, persist the assistant reply, reload the SQLite facade, and
   assert the reply survives.
 - SEO foundation docs: quick start, privacy, FAQ, and Ollama CORS troubleshooting

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,4 +1,5 @@
 import mdx from "@astrojs/mdx"
+import { unified } from "@astrojs/markdown-remark"
 import sitemap from "@astrojs/sitemap"
 import starlight from "@astrojs/starlight"
 import { defineConfig } from "astro/config"
@@ -66,7 +67,9 @@ export default defineConfig({
      * architecture page is the only one with diagrams; load is lazy
      * via dynamic import in the init script below.
      */
-    rehypePlugins: [[rehypeMermaid, { strategy: "pre-mermaid" }]]
+    processor: unified({
+      rehypePlugins: [[rehypeMermaid, { strategy: "pre-mermaid" }]]
+    })
   },
   integrations: [
     starlight({
@@ -155,16 +158,22 @@ export default defineConfig({
         {
           label: "Guides",
           items: [
+            { label: "Quick Start", slug: "guides/quick-start" },
             { label: "Provider Setup", slug: "guides/provider-setup" },
             {
               label: "Context, Images, and Tools",
               slug: "guides/context-and-tools"
+            },
+            {
+              label: "Fix Ollama CORS errors",
+              slug: "guides/troubleshooting/ollama-cors-error"
             }
           ]
         },
         {
           label: "Concepts",
           items: [
+            { label: "Privacy", slug: "concepts/privacy" },
             { label: "Architecture", slug: "concepts/architecture" },
             {
               label: "Provider capabilities",
@@ -190,6 +199,7 @@ export default defineConfig({
         {
           label: "About",
           items: [
+            { label: "FAQ", slug: "about/faq" },
             { label: "Changelog", slug: "about/changelog" },
             { label: "Keyboard Shortcuts", slug: "about/keyboard-shortcuts" }
           ]

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,17 +11,18 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.0",
-    "astro": "6.1.10",
+    "astro": "7.0.3",
     "postcss": "8.5.10",
     "tailwindcss": "4.3.0"
   },
   "dependencies": {
-    "@astrojs/mdx": "^5.0.6",
-    "@astrojs/sitemap": "^3.7.2",
-    "@astrojs/starlight": "^0.39.2",
+    "@astrojs/markdown-remark": "7.2.0",
+    "@astrojs/mdx": "^7.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/starlight": "^0.41.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
-    "astro-og-canvas": "^0.11.1",
+    "astro-og-canvas": "^0.12.0",
     "canvaskit-wasm": "^0.41.1",
     "rehype-mermaid": "^3.0.0",
     "starlight-typedoc": "^0.23.0",

--- a/docs/src/components/seo/FAQPageJsonLd.astro
+++ b/docs/src/components/seo/FAQPageJsonLd.astro
@@ -1,0 +1,27 @@
+---
+type FAQItem = {
+  question: string
+  answer: string
+}
+
+interface Props {
+  items: FAQItem[]
+}
+
+const { items } = Astro.props
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: items.map((item) => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.answer
+    }
+  }))
+}
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/docs/src/content/docs/about/faq.mdx
+++ b/docs/src/content/docs/about/faq.mdx
@@ -1,0 +1,96 @@
+---
+title: Ollama Client FAQ
+description: Common questions about Ollama Client, local LLM providers, privacy, browser support, RAG, web search, and CORS setup.
+---
+
+import FAQPageJsonLd from "../../../components/seo/FAQPageJsonLd.astro"
+
+export const faqItems = [
+  {
+    question: "What is Ollama Client?",
+    answer:
+      "Ollama Client is an open-source browser extension for private, local-first AI chat with Ollama, LM Studio, llama.cpp, vLLM, LocalAI, KoboldCPP, and other OpenAI-compatible servers."
+  },
+  {
+    question: "Does Ollama Client require OpenAI?",
+    answer:
+      "No. Ollama Client is designed for local and self-hosted providers. You can use Ollama, LM Studio, llama.cpp, vLLM, LocalAI, or KoboldCPP without any OpenAI account."
+  },
+  {
+    question: "Where is my chat history stored?",
+    answer:
+      "Chat history is stored locally in the browser extension using SQLite in IndexedDB. Uploaded-file vectors and knowledge sets also stay in local browser storage."
+  },
+  {
+    question: "Can Ollama Client read the current web page?",
+    answer:
+      "Yes, when tab access and page context are enabled. The extension can add selected text, current page content, tab context, uploaded files, and optional web search results to a chat."
+  },
+  {
+    question: "Why do I see a 403 or CORS error with Ollama?",
+    answer:
+      "Firefox and strict local servers may block extension origins. For Ollama, allow browser-extension origins with OLLAMA_ORIGINS, then restart Ollama and retry."
+  }
+]
+
+<FAQPageJsonLd items={faqItems} />
+
+Ollama Client is a local-first browser extension for chatting with local and
+self-hosted AI models. It runs in Chrome and Firefox and connects to providers
+you control: Ollama, LM Studio, llama.cpp, vLLM, LocalAI, KoboldCPP, or another
+OpenAI-compatible server.
+
+## Does Ollama Client send my data to a cloud service?
+
+No cloud service is required by Ollama Client. Chat history, settings, uploaded
+files, and knowledge indexes are stored locally in the browser extension. Model
+requests go to the provider endpoint you configure.
+
+If you configure a remote provider, the prompt data needed for that request goes
+to that remote endpoint. If you configure a local provider such as Ollama or LM
+Studio on `localhost`, requests stay on your machine.
+
+## Which providers work with Ollama Client?
+
+Ollama Client supports:
+
+- Ollama
+- LM Studio
+- llama.cpp server
+- vLLM
+- LocalAI
+- KoboldCPP
+- Other OpenAI-compatible servers through the shared OpenAI-compatible adapter
+
+See [Provider Setup](/guides/provider-setup/) for endpoints and setup steps.
+
+## Is Ollama Client an Open WebUI alternative?
+
+Yes, for users who want a browser extension instead of a self-hosted web
+application. Open WebUI is a server-hosted interface. Ollama Client lives in the
+browser side panel and focuses on page context, local storage, RAG, web search,
+and browser-aware tools.
+
+## Can I use files and RAG locally?
+
+Yes. Ollama Client can process uploaded files and store local vector indexes for
+retrieval-augmented generation. File retrieval is local-first: uploaded content
+and embeddings are stored in browser storage, not in a hosted service.
+
+## Can models search the web?
+
+Yes, if you enable web search and configure a backend. Supported backends include
+SearXNG, Brave Search, and Tavily. Web search is optional, and API keys stay in
+local extension storage.
+
+## How do I fix a 403 or CORS error?
+
+For Ollama, set `OLLAMA_ORIGINS` so the local server accepts requests from
+browser-extension origins:
+
+```bash
+OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
+```
+
+For persistent setup and platform-specific steps, see
+[Fix Ollama CORS errors](/guides/troubleshooting/ollama-cors-error/).

--- a/docs/src/content/docs/concepts/privacy.md
+++ b/docs/src/content/docs/concepts/privacy.md
@@ -1,0 +1,81 @@
+---
+title: Local-first privacy in Ollama Client
+description: How Ollama Client stores chats, files, settings, permissions, and model requests for private local AI workflows.
+---
+
+Ollama Client is designed around local-first AI chat. The extension stores user
+data in browser storage and sends prompts only to the provider endpoint you
+configure.
+
+## What stays on your device?
+
+These data types are stored locally by the extension:
+
+- Chat sessions and messages
+- Uploaded-file metadata and local retrieval indexes
+- Knowledge sets and embeddings
+- Provider settings and model mappings
+- Web-search configuration
+- Browser permission state and feature settings
+
+Chat history uses SQLite-in-WASM persisted to IndexedDB. Vector storage and
+knowledge sets use local IndexedDB storage.
+
+## What can leave your device?
+
+Prompt data leaves your device only when needed for the provider you choose.
+
+If your provider is local, such as Ollama at `http://localhost:11434` or LM
+Studio at `http://localhost:1234/v1`, requests stay on your machine. If you
+configure a remote OpenAI-compatible server, prompts and selected context are
+sent to that remote server.
+
+Optional web search can contact the backend you configure, such as SearXNG,
+Brave Search, or Tavily.
+
+## Browser permissions are explicit
+
+Browser features such as tab access, recently closed sessions, screenshots, and
+downloads are controlled through extension permissions and visible settings. The
+model-tools inventory in **Privacy & permissions** shows which tools are
+available and why.
+
+## Page and tab context are scoped
+
+Ollama Client can read current-page or tab context only when the related setting
+and browser access allow it. Excluded and unreadable URLs are filtered before
+content is used for chat or model-callable tools.
+
+## Uploaded files and local RAG
+
+Uploaded files are processed locally for retrieval. The extension can store
+chunks and embeddings in browser storage so future chats can retrieve relevant
+context.
+
+## Web search is optional
+
+Web search is off unless configured. When enabled, the model can use the selected
+web-search backend through the tool system. API keys are stored locally and are
+not logged by the extension.
+
+## Reset and backup
+
+The Data & backup settings let you export or reset local data. Reset maps include
+provider configuration and API keys so a provider reset removes stored secrets.
+
+## FAQ
+
+### Is Ollama Client private by default?
+
+It is local-first by default. Privacy still depends on the provider endpoint and
+optional features you enable.
+
+### Does Ollama Client index browser history automatically?
+
+Browser knowledge features are optional and permission-gated. Keep them disabled
+if you do not want browser history or bookmarks available for local retrieval.
+
+### Where should I check permissions?
+
+Open **Privacy & permissions** in settings. It shows browser permissions, tool
+families, and per-model tool availability.

--- a/docs/src/content/docs/guides/quick-start.md
+++ b/docs/src/content/docs/guides/quick-start.md
@@ -1,0 +1,101 @@
+---
+title: Ollama quick start in Chrome or Firefox
+description: Connect Ollama Client to Ollama, LM Studio, or llama.cpp and send your first local AI chat from the browser side panel.
+---
+
+Ollama Client lets you chat with a local LLM from the browser side panel. The
+fastest path is: start a local provider, install the extension, choose a model,
+and send your first message.
+
+## 1. Start a local provider
+
+Use any supported local or OpenAI-compatible server.
+
+### Ollama
+
+```bash
+ollama serve
+ollama pull llama3.2
+```
+
+Default URL: `http://localhost:11434`
+
+### LM Studio
+
+Open LM Studio, start the local server, and load a model.
+
+Default URL: `http://localhost:1234/v1`
+
+### llama.cpp server
+
+```bash
+llama-server -m ~/Library/Caches/llama.cpp/model.gguf --port 8000 --host 0.0.0.0
+```
+
+Default URL: `http://localhost:8000/v1`
+
+## 2. Install Ollama Client
+
+Install the extension, open the side panel, and go to **Setup** if the provider
+connection is not detected automatically.
+
+Use [Provider Setup](/guides/provider-setup/) for full provider-specific
+configuration.
+
+## 3. Pick a model
+
+Open the model selector and choose a model from your provider. If a model list is
+empty, check that the provider is running and that the base URL matches the
+server.
+
+## 4. Send your first message
+
+Ask a normal question. Ollama Client streams the answer into the side panel and
+stores the chat locally.
+
+## 5. Add page context or files
+
+After the first chat works, enable the context controls you need:
+
+- **Page & tabs** for current-page and tab context.
+- **Knowledge & web** for uploaded files, local RAG, and optional web search.
+- **Privacy & permissions** for browser permissions and model-callable tools.
+
+## Common first-run problems
+
+### The provider says 403 or CORS
+
+Firefox and strict local servers may reject browser-extension origins. For
+Ollama, set:
+
+```bash
+OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
+```
+
+See [Fix Ollama CORS errors](/guides/troubleshooting/ollama-cors-error/).
+
+### The model list is empty
+
+Confirm the provider is running, the base URL is correct, and at least one model
+is available locally.
+
+### Chat works but tools do not
+
+Tool calling depends on model capability plus the enabled tool family settings.
+Check **Privacy & permissions** for the live tool inventory.
+
+## FAQ
+
+### Does this require OpenAI?
+
+No. Ollama Client works with local and self-hosted providers. OpenAI-compatible
+means the server speaks the OpenAI API shape; it does not require OpenAI.
+
+### Does chat history stay local?
+
+Yes. Chat history is stored locally in browser extension storage.
+
+### Can I use this as an Open WebUI alternative?
+
+Yes, if you want a browser extension and side panel instead of a self-hosted web
+app.

--- a/docs/src/content/docs/guides/troubleshooting/ollama-cors-error.md
+++ b/docs/src/content/docs/guides/troubleshooting/ollama-cors-error.md
@@ -1,0 +1,97 @@
+---
+title: Fix Ollama CORS errors in browser extensions
+description: Resolve 403 Forbidden and CORS errors when Ollama Client connects to a local Ollama server from Chrome or Firefox.
+---
+
+A `403 Forbidden` or CORS error usually means Ollama rejected the browser
+extension origin. This is most common in Firefox, where extensions cannot use the
+same declarative network request CORS workaround that Chromium supports.
+
+## Quick fix
+
+Start Ollama with browser-extension origins allowed:
+
+```bash
+OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
+```
+
+Then reopen Ollama Client and retry the connection.
+
+## macOS persistent setup
+
+If Ollama runs as a launch service, set `OLLAMA_ORIGINS` in the service
+environment and restart Ollama.
+
+For a shell session:
+
+```bash
+export OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*"
+ollama serve
+```
+
+## Linux systemd setup
+
+Create or edit an Ollama service override:
+
+```bash
+sudo systemctl edit ollama
+```
+
+Add:
+
+```ini
+[Service]
+Environment="OLLAMA_ORIGINS=chrome-extension://*,moz-extension://*"
+```
+
+Reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
+## Windows PowerShell setup
+
+Set the environment variable before starting Ollama:
+
+```powershell
+$env:OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*"
+ollama serve
+```
+
+For a persistent user variable:
+
+```powershell
+[Environment]::SetEnvironmentVariable("OLLAMA_ORIGINS", "chrome-extension://*,moz-extension://*", "User")
+```
+
+Restart Ollama after changing the value.
+
+## Chrome vs Firefox
+
+Chromium browsers can use extension-side CORS rules in more cases. Firefox is
+stricter, so the Ollama server often needs the explicit `OLLAMA_ORIGINS` value.
+
+## OpenAI-compatible local servers
+
+LM Studio, llama.cpp, vLLM, LocalAI, and KoboldCPP may have their own
+CORS/origin settings. If you see a local `401` or `403` from one of these
+servers, check that its API server accepts browser-extension origins and that
+the base URL in Ollama Client points to the local OpenAI-compatible endpoint.
+
+## FAQ
+
+### Is this an API key problem?
+
+Usually no for local providers. A local `403` often means origin/CORS rejection,
+not bad credentials.
+
+### Do I need both Chrome and Firefox origins?
+
+Using both is convenient if you test the extension in multiple browsers.
+
+### Is `OLLAMA_ORIGINS="*"` safe?
+
+Prefer the narrower browser-extension origins shown above. Use broader origins
+only if you understand the local network exposure.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -10,23 +10,62 @@ import {
 const title = LANDING_TITLE
 const description = LANDING_DESCRIPTION
 
+const homepageFaq = [
+  {
+    question: "Does Ollama Client send chats to a cloud service?",
+    answer:
+      "No. Ollama Client stores chats and knowledge locally and sends model requests only to the provider endpoint you configure, such as Ollama, LM Studio, llama.cpp, vLLM, LocalAI, or KoboldCPP."
+  },
+  {
+    question: "Can I use Ollama Client with LM Studio or llama.cpp?",
+    answer:
+      "Yes. Ollama Client supports Ollama plus local OpenAI-compatible servers including LM Studio, llama.cpp, vLLM, LocalAI, and KoboldCPP."
+  },
+  {
+    question: "Is Ollama Client an Open WebUI alternative?",
+    answer:
+      "It can be, if you want a browser extension instead of a self-hosted web app. Ollama Client focuses on local-first chat, page context, files, web search, and browser tools inside Chrome or Firefox."
+  }
+]
+
 const jsonLd = {
   "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: SITE_TITLE,
-  description,
-  applicationCategory: "BrowserApplication",
-  operatingSystem: "Chrome",
-  author: {
-    "@type": "Person",
-    name: "Shishir Chaurasiya",
-    url: "https://www.shishirchaurasiya.in/"
-  },
-  url: "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
-  downloadUrl:
-    "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
-  codeRepository: "https://github.com/Shishir435/ollama-client",
-  softwareVersion: APP_VERSION
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      name: SITE_TITLE,
+      description,
+      applicationCategory: "BrowserApplication",
+      operatingSystem: "Chrome, Firefox",
+      browserRequirements: "Chrome MV3 or Firefox MV2 compatible browser",
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD"
+      },
+      author: {
+        "@type": "Person",
+        name: "Shishir Chaurasiya",
+        url: "https://www.shishirchaurasiya.in/"
+      },
+      url: "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
+      downloadUrl:
+        "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
+      codeRepository: "https://github.com/Shishir435/ollama-client",
+      softwareVersion: APP_VERSION
+    },
+    {
+      "@type": "FAQPage",
+      mainEntity: homepageFaq.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer
+        }
+      }))
+    }
+  ]
 }
 
 const features = [
@@ -104,9 +143,11 @@ const stack = [
       Chat with local LLMs, right in your browser.
     </h1>
     <p class="mt-5 max-w-2xl text-balance text-[15px] leading-relaxed text-foreground/70">
-      Connect Ollama, LM Studio, llama.cpp, or any OpenAI-compatible server.
-      Provider-aware routing, streaming responses, local retrieval — all without
-      a mandatory cloud API.
+      Ollama Client is an open-source browser extension for Ollama, LM Studio,
+      llama.cpp, vLLM, LocalAI, KoboldCPP, and other OpenAI-compatible servers.
+      Chat with local AI models inside Chrome and Firefox with RAG, file upload,
+      web search, tool calling, and page context — all without a mandatory cloud
+      API.
     </p>
     <div class="mt-8 flex flex-wrap items-center gap-3">
       <a

--- a/docs/src/seo/constants.mjs
+++ b/docs/src/seo/constants.mjs
@@ -78,9 +78,11 @@ export const SITE_TITLE = "Ollama Client"
 export const SITE_DESCRIPTION =
   "Privacy-first browser extension for local LLM chat with Ollama, LM Studio, llama.cpp, and OpenAI-compatible servers."
 
-export const LANDING_TITLE = "Ollama Client — Local AI chat in your browser"
+export const LANDING_TITLE =
+  "Ollama Client — Ollama browser extension for local AI"
 
-export const LANDING_DESCRIPTION = `${SITE_DESCRIPTION} Local-first by design.`
+export const LANDING_DESCRIPTION =
+  "Use Ollama, LM Studio, llama.cpp, vLLM, LocalAI, or KoboldCPP inside Chrome and Firefox with local-first RAG, files, tools, and page context."
 
 export const KEYWORDS =
-  "ollama, local llm, browser extension, chrome extension, firefox extension, side panel, rag, embeddings, local-first, privacy, lm studio, llama.cpp, openai compatible, open source"
+  "ollama browser extension, local llm browser extension, chrome extension for ollama, lm studio browser extension, open webui alternative, local ai assistant, offline ai browser, private ai chat, local rag, browser ai agent, self-hosted ai, firefox extension, llama.cpp, vllm, localai, koboldcpp, openai compatible, open source"

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss/index.css";
 @import "./tokens.css";
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.23",
+  "version": "0.11.24",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,15 +264,18 @@ importers:
 
   docs:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: 7.2.0
+        version: 7.2.0
       '@astrojs/mdx':
-        specifier: ^5.0.6
-        version: 5.0.6(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))
+        specifier: ^7.0.0
+        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))
       '@astrojs/sitemap':
-        specifier: ^3.7.2
-        version: 3.7.2
+        specifier: ^3.7.3
+        version: 3.7.3
       '@astrojs/starlight':
-        specifier: ^0.39.2
-        version: 0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
+        specifier: ^0.41.1
+        version: 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))(typescript@5.9.3)
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
@@ -280,8 +283,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       astro-og-canvas:
-        specifier: ^0.11.1
-        version: 0.11.1(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))
+        specifier: ^0.12.0
+        version: 0.12.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -290,7 +293,7 @@ importers:
         version: 3.0.0(playwright@1.60.0)
       starlight-typedoc:
         specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
+        version: 0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -302,8 +305,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       astro:
-        specifier: 6.1.10
-        version: 6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)
+        specifier: 7.0.3
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
       postcss:
         specifier: 8.5.10
         version: 8.5.10
@@ -339,45 +342,107 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@astrojs/compiler@3.0.1':
-    resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
+  '@astrojs/compiler-binding-darwin-arm64@0.2.3':
+    resolution: {integrity: sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@astrojs/internal-helpers@0.9.0':
-    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
+  '@astrojs/compiler-binding-darwin-x64@0.2.3':
+    resolution: {integrity: sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
 
-  '@astrojs/internal-helpers@0.9.1':
-    resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.3':
+    resolution: {integrity: sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
-  '@astrojs/markdown-remark@7.1.1':
-    resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
+  '@astrojs/compiler-binding-linux-arm64-musl@0.2.3':
+    resolution: {integrity: sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
-  '@astrojs/markdown-remark@7.1.2':
-    resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
+  '@astrojs/compiler-binding-linux-x64-gnu@0.2.3':
+    resolution: {integrity: sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
-  '@astrojs/mdx@5.0.6':
-    resolution: {integrity: sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==}
+  '@astrojs/compiler-binding-linux-x64-musl@0.2.3':
+    resolution: {integrity: sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@astrojs/compiler-binding-wasm32-wasi@0.2.3':
+    resolution: {integrity: sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.3':
+    resolution: {integrity: sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@astrojs/compiler-binding-win32-x64-msvc@0.2.3':
+    resolution: {integrity: sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@astrojs/compiler-binding@0.2.3':
+    resolution: {integrity: sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@astrojs/compiler-rs@0.2.3':
+    resolution: {integrity: sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA==}
+
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
+
+  '@astrojs/markdown-satteri@0.3.2':
+    resolution: {integrity: sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==}
+
+  '@astrojs/mdx@7.0.0':
+    resolution: {integrity: sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
-      astro: ^6.0.0
-
-  '@astrojs/prism@4.0.1':
-    resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
-    engines: {node: '>=22.12.0'}
+      '@astrojs/markdown-satteri': ^0.3.1-alpha.0
+      astro: ^7.0.0-alpha.0
+    peerDependenciesMeta:
+      '@astrojs/markdown-satteri':
+        optional: true
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
 
-  '@astrojs/sitemap@3.7.2':
-    resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
+  '@astrojs/sitemap@3.7.3':
+    resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
-  '@astrojs/starlight@0.39.2':
-    resolution: {integrity: sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA==}
+  '@astrojs/starlight@0.41.1':
+    resolution: {integrity: sha512-avf2OmrVg6GdVU18juebjjIIuLa+uS3syHuJ/3yDaEFP/8it+YvcxRrYDSf7K6rC4v770UxIddba2hAqQyTeYA==}
     peerDependencies:
-      astro: ^6.0.0
+      '@astrojs/markdown-remark': ^7.2.0
+      astro: ^7.0.2
+    peerDependenciesMeta:
+      '@astrojs/markdown-remark':
+        optional: true
 
-  '@astrojs/telemetry@3.3.1':
-    resolution: {integrity: sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==}
+  '@astrojs/telemetry@3.3.2':
+    resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@babel/code-frame@7.29.0':
@@ -645,6 +710,55 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bruits/satteri-darwin-arm64@0.9.4':
+    resolution: {integrity: sha512-W3MSUkr2mZRR8Stoe+lqNAyzQzRuFMU8WffV9IvFSxTok0LGWR0ZZQPLELU4QTRiUbhL2Y4VUP9vV7pj8rHjgg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bruits/satteri-darwin-x64@0.9.4':
+    resolution: {integrity: sha512-DXOuuaE1lsv7mpk2mOvGrzqoEWEvOIZEO/fXVa7zfM23Iob+CBjBkRAMwpHA4pmZ3j6Gj7WJzPKw0kQ7w741AQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bruits/satteri-linux-arm64-gnu@0.9.4':
+    resolution: {integrity: sha512-gJxU9rGGoqIznSEgEzpjxkry24jeHuMpoo1tCIAhHYh7WaD3j5F8zt3jmHxEaN1Uwa+K5+wFgIR2uIGOnMzEmw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@bruits/satteri-linux-arm64-musl@0.9.4':
+    resolution: {integrity: sha512-Wjzu9hmmAbfmDkBfPI1VdZygJtYz9uYZQnkEyrXi6S2JFi+2pXQ1A5irj38bqm0IZmWcTbk0cVG4NZnPdtVNJA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@bruits/satteri-linux-x64-gnu@0.9.4':
+    resolution: {integrity: sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@bruits/satteri-linux-x64-musl@0.9.4':
+    resolution: {integrity: sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@bruits/satteri-wasm32-wasi@0.9.4':
+    resolution: {integrity: sha512-/CEG8LUlpaBEnhFnYVn0UnlHFLs51UhrkJBUPDUXLzkadzAcnR88iRA/nOl7Zwhjb4WhfBV4p3P5qeOJMtH0iA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@bruits/satteri-win32-arm64-msvc@0.9.4':
+    resolution: {integrity: sha512-E1ZPQbgCtFKiU7pFYVndynvY7ne4coeVDUgnVThErSFlJ2ceQCBZrfRTD1lzrIDy63Bbqo+g/cZY9duw+JYjIw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@bruits/satteri-win32-x64-msvc@0.9.4':
+    resolution: {integrity: sha512-5I7SiarsNdAUuhJb50CXJPTwr/ECVrBoU+fymoLjChK5fW//+srhY4lstcNTzgFRtQSYfVtm4OQZz16CVMeTeA==}
+    cpu: [x64]
+    os: [win32]
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -716,14 +830,29 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -734,8 +863,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm@0.27.7':
     resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -746,8 +887,20 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -758,8 +911,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -770,8 +935,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -782,8 +959,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -794,8 +983,20 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -806,8 +1007,20 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -818,8 +1031,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -830,8 +1055,20 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -842,8 +1079,20 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.7':
     resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -854,8 +1103,20 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -866,8 +1127,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -878,17 +1151,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@expressive-code/core@0.42.0':
-    resolution: {integrity: sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
-  '@expressive-code/plugin-frames@0.42.0':
-    resolution: {integrity: sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA==}
+  '@expressive-code/core@0.44.0':
+    resolution: {integrity: sha512-xgiF2P6tYUbrhi3+x0S8xHZWT1t3Bvb3U91tAtRbLb9HLejLvYc5GZUqKICKLaUN4iSGhhNJu2fM/aH8e5yCMg==}
 
-  '@expressive-code/plugin-shiki@0.42.0':
-    resolution: {integrity: sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g==}
+  '@expressive-code/plugin-frames@0.44.0':
+    resolution: {integrity: sha512-V6M6+zVc1GzqCvXkQHc2m5rcFOIVzJgMq5gnfrMnVf2gwtj/sg4H93c1f/mGeqHycubwkHFUDyParAOiGeDZeA==}
 
-  '@expressive-code/plugin-text-markers@0.42.0':
-    resolution: {integrity: sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ==}
+  '@expressive-code/plugin-shiki@0.44.0':
+    resolution: {integrity: sha512-RZsdaqlbGqyAQKuoX4myQXxjmiE2l5KBpJ/gKPh62tCdIdpWyjbzVqSo8+5XsezZxkfi8AJ/J6EUaBTPROFX/Q==}
+
+  '@expressive-code/plugin-text-markers@0.44.0':
+    resolution: {integrity: sha512-0/m3A5b+lz2upyNq+wzZ1S69HRoJmyFs5LsR42lVZ9pmGRlBiSBYQpvqlji4DBj1+Riamxc0AvcCr5kuzOQeWA==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1238,6 +1517,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -2070,6 +2355,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2441,6 +2729,10 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  am-i-vibing@0.4.0:
+    resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
+    hasBin: true
+
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
@@ -2522,20 +2814,25 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro-expressive-code@0.42.0:
-    resolution: {integrity: sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag==}
+  astro-expressive-code@0.44.0:
+    resolution: {integrity: sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw==}
     peerDependencies:
-      astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
+      astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0
 
-  astro-og-canvas@0.11.1:
-    resolution: {integrity: sha512-6omy7MJeOPwxdYH5+eL3zFIY9MhuDRUMuASuCx/eXNrHGUogq9ZHdx19A428KtWhLVuXVcLt7Klw5fxqASAHmg==}
+  astro-og-canvas@0.12.0:
+    resolution: {integrity: sha512-XqbChMkPZvBV0jxu3i9hapgYK3gSjO1+MFBq060w+NT9k1XL+BYjdcQ80ZZs45r6+EASgIYmlqjEL7zfLD9T7A==}
     peerDependencies:
-      astro: ^5.0.0 || ^6.0.0-alpha
+      astro: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  astro@6.1.10:
-    resolution: {integrity: sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==}
+  astro@7.0.3:
+    resolution: {integrity: sha512-CK+G+Tl2DMV1EXCwVG45vyurxf2IfRTklMxDhRKn+tst9Yl8rWXpudL62Fa6zin5Bt968FBvuyASj1aJShROZg==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
+    peerDependencies:
+      '@astrojs/markdown-remark': 7.2.0
+    peerDependenciesMeta:
+      '@astrojs/markdown-remark':
+        optional: true
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
@@ -3211,8 +3508,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3235,9 +3532,6 @@ packages:
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -3392,6 +3686,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3481,8 +3780,8 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  expressive-code@0.42.0:
-    resolution: {integrity: sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==}
+  expressive-code@0.44.0:
+    resolution: {integrity: sha512-JXVWVNCKlLuZLMQH8cOiDUSosT0Bb+elwE/dbAkpwFwDFmyFyWlECoWZIohh2FkIF1iI67TQJ+Ts9k7oNDh2qA==}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3682,6 +3981,10 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  get-tsconfig@5.0.0-beta.4:
+    resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
+    engines: {node: '>=20.20.0'}
 
   giget@3.2.0:
     resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
@@ -4206,6 +4509,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -5179,6 +5485,10 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  process-ancestry@0.1.0:
+    resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
+    engines: {node: '>=18.0.0'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -5392,8 +5702,8 @@ packages:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
     engines: {node: '>=12'}
 
-  rehype-expressive-code@0.42.0:
-    resolution: {integrity: sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA==}
+  rehype-expressive-code@0.44.0:
+    resolution: {integrity: sha512-5r74C5F2sMR3X+QJH8OKWgZBO/cqRw5W1fLT6GVlSfLqepk+4j8tGFkyPqZYWjwntsBHzKPDH2zI68sZ7ScLfA==}
 
   rehype-format@5.0.1:
     resolution: {integrity: sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==}
@@ -5460,6 +5770,9 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -5553,6 +5866,9 @@ packages:
     resolution: {integrity: sha512-ld+kQU8YTdGNjOLfRWBzewJpU5cwEv/h5yyqlSeJcj6Yh8U4TDA9UA5FPicqDz/xgRPWRSYIQNiFks21TbA9KQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  satteri@0.9.4:
+    resolution: {integrity: sha512-BKob126Tay84diOZsnVNH/Q/c+3njPJTCad3w5zLKa6j8bVjxskPNHDtxrMwYK4bN/RlqUSdMnPwKY4k65EMOQ==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -5947,16 +6263,6 @@ packages:
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -6192,6 +6498,10 @@ packages:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
     engines: {node: '>=18'}
 
+  url-extras@0.1.0:
+    resolution: {integrity: sha512-8tzwTeXFPuX/5PHuCDQE5Dd9Ts4rwoq2t9aIT+HS4iAVpmj5l4Ao7Q+BuuFjvWRqrLswBhQDk8O96ZicgCqQqw==}
+    engines: {node: '>=20'}
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -6258,46 +6568,6 @@ packages:
     resolution: {integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  vite@7.3.3:
-    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vite@8.0.14:
     resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
@@ -6689,50 +6959,78 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@astrojs/compiler@3.0.1': {}
+  '@astrojs/compiler-binding-darwin-arm64@0.2.3':
+    optional: true
 
-  '@astrojs/internal-helpers@0.9.0':
-    dependencies:
-      picomatch: 4.0.4
+  '@astrojs/compiler-binding-darwin-x64@0.2.3':
+    optional: true
 
-  '@astrojs/internal-helpers@0.9.1':
-    dependencies:
-      picomatch: 4.0.4
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.3':
+    optional: true
 
-  '@astrojs/markdown-remark@7.1.1':
+  '@astrojs/compiler-binding-linux-arm64-musl@0.2.3':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-x64-gnu@0.2.3':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-x64-musl@0.2.3':
+    optional: true
+
+  '@astrojs/compiler-binding-wasm32-wasi@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/prism': 4.0.1
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.3':
+    optional: true
+
+  '@astrojs/compiler-binding-win32-x64-msvc@0.2.3':
+    optional: true
+
+  '@astrojs/compiler-binding@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    optionalDependencies:
+      '@astrojs/compiler-binding-darwin-arm64': 0.2.3
+      '@astrojs/compiler-binding-darwin-x64': 0.2.3
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.2.3
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.2.3
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.2.3
+      '@astrojs/compiler-binding-linux-x64-musl': 0.2.3
+      '@astrojs/compiler-binding-wasm32-wasi': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.2.3
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.2.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler-rs@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@astrojs/compiler-binding': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/internal-helpers@0.10.0':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       js-yaml: 4.1.1
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
+      picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.0.2
       smol-toml: 1.6.1
       unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
-  '@astrojs/markdown-remark@7.1.2':
+  '@astrojs/markdown-remark@7.2.0':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/internal-helpers': 0.10.0
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -6740,9 +7038,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -6751,12 +7046,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))':
+  '@astrojs/markdown-satteri@0.3.2':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.2
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      satteri: 0.9.4
+
+  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -6767,34 +7070,32 @@ snapshots:
       source-map: 0.7.6
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    optionalDependencies:
+      '@astrojs/markdown-satteri': 0.3.2
     transitivePeerDependencies:
       - supports-color
-
-  '@astrojs/prism@4.0.1':
-    dependencies:
-      prismjs: 1.30.0
 
   '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/sitemap@3.7.2':
+  '@astrojs/sitemap@3.7.3':
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)':
+  '@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.2
-      '@astrojs/mdx': 5.0.6(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))
-      '@astrojs/sitemap': 3.7.2
+      '@astrojs/markdown-satteri': 0.3.2
+      '@astrojs/mdx': 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))
+      '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
+      astro-expressive-code: 0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6811,18 +7112,20 @@ snapshots:
       rehype: 13.0.2
       rehype-format: 5.0.1
       remark-directive: 4.0.0
+      satteri: 0.9.4
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    optionalDependencies:
+      '@astrojs/markdown-remark': 7.2.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@astrojs/telemetry@3.3.1':
+  '@astrojs/telemetry@3.3.2':
     dependencies:
       ci-info: 4.4.0
-      dlv: 1.1.3
       dset: 3.1.4
       is-docker: 4.0.0
       is-wsl: 3.1.1
@@ -7111,6 +7414,37 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bruits/satteri-darwin-arm64@0.9.4':
+    optional: true
+
+  '@bruits/satteri-darwin-x64@0.9.4':
+    optional: true
+
+  '@bruits/satteri-linux-arm64-gnu@0.9.4':
+    optional: true
+
+  '@bruits/satteri-linux-arm64-musl@0.9.4':
+    optional: true
+
+  '@bruits/satteri-linux-x64-gnu@0.9.4':
+    optional: true
+
+  '@bruits/satteri-linux-x64-musl@0.9.4':
+    optional: true
+
+  '@bruits/satteri-wasm32-wasi@0.9.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@bruits/satteri-win32-arm64-msvc@0.9.4':
+    optional: true
+
+  '@bruits/satteri-win32-x64-msvc@0.9.4':
+    optional: true
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -7191,7 +7525,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7201,85 +7546,168 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@expressive-code/core@0.42.0':
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@expressive-code/core@0.44.0':
     dependencies:
       '@ctrl/tinycolor': 4.2.0
       hast-util-select: 6.0.4
@@ -7291,18 +7719,18 @@ snapshots:
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
-  '@expressive-code/plugin-frames@0.42.0':
+  '@expressive-code/plugin-frames@0.44.0':
     dependencies:
-      '@expressive-code/core': 0.42.0
+      '@expressive-code/core': 0.44.0
 
-  '@expressive-code/plugin-shiki@0.42.0':
+  '@expressive-code/plugin-shiki@0.44.0':
     dependencies:
-      '@expressive-code/core': 0.42.0
+      '@expressive-code/core': 0.44.0
       shiki: 4.0.2
 
-  '@expressive-code/plugin-text-markers@0.42.0':
+  '@expressive-code/plugin-text-markers@0.44.0':
     dependencies:
-      '@expressive-code/core': 0.42.0
+      '@expressive-code/core': 0.44.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7612,6 +8040,13 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -8242,6 +8677,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -8402,7 +8842,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  '@types/estree@1.0.8': {}
+  '@types/estree@1.0.8':
+    optional: true
 
   '@types/estree@1.0.9': {}
 
@@ -8676,6 +9117,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  am-i-vibing@0.4.0:
+    dependencies:
+      process-ancestry: 0.1.0
+
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
@@ -8741,45 +9186,49 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)):
+  astro-expressive-code@0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)):
     dependencies:
-      astro: 6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)
-      rehype-expressive-code: 0.42.0
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
+      rehype-expressive-code: 0.44.0
+      url-extras: 0.1.0
 
-  astro-og-canvas@0.11.1(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)):
+  astro-og-canvas@0.12.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)):
     dependencies:
-      astro: 6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0):
+  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0):
     dependencies:
-      '@astrojs/compiler': 3.0.1
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/telemetry': 3.3.1
+      '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-satteri': 0.3.2
+      '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      am-i-vibing: 0.4.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       ci-info: 4.4.0
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.1.0
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       flattie: 1.1.1
       fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
       js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
       mrmime: 2.0.1
@@ -8798,18 +9247,18 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
-      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0))
+      vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
+      '@astrojs/markdown-remark': 7.2.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8820,6 +9269,8 @@ snapshots:
       - '@azure/storage-blob'
       - '@capacitor/preferences'
       - '@deno/kv'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@netlify/blobs'
       - '@planetscale/database'
       - '@types/node'
@@ -8827,22 +9278,20 @@ snapshots:
       - '@vercel/blob'
       - '@vercel/functions'
       - '@vercel/kv'
+      - '@vitejs/devtools'
       - aws4fetch
       - db0
       - idb-keyval
       - ioredis
       - jiti
       - less
-      - lightningcss
       - rollup
       - sass
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
@@ -9514,7 +9963,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -9531,8 +9980,6 @@ snapshots:
   dingbat-to-unicode@1.0.1: {}
 
   direction@2.0.1: {}
-
-  dlv@1.1.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -9707,6 +10154,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
@@ -9833,12 +10309,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expressive-code@0.42.0:
+  expressive-code@0.44.0:
     dependencies:
-      '@expressive-code/core': 0.42.0
-      '@expressive-code/plugin-frames': 0.42.0
-      '@expressive-code/plugin-shiki': 0.42.0
-      '@expressive-code/plugin-text-markers': 0.42.0
+      '@expressive-code/core': 0.44.0
+      '@expressive-code/plugin-frames': 0.44.0
+      '@expressive-code/plugin-shiki': 0.44.0
+      '@expressive-code/plugin-text-markers': 0.44.0
 
   exsolve@1.0.8: {}
 
@@ -10026,6 +10502,10 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   giget@3.2.0: {}
 
@@ -10613,6 +11093,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.1:
     dependencies:
@@ -11918,6 +12400,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  process-ancestry@0.1.0: {}
+
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
@@ -12139,9 +12623,9 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  rehype-expressive-code@0.42.0:
+  rehype-expressive-code@0.44.0:
     dependencies:
-      expressive-code: 0.42.0
+      expressive-code: 0.44.0
 
   rehype-format@5.0.1:
     dependencies:
@@ -12262,6 +12746,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -12361,6 +12847,7 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.4
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
+    optional: true
 
   roughjs@4.6.6:
     dependencies:
@@ -12407,6 +12894,23 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
     optional: true
+
+  satteri@0.9.4:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+    optionalDependencies:
+      '@bruits/satteri-darwin-arm64': 0.9.4
+      '@bruits/satteri-darwin-x64': 0.9.4
+      '@bruits/satteri-linux-arm64-gnu': 0.9.4
+      '@bruits/satteri-linux-arm64-musl': 0.9.4
+      '@bruits/satteri-linux-x64-gnu': 0.9.4
+      '@bruits/satteri-linux-x64-musl': 0.9.4
+      '@bruits/satteri-wasm32-wasi': 0.9.4
+      '@bruits/satteri-win32-arm64-msvc': 0.9.4
+      '@bruits/satteri-win32-x64-msvc': 0.9.4
 
   sax@1.6.0: {}
 
@@ -12657,9 +13161,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.23.0(@astrojs/starlight@0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
+  starlight-typedoc@0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      '@astrojs/starlight': 0.39.2(astro@6.1.10(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(rollup@4.60.4)(sass@1.89.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
+      '@astrojs/starlight': 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(yaml@2.9.0))(typescript@5.9.3)
       github-slugger: 2.0.0
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
@@ -12852,10 +13356,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
-
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -13058,6 +13558,8 @@ snapshots:
       semver: 7.8.1
       xdg-basedir: 5.1.0
 
+  url-extras@0.1.0: {}
+
   url-parse@1.5.10:
     dependencies:
       querystringify: 2.2.0
@@ -13148,23 +13650,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.4
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.12.4
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      less: 4.3.0
-      lightningcss: 1.32.0
-      sass: 1.89.0
-      yaml: 2.9.0
-
   vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -13181,9 +13666,25 @@ snapshots:
       sass: 1.89.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)):
+  vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(lightningcss@1.32.0)(sass@1.89.0)(yaml@2.9.0)
+      '@types/node': 24.12.4
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      less: 4.3.0
+      sass: 1.89.0
+      yaml: 2.9.0
+
+  vitefu@1.1.3(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)
 
   vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(yaml@2.9.0)):
     dependencies:

--- a/src/lib/providers/__tests__/provider-errors.test.ts
+++ b/src/lib/providers/__tests__/provider-errors.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { isAppError } from "@/lib/error-utils"
 import { OllamaProvider } from "../ollama"
-import { providerErrorUserMessage } from "../provider-errors"
+import {
+  isLocalProviderBaseUrl,
+  providerErrorUserMessage
+} from "../provider-errors"
 import { type ProviderConfig, ProviderType } from "../types"
 
 describe("providerErrorUserMessage", () => {
@@ -17,6 +20,34 @@ describe("providerErrorUserMessage", () => {
 
   it("explains the vision case on 400", () => {
     expect(providerErrorUserMessage(400).toLowerCase()).toContain("vision")
+  })
+
+  it("points local 401/403 responses at CORS setup instead of credentials", () => {
+    const msg = providerErrorUserMessage(403, {
+      baseUrl: "http://localhost:1234/v1"
+    })
+
+    expect(msg).toContain("CORS")
+    expect(msg).toContain("OLLAMA_ORIGINS")
+    expect(msg).not.toContain("Check the API key")
+  })
+
+  it("keeps credential guidance for remote 401/403 responses", () => {
+    const msg = providerErrorUserMessage(401, {
+      baseUrl: "https://api.example.com/v1"
+    })
+
+    expect(msg).toContain("credentials")
+    expect(msg).not.toContain("OLLAMA_ORIGINS")
+  })
+})
+
+describe("isLocalProviderBaseUrl", () => {
+  it("detects local provider URLs", () => {
+    expect(isLocalProviderBaseUrl("http://localhost:11434/v1")).toBe(true)
+    expect(isLocalProviderBaseUrl("http://127.0.0.1:1234/v1")).toBe(true)
+    expect(isLocalProviderBaseUrl("http://studio.localhost:1234/v1")).toBe(true)
+    expect(isLocalProviderBaseUrl("https://api.example.com/v1")).toBe(false)
   })
 })
 

--- a/src/lib/providers/__tests__/provider-errors.test.ts
+++ b/src/lib/providers/__tests__/provider-errors.test.ts
@@ -28,7 +28,8 @@ describe("providerErrorUserMessage", () => {
     })
 
     expect(msg).toContain("CORS")
-    expect(msg).toContain("OLLAMA_ORIGINS")
+    expect(msg).toContain("provider's CORS or origin settings")
+    expect(msg).not.toContain("OLLAMA_ORIGINS")
     expect(msg).not.toContain("Check the API key")
   })
 

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -219,7 +219,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
         status: response.status,
         providerId: this.id,
         retryable: response.status >= 500,
-        userMessage: providerErrorUserMessage(response.status),
+        userMessage: providerErrorUserMessage(response.status, { baseUrl }),
         debug: errorText
       })
     }
@@ -432,6 +432,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           status: response.status,
           providerId: this.id,
           retryable: response.status >= 500,
+          userMessage: providerErrorUserMessage(response.status, { baseUrl }),
           debug: errorText
         }
       )
@@ -467,6 +468,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           status: response.status,
           providerId: this.id,
           retryable: response.status >= 500,
+          userMessage: providerErrorUserMessage(response.status, { baseUrl }),
           debug: errorText
         }
       )

--- a/src/lib/providers/provider-errors.ts
+++ b/src/lib/providers/provider-errors.ts
@@ -9,7 +9,7 @@ import { EXTERNAL_URLS } from "@/lib/constants/urls"
 export const localCorsForbiddenMessage = (status = 403): string =>
   `Your local provider blocked this request (${status} ${
     status === 401 ? "Unauthorized" : "Forbidden"
-  }). This is a CORS / origin block — most common on Firefox, which can't rewrite the request origin the way Chromium does. Allow this extension by setting OLLAMA_ORIGINS on your server (e.g. "chrome-extension://*,moz-extension://*"), then retry. Step-by-step: ${EXTERNAL_URLS.SETUP_GUIDE}`
+  }). This is likely a CORS / origin block — most common on Firefox, which can't rewrite the request origin the way Chromium does. Allow chrome-extension://* and moz-extension://* in your provider's CORS or origin settings, then retry. Provider-specific setup: ${EXTERNAL_URLS.SETUP_GUIDE}`
 
 export const isLocalProviderBaseUrl = (baseUrl?: string): boolean => {
   if (!baseUrl) return true

--- a/src/lib/providers/provider-errors.ts
+++ b/src/lib/providers/provider-errors.ts
@@ -11,16 +11,38 @@ export const localCorsForbiddenMessage = (status = 403): string =>
     status === 401 ? "Unauthorized" : "Forbidden"
   }). This is a CORS / origin block — most common on Firefox, which can't rewrite the request origin the way Chromium does. Allow this extension by setting OLLAMA_ORIGINS on your server (e.g. "chrome-extension://*,moz-extension://*"), then retry. Step-by-step: ${EXTERNAL_URLS.SETUP_GUIDE}`
 
+export const isLocalProviderBaseUrl = (baseUrl?: string): boolean => {
+  if (!baseUrl) return true
+
+  try {
+    const { hostname } = new URL(baseUrl)
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost")
+    )
+  } catch {
+    return false
+  }
+}
+
 /**
  * Map a provider HTTP status to a clean, user-facing message. Keeps raw
  * provider response bodies (which can be JSON or stack traces) out of the chat
  * UI — those stay in the error's `debug` field for diagnostics.
  */
-export const providerErrorUserMessage = (status: number): string => {
+export const providerErrorUserMessage = (
+  status: number,
+  options: { baseUrl?: string } = {}
+): string => {
   if (status === 400) {
     return "The provider rejected the request. The selected model may not support this input — for example, images on a model without vision support."
   }
   if (status === 401 || status === 403) {
+    if (isLocalProviderBaseUrl(options.baseUrl)) {
+      return localCorsForbiddenMessage(status)
+    }
     return "The provider rejected your credentials. Check the API key or access for this provider."
   }
   if (status === 404) {

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { createRequire } from "node:module"
 import {
-  afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -56,6 +56,9 @@ beforeAll(() => {
     wasm.byteOffset,
     wasm.byteOffset + wasm.byteLength
   )
+})
+
+const stubWasmFetch = () => {
   // db.ts fetches the wasm via chrome.runtime.getURL(...) then .arrayBuffer().
   // Serve the real binary so the engine boots without a network/extension host.
   vi.stubGlobal(
@@ -65,7 +68,7 @@ beforeAll(() => {
       arrayBuffer: async () => wasmBuffer
     }))
   )
-})
+}
 
 const streamResponse = (chunks: string[]) =>
   new Response(
@@ -81,7 +84,7 @@ const streamResponse = (chunks: string[]) =>
     { headers: { "Content-Type": "text/event-stream" } }
   )
 
-afterAll(() => {
+afterEach(() => {
   vi.unstubAllGlobals()
 })
 
@@ -119,6 +122,7 @@ const clearSqliteStore = (): Promise<void> =>
 
 beforeEach(async () => {
   await clearSqliteStore()
+  stubWasmFetch()
 }, TIMEOUT)
 
 // Re-import the facade + db module fresh. After `vi.resetModules()` this

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -10,7 +10,12 @@ import {
   vi
 } from "vitest"
 import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
-import { ProviderStorageKey } from "@/lib/providers/types"
+import { OpenAICompatibleProvider } from "@/lib/providers/openai-compatible"
+import {
+  ProviderId,
+  ProviderStorageKey,
+  ProviderType
+} from "@/lib/providers/types"
 
 /**
  * Functional durability smoke (PROJECT_PLAN S1/S2).
@@ -43,10 +48,11 @@ const TIMEOUT = 25_000
 
 const require = createRequire(import.meta.url)
 const wasmPath = require.resolve("sql.js/dist/sql-wasm.wasm")
+let wasmBuffer: ArrayBuffer
 
 beforeAll(() => {
   const wasm = readFileSync(wasmPath)
-  const wasmBuffer = wasm.buffer.slice(
+  wasmBuffer = wasm.buffer.slice(
     wasm.byteOffset,
     wasm.byteOffset + wasm.byteLength
   )
@@ -60,6 +66,20 @@ beforeAll(() => {
     }))
   )
 })
+
+const streamResponse = (chunks: string[]) =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder()
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk))
+        }
+        controller.close()
+      }
+    }),
+    { headers: { "Content-Type": "text/event-stream" } }
+  )
 
 afterAll(() => {
   vi.unstubAllGlobals()
@@ -223,4 +243,83 @@ describe("S2 — reset actually wipes data", () => {
       allKeys.every((key) => typeof key === "string" && key.length > 1)
     ).toBe(true)
   })
+})
+
+describe("S3 — provider round-trip persists after reload", () => {
+  it(
+    "streams from a mock OpenAI-compatible provider and persists the reply",
+    async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL) => {
+          const url = input.toString()
+          if (url.includes("/chat/completions")) {
+            return streamResponse([
+              `data: ${JSON.stringify({
+                choices: [{ delta: { content: "hello " } }]
+              })}\n\n`,
+              `data: ${JSON.stringify({
+                choices: [{ delta: { content: "from mock" } }]
+              })}\n\n`,
+              "data: [DONE]\n\n"
+            ])
+          }
+
+          return {
+            ok: true,
+            arrayBuffer: async () => wasmBuffer
+          }
+        })
+      )
+
+      const first = await bootFreshContext()
+      await first.facade.addSession(makeSession("s-provider-round-trip"))
+      await first.facade.addMessage({
+        sessionId: "s-provider-round-trip",
+        role: "user",
+        content: "say hello",
+        timestamp: 1_700_000_000_004
+      })
+
+      const provider = new OpenAICompatibleProvider({
+        id: ProviderId.OPENAI,
+        name: "Mock local OpenAI-compatible",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://localhost:3210/v1"
+      })
+
+      let content = ""
+      await provider.streamChat(
+        {
+          model: "mock-model",
+          messages: [{ role: "user", content: "say hello" }]
+        },
+        (chunk) => {
+          content += chunk.delta ?? ""
+        }
+      )
+
+      expect(content).toBe("hello from mock")
+
+      await first.facade.addMessage({
+        sessionId: "s-provider-round-trip",
+        role: "assistant",
+        content,
+        timestamp: 1_700_000_000_005,
+        done: true
+      })
+      await first.db.flushSave()
+
+      const second = await bootFreshContext()
+      const messages = await second.facade.getMessagesBySession(
+        "s-provider-round-trip"
+      )
+      expect(messages.map((m) => m.content)).toEqual([
+        "say hello",
+        "hello from mock"
+      ])
+    },
+    TIMEOUT
+  )
 })

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -231,7 +231,6 @@ function cleanOldMarkdown() {
   rmSync(join(PUBLIC_DIR, "llms.txt"), { force: true })
   rmSync(join(PUBLIC_DIR, "llms-full.txt"), { force: true })
   rmSync(join(PUBLIC_DIR, "ai.txt"), { force: true })
-  rmSync(join(PUBLIC_DIR, "robots.txt"), { force: true })
 
   for (const path of walk(PUBLIC_DIR)) {
     if (path.endsWith(".md")) {

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -42,7 +42,11 @@ type DocPage = {
 }
 
 const DOC_ORDER = [
+  "about/faq",
+  "guides/quick-start",
   "guides/provider-setup",
+  "guides/troubleshooting/ollama-cors-error",
+  "concepts/privacy",
   "concepts/architecture",
   "concepts/provider-matrix",
   "internal/frontend-design-system",


### PR DESCRIPTION
## Summary
- bump package version to 0.11.24 and update release notes
- add SEO foundation docs, FAQ structured data, and changelog compare links through 0.11.24
- upgrade docs to Astro 7 and Starlight 0.41
- improve local OpenAI-compatible 401/403 CORS guidance and add provider durability smoke coverage

## Validation
- pnpm typecheck
- pnpm lint:check
- pnpm test:run
- pnpm docs:build
- pnpm check:generated
- pre-push: check:i18n, test:run, build, docs:build

## Release note
After merge, create and push the matching release tag, for example `v0.11.24`, so changelog compare links resolve cleanly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the 0.11.24 release: bumps the package version, adds SEO-oriented docs pages (Quick Start, Privacy, FAQ, CORS troubleshooting) with FAQPage JSON-LD structured data, upgrades the docs site to Astro 7 and Starlight 0.41, and fixes local-provider 401/403 error messages to give generic CORS/origin guidance instead of Ollama-specific `OLLAMA_ORIGINS` instructions.

- **Provider error fix**: `localCorsForbiddenMessage` no longer names `OLLAMA_ORIGINS`; the message is now accurate for LM Studio, llama.cpp, vLLM, LocalAI, and KoboldCPP. A new test suite (`provider-errors.test.ts`) asserts the absence of Ollama-specific text and correct routing between local and remote error paths.
- **S3 smoke test**: A new end-to-end durability suite streams a mock OpenAI-compatible SSE response, persists the assistant reply to SQLite, and asserts survival across a simulated service-worker cold restart via `vi.resetModules()`.
- **Docs upgrade**: Astro 7 replaces `markdown.rehypePlugins` with `processor: unified({…})` from `@astrojs/markdown-remark`; changelog compare links are backfilled from v0.8.0 through v0.11.24.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all code changes are well-tested and the provider error fix is confirmed by a dedicated test asserting generic CORS guidance for all local providers.

The core logic change — rewriting the local 401/403 error message to remove OLLAMA_ORIGINS — is small, targeted, and backed by a new test that explicitly asserts the Ollama-specific text is absent. The S3 smoke test is structurally sound: it stubs fetch to serve real WASM + mock SSE, resets modules to simulate a cold service-worker restart, and asserts the full round-trip. The Astro 7 / Starlight 0.41 upgrade touches only the docs sub-package and is validated by a docs build. The only concern is a content-quality nit in the AI-readable doc generator.

tools/generate-llms-docs.ts — the cleanMarkdown function does not strip MDX export const blocks, so the raw faqItems JavaScript will appear in the generated about/faq.md LLM doc.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/providers/provider-errors.ts | Local 401/403 error message rewritten to be provider-agnostic: OLLAMA_ORIGINS removed, replaced with generic CORS/origin guidance; test confirms no Ollama-specific text leaks through. |
| src/lib/providers/__tests__/provider-errors.test.ts | New test suite covers local vs. remote 401/403 routing, OLLAMA_ORIGINS absence, and credential guidance for remote endpoints; assertion coverage is complete for the changed logic. |
| src/lib/repositories/__tests__/chat-durability.smoke.test.ts | New S3 suite adds end-to-end OpenAI-compatible provider round-trip: streams mock SSE, persists to SQLite facade, flushes, reloads via vi.resetModules(), and asserts both messages survive; fetch stub handles WASM and chat-completions URLs correctly. |
| tools/generate-llms-docs.ts | cleanMarkdown strips import statements and JSX component tags but not MDX export const blocks; the new faq.mdx exports a faqItems array that will appear verbatim as raw JS in the generated about/faq.md LLM-readable file. |
| docs/astro.config.mjs | Astro 7 + Starlight 0.41 upgrade: markdown.rehypePlugins replaced with processor: unified({…}) from @astrojs/markdown-remark; three new sidebar entries added for Quick Start, CORS troubleshooting, Privacy, and FAQ pages. |
| docs/src/content/docs/about/faq.mdx | New FAQ page with FAQPage JSON-LD structured data; the export const faqItems block is MDX-specific and will not be stripped by cleanMarkdown in the AI docs generator, leaving raw JS in the generated LLM file. |
| CHANGELOG.md | Adds 0.11.24 entry with accurate release notes; backfills compare links from v0.8.0 through v0.11.24; the [Unreleased] link correctly points to HEAD from v0.11.24. |
| package.json | Version bump from 0.11.23 to 0.11.24, no other changes. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Error from Provider] --> B{status 401 or 403?}
    B -- No --> C[Other status handlers\n400 / 404 / 408 / 429 / 5xx]
    B -- Yes --> D{isLocalProviderBaseUrl?}
    D -- Yes\nlocalhost / 127.0.0.1 / ::1 --> E[localCorsForbiddenMessage\nGeneric CORS/origin guidance\nNo OLLAMA_ORIGINS mention\nLinks to SETUP_GUIDE]
    D -- No\nremote URL --> F[Credential guidance\nCheck API key / access]
    C --> G[User-facing message]
    E --> G
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HTTP Error from Provider] --> B{status 401 or 403?}
    B -- No --> C[Other status handlers\n400 / 404 / 408 / 429 / 5xx]
    B -- Yes --> D{isLocalProviderBaseUrl?}
    D -- Yes\nlocalhost / 127.0.0.1 / ::1 --> E[localCorsForbiddenMessage\nGeneric CORS/origin guidance\nNo OLLAMA_ORIGINS mention\nLinks to SETUP_GUIDE]
    D -- No\nremote URL --> F[Credential guidance\nCheck API key / access]
    C --> G[User-facing message]
    E --> G
    F --> G
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/providers/provider-errors.ts`, line 9-12 ([link](https://github.com/shishir435/ollama-client/blob/2834eb52e325809e250a6e35acd1d558f241ade1/src/lib/providers/provider-errors.ts#L9-L12)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OLLAMA_ORIGINS guidance shown to non-Ollama local providers**

   `localCorsForbiddenMessage` is now surfaced by `providerErrorUserMessage` for any local base URL — including LM Studio (`localhost:1234/v1`), llama.cpp (`localhost:8000/v1`), vLLM, LocalAI, and KoboldCPP. Those servers do not honour `OLLAMA_ORIGINS`; telling their users to set it gives incorrect, unhelpful guidance. Only the Ollama-specific provider (`ollama.ts`) should be pointing users at `OLLAMA_ORIGINS`; the generic case used by `OpenAICompatibleProvider` should say something like "check your provider's CORS/origin settings" and link to the troubleshooting page, without naming Ollama's environment variable.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fproviders%2Fprovider-errors.ts%0ALine%3A%209-12%0A%0AComment%3A%0A**OLLAMA_ORIGINS%20guidance%20shown%20to%20non-Ollama%20local%20providers**%0A%0A%60localCorsForbiddenMessage%60%20is%20now%20surfaced%20by%20%60providerErrorUserMessage%60%20for%20any%20local%20base%20URL%20%E2%80%94%20including%20LM%20Studio%20%28%60localhost%3A1234%2Fv1%60%29%2C%20llama.cpp%20%28%60localhost%3A8000%2Fv1%60%29%2C%20vLLM%2C%20LocalAI%2C%20and%20KoboldCPP.%20Those%20servers%20do%20not%20honour%20%60OLLAMA_ORIGINS%60%3B%20telling%20their%20users%20to%20set%20it%20gives%20incorrect%2C%20unhelpful%20guidance.%20Only%20the%20Ollama-specific%20provider%20%28%60ollama.ts%60%29%20should%20be%20pointing%20users%20at%20%60OLLAMA_ORIGINS%60%3B%20the%20generic%20case%20used%20by%20%60OpenAICompatibleProvider%60%20should%20say%20something%20like%20%22check%20your%20provider's%20CORS%2Forigin%20settings%22%20and%20link%20to%20the%20troubleshooting%20page%2C%20without%20naming%20Ollama's%20environment%20variable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2F0-11-24-release-confidence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2F0-11-24-release-confidence%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fproviders%2Fprovider-errors.ts%0ALine%3A%209-12%0A%0AComment%3A%0A**OLLAMA_ORIGINS%20guidance%20shown%20to%20non-Ollama%20local%20providers**%0A%0A%60localCorsForbiddenMessage%60%20is%20now%20surfaced%20by%20%60providerErrorUserMessage%60%20for%20any%20local%20base%20URL%20%E2%80%94%20including%20LM%20Studio%20%28%60localhost%3A1234%2Fv1%60%29%2C%20llama.cpp%20%28%60localhost%3A8000%2Fv1%60%29%2C%20vLLM%2C%20LocalAI%2C%20and%20KoboldCPP.%20Those%20servers%20do%20not%20honour%20%60OLLAMA_ORIGINS%60%3B%20telling%20their%20users%20to%20set%20it%20gives%20incorrect%2C%20unhelpful%20guidance.%20Only%20the%20Ollama-specific%20provider%20%28%60ollama.ts%60%29%20should%20be%20pointing%20users%20at%20%60OLLAMA_ORIGINS%60%3B%20the%20generic%20case%20used%20by%20%60OpenAICompatibleProvider%60%20should%20say%20something%20like%20%22check%20your%20provider's%20CORS%2Forigin%20settings%22%20and%20link%20to%20the%20troubleshooting%20page%2C%20without%20naming%20Ollama's%20environment%20variable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `tools/generate-llms-docs.ts`, line 230-241 ([link](https://github.com/shishir435/ollama-client/blob/2834eb52e325809e250a6e35acd1d558f241ade1/tools/generate-llms-docs.ts#L230-L241)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`robots.txt` is deleted but never regenerated**

   `cleanOldMarkdown` deletes `docs/public/robots.txt` on every run, but there is no corresponding `writeRobotsTxt()` call in `main()`. Any `robots.txt` committed to `docs/public/` is permanently removed each time this tool executes (e.g. during `docs:build`), which would prevent search engines from reading crawl directives. Either add a regeneration step, or remove the `robots.txt` deletion if the file is managed outside this script (e.g. generated by Astro itself).

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Fgenerate-llms-docs.ts%0ALine%3A%20230-241%0A%0AComment%3A%0A**%60robots.txt%60%20is%20deleted%20but%20never%20regenerated**%0A%0A%60cleanOldMarkdown%60%20deletes%20%60docs%2Fpublic%2Frobots.txt%60%20on%20every%20run%2C%20but%20there%20is%20no%20corresponding%20%60writeRobotsTxt%28%29%60%20call%20in%20%60main%28%29%60.%20Any%20%60robots.txt%60%20committed%20to%20%60docs%2Fpublic%2F%60%20is%20permanently%20removed%20each%20time%20this%20tool%20executes%20%28e.g.%20during%20%60docs%3Abuild%60%29%2C%20which%20would%20prevent%20search%20engines%20from%20reading%20crawl%20directives.%20Either%20add%20a%20regeneration%20step%2C%20or%20remove%20the%20%60robots.txt%60%20deletion%20if%20the%20file%20is%20managed%20outside%20this%20script%20%28e.g.%20generated%20by%20Astro%20itself%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22feature%2F0-11-24-release-confidence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2F0-11-24-release-confidence%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Fgenerate-llms-docs.ts%0ALine%3A%20230-241%0A%0AComment%3A%0A**%60robots.txt%60%20is%20deleted%20but%20never%20regenerated**%0A%0A%60cleanOldMarkdown%60%20deletes%20%60docs%2Fpublic%2Frobots.txt%60%20on%20every%20run%2C%20but%20there%20is%20no%20corresponding%20%60writeRobotsTxt%28%29%60%20call%20in%20%60main%28%29%60.%20Any%20%60robots.txt%60%20committed%20to%20%60docs%2Fpublic%2F%60%20is%20permanently%20removed%20each%20time%20this%20tool%20executes%20%28e.g.%20during%20%60docs%3Abuild%60%29%2C%20which%20would%20prevent%20search%20engines%20from%20reading%20crawl%20directives.%20Either%20add%20a%20regeneration%20step%2C%20or%20remove%20the%20%60robots.txt%60%20deletion%20if%20the%20file%20is%20managed%20outside%20this%20script%20%28e.g.%20generated%20by%20Astro%20itself%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shishir435%2Follama-client&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(sqlite): isolate provider fetch moc..."](https://github.com/shishir435/ollama-client/commit/dd16b700cd47a69652a0d500654cdae9ab1e612a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40618380)</sub>

<!-- /greptile_comment -->