### PR TITLE
Prepare 0.11.25 release polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   while preserving the rendered documentation prose.
 - Bumped package version to `0.11.25`.
 
+### Fixed
+- Selection Actions now preserve configured model system instructions and
+  requested output language instead of biasing extraction results toward English.
+- Message footers use explicit export and delete actions instead of ambiguous
+  ellipsis menus, and chat-memory sources use a primary-colored user icon.
+
 ## [0.11.24] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.11.25] - 2026-06-30
+
+### Added
+- Session-title filtering in the chat-session sidebar, with localized empty and
+  clear-search states.
+- S4 vector durability smoke coverage: persist a chunk, reload the module graph,
+  and verify similarity search still finds it.
+
+### Changed
+- Updated shadcn tooling and added restrained scroll fades plus live-status
+  shimmer to existing chat and settings surfaces.
+- AI-readable docs now remove MDX `export const` data and SEO-only FAQ markup
+  while preserving the rendered documentation prose.
+- Bumped package version to `0.11.25`.
+
 ## [0.11.24] - 2026-06-29
 
 ### Added
@@ -397,7 +412,8 @@ Consolidated 0.11.x line: the "agent's hands" features plus a data-integrity har
 ### Documentation
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.11.24...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.11.25...HEAD
+[0.11.25]: https://github.com/Shishir435/ollama-client/compare/v0.11.24...v0.11.25
 [0.11.24]: https://github.com/Shishir435/ollama-client/compare/v0.11.23...v0.11.24
 [0.11.23]: https://github.com/Shishir435/ollama-client/compare/v0.11.22...v0.11.23
 [0.11.22]: https://github.com/Shishir435/ollama-client/compare/v0.11.20...v0.11.22

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.11.24",
+  "version": "0.11.25",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [
@@ -145,7 +145,7 @@
     "playwright": "^1.60.0",
     "postcss": "8.5.10",
     "rollup-plugin-visualizer": "^6.0.11",
-    "shadcn": "^4.8.0",
+    "shadcn": "^4.12.0",
     "tailwindcss": "4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: ^6.0.11
         version: 6.0.11(rolldown@1.0.2)(rollup@4.60.4)
       shadcn:
-        specifier: ^4.8.0
-        version: 4.8.0(@types/node@22.19.19)(typescript@5.9.3)
+        specifier: ^4.12.0
+        version: 4.12.0(typescript@5.9.3)
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
@@ -3400,10 +3400,6 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -3837,10 +3833,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -3906,10 +3898,6 @@ packages:
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -5160,10 +5148,6 @@ packages:
       encoding:
         optional: true
 
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
@@ -5918,8 +5902,9 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.8.0:
-    resolution: {integrity: sha512-LAm3I/1FdoU/zu5GVG8Hbna4X9zlzEG5TeeCPXqsopkjvGk8QUF9OFhqeRN8oM6Oh/ynUI/yQHZxQAO3Ymcqsg==}
+  shadcn@4.12.0:
+    resolution: {integrity: sha512-o781ieQziCnXH2FKsEqxp1fnbHdbgAPO9inTSPeZ59hQfsZXuMGp3ul8oFSV5KQS4nbUK9b+DrDE6C7OvfKKQQ==}
+    engines: {node: '>=20.18.1'}
     hasBin: true
 
   sharp@0.34.5:
@@ -6351,6 +6336,10 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -6679,10 +6668,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
@@ -7872,7 +7857,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/ansi@2.0.5': {}
+  '@inquirer/ansi@2.0.5':
+    optional: true
 
   '@inquirer/confirm@6.0.13(@types/node@22.19.19)':
     dependencies:
@@ -7880,6 +7866,7 @@ snapshots:
       '@inquirer/type': 4.0.5(@types/node@22.19.19)
     optionalDependencies:
       '@types/node': 22.19.19
+    optional: true
 
   '@inquirer/core@11.1.10(@types/node@22.19.19)':
     dependencies:
@@ -7892,12 +7879,15 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 22.19.19
+    optional: true
 
-  '@inquirer/figures@2.0.5': {}
+  '@inquirer/figures@2.0.5':
+    optional: true
 
   '@inquirer/type@4.0.5(@types/node@22.19.19)':
     optionalDependencies:
       '@types/node': 22.19.19
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7986,6 +7976,7 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true
@@ -8069,16 +8060,20 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@open-draft/deferred-promise@2.2.0': {}
+  '@open-draft/deferred-promise@2.2.0':
+    optional: true
 
-  '@open-draft/deferred-promise@3.0.0': {}
+  '@open-draft/deferred-promise@3.0.0':
+    optional: true
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
+    optional: true
 
-  '@open-draft/until@2.1.0': {}
+  '@open-draft/until@2.1.0':
+    optional: true
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -8941,8 +8936,10 @@ snapshots:
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 22.19.19
+    optional: true
 
-  '@types/statuses@2.0.6': {}
+  '@types/statuses@2.0.6':
+    optional: true
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -9525,7 +9522,8 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
-  cli-width@4.1.0: {}
+  cli-width@4.1.0:
+    optional: true
 
   cliui@8.0.1:
     dependencies:
@@ -9889,8 +9887,6 @@ snapshots:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.18.1
-
-  data-uri-to-buffer@4.0.1: {}
 
   data-urls@5.0.0:
     dependencies:
@@ -10336,7 +10332,8 @@ snapshots:
 
   fast-string-truncated-width@1.2.1: {}
 
-  fast-string-truncated-width@3.0.3: {}
+  fast-string-truncated-width@3.0.3:
+    optional: true
 
   fast-string-width@1.1.0:
     dependencies:
@@ -10345,6 +10342,7 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+    optional: true
 
   fast-uri@3.1.2: {}
 
@@ -10355,6 +10353,7 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+    optional: true
 
   fastq@1.20.1:
     dependencies:
@@ -10363,11 +10362,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
 
   fflate@0.8.3: {}
 
@@ -10432,10 +10426,6 @@ snapshots:
       web-streams-polyfill: 4.0.0-beta.3
 
   formdata-node@6.0.3: {}
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -10531,7 +10521,8 @@ snapshots:
 
   graceful-readlink@1.0.1: {}
 
-  graphql@16.14.0: {}
+  graphql@16.14.0:
+    optional: true
 
   growly@1.3.0: {}
 
@@ -10779,6 +10770,7 @@ snapshots:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
+    optional: true
 
   highlight.js@11.11.1: {}
 
@@ -10968,7 +10960,8 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-node-process@1.2.0: {}
+  is-node-process@1.2.0:
+    optional: true
 
   is-npm@6.1.0: {}
 
@@ -11992,6 +11985,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   multimatch@6.0.0:
     dependencies:
@@ -12000,7 +11994,8 @@ snapshots:
       array-union: 3.0.1
       minimatch: 3.1.5
 
-  mute-stream@3.0.0: {}
+  mute-stream@3.0.0:
+    optional: true
 
   nano-spawn@2.1.0: {}
 
@@ -12039,12 +12034,6 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-forge@1.4.0: {}
 
@@ -12172,7 +12161,8 @@ snapshots:
 
   os-shim@0.1.3: {}
 
-  outvariant@1.4.3: {}
+  outvariant@1.4.3:
+    optional: true
 
   p-limit@7.3.0:
     dependencies:
@@ -12222,7 +12212,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -12274,7 +12264,8 @@ snapshots:
 
   path-key@4.0.0: {}
 
-  path-to-regexp@6.3.0: {}
+  path-to-regexp@6.3.0:
+    optional: true
 
   path-to-regexp@8.4.2: {}
 
@@ -12778,7 +12769,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  rettime@0.11.11: {}
+  rettime@0.11.11:
+    optional: true
 
   reusify@1.1.0: {}
 
@@ -12954,7 +12946,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  set-cookie-parser@3.1.0: {}
+  set-cookie-parser@3.1.0:
+    optional: true
 
   set-value@4.1.0:
     dependencies:
@@ -12965,10 +12958,10 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.8.0(@types/node@22.19.19)(typescript@5.9.3):
+  shadcn@4.12.0(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.67.0
@@ -12984,10 +12977,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 11.3.5
       fuzzysort: 3.1.0
-      https-proxy-agent: 7.0.6
       kleur: 4.1.5
-      msw: 2.14.6(@types/node@22.19.19)(typescript@5.9.3)
-      node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
       postcss: 8.5.10
@@ -12998,12 +12988,12 @@ snapshots:
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
+      undici: 7.28.0
       validate-npm-package-name: 7.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
-      - '@types/node'
       - babel-plugin-macros
       - supports-color
       - typescript
@@ -13176,7 +13166,8 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
-  strict-event-emitter@0.5.1: {}
+  strict-event-emitter@0.5.1:
+    optional: true
 
   string-argv@0.3.2: {}
 
@@ -13272,7 +13263,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tagged-tag@1.0.0: {}
+  tagged-tag@1.0.0:
+    optional: true
 
   tailwind-merge@3.6.0: {}
 
@@ -13313,11 +13305,13 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.30: {}
+  tldts-core@7.0.30:
+    optional: true
 
   tldts@7.0.30:
     dependencies:
       tldts-core: 7.0.30
+    optional: true
 
   tmp@0.2.5: {}
 
@@ -13339,6 +13333,7 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
+    optional: true
 
   tr46@0.0.3: {}
 
@@ -13380,6 +13375,7 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+    optional: true
 
   type-is@2.1.0:
     dependencies:
@@ -13425,6 +13421,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@7.25.0: {}
+
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -13537,7 +13535,8 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
-  until-async@3.0.2: {}
+  until-async@3.0.2:
+    optional: true
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -13754,8 +13753,6 @@ snapshots:
       - supports-color
 
   web-namespaces@2.0.1: {}
-
-  web-streams-polyfill@3.3.3: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
 

--- a/src/background/handlers/__tests__/handle-selection-action.test.ts
+++ b/src/background/handlers/__tests__/handle-selection-action.test.ts
@@ -98,6 +98,32 @@ describe("handleSelectionAction", () => {
     })
   })
 
+  it("passes the configured model system prompt into the selection action", async () => {
+    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
+        return { modelId: "llama3:latest", providerId: "ollama" }
+      }
+      if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
+        return {
+          "llama3:latest": { system: "Antworte immer auf Deutsch." }
+        }
+      }
+      return undefined
+    })
+
+    const port = createMockPort(MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION)
+    await handleSelectionAction(message, port, createMockIsPortClosed(false))
+
+    const request = mockStreamChat.mock.calls[0][0]
+    expect(request.messages[0]).toEqual(
+      expect.objectContaining({
+        role: "system",
+        content: expect.stringContaining("Antworte immer auf Deutsch.")
+      })
+    )
+  })
+
   it("returns friendly error when no model is selected", async () => {
     const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
     vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(undefined)

--- a/src/background/handlers/__tests__/handle-selection-action.test.ts
+++ b/src/background/handlers/__tests__/handle-selection-action.test.ts
@@ -124,6 +124,26 @@ describe("handleSelectionAction", () => {
     )
   })
 
+  it("does not inject the default model system prompt when none is configured", async () => {
+    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
+        return { modelId: "llama3:latest", providerId: "ollama" }
+      }
+      // No MODEL_CONFIGS entry: resolveModelConfig would merge the default
+      // "format with markdown" system prompt, which must not leak into the
+      // selection action (it conflicts with "Return plain text only").
+      return undefined
+    })
+
+    const port = createMockPort(MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION)
+    await handleSelectionAction(message, port, createMockIsPortClosed(false))
+
+    const request = mockStreamChat.mock.calls[0][0]
+    expect(request.messages[0].content).not.toContain("markdown")
+    expect(request.messages[0].content).not.toContain("helpful, honest")
+  })
+
   it("returns friendly error when no model is selected", async () => {
     const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
     vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(undefined)

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -54,7 +54,7 @@ export const handleSelectionAction = async (
       model,
       providerId
     )
-    const prompt = buildSelectionActionPrompt(msg.payload)
+    const prompt = buildSelectionActionPrompt(msg.payload, modelParams.system)
 
     await provider.streamChat(
       {

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -54,7 +54,16 @@ export const handleSelectionAction = async (
       model,
       providerId
     )
-    const prompt = buildSelectionActionPrompt(msg.payload, modelParams.system)
+    // Use the user's explicitly configured system prompt, not the
+    // default-merged one. DEFAULT_MODEL_CONFIG.system ("...format with
+    // markdown...") conflicts with the selection action's "Return plain text
+    // only" instruction, so only forward a system prompt the user actually set.
+    const configuredSystemPrompt =
+      modelConfigMap[model]?.system?.trim() || undefined
+    const prompt = buildSelectionActionPrompt(
+      msg.payload,
+      configuredSystemPrompt
+    )
 
     await provider.streamChat(
       {

--- a/src/components/actions/action-menu-grid.tsx
+++ b/src/components/actions/action-menu-grid.tsx
@@ -30,6 +30,14 @@ interface ActionMenuGridProps extends React.ComponentProps<"div"> {
   tooltipSideOffset?: React.ComponentProps<typeof TooltipContent>["sideOffset"]
 }
 
+const GRID_COLUMNS: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+  4: "grid-cols-4",
+  5: "grid-cols-5"
+}
+
 export function ActionMenuGrid({
   actions,
   className,
@@ -42,10 +50,17 @@ export function ActionMenuGrid({
 
   if (visibleActions.length === 0) return null
 
+  // Columns track the item count (capped at 5) so a 4-item menu doesn't
+  // leave a trailing empty cell from a fixed 5-column track. Full class
+  // literals so Tailwind's JIT can see them (no dynamic interpolation).
+  const columnClass =
+    GRID_COLUMNS[Math.min(visibleActions.length, 5)] ?? "grid-cols-5"
+
   return (
     <div
       className={cn(
-        "grid grid-cols-5 justify-items-center gap-0.5 px-1 py-1",
+        "grid justify-items-center gap-0.5 px-1 py-1",
+        columnClass,
         className
       )}
       {...props}>

--- a/src/components/settings/settings-mobile-nav.tsx
+++ b/src/components/settings/settings-mobile-nav.tsx
@@ -19,7 +19,7 @@ export const SettingsMobileNav = ({
     <nav
       className={cn("mb-6 lg:hidden", className)}
       aria-label="Settings navigation">
-      <div className="flex gap-0.5 overflow-x-auto rounded-panel bg-muted/60 p-1 scrollbar-none">
+      <div className="scroll-fade-x flex gap-0.5 overflow-x-auto rounded-panel bg-muted/60 p-1 scrollbar-none">
         {items.map((item) => {
           const Icon = item.icon
           const isActive = activeTab === item.key

--- a/src/features/chat/components/__tests__/chat-message-content.test.tsx
+++ b/src/features/chat/components/__tests__/chat-message-content.test.tsx
@@ -41,9 +41,7 @@ describe("ChatMessageContent", () => {
       />
     )
 
-    expect(screen.getAllByText("Preparing context...").length).toBeGreaterThan(
-      0
-    )
+    expect(screen.getAllByText("Preparing context").length).toBeGreaterThan(0)
     expect(screen.queryByText("Typing")).not.toBeInTheDocument()
   })
 

--- a/src/features/chat/components/__tests__/chat-message-footer.test.tsx
+++ b/src/features/chat/components/__tests__/chat-message-footer.test.tsx
@@ -51,13 +51,12 @@ describe("ChatMessageFooter", () => {
       />
     )
 
+    // Export + delete now collapse into a single "..." overflow trigger
+    // (closed by default), so neither is rendered inline.
+    expect(screen.getByRole("button", { name: /More/i })).toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: /More/i })
+      screen.queryByRole("button", { name: /Delete Message/i })
     ).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Export/i })).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: /Delete Message/i })
-    ).toBeInTheDocument()
     expect(screen.getByText("deepseek-r1:8b")).toBeInTheDocument()
   })
 })

--- a/src/features/chat/components/__tests__/chat-message-footer.test.tsx
+++ b/src/features/chat/components/__tests__/chat-message-footer.test.tsx
@@ -51,10 +51,13 @@ describe("ChatMessageFooter", () => {
       />
     )
 
-    expect(screen.getByRole("button", { name: /More/i })).toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: /Delete Message/i })
+      screen.queryByRole("button", { name: /More/i })
     ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Export/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Delete Message/i })
+    ).toBeInTheDocument()
     expect(screen.getByText("deepseek-r1:8b")).toBeInTheDocument()
   })
 })

--- a/src/features/chat/components/__tests__/reasoning-trace.test.tsx
+++ b/src/features/chat/components/__tests__/reasoning-trace.test.tsx
@@ -156,9 +156,7 @@ describe("ReasoningTrace", () => {
       />
     )
 
-    expect(
-      screen.getByText(/Searching memory...: 2 results/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Searching memory: 2 results/)).toBeInTheDocument()
     expect(screen.getByText("What about it?")).toBeInTheDocument()
     expect(screen.getByText("What about tool calling?")).toBeInTheDocument()
     expect(screen.getByText("PR notes, Tool docs")).toBeInTheDocument()
@@ -336,10 +334,8 @@ describe("ReasoningTrace", () => {
       <ReasoningTrace message={{ role: "assistant", content: "" }} isLoading />
     )
 
-    expect(screen.getAllByText("Preparing context...").length).toBeGreaterThan(
-      0
-    )
-    expect(screen.queryByText("Answering...")).not.toBeInTheDocument()
+    expect(screen.getAllByText("Preparing context").length).toBeGreaterThan(0)
+    expect(screen.queryByText("Answering")).not.toBeInTheDocument()
   })
 
   it("shows answering while visible text is streaming", () => {
@@ -350,8 +346,8 @@ describe("ReasoningTrace", () => {
       />
     )
 
-    expect(screen.getAllByText("Answering...").length).toBeGreaterThan(0)
-    expect(screen.queryByText("Preparing context...")).not.toBeInTheDocument()
+    expect(screen.getAllByText("Answering").length).toBeGreaterThan(0)
+    expect(screen.queryByText("Preparing context")).not.toBeInTheDocument()
   })
 
   it("shows provider-agnostic tool labels and error detail", () => {

--- a/src/features/chat/components/chat-message-footer.tsx
+++ b/src/features/chat/components/chat-message-footer.tsx
@@ -1,20 +1,15 @@
 import { useTranslation } from "react-i18next"
 
-import {
-  type ActionMenuItemConfig,
-  TooltipActionButton
-} from "@/components/actions"
+import { TooltipActionButton } from "@/components/actions"
 import { chatIconBtnCls } from "@/features/chat/lib/chat-styles"
 import { ChatSessionActions } from "@/features/sessions/components/chat-session-actions"
+import { buildExportActionItems } from "@/features/sessions/lib/export-action-items"
 import {
-  BookOpen,
   Bot,
   ChevronLeft,
   ChevronRight,
-  Code,
-  FileDown,
-  FileText,
   GitFork,
+  MoreHorizontal,
   Trash2
 } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
@@ -63,40 +58,14 @@ export const ChatMessageFooter = ({
     onNavigate?.(targetNodeId)
   }
 
-  const exportItems: ActionMenuItemConfig[] = [
-    onExport
-      ? {
-          key: "markdown",
-          label: "Markdown",
-          onClick: () => onExport("markdown"),
-          icon: <BookOpen className="icon-xs" />
-        }
-      : null,
-    onExport
-      ? {
-          key: "pdf",
-          label: "PDF",
-          onClick: () => onExport("pdf"),
-          icon: <FileDown className="icon-xs" />
-        }
-      : null,
-    onExport
-      ? {
-          key: "json",
-          label: "JSON",
-          onClick: () => onExport("json"),
-          icon: <Code className="icon-xs" />
-        }
-      : null,
-    onExport
-      ? {
-          key: "text",
-          label: "Text",
-          onClick: () => onExport("text"),
-          icon: <FileText className="icon-xs" />
-        }
-      : null
-  ].filter(Boolean) as ActionMenuItemConfig[]
+  const exportItems = onExport
+    ? buildExportActionItems(t, {
+        onMarkdown: () => onExport("markdown"),
+        onPdf: () => onExport("pdf"),
+        onJson: () => onExport("json"),
+        onText: () => onExport("text")
+      })
+    : []
   const footerButtonClass = cn(chatIconBtnCls, "[&_svg]:icon-xs")
 
   return (
@@ -178,26 +147,25 @@ export const ChatMessageFooter = ({
           />
         )}
 
-        {exportItems.length > 0 && (
+        {(exportItems.length > 0 || onDelete) && (
           <ChatSessionActions
             actions={exportItems}
+            destructiveAction={
+              onDelete
+                ? {
+                    label: t("chat.actions.delete"),
+                    ariaLabel: t("chat.actions.delete"),
+                    icon: <Trash2 className="icon-sm" />,
+                    onClick: onDelete
+                  }
+                : undefined
+            }
             trigger={{
-              ariaLabel: t("chat.actions.export"),
-              tooltip: t("chat.actions.export"),
-              icon: <FileDown className="icon-xs" />,
+              ariaLabel: t("chat.actions.more"),
+              tooltip: t("chat.actions.more"),
+              icon: <MoreHorizontal className="icon-xs" />,
               className: footerButtonClass
             }}
-          />
-        )}
-
-        {onDelete && (
-          <TooltipActionButton
-            variant="ghost"
-            label={t("chat.actions.delete")}
-            size="icon"
-            className={footerButtonClass}
-            onClick={onDelete}
-            icon={<Trash2 className="icon-xs" />}
           />
         )}
       </div>

--- a/src/features/chat/components/chat-message-footer.tsx
+++ b/src/features/chat/components/chat-message-footer.tsx
@@ -63,7 +63,7 @@ export const ChatMessageFooter = ({
     onNavigate?.(targetNodeId)
   }
 
-  const actionItems: ActionMenuItemConfig[] = [
+  const exportItems: ActionMenuItemConfig[] = [
     onExport
       ? {
           key: "markdown",
@@ -94,15 +94,6 @@ export const ChatMessageFooter = ({
           label: "Text",
           onClick: () => onExport("text"),
           icon: <FileText className="icon-xs" />
-        }
-      : null,
-    onDelete
-      ? {
-          key: "delete",
-          label: t("chat.actions.delete"),
-          onClick: () => onDelete(),
-          icon: <Trash2 className="icon-xs" />,
-          destructive: true
         }
       : null
   ].filter(Boolean) as ActionMenuItemConfig[]
@@ -187,7 +178,28 @@ export const ChatMessageFooter = ({
           />
         )}
 
-        {actionItems.length > 0 && <ChatSessionActions actions={actionItems} />}
+        {exportItems.length > 0 && (
+          <ChatSessionActions
+            actions={exportItems}
+            trigger={{
+              ariaLabel: t("chat.actions.export"),
+              tooltip: t("chat.actions.export"),
+              icon: <FileDown className="icon-xs" />,
+              className: footerButtonClass
+            }}
+          />
+        )}
+
+        {onDelete && (
+          <TooltipActionButton
+            variant="ghost"
+            label={t("chat.actions.delete")}
+            size="icon"
+            className={footerButtonClass}
+            onClick={onDelete}
+            icon={<Trash2 className="icon-xs" />}
+          />
+        )}
       </div>
 
       {isUser ? (

--- a/src/features/chat/components/reasoning-trace.tsx
+++ b/src/features/chat/components/reasoning-trace.tsx
@@ -41,8 +41,7 @@ const statusClass = (status: TraceStatus) =>
     error: "text-status-danger"
   })[status]
 
-const getDisplayLabel = (label: string, status: TraceStatus) =>
-  status === "running" ? `${label}...` : label
+const getDisplayLabel = (label: string) => label
 
 const getToolRunStatus = (run: ToolRun): TraceStatus =>
   run.status === "running"
@@ -369,8 +368,8 @@ export const ReasoningTrace = ({
     ? activeStep.status === "error" && activeStep.detail
       ? `${activeStep.label}: ${activeStep.detail}`
       : activeStep.preview
-        ? `${getDisplayLabel(activeStep.label, activeStep.status)}: ${activeStep.preview}`
-        : getDisplayLabel(activeStep.label, activeStep.status)
+        ? `${getDisplayLabel(activeStep.label)}: ${activeStep.preview}`
+        : getDisplayLabel(activeStep.label)
     : undefined
 
   const reasoningLabel = t("chat.reasoning.title")
@@ -382,7 +381,7 @@ export const ReasoningTrace = ({
           <span className="sr-only">{t("chat.reasoning.aria_label")}</span>
           {steps.map((step) => {
             const Icon = step.icon ?? Circle
-            const label = getDisplayLabel(step.label, step.status)
+            const label = getDisplayLabel(step.label)
             const tooltip = step.detail ? `${label}: ${step.detail}` : label
             return (
               <TooltipActionButton
@@ -494,7 +493,6 @@ const ActivityStepRow = ({ event }: { event: ActivityEvent }) => {
             statusClass(status)
           )}>
           {event.label}
-          {status === "running" ? "…" : ""}
         </span>
         {event.resultCount !== undefined && (
           <span className="text-micro text-muted-foreground/70">

--- a/src/features/chat/components/reasoning-trace.tsx
+++ b/src/features/chat/components/reasoning-trace.tsx
@@ -418,7 +418,8 @@ export const ReasoningTrace = ({
               "min-w-0 flex-1 truncate pr-1 text-2xs",
               activeStep?.status === "error"
                 ? "text-status-danger"
-                : "text-muted-foreground"
+                : "text-muted-foreground",
+              activeStep?.status === "running" && "shimmer"
             )}>
             {activeLabel}
           </span>
@@ -445,7 +446,7 @@ export const ReasoningTrace = ({
       {hasDetails && detailsOpen && (
         <div
           ref={reasoningBodyRef}
-          className="flex max-h-72 flex-col gap-2 overflow-y-auto rounded-panel border border-border/30 bg-background/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+          className="scroll-fade-y flex max-h-72 flex-col gap-2 overflow-y-auto rounded-panel border border-border/30 bg-background/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
           {activityEvents.length > 0 && (
             <ol className="flex flex-col gap-1.5">
               {activityEvents.map((event) => (

--- a/src/features/chat/components/unified-sources-sheet.tsx
+++ b/src/features/chat/components/unified-sources-sheet.tsx
@@ -14,7 +14,8 @@ import {
   FileText,
   Globe,
   Info,
-  type LucideIcon
+  type LucideIcon,
+  User
 } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 import { ChunkFeedbackButton } from "./chunk-feedback-button"
@@ -82,8 +83,12 @@ const SourceRow = ({
 }) => {
   const { t } = useTranslation()
   const isWeb = group === "web"
+  const isUserMessage =
+    group === "knowledge" &&
+    item.source === "chat" &&
+    item.title === "User message"
   const host = isWeb && item.url ? (hostOf(item.url) ?? item.url) : undefined
-  const Icon = GROUP_META[group].icon
+  const Icon = isUserMessage ? User : GROUP_META[group].icon
 
   return (
     <div className="group/row">
@@ -93,7 +98,9 @@ const SourceRow = ({
             "mt-0.5 flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-control",
             isWeb
               ? "border border-border/50 bg-background"
-              : GROUP_META[group].chip
+              : isUserMessage
+                ? "bg-primary/10 text-primary"
+                : GROUP_META[group].chip
           )}>
           {isWeb && item.url ? (
             <WebSourceFavicon url={item.url} />

--- a/src/features/chat/components/unified-sources-sheet.tsx
+++ b/src/features/chat/components/unified-sources-sheet.tsx
@@ -343,7 +343,7 @@ export function UnifiedSourcesSheet({
         meta={subtitle}
         className="w-[min(32rem,calc(100vw-1rem))]">
         {tabs.length > 2 && (
-          <div className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border/35 px-1.5 scrollbar-none sm:gap-1 sm:px-3">
+          <div className="scroll-fade-x flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border/35 px-1.5 scrollbar-none sm:gap-1 sm:px-3">
             {tabs.map((tab) => {
               const Icon = tab.icon
               const isActive = activeGroup === tab.key

--- a/src/features/prompt/components/prompt-selector-sheet.tsx
+++ b/src/features/prompt/components/prompt-selector-sheet.tsx
@@ -162,7 +162,7 @@ export function PromptSelectorSheet({
         </div>
 
         {categories.length > 0 && (
-          <div className="flex gap-1 overflow-x-auto scrollbar-none">
+          <div className="scroll-fade-x flex gap-1 overflow-x-auto scrollbar-none">
             <Button
               type="button"
               variant={selectedCategory === null ? "secondary" : "ghost"}

--- a/src/features/selection-actions/__tests__/prompt-builder.test.ts
+++ b/src/features/selection-actions/__tests__/prompt-builder.test.ts
@@ -54,6 +54,37 @@ describe("selection action prompt builder", () => {
     expect(prompt.messages[1].content).toContain("Make this more polite.")
   })
 
+  it("preserves configured language instructions", () => {
+    const prompt = buildSelectionActionPrompt(
+      {
+        actionId: "custom",
+        selection: {
+          ...selection,
+          selectedText: "Das ist ein deutscher Text."
+        },
+        customInstruction: "Fasse den Text kurz zusammen."
+      },
+      "Antworte immer auf Deutsch."
+    )
+
+    expect(prompt.messages[0].content).toContain("Antworte immer auf Deutsch.")
+    expect(prompt.messages[1].content).toContain(
+      "Follow any output language requested"
+    )
+    expect(prompt.messages[1].content).toContain(
+      "Fasse den Text kurz zusammen."
+    )
+  })
+
+  it("keeps translate-to-English explicit", () => {
+    const prompt = buildSelectionActionPrompt({
+      actionId: "translate-english",
+      selection: { ...selection, selectedText: "Guten Morgen." }
+    })
+
+    expect(prompt.messages[1].content).toContain("Output in English.")
+  })
+
   it("ignores customInstruction for non-custom actions", () => {
     const prompt = buildSelectionActionPrompt({
       actionId: "shorten",

--- a/src/features/selection-actions/overlay-shadow-styles.ts
+++ b/src/features/selection-actions/overlay-shadow-styles.ts
@@ -31,6 +31,15 @@ export const buildShadowStyles = (appStyles: string): string => `
     --radius-md: 8px;
     --radius-lg: 10px;
     --radius-xl: 14px;
+    /*
+     * Custom radius tokens used by shared primitives (Card -> rounded-panel,
+     * buttons -> rounded-control). Defined in globals.css :root, but that
+     * sheet isn't loaded in this shadow root, so pin them here or rounded-*
+     * collapses to 0 and the panel renders square corners.
+     */
+    --radius-control: calc(var(--radius) - 1px);
+    --radius-panel: calc(var(--radius) + 1px);
+    --radius-chip: 999rem;
 
     /* Light mode tokens */
     --background: oklch(1 0 0);

--- a/src/features/selection-actions/prompt-builder.ts
+++ b/src/features/selection-actions/prompt-builder.ts
@@ -5,21 +5,29 @@ import type {
 } from "@/features/selection-actions/types"
 
 const SYSTEM_PROMPT =
-  "You are a private local AI assistant running inside the user's browser. Follow the requested text operation. Return only the final transformed text unless the user explicitly asks for explanation. Never claim facts that are not present in the selected text."
+  "You are a private local AI assistant running inside the user's browser. Follow the requested text operation and any configured language or tone instructions. Return only the final transformed text unless the user explicitly asks for explanation. Never claim facts that are not present in the selected text."
 
 export const buildSelectionActionPrompt = (
-  request: SelectionActionRequest
+  request: SelectionActionRequest,
+  modelSystemPrompt?: string
 ): SelectionActionPrompt => {
   const action = getSelectionAction(request.actionId)
   const customInstruction =
     request.actionId === "custom" ? request.customInstruction?.trim() : ""
   const instruction = customInstruction || action.instruction
+  const configuredSystemPrompt = modelSystemPrompt?.trim()
+  const languageRequirement =
+    request.actionId === "translate-english"
+      ? "Output in English."
+      : "Follow any output language requested by the configured system prompt or custom instruction. Otherwise, use the same language as the selected text."
 
   return {
     messages: [
       {
         role: "system",
-        content: SYSTEM_PROMPT
+        content: [configuredSystemPrompt, SYSTEM_PROMPT]
+          .filter(Boolean)
+          .join("\n\n")
       },
       {
         role: "user",
@@ -36,7 +44,8 @@ export const buildSelectionActionPrompt = (
           "- Keep the result focused on the selected text.",
           "- Return plain text only.",
           "- Do not mention that you are an AI.",
-          "- Do not invent facts not present in the selected text."
+          "- Do not invent facts not present in the selected text.",
+          `- ${languageRequirement}`
         ].join("\n")
       }
     ]

--- a/src/features/sessions/components/__tests__/chat-session-list.test.tsx
+++ b/src/features/sessions/components/__tests__/chat-session-list.test.tsx
@@ -102,4 +102,25 @@ describe("ChatSessionList", () => {
     expect(onDelete).toHaveBeenCalledWith("today")
     vi.useRealTimers()
   })
+
+  it("filters sessions by title and shows a no-match state", () => {
+    vi.useFakeTimers({ now })
+    const props = {
+      sessions: [
+        session("Release notes", now),
+        session("Provider setup", now - day)
+      ],
+      currentSessionId: null,
+      onSelect: vi.fn(),
+      onDelete: vi.fn()
+    }
+    const { rerender } = render(<ChatSessionList {...props} query="provider" />)
+
+    expect(screen.getByText("Provider setup")).toBeInTheDocument()
+    expect(screen.queryByText("Release notes")).not.toBeInTheDocument()
+
+    rerender(<ChatSessionList {...props} query="missing" />)
+    expect(screen.getByText("sessions.selector.no_matches")).toBeInTheDocument()
+    vi.useRealTimers()
+  })
 })

--- a/src/features/sessions/components/__tests__/chat-session-list.test.tsx
+++ b/src/features/sessions/components/__tests__/chat-session-list.test.tsx
@@ -23,21 +23,18 @@ vi.mock("react-virtuoso", () => ({
 
 vi.mock("@/features/sessions/components/chat-session-actions", () => ({
   ChatSessionActions: ({
-    actions
+    destructiveAction
   }: {
-    actions: { key: string; onClick: () => void }[]
-  }) => {
-    const deleteAction = actions.find((a) => a.key === "delete")
-    return (
-      <div>
-        {deleteAction && (
-          <button type="button" onClick={deleteAction.onClick}>
-            delete
-          </button>
-        )}
-      </div>
-    )
-  }
+    destructiveAction?: { onClick: () => void }
+  }) => (
+    <div>
+      {destructiveAction && (
+        <button type="button" onClick={destructiveAction.onClick}>
+          delete
+        </button>
+      )}
+    </div>
+  )
 }))
 
 vi.mock("@/features/sessions/stores/chat-session-store", () => {

--- a/src/features/sessions/components/chat-session-actions.tsx
+++ b/src/features/sessions/components/chat-session-actions.tsx
@@ -58,6 +58,8 @@ export const ChatSessionActions = ({
     size = "icon"
   } = trigger
 
+  const hasGridActions = actions.some((action) => !action.hidden)
+
   const triggerClassName = cn(
     "size-7 shrink-0 rounded-control transition-all duration-200",
     "hover:bg-muted hover:text-foreground",
@@ -83,12 +85,14 @@ export const ChatSessionActions = ({
         align="end"
         sideOffset={6}
         className="w-auto rounded-panel border-muted/60 p-0.5 shadow-md data-open:animate-none data-closed:animate-none">
-        <DropdownMenuGroup>
-          <ActionMenuGrid actions={actions} />
-        </DropdownMenuGroup>
+        {hasGridActions && (
+          <DropdownMenuGroup>
+            <ActionMenuGrid actions={actions} />
+          </DropdownMenuGroup>
+        )}
         {destructiveAction && (
           <>
-            <DropdownMenuSeparator />
+            {hasGridActions && <DropdownMenuSeparator />}
             <DropdownMenuItem
               onClick={destructiveAction.onClick}
               aria-label={destructiveAction.ariaLabel}

--- a/src/features/sessions/components/chat-session-actions.tsx
+++ b/src/features/sessions/components/chat-session-actions.tsx
@@ -8,13 +8,23 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import { MoreHorizontal } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 
+export interface ChatSessionDestructiveAction {
+  label: React.ReactNode
+  ariaLabel?: string
+  icon: React.ReactNode
+  onClick: () => void
+}
+
 export interface ChatSessionActionsProps {
   actions: ActionMenuItemConfig[]
+  destructiveAction?: ChatSessionDestructiveAction
   trigger?: {
     ariaLabel?: string
     tooltip?: string
@@ -35,13 +45,14 @@ export interface ChatSessionActionsProps {
 
 export const ChatSessionActions = ({
   actions,
+  destructiveAction,
   trigger = {}
 }: ChatSessionActionsProps) => {
   const { t } = useTranslation()
   const {
     ariaLabel = t("sessions.actions.more_default"),
     tooltip = t("sessions.actions.tooltip"),
-    icon = <MoreHorizontal className="icon-md" />,
+    icon = <MoreHorizontal className="icon-xs" />,
     className = "",
     variant = "ghost",
     size = "icon"
@@ -75,6 +86,18 @@ export const ChatSessionActions = ({
         <DropdownMenuGroup>
           <ActionMenuGrid actions={actions} />
         </DropdownMenuGroup>
+        {destructiveAction && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={destructiveAction.onClick}
+              aria-label={destructiveAction.ariaLabel}
+              className="gap-2 rounded-control text-destructive hover:bg-destructive/10 focus:bg-destructive/10 focus:text-destructive">
+              {destructiveAction.icon}
+              <span>{destructiveAction.label}</span>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/features/sessions/components/chat-session-empty.tsx
+++ b/src/features/sessions/components/chat-session-empty.tsx
@@ -1,19 +1,33 @@
-import { MessageSquare } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { MessageSquare, Search } from "@/lib/lucide-icon"
 
-export const ChatSessionEmpty = () => {
+export const ChatSessionEmpty = ({
+  variant = "sessions"
+}: {
+  variant?: "sessions" | "search"
+}) => {
   const { t } = useTranslation()
+  const isSearch = variant === "search"
+  const Icon = isSearch ? Search : MessageSquare
 
   return (
     <div className="flex flex-col items-center justify-center py-8 text-center h-full">
       <div className="mb-3 rounded-chip bg-sidebar-accent p-3">
-        <MessageSquare className="icon-xl text-sidebar-foreground/70" />
+        <Icon className="icon-xl text-sidebar-foreground/70" />
       </div>
       <p className="text-sm text-sidebar-foreground/80">
-        {t("sessions.selector.no_sessions")}
+        {t(
+          isSearch
+            ? "sessions.selector.no_matches"
+            : "sessions.selector.no_sessions"
+        )}
       </p>
       <p className="mt-1 text-xs text-sidebar-foreground/60">
-        {t("sessions.selector.no_sessions_hint")}
+        {t(
+          isSearch
+            ? "sessions.selector.no_matches_hint"
+            : "sessions.selector.no_sessions_hint"
+        )}
       </p>
     </div>
   )

--- a/src/features/sessions/components/chat-session-item.tsx
+++ b/src/features/sessions/components/chat-session-item.tsx
@@ -1,14 +1,9 @@
 import { MessageSquare } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useChatExport } from "@/features/sessions/hooks/use-export-chat"
+import { buildExportActionItems } from "@/features/sessions/lib/export-action-items"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
-import {
-  Code,
-  FileDown,
-  FileText,
-  MoreHorizontal,
-  Trash2
-} from "@/lib/lucide-icon"
+import { MoreHorizontal, Trash2 } from "@/lib/lucide-icon"
 import { cn } from "@/lib/utils"
 import type { ChatSession } from "@/types"
 import { ChatSessionActions } from "./chat-session-actions"
@@ -42,41 +37,12 @@ export const ChatSessionItem = ({
   })
 
   const actionItems = current
-    ? [
-        {
-          key: "json",
-          label: t("sessions.export.format_json"),
-          icon: <FileDown className="icon-md" />,
-          onClick: () => exportSessionAsJson(current)
-        },
-        {
-          key: "pdf",
-          label: t("sessions.export.format_pdf"),
-          icon: <FileDown className="icon-md" />,
-          onClick: () => exportSessionAsPdf(current)
-        },
-        {
-          key: "markdown",
-          label: t("sessions.export.format_markdown"),
-          icon: <Code className="icon-md" />,
-          onClick: () => exportSessionAsMarkdown(current)
-        },
-        {
-          key: "text",
-          label: t("sessions.export.format_text"),
-          icon: <FileText className="icon-md" />,
-          onClick: () => exportSessionAsText(current)
-        },
-        {
-          key: "delete",
-          label: t("sessions.delete.tooltip"),
-          tooltip: t("sessions.delete.tooltip"),
-          ariaLabel: t("sessions.delete.aria_label", { title: session.title }),
-          icon: <Trash2 className="icon-md" />,
-          destructive: true,
-          onClick: () => onDelete(session.id)
-        }
-      ]
+    ? buildExportActionItems(t, {
+        onMarkdown: () => exportSessionAsMarkdown(current),
+        onPdf: () => exportSessionAsPdf(current),
+        onJson: () => exportSessionAsJson(current),
+        onText: () => exportSessionAsText(current)
+      })
     : []
 
   return (
@@ -127,10 +93,22 @@ export const ChatSessionItem = ({
       <div className="flex shrink-0 items-center gap-0.5 pr-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
         <ChatSessionActions
           actions={actionItems}
+          destructiveAction={
+            current
+              ? {
+                  label: t("sessions.delete.tooltip"),
+                  ariaLabel: t("sessions.delete.aria_label", {
+                    title: session.title
+                  }),
+                  icon: <Trash2 className="icon-sm" />,
+                  onClick: () => onDelete(session.id)
+                }
+              : undefined
+          }
           trigger={{
             ariaLabel: t("sessions.actions.more", { title: session.title }),
             tooltip: t("sessions.actions.tooltip"),
-            icon: <MoreHorizontal className="icon-md" />
+            icon: <MoreHorizontal className="icon-xs" />
           }}
         />
       </div>

--- a/src/features/sessions/components/chat-session-list.tsx
+++ b/src/features/sessions/components/chat-session-list.tsx
@@ -12,6 +12,7 @@ type SessionListRow =
 
 export interface ChatSessionListProps {
   sessions: ChatSession[]
+  query?: string
   currentSessionId: string | null
   onSelect: (id: string) => void
   onDelete: (id: string) => void
@@ -19,22 +20,33 @@ export interface ChatSessionListProps {
 
 export const ChatSessionList = ({
   sessions,
+  query = "",
   currentSessionId,
   onSelect,
   onDelete
 }: ChatSessionListProps) => {
+  const filteredSessions = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase()
+    if (!normalizedQuery) return sessions
+    return sessions.filter((session) =>
+      session.title.toLocaleLowerCase().includes(normalizedQuery)
+    )
+  }, [query, sessions])
   const rows = useMemo<SessionListRow[]>(
     () =>
-      groupChatSessions(sessions).flatMap((group) => [
+      groupChatSessions(filteredSessions).flatMap((group) => [
         { type: "group", id: group.id },
         ...group.sessions.map(
           (session): SessionListRow => ({ type: "session", session })
         )
       ]),
-    [sessions]
+    [filteredSessions]
   )
 
   if (sessions.length === 0) return <ChatSessionEmpty />
+  if (filteredSessions.length === 0) {
+    return <ChatSessionEmpty variant="search" />
+  }
 
   return (
     <Virtuoso

--- a/src/features/sessions/components/chat-session-selector.tsx
+++ b/src/features/sessions/components/chat-session-selector.tsx
@@ -3,9 +3,11 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { TooltipActionButton } from "@/components/actions"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
+import { Search, X } from "@/lib/lucide-icon"
 import { ChatSessionFooter } from "./chat-session-footer"
 import { ChatSessionList } from "./chat-session-list"
 import { ChatSessionSidebarHeader } from "./chat-session-sidebar-header"
@@ -19,6 +21,7 @@ export const ChatSessionSelector = ({
 }: ChatSessionSelectorProps) => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
+  const [sessionQuery, setSessionQuery] = useState("")
   const {
     sessions,
     currentSessionId,
@@ -69,12 +72,36 @@ export const ChatSessionSelector = ({
               aria-label={t("sessions.selector.create_new_aria")}>
               {t("sessions.selector.start_new")}
             </Button>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 icon-sm -translate-y-1/2 text-sidebar-foreground/50" />
+              <Input
+                type="search"
+                value={sessionQuery}
+                onChange={(event) => setSessionQuery(event.target.value)}
+                placeholder={t("sessions.selector.search_placeholder")}
+                aria-label={t("sessions.selector.search_placeholder")}
+                className="h-9 bg-background/70 pl-8 pr-8 [&::-webkit-search-cancel-button]:appearance-none"
+              />
+              {sessionQuery && (
+                <TooltipActionButton
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  label={t("sessions.selector.clear_search")}
+                  onClick={() => setSessionQuery("")}
+                  className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-sidebar-foreground/60"
+                  icon={X}
+                  iconClassName="icon-xs"
+                />
+              )}
+            </div>
             {searchTrigger}
           </div>
 
           <div className="h-full flex-1 px-2">
             <ChatSessionList
               sessions={sessions}
+              query={sessionQuery}
               currentSessionId={currentSessionId}
               onSelect={setCurrentSessionId}
               onDelete={deleteSession}

--- a/src/features/sessions/components/chat-session-selector.tsx
+++ b/src/features/sessions/components/chat-session-selector.tsx
@@ -30,15 +30,20 @@ export const ChatSessionSelector = ({
     deleteSession
   } = useChatSessions()
 
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open)
+    if (!open) setSessionQuery("")
+  }
+
   useKeyboardShortcuts({
     closeSidebar: (e) => {
       e.preventDefault()
-      setIsOpen((prev) => !prev)
+      handleOpenChange(!isOpen)
     }
   })
 
   return (
-    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <TooltipActionButton
         label={t("sessions.selector.title")}
         trigger={

--- a/src/features/sessions/lib/export-action-items.tsx
+++ b/src/features/sessions/lib/export-action-items.tsx
@@ -1,0 +1,49 @@
+import type { TFunction } from "i18next"
+
+import type { ActionMenuItemConfig } from "@/components/actions"
+import { Code, FileDown, FileText, Hash } from "@/lib/lucide-icon"
+
+export interface ExportActionHandlers {
+  onMarkdown: () => void
+  onPdf: () => void
+  onJson: () => void
+  onText: () => void
+}
+
+/**
+ * Canonical export-format menu items shared by every "..." overflow menu
+ * (chat message footer + session list row). Centralized so the format→icon
+ * mapping and icon size stay identical across surfaces — distinct glyph per
+ * format, all `icon-sm` to read inside the grid's `size-8` cells.
+ */
+export function buildExportActionItems(
+  t: TFunction,
+  handlers: ExportActionHandlers
+): ActionMenuItemConfig[] {
+  return [
+    {
+      key: "markdown",
+      label: t("sessions.export.format_markdown"),
+      icon: <Hash className="icon-sm" />,
+      onClick: handlers.onMarkdown
+    },
+    {
+      key: "pdf",
+      label: t("sessions.export.format_pdf"),
+      icon: <FileDown className="icon-sm" />,
+      onClick: handlers.onPdf
+    },
+    {
+      key: "json",
+      label: t("sessions.export.format_json"),
+      icon: <Code className="icon-sm" />,
+      onClick: handlers.onJson
+    },
+    {
+      key: "text",
+      label: t("sessions.export.format_text"),
+      icon: <FileText className="icon-sm" />,
+      onClick: handlers.onText
+    }
+  ]
+}

--- a/src/lib/__tests__/generate-llms-docs.test.ts
+++ b/src/lib/__tests__/generate-llms-docs.test.ts
@@ -33,4 +33,14 @@ Yes.`
       "# Public"
     )
   })
+
+  it("removes paired-tag FAQPageJsonLd without a placeholder", () => {
+    const cleaned = cleanMarkdown(
+      "<FAQPageJsonLd items={faqItems}>\n  child\n</FAQPageJsonLd>\n\n# Public"
+    )
+
+    expect(cleaned).not.toContain("FAQPageJsonLd")
+    expect(cleaned).not.toContain("Rendered component")
+    expect(cleaned).toContain("# Public")
+  })
 })

--- a/src/lib/__tests__/generate-llms-docs.test.ts
+++ b/src/lib/__tests__/generate-llms-docs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { cleanMarkdown } from "../../../tools/generate-llms-docs"
+
+describe("cleanMarkdown", () => {
+  it("removes multiline MDX export declarations but keeps prose", () => {
+    const markdown = `import FAQ from "./FAQ.astro"
+
+export const faqItems = [
+  {
+    question: "What is Ollama Client?",
+    answer: "A local-first browser extension."
+  }
+]
+
+<FAQPageJsonLd items={faqItems} />
+
+## Does it stay local?
+
+Yes.`
+
+    const cleaned = cleanMarkdown(markdown)
+
+    expect(cleaned).not.toContain("export const")
+    expect(cleaned).not.toContain("question:")
+    expect(cleaned).not.toContain("answer:")
+    expect(cleaned).not.toContain("FAQPageJsonLd")
+    expect(cleaned).toContain("## Does it stay local?")
+    expect(cleaned).toContain("Yes.")
+  })
+
+  it("removes single-line exported values", () => {
+    expect(cleanMarkdown("export const draft = true\n\n# Public")).toBe(
+      "# Public"
+    )
+  })
+})

--- a/src/lib/embeddings/__tests__/vector-durability.smoke.test.ts
+++ b/src/lib/embeddings/__tests__/vector-durability.smoke.test.ts
@@ -11,23 +11,26 @@ const bootFreshVectorContext = async () => {
   return { ...vectorStore, hnswIndexManager }
 }
 
-const clearVectorDatabase = async () => {
-  const context = await bootFreshVectorContext()
-  await context.vectorDb.delete()
-  context.vectorDb.close()
+const dropVectorDatabase = async () => {
+  vi.resetModules()
+  const vectorStore = await import("@/lib/embeddings/vector-store")
+  await vectorStore.vectorDb.delete()
+  vectorStore.vectorDb.close()
+}
+
+const closeTrackedDatabases = () => {
+  for (const database of openDatabases) database.close()
   openDatabases.length = 0
 }
 
-beforeEach(clearVectorDatabase)
+beforeEach(async () => {
+  closeTrackedDatabases()
+  await dropVectorDatabase()
+})
 
 afterEach(async () => {
-  for (const database of openDatabases) database.close()
-  openDatabases.length = 0
-
-  const cleanup = await bootFreshVectorContext()
-  await cleanup.vectorDb.delete()
-  cleanup.vectorDb.close()
-  openDatabases.length = 0
+  closeTrackedDatabases()
+  await dropVectorDatabase()
 })
 
 describe("S4 - vector search survives a service-worker restart", () => {

--- a/src/lib/embeddings/__tests__/vector-durability.smoke.test.ts
+++ b/src/lib/embeddings/__tests__/vector-durability.smoke.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const openDatabases: Array<{ close: () => void; delete: () => Promise<void> }> =
+  []
+
+const bootFreshVectorContext = async () => {
+  vi.resetModules()
+  const vectorStore = await import("@/lib/embeddings/vector-store")
+  const { hnswIndexManager } = await import("@/lib/embeddings/hnsw-index")
+  openDatabases.push(vectorStore.vectorDb)
+  return { ...vectorStore, hnswIndexManager }
+}
+
+const clearVectorDatabase = async () => {
+  const context = await bootFreshVectorContext()
+  await context.vectorDb.delete()
+  context.vectorDb.close()
+  openDatabases.length = 0
+}
+
+beforeEach(clearVectorDatabase)
+
+afterEach(async () => {
+  for (const database of openDatabases) database.close()
+  openDatabases.length = 0
+
+  const cleanup = await bootFreshVectorContext()
+  await cleanup.vectorDb.delete()
+  cleanup.vectorDb.close()
+  openDatabases.length = 0
+})
+
+describe("S4 - vector search survives a service-worker restart", () => {
+  it("finds a persisted chunk after loading a fresh module graph", async () => {
+    const embedding = [1, 0, 0, 0]
+    const first = await bootFreshVectorContext()
+
+    await first.storeVector("durable vector sentinel", embedding, {
+      source: "restart-smoke.txt",
+      type: "file",
+      fileId: "restart-smoke",
+      timestamp: Date.now()
+    })
+    await first.hnswIndexManager.buildIndex(undefined, embedding.length)
+
+    expect(await first.vectorDb.vectors.count()).toBe(1)
+    first.vectorDb.close()
+
+    const second = await bootFreshVectorContext()
+    const results = await second.searchSimilarVectors(embedding, {
+      limit: 1,
+      minSimilarity: 0.99,
+      type: "file"
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].document.content).toBe("durable vector sentinel")
+    expect(results[0].document.metadata.fileId).toBe("restart-smoke")
+  })
+})

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Neuen Chat erstellen",
       "create_new_aria": "Neuen Chat erstellen",
       "start_new": "Neuen Chat starten",
+      "search_placeholder": "Chats nach Titel durchsuchen...",
+      "clear_search": "Chatsuche löschen",
       "no_sessions": "Noch keine Chat-Sitzungen",
       "no_sessions_hint": "Erstellen Sie Ihren ersten Chat, um zu beginnen",
+      "no_matches": "Keine passenden Chats",
+      "no_matches_hint": "Versuchen Sie einen anderen Titel.",
       "session_count": "{{count}} Sitzung",
       "session_count_plural": "{{count}} Sitzungen"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Create New Chat",
       "create_new_aria": "Create New Chat",
       "start_new": "Start New Chat",
+      "search_placeholder": "Search chats by title...",
+      "clear_search": "Clear chat search",
       "no_sessions": "No chat sessions yet",
       "no_sessions_hint": "Create your first chat to get started",
+      "no_matches": "No matching chats",
+      "no_matches_hint": "Try a different title.",
       "session_count": "{{count}} session",
       "session_count_plural": "{{count}} sessions"
     },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Crear Nuevo Chat",
       "create_new_aria": "Crear Nuevo Chat",
       "start_new": "Iniciar Nuevo Chat",
+      "search_placeholder": "Buscar chats por título...",
+      "clear_search": "Borrar búsqueda de chats",
       "no_sessions": "Aún no hay sesiones de chat",
       "no_sessions_hint": "Crea tu primer chat para empezar",
+      "no_matches": "No hay chats coincidentes",
+      "no_matches_hint": "Prueba con otro título.",
       "session_count": "{{count}} sesión",
       "session_count_plural": "{{count}} sesiones"
     },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Créer un Nouveau Chat",
       "create_new_aria": "Créer un Nouveau Chat",
       "start_new": "Démarrer un Nouveau Chat",
+      "search_placeholder": "Rechercher les chats par titre...",
+      "clear_search": "Effacer la recherche",
       "no_sessions": "Aucune session de chat pour l'instant",
       "no_sessions_hint": "Créez votre premier chat pour commencer",
+      "no_matches": "Aucun chat correspondant",
+      "no_matches_hint": "Essayez un autre titre.",
       "session_count": "{{count}} session",
       "session_count_plural": "{{count}} sessions"
     },

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -675,8 +675,12 @@
       "create_new": "नई चैट बनाएँ",
       "create_new_aria": "नई चैट बनाएँ",
       "start_new": "नई चैट शुरू करें",
+      "search_placeholder": "शीर्षक से चैट खोजें...",
+      "clear_search": "चैट खोज साफ़ करें",
       "no_sessions": "अभी तक कोई चैट सेशन नहीं है",
       "no_sessions_hint": "शुरू करने के लिए अपनी पहली चैट बनाएँ",
+      "no_matches": "कोई मेल खाती चैट नहीं",
+      "no_matches_hint": "कोई दूसरा शीर्षक आज़माएँ।",
       "session_count": "{{count}} सेशन",
       "session_count_plural": "{{count}} सेशन"
     },

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Crea Nuova Chat",
       "create_new_aria": "Crea Nuova Chat",
       "start_new": "Inizia Nuova Chat",
+      "search_placeholder": "Cerca chat per titolo...",
+      "clear_search": "Cancella ricerca chat",
       "no_sessions": "Nessuna sessione di chat ancora",
       "no_sessions_hint": "Crea la tua prima chat per iniziare",
+      "no_matches": "Nessuna chat corrispondente",
+      "no_matches_hint": "Prova un titolo diverso.",
       "session_count": "{{count}} sessione",
       "session_count_plural": "{{count}} sessioni"
     },

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -675,8 +675,12 @@
       "create_new": "新しいチャットを作成",
       "create_new_aria": "新しいチャットを作成",
       "start_new": "新しいチャットを開始",
+      "search_placeholder": "タイトルでチャットを検索...",
+      "clear_search": "チャット検索をクリア",
       "no_sessions": "チャットセッションはまだありません",
       "no_sessions_hint": "最初のチャットを作成して始めましょう",
+      "no_matches": "一致するチャットはありません",
+      "no_matches_hint": "別のタイトルを試してください。",
       "session_count": "{{count}} セッション",
       "session_count_plural": "{{count}} セッション"
     },

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -675,8 +675,12 @@
       "create_new": "Создать новый чат",
       "create_new_aria": "Создать новый чат",
       "start_new": "Начать новый чат",
+      "search_placeholder": "Искать чаты по названию...",
+      "clear_search": "Очистить поиск чатов",
       "no_sessions": "Нет сессий чата",
       "no_sessions_hint": "Создайте свой первый чат, чтобы начать",
+      "no_matches": "Подходящих чатов нет",
+      "no_matches_hint": "Попробуйте другое название.",
       "session_count": "{{count}} сессия",
       "session_count_plural": "{{count}} сессий"
     },

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -675,8 +675,12 @@
       "create_new": "创建新聊天",
       "create_new_aria": "创建新聊天",
       "start_new": "开始新聊天",
+      "search_placeholder": "按标题搜索聊天...",
+      "clear_search": "清除聊天搜索",
       "no_sessions": "暂无聊天会话",
       "no_sessions_hint": "创建您的第一个聊天即可开始",
+      "no_matches": "没有匹配的聊天",
+      "no_matches_hint": "请尝试其他标题。",
       "session_count": "{{count}} 个会话",
       "session_count_plural": "{{count}} 个会话"
     },

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -17,7 +17,7 @@ import {
   writeFileSync
 } from "node:fs"
 import { dirname, join, relative } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import {
   SITE_DESCRIPTION,
@@ -89,9 +89,53 @@ function routeFromSource(path: string) {
     : withoutExt
 }
 
-function cleanMarkdown(body: string) {
-  return body
+function stripMdxExportDeclarations(body: string) {
+  const lines = body.split("\n")
+  const cleaned: string[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^\s*export\s+(?:const|let|var)\s+/.test(lines[index])) {
+      cleaned.push(lines[index])
+      continue
+    }
+
+    let depth = 0
+    let quote: '"' | "'" | "`" | null = null
+    let escaped = false
+
+    do {
+      const line = lines[index]
+      for (const char of line) {
+        if (escaped) {
+          escaped = false
+          continue
+        }
+        if (quote) {
+          if (char === "\\") escaped = true
+          else if (char === quote) quote = null
+          continue
+        }
+        if (char === '"' || char === "'" || char === "`") {
+          quote = char
+        } else if (char === "{" || char === "[" || char === "(") {
+          depth += 1
+        } else if (char === "}" || char === "]" || char === ")") {
+          depth -= 1
+        }
+      }
+      index += 1
+    } while (index < lines.length && (depth > 0 || quote))
+
+    index -= 1
+  }
+
+  return cleaned.join("\n")
+}
+
+export function cleanMarkdown(body: string) {
+  return stripMdxExportDeclarations(body)
     .replace(/^import\s+.*$/gm, "")
+    .replace(/<FAQPageJsonLd\b[^>]*\/>/g, "")
     .replace(
       /<([A-Z][A-Za-z0-9.]*)\b[^>]*>([\s\S]*?)<\/\1>/g,
       "\n\n$2\n\n"
@@ -252,4 +296,9 @@ function main() {
   console.log(`Generated llms.txt, llms-full.txt, ai.txt, and ${pages.length} page markdown files`)
 }
 
-main()
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main()
+}

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -136,6 +136,7 @@ export function cleanMarkdown(body: string) {
   return stripMdxExportDeclarations(body)
     .replace(/^import\s+.*$/gm, "")
     .replace(/<FAQPageJsonLd\b[^>]*\/>/g, "")
+    .replace(/<FAQPageJsonLd\b[^>]*>[\s\S]*?<\/FAQPageJsonLd>/g, "")
     .replace(
       /<([A-Z][A-Za-z0-9.]*)\b[^>]*>([\s\S]*?)<\/\1>/g,
       "\n\n$2\n\n"


### PR DESCRIPTION
## Summary

- bump the extension to 0.11.25 and upgrade shadcn tooling to 4.12
- fix Selection Actions so configured system and output-language instructions reach the model
- replace ambiguous message ellipsis menus with explicit export and delete actions
- use a primary-colored user icon for user-message knowledge sources
- remove MDX export data and SEO-only FAQ markup from AI-readable docs
- add an S4 vector restart smoke test
- add localized session-title filtering with clear and no-results states
- apply scroll fades to existing overflow surfaces and shimmer only to active reasoning status

## Why

The 0.11.x line still lacked a real vector persistence check and basic session-list organization. Selection Actions also dropped configured model system prompts, causing language instructions to be ignored. This release closes those small reliability and usability gaps without changing provider, storage, or streaming contracts.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` (229 files, 1785 tests)
- `pnpm build`
- `pnpm build:firefox`
- `pnpm docs:build` (69 pages)
- `pnpm verify:browser-smoke`
- local Chromium extension and Firefox runtime automation, including live Ollama chat

## Release

After merge, create and push tag `v0.11.25`.

Closes #159

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the 0.11.25 release polish: it fixes Selection Actions dropping user-configured model system prompts (causing language instructions to be silently ignored), refactors the per-message overflow menu into explicit export and delete actions backed by a new shared `buildExportActionItems` helper, and adds locale-sensitive session-title search with proper state reset on sheet close.

- **Selection Action prompt fix**: `handle-selection-action.ts` now reads the raw `modelConfigMap` system prompt instead of the default-merged one, and `buildSelectionActionPrompt` prepends it alongside a per-action language requirement rule — preventing the Markdown formatting default from conflicting with \"Return plain text only.\"
- **Session list search**: `ChatSessionSelector` gains a controlled search input whose state is cleared on sheet close; `ChatSessionList` filters via a locale-aware `useMemo` and surfaces a variant-aware `ChatSessionEmpty` when no sessions match.
- **UI polish**: ellipsis menus now separate destructive actions with a `DropdownMenuSeparator`, `ReasoningTrace` swaps inline `...` ellipsis for a CSS shimmer on the active step, `scroll-fade-x/y` is applied to existing overflow surfaces, and an S4 vector-restart smoke test is added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped, thoroughly tested (229 files, 1785 tests), and do not touch provider, storage, or streaming contracts.

All core logic changes (selection action prompt construction, session filtering, export action centralization) are covered by new or updated unit tests. The translate-english + configured-language-system-prompt interaction is a known edge case handled by design. The stripMdxExportDeclarations comment-tracking gap is limited to the doc-generation tooling and is very unlikely to be triggered in practice.

The stripMdxExportDeclarations function in tools/generate-llms-docs.ts and buildSelectionActionPrompt in src/features/selection-actions/prompt-builder.ts are the two files with minor edge-case notes worth a second glance.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/background/handlers/handle-selection-action.ts | Bug fix: reads the raw modelConfigMap system prompt (trimmed, || undefined) instead of the default-merged one, correctly preventing the markdown formatting default from overriding the selection action's plain-text-only requirement. |
| src/features/selection-actions/prompt-builder.ts | Extends buildSelectionActionPrompt to accept and prepend a configured system prompt; adds per-action language requirement rules. Minor edge case: translate-english instruction can conflict with a configured non-English system prompt (model-dependent resolution). |
| tools/generate-llms-docs.ts | New stripMdxExportDeclarations parser strips multi-line MDX export declarations; adds FAQPageJsonLd removal and paired-tag fallback regex; guards main() with ESM direct-execution check to allow cleanMarkdown unit tests. The bracket-depth tracker doesn't handle // comments, which could over-consume content after a line ending with an unbalanced { in a comment. |
| src/features/sessions/components/chat-session-selector.tsx | Adds session title search with a controlled Input; handleOpenChange correctly clears sessionQuery on close, addressing the stale-query concern. Keyboard shortcut toggle updated accordingly. |
| src/features/sessions/components/chat-session-list.tsx | Adds client-side locale-sensitive filtering via useMemo; correctly shows no-sessions empty state before the no-matches state to avoid ambiguity; rows memo depends on filteredSessions correctly. |
| src/features/sessions/lib/export-action-items.tsx | New shared helper de-duplicates export action items across chat message footer and session list; uses distinct glyphs per format (Hash/FileDown/Code/FileText) at icon-sm. Existing hardcoded English labels in chat-message-footer are replaced with i18n keys. |
| src/features/sessions/components/chat-session-actions.tsx | Adds first-class destructiveAction prop rendered as a separate DropdownMenuItem with a separator; hasGridActions guard prevents an empty DropdownMenuGroup. Correct conditional separator logic. |
| src/lib/embeddings/__tests__/vector-durability.smoke.test.ts | New S4 smoke test verifies vector search survives a module-reset cycle; uses separate bootFreshVectorContext / dropVectorDatabase helpers and explicit close tracking. |
| src/features/chat/components/reasoning-trace.tsx | Removes the inline ... ellipsis appended to running-step labels and replaces it with a shimmer CSS class on the active label span; adds scroll-fade-y to the reasoning detail body. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SW as Background Handler
    participant Store as plasmoGlobalStorage
    participant PB as buildSelectionActionPrompt
    participant Model as Provider.streamChat

    SW->>Store: get(MODEL_CONFIGS)
    Store-->>SW: modelConfigMap
    SW->>SW: "configuredSystemPrompt = modelConfigMap[model]?.system?.trim() || undefined"
    SW->>PB: buildSelectionActionPrompt(payload, configuredSystemPrompt)
    PB->>PB: [configuredSystemPrompt, SYSTEM_PROMPT].filter(Boolean).join()
    PB->>PB: languageRequirement (translate-english → Output in English. else defer to system)
    PB-->>SW: "SelectionActionPrompt { messages }"
    SW->>Model: "streamChat({ messages, model, ... })"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SW as Background Handler
    participant Store as plasmoGlobalStorage
    participant PB as buildSelectionActionPrompt
    participant Model as Provider.streamChat

    SW->>Store: get(MODEL_CONFIGS)
    Store-->>SW: modelConfigMap
    SW->>SW: "configuredSystemPrompt = modelConfigMap[model]?.system?.trim() || undefined"
    SW->>PB: buildSelectionActionPrompt(payload, configuredSystemPrompt)
    PB->>PB: [configuredSystemPrompt, SYSTEM_PROMPT].filter(Boolean).join()
    PB->>PB: languageRequirement (translate-english → Output in English. else defer to system)
    PB-->>SW: "SelectionActionPrompt { messages }"
    SW->>Model: "streamChat({ messages, model, ... })"
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(selection-actions): forward only use..."](https://github.com/shishir435/ollama-client/commit/d413003677c8b651866dc39a4c9cd6ce871f55f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40882984)</sub>

<!-- /greptile_comment -->