### PR TITLE
Keep provider API keys device-local

### DIFF
--- a/src/hooks/__tests__/use-reset-app-storage.test.ts
+++ b/src/hooks/__tests__/use-reset-app-storage.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useResetAppStorage } from "@/hooks/use-reset-app-storage"
+import { STORAGE_KEYS } from "@/lib/constants"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { getAllResetKeys } from "@/lib/get-all-reset-keys"
 import {
@@ -88,6 +89,7 @@ describe("useResetAppStorage", () => {
 
     expect(keys.LANGUAGE).toEqual(["app-language"])
     expect(keys.PROVIDER).toContain(ProviderStorageKey.CONFIG)
+    expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
     expect(keys.PROVIDER).toContain(ProviderStorageKey.MODEL_MAPPINGS)
   })
 })

--- a/src/hooks/__tests__/use-reset-app-storage.test.ts
+++ b/src/hooks/__tests__/use-reset-app-storage.test.ts
@@ -90,6 +90,7 @@ describe("useResetAppStorage", () => {
     expect(keys.LANGUAGE).toEqual(["app-language"])
     expect(keys.PROVIDER).toContain(ProviderStorageKey.CONFIG)
     expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
+    expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
     expect(keys.PROVIDER).toContain(ProviderStorageKey.MODEL_MAPPINGS)
   })
 })

--- a/src/hooks/__tests__/use-reset-app-storage.test.ts
+++ b/src/hooks/__tests__/use-reset-app-storage.test.ts
@@ -9,7 +9,10 @@ import {
   plasmoGlobalStorage,
   removePlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
-import { withProviderPersistenceLock } from "@/lib/providers/provider-secret-store"
+import {
+  resetProviderStorageUnlocked,
+  withProviderPersistenceLock
+} from "@/lib/providers/provider-secret-store"
 import { ProviderStorageKey } from "@/lib/providers/types"
 import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
@@ -24,6 +27,7 @@ vi.mock("@/lib/sqlite/db", () => ({
 }))
 
 vi.mock("@/lib/providers/provider-secret-store", () => ({
+  resetProviderStorageUnlocked: vi.fn().mockResolvedValue(undefined),
   withProviderPersistenceLock: vi.fn(
     async (operation: () => Promise<unknown>) => operation()
   )
@@ -56,6 +60,7 @@ describe("useResetAppStorage", () => {
     expect(plasmoGlobalStorage.clear).toHaveBeenCalled()
     expect(plasmoDeviceStorage.clear).toHaveBeenCalled()
     expect(withProviderPersistenceLock).toHaveBeenCalledOnce()
+    expect(resetProviderStorageUnlocked).toHaveBeenCalled()
   })
 
   it("should reset only chat sessions when key is 'CHAT_SESSIONS'", async () => {
@@ -109,39 +114,27 @@ describe("useResetAppStorage", () => {
     expect(withProviderPersistenceLock).toHaveBeenCalledOnce()
     expect(removePlasmoStoredValue).not.toHaveBeenCalled()
 
-    const lockedReset = runLockedReset?.()
-    await Promise.resolve()
-
-    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
-      ProviderStorageKey.CONFIG
-    )
-    await lockedReset
-    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
-      STORAGE_KEYS.PROVIDER.SECRETS
-    )
-    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
-      STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+    await runLockedReset?.()
+    expect(resetProviderStorageUnlocked).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        ProviderStorageKey.CONFIG,
+        STORAGE_KEYS.PROVIDER.SECRETS,
+        STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL,
+        STORAGE_KEYS.PROVIDER.RESET_JOURNAL
+      ])
     )
   })
 
-  it("keeps credentials when provider config removal fails", async () => {
-    vi.mocked(removePlasmoStoredValue).mockImplementation(async (key) => {
-      if (key === ProviderStorageKey.CONFIG) {
-        throw new Error("sync removal failed")
-      }
-    })
+  it("reports durable provider reset failures", async () => {
+    vi.mocked(resetProviderStorageUnlocked).mockRejectedValueOnce(
+      new Error("reset interrupted")
+    )
 
     const { result } = renderHook(() => useResetAppStorage())
     const message = await result.current("PROVIDER")
 
     expect(message).toBe("Failed to reset app data. Check console for details.")
-    expect(removePlasmoStoredValue).toHaveBeenCalledTimes(1)
-    expect(removePlasmoStoredValue).not.toHaveBeenCalledWith(
-      STORAGE_KEYS.PROVIDER.SECRETS
-    )
-    expect(removePlasmoStoredValue).not.toHaveBeenCalledWith(
-      STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
-    )
+    expect(removePlasmoStoredValue).not.toHaveBeenCalled()
   })
 
   it("includes string storage keys and provider secrets in module reset maps", () => {
@@ -151,6 +144,7 @@ describe("useResetAppStorage", () => {
     expect(keys.PROVIDER).toContain(ProviderStorageKey.CONFIG)
     expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
     expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
+    expect(keys.PROVIDER).toContain(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)
     expect(keys.PROVIDER).toContain(ProviderStorageKey.MODEL_MAPPINGS)
   })
 })

--- a/src/hooks/__tests__/use-reset-app-storage.test.ts
+++ b/src/hooks/__tests__/use-reset-app-storage.test.ts
@@ -9,6 +9,7 @@ import {
   plasmoGlobalStorage,
   removePlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
+import { withProviderPersistenceLock } from "@/lib/providers/provider-secret-store"
 import { ProviderStorageKey } from "@/lib/providers/types"
 import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
@@ -20,6 +21,12 @@ vi.mock("@/lib/embeddings/feedback-service", () => ({
 
 vi.mock("@/lib/sqlite/db", () => ({
   resetSQLiteDatabase: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock("@/lib/providers/provider-secret-store", () => ({
+  withProviderPersistenceLock: vi.fn(
+    async (operation: () => Promise<unknown>) => operation()
+  )
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
@@ -48,6 +55,7 @@ describe("useResetAppStorage", () => {
     expect(feedbackService.clearAllFeedback).toHaveBeenCalled()
     expect(plasmoGlobalStorage.clear).toHaveBeenCalled()
     expect(plasmoDeviceStorage.clear).toHaveBeenCalled()
+    expect(withProviderPersistenceLock).toHaveBeenCalledOnce()
   })
 
   it("should reset only chat sessions when key is 'CHAT_SESSIONS'", async () => {
@@ -82,6 +90,58 @@ describe("useResetAppStorage", () => {
     expect(removePlasmoStoredValue).toHaveBeenCalled()
     expect(resetSQLiteDatabase).not.toHaveBeenCalled()
     expect(feedbackService.clearAllFeedback).not.toHaveBeenCalled()
+    expect(withProviderPersistenceLock).not.toHaveBeenCalled()
+  })
+
+  it("holds the provider persistence lock while removing provider keys", async () => {
+    let runLockedReset: (() => Promise<unknown>) | undefined
+    vi.mocked(withProviderPersistenceLock).mockImplementationOnce(
+      async (operation) => {
+        runLockedReset = operation
+        return new Promise(() => undefined)
+      }
+    )
+
+    const { result } = renderHook(() => useResetAppStorage())
+    void result.current("PROVIDER")
+    await Promise.resolve()
+
+    expect(withProviderPersistenceLock).toHaveBeenCalledOnce()
+    expect(removePlasmoStoredValue).not.toHaveBeenCalled()
+
+    const lockedReset = runLockedReset?.()
+    await Promise.resolve()
+
+    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
+      ProviderStorageKey.CONFIG
+    )
+    await lockedReset
+    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
+      STORAGE_KEYS.PROVIDER.SECRETS
+    )
+    expect(removePlasmoStoredValue).toHaveBeenCalledWith(
+      STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+    )
+  })
+
+  it("keeps credentials when provider config removal fails", async () => {
+    vi.mocked(removePlasmoStoredValue).mockImplementation(async (key) => {
+      if (key === ProviderStorageKey.CONFIG) {
+        throw new Error("sync removal failed")
+      }
+    })
+
+    const { result } = renderHook(() => useResetAppStorage())
+    const message = await result.current("PROVIDER")
+
+    expect(message).toBe("Failed to reset app data. Check console for details.")
+    expect(removePlasmoStoredValue).toHaveBeenCalledTimes(1)
+    expect(removePlasmoStoredValue).not.toHaveBeenCalledWith(
+      STORAGE_KEYS.PROVIDER.SECRETS
+    )
+    expect(removePlasmoStoredValue).not.toHaveBeenCalledWith(
+      STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+    )
   })
 
   it("includes string storage keys and provider secrets in module reset maps", () => {

--- a/src/hooks/use-reset-app-storage.ts
+++ b/src/hooks/use-reset-app-storage.ts
@@ -8,8 +8,10 @@ import {
   plasmoGlobalStorage,
   removePlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
-import { withProviderPersistenceLock } from "@/lib/providers/provider-secret-store"
-import { ProviderStorageKey } from "@/lib/providers/types"
+import {
+  resetProviderStorageUnlocked,
+  withProviderPersistenceLock
+} from "@/lib/providers/provider-secret-store"
 import { sendRuntimeMessage } from "@/lib/runtime-messages"
 import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
@@ -30,6 +32,7 @@ export const useResetAppStorage = () => {
 
       if (key === "all") {
         await withProviderPersistenceLock(async () => {
+          await resetProviderStorageUnlocked(allKeys.PROVIDER || [])
           await plasmoGlobalStorage.clear()
           await plasmoDeviceStorage.clear()
         })
@@ -41,18 +44,9 @@ export const useResetAppStorage = () => {
             Promise.all(keysToRemove.map((key) => removePlasmoStoredValue(key)))
 
           if (key === "PROVIDER") {
-            await withProviderPersistenceLock(async () => {
-              // Remove public config before local credentials. If sync removal
-              // fails, the configured providers retain usable credentials.
-              await removePlasmoStoredValue(ProviderStorageKey.CONFIG)
-              await Promise.all(
-                keysToRemove
-                  .filter(
-                    (storageKey) => storageKey !== ProviderStorageKey.CONFIG
-                  )
-                  .map((storageKey) => removePlasmoStoredValue(storageKey))
-              )
-            })
+            await withProviderPersistenceLock(() =>
+              resetProviderStorageUnlocked(keysToRemove)
+            )
           } else {
             await removeKeys()
           }

--- a/src/hooks/use-reset-app-storage.ts
+++ b/src/hooks/use-reset-app-storage.ts
@@ -8,6 +8,8 @@ import {
   plasmoGlobalStorage,
   removePlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
+import { withProviderPersistenceLock } from "@/lib/providers/provider-secret-store"
+import { ProviderStorageKey } from "@/lib/providers/types"
 import { sendRuntimeMessage } from "@/lib/runtime-messages"
 import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
@@ -27,15 +29,33 @@ export const useResetAppStorage = () => {
       }
 
       if (key === "all") {
-        await plasmoGlobalStorage.clear()
-        await plasmoDeviceStorage.clear()
+        await withProviderPersistenceLock(async () => {
+          await plasmoGlobalStorage.clear()
+          await plasmoDeviceStorage.clear()
+        })
         sessionStorage.clear()
       } else if (key !== "CHAT_SESSIONS" && key !== "FEEDBACK") {
         const keysToRemove = allKeys[key] || []
         if (keysToRemove.length > 0) {
-          await Promise.all(
-            keysToRemove.map((key) => removePlasmoStoredValue(key))
-          )
+          const removeKeys = () =>
+            Promise.all(keysToRemove.map((key) => removePlasmoStoredValue(key)))
+
+          if (key === "PROVIDER") {
+            await withProviderPersistenceLock(async () => {
+              // Remove public config before local credentials. If sync removal
+              // fails, the configured providers retain usable credentials.
+              await removePlasmoStoredValue(ProviderStorageKey.CONFIG)
+              await Promise.all(
+                keysToRemove
+                  .filter(
+                    (storageKey) => storageKey !== ProviderStorageKey.CONFIG
+                  )
+                  .map((storageKey) => removePlasmoStoredValue(storageKey))
+              )
+            })
+          } else {
+            await removeKeys()
+          }
         }
       }
 

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -76,6 +76,8 @@ export const STORAGE_KEYS = {
     BASE_URL: "provider-base-url",
     /** Device-local provider credentials; never store this key in sync. */
     SECRETS: "llm_provider_secrets_v1",
+    /** Recovery journal for cross-area provider config commits. */
+    PERSISTENCE_JOURNAL: "llm_provider_persistence_journal_v1",
     SELECTED_MODEL: "provider-selected-model",
     SELECTED_MODEL_REF: "provider-selected-model-ref",
     SELECTION_CONFLICT_MODEL: "provider-selection-conflict-model",

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -78,6 +78,8 @@ export const STORAGE_KEYS = {
     SECRETS: "llm_provider_secrets_v1",
     /** Recovery journal for cross-area provider config commits. */
     PERSISTENCE_JOURNAL: "llm_provider_persistence_journal_v1",
+    /** Durable tombstone for interrupted provider-data resets. */
+    RESET_JOURNAL: "llm_provider_reset_journal_v1",
     SELECTED_MODEL: "provider-selected-model",
     SELECTED_MODEL_REF: "provider-selected-model-ref",
     SELECTION_CONFLICT_MODEL: "provider-selection-conflict-model",

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -74,6 +74,8 @@ export const LEGACY_STORAGE_KEYS = {
 export const STORAGE_KEYS = {
   PROVIDER: {
     BASE_URL: "provider-base-url",
+    /** Device-local provider credentials; never store this key in sync. */
+    SECRETS: "llm_provider_secrets_v1",
     SELECTED_MODEL: "provider-selected-model",
     SELECTED_MODEL_REF: "provider-selected-model-ref",
     SELECTION_CONFLICT_MODEL: "provider-selection-conflict-model",

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -218,6 +218,47 @@ describe("ProviderManager", () => {
     ).toBe(true)
   })
 
+  it("locks concurrent provider read-modify-write operations", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
+    let releaseFirstWrite: (() => void) | undefined
+    const firstWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+    stores.local.set.mockImplementationOnce(
+      async (key: string, value: unknown) => {
+        localBacking.set(key, value)
+        await firstWriteBlocked
+      }
+    )
+
+    const enableLmStudio = ProviderManager.updateProviderConfig(
+      ProviderId.LM_STUDIO,
+      { enabled: true }
+    )
+    await vi.waitFor(() => expect(stores.local.set).toHaveBeenCalledTimes(1))
+
+    const enableLlamaCpp = ProviderManager.updateProviderConfig(
+      ProviderId.LLAMA_CPP,
+      { enabled: true }
+    )
+    await Promise.resolve()
+
+    // Second transaction cannot read its snapshot while first write is open.
+    expect(stores.sync.get).toHaveBeenCalledTimes(3)
+    releaseFirstWrite?.()
+    await Promise.all([enableLmStudio, enableLlamaCpp])
+
+    const stored = syncBacking.get(
+      ProviderStorageKey.CONFIG
+    ) as ProviderConfig[]
+    expect(
+      stored.find((provider) => provider.id === ProviderId.LM_STUDIO)?.enabled
+    ).toBe(true)
+    expect(
+      stored.find((provider) => provider.id === ProviderId.LLAMA_CPP)?.enabled
+    ).toBe(true)
+  })
+
   it("removes a cleared API key from local storage", async () => {
     syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
     localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
 import { DEFAULT_PROVIDERS, ProviderManager } from "../manager"
 import {
   isCustomProviderId,
+  type ProviderConfig,
   ProviderId,
   ProviderStorageKey,
   ProviderType
@@ -141,6 +142,80 @@ describe("ProviderManager", () => {
       "local write failed"
     )
     expect(syncBacking.get(ProviderStorageKey.CONFIG)).toEqual(legacyProviders)
+  })
+
+  it("serializes overlapping provider saves across both storage areas", async () => {
+    const events: string[] = []
+    let releaseFirstLocalWrite: (() => void) | undefined
+    const firstLocalWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstLocalWrite = resolve
+    })
+    const firstProviders = [
+      ...DEFAULT_PROVIDERS,
+      {
+        id: "custom:openai:first",
+        type: ProviderType.OPENAI,
+        name: "First",
+        enabled: true,
+        baseUrl: "https://first.example/v1",
+        apiKey: "sk-first"
+      }
+    ]
+    const secondProviders = [
+      ...DEFAULT_PROVIDERS,
+      {
+        id: "custom:openai:second",
+        type: ProviderType.OPENAI,
+        name: "Second",
+        enabled: true,
+        baseUrl: "https://second.example/v1",
+        apiKey: "sk-second"
+      }
+    ]
+
+    stores.local.set
+      .mockImplementationOnce(async (key: string, value: unknown) => {
+        events.push("local:first")
+        localBacking.set(key, value)
+        await firstLocalWriteBlocked
+      })
+      .mockImplementationOnce(async (key: string, value: unknown) => {
+        events.push("local:second")
+        localBacking.set(key, value)
+      })
+    stores.sync.set.mockImplementation(async (key: string, value: unknown) => {
+      const configs = value as ProviderConfig[]
+      events.push(
+        configs.some((provider) => provider.id === "custom:openai:first")
+          ? "sync:first"
+          : "sync:second"
+      )
+      syncBacking.set(key, value)
+    })
+
+    const firstSave = ProviderManager.saveProviders(firstProviders)
+    await vi.waitFor(() => expect(events).toEqual(["local:first"]))
+    const secondSave = ProviderManager.saveProviders(secondProviders)
+
+    await Promise.resolve()
+    expect(events).toEqual(["local:first"])
+    releaseFirstLocalWrite?.()
+    await Promise.all([firstSave, secondSave])
+
+    expect(events).toEqual([
+      "local:first",
+      "sync:first",
+      "local:second",
+      "sync:second"
+    ])
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      "custom:openai:second": "sk-second"
+    })
+    expect(
+      (syncBacking.get(ProviderStorageKey.CONFIG) as ProviderConfig[]).some(
+        (provider) => provider.id === "custom:openai:second"
+      )
+    ).toBe(true)
   })
 
   it("removes a cleared API key from local storage", async () => {

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -144,6 +144,138 @@ describe("ProviderManager", () => {
     expect(syncBacking.get(ProviderStorageKey.CONFIG)).toEqual(legacyProviders)
   })
 
+  it("rolls local credentials back when the sync commit fails", async () => {
+    const provider = {
+      id: "custom:openai:rollback",
+      type: ProviderType.OPENAI,
+      name: "Rollback remote",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS, provider])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [provider.id]: "sk-preserved"
+    })
+    stores.sync.set.mockRejectedValueOnce(new Error("sync write failed"))
+
+    await expect(
+      ProviderManager.saveProviders([...DEFAULT_PROVIDERS])
+    ).rejects.toThrow("sync write failed")
+
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      [provider.id]: "sk-preserved"
+    })
+    expect(syncBacking.get(ProviderStorageKey.CONFIG)).toContainEqual(provider)
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      false
+    )
+  })
+
+  it("repairs an interruption after journaling but before the sync commit", async () => {
+    const provider = {
+      id: "custom:openai:recover-pre-commit",
+      type: ProviderType.OPENAI,
+      name: "Recover pre-commit",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS, provider])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [provider.id]: "sk-before-interruption"
+    })
+    stores.local.set
+      .mockImplementationOnce(async (key: string, value: unknown) => {
+        localBacking.set(key, value)
+      })
+      .mockRejectedValueOnce(new Error("secret write interrupted"))
+
+    await expect(
+      ProviderManager.saveProviders([...DEFAULT_PROVIDERS])
+    ).rejects.toThrow("secret write interrupted")
+    expect(stores.sync.set).not.toHaveBeenCalled()
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      true
+    )
+
+    await expect(
+      ProviderManager.getProviderConfig(provider.id)
+    ).resolves.toMatchObject({ apiKey: "sk-before-interruption" })
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      false
+    )
+  })
+
+  it("repairs an interrupted rollback from the durable journal", async () => {
+    const provider = {
+      id: "custom:openai:recover-rollback",
+      type: ProviderType.OPENAI,
+      name: "Recover rollback",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS, provider])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [provider.id]: "sk-recovered"
+    })
+    stores.local.set
+      .mockImplementationOnce(async (key: string, value: unknown) => {
+        localBacking.set(key, value)
+      })
+      .mockImplementationOnce(async (key: string, value: unknown) => {
+        localBacking.set(key, value)
+      })
+      .mockRejectedValueOnce(new Error("rollback write failed"))
+    stores.sync.set.mockRejectedValueOnce(new Error("sync write failed"))
+
+    await expect(
+      ProviderManager.saveProviders([...DEFAULT_PROVIDERS])
+    ).rejects.toThrow("credential rollback both failed")
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({})
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      true
+    )
+
+    await expect(
+      ProviderManager.getProviderConfig(provider.id)
+    ).resolves.toMatchObject({ apiKey: "sk-recovered" })
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      [provider.id]: "sk-recovered"
+    })
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      false
+    )
+  })
+
+  it("rolls a committed revision forward when journal cleanup was interrupted", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
+    const provider = {
+      id: "custom:openai:recover-commit",
+      type: ProviderType.OPENAI,
+      name: "Recover commit",
+      enabled: true,
+      baseUrl: "https://example.com/v1",
+      apiKey: "sk-committed"
+    }
+    stores.local.remove.mockRejectedValueOnce(new Error("cleanup failed"))
+
+    await expect(
+      ProviderManager.saveProviders([...DEFAULT_PROVIDERS, provider])
+    ).rejects.toThrow("cleanup failed")
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      true
+    )
+
+    await expect(
+      ProviderManager.getProviderConfig(provider.id)
+    ).resolves.toMatchObject({ apiKey: "sk-committed" })
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      [provider.id]: "sk-committed"
+    })
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      false
+    )
+  })
+
   it("serializes overlapping provider saves across both storage areas", async () => {
     const events: string[] = []
     let releaseFirstLocalWrite: (() => void) | undefined
@@ -173,16 +305,24 @@ describe("ProviderManager", () => {
       }
     ]
 
-    stores.local.set
-      .mockImplementationOnce(async (key: string, value: unknown) => {
-        events.push("local:first")
-        localBacking.set(key, value)
-        await firstLocalWriteBlocked
-      })
-      .mockImplementationOnce(async (key: string, value: unknown) => {
-        events.push("local:second")
-        localBacking.set(key, value)
-      })
+    stores.local.set.mockImplementation(async (key: string, value: unknown) => {
+      const revisionValue =
+        key === STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+          ? (value as { nextPublicConfigs: ProviderConfig[] }).nextPublicConfigs
+          : value
+      const revision = JSON.stringify(revisionValue).includes(
+        "custom:openai:first"
+      )
+        ? "first"
+        : "second"
+      if (key === STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL) {
+        events.push(`journal:${revision}`)
+      } else {
+        events.push(`local:${revision}`)
+      }
+      localBacking.set(key, value)
+      if (events.length === 1) await firstLocalWriteBlocked
+    })
     stores.sync.set.mockImplementation(async (key: string, value: unknown) => {
       const configs = value as ProviderConfig[]
       events.push(
@@ -194,17 +334,19 @@ describe("ProviderManager", () => {
     })
 
     const firstSave = ProviderManager.saveProviders(firstProviders)
-    await vi.waitFor(() => expect(events).toEqual(["local:first"]))
+    await vi.waitFor(() => expect(events).toEqual(["journal:first"]))
     const secondSave = ProviderManager.saveProviders(secondProviders)
 
     await Promise.resolve()
-    expect(events).toEqual(["local:first"])
+    expect(events).toEqual(["journal:first"])
     releaseFirstLocalWrite?.()
     await Promise.all([firstSave, secondSave])
 
     expect(events).toEqual([
+      "journal:first",
       "local:first",
       "sync:first",
+      "journal:second",
       "local:second",
       "sync:second"
     ])

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -16,10 +16,16 @@ const stores = vi.hoisted(() => ({
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
   plasmoGlobalStorage: stores.sync,
-  plasmoDeviceStorage: stores.local
+  plasmoDeviceStorage: stores.local,
+  removePlasmoStoredValue: vi.fn(async (key: string) =>
+    key.startsWith("llm_provider_")
+      ? stores.local.remove(key)
+      : stores.sync.remove(key)
+  )
 }))
 
 import { DEFAULT_PROVIDERS, ProviderManager } from "../manager"
+import { resetProviderStorageUnlocked } from "../provider-secret-store"
 import {
   isCustomProviderId,
   type ProviderConfig,
@@ -274,6 +280,55 @@ describe("ProviderManager", () => {
     expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
       false
     )
+  })
+
+  it("finishes an interrupted provider reset before restoring defaults", async () => {
+    const removedProvider = {
+      id: "custom:openai:reset-interrupted",
+      type: ProviderType.OPENAI,
+      name: "Reset interrupted",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [
+      ...DEFAULT_PROVIDERS,
+      removedProvider
+    ])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [removedProvider.id]: "sk-must-be-cleared"
+    })
+    let interruptSecretRemoval = true
+    stores.local.remove.mockImplementation(async (key: string) => {
+      if (key === STORAGE_KEYS.PROVIDER.SECRETS && interruptSecretRemoval) {
+        interruptSecretRemoval = false
+        throw new Error("secret cleanup interrupted")
+      }
+      localBacking.delete(key)
+    })
+
+    await expect(
+      resetProviderStorageUnlocked([
+        ProviderStorageKey.CONFIG,
+        STORAGE_KEYS.PROVIDER.SECRETS,
+        STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL,
+        STORAGE_KEYS.PROVIDER.RESET_JOURNAL
+      ])
+    ).rejects.toThrow("secret cleanup interrupted")
+
+    expect(syncBacking.has(ProviderStorageKey.CONFIG)).toBe(false)
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      [removedProvider.id]: "sk-must-be-cleared"
+    })
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)).toBe(true)
+
+    const providers = await ProviderManager.getProviders()
+
+    expect(providers).toEqual(DEFAULT_PROVIDERS)
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({})
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)).toBe(false)
+    expect(
+      JSON.stringify(syncBacking.get(ProviderStorageKey.CONFIG))
+    ).not.toContain(removedProvider.id)
   })
 
   it("serializes overlapping provider saves across both storage areas", async () => {

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { STORAGE_KEYS } from "@/lib/constants"
 
-const storage = vi.hoisted(() => ({
-  get: vi.fn(),
-  set: vi.fn(),
-  remove: vi.fn()
+const stores = vi.hoisted(() => ({
+  sync: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn()
+  },
+  local: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn()
+  }
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: storage
+  plasmoGlobalStorage: stores.sync,
+  plasmoDeviceStorage: stores.local
 }))
 
 import { DEFAULT_PROVIDERS, ProviderManager } from "../manager"
@@ -19,18 +28,31 @@ import {
 } from "../types"
 
 /** Back the mock with a real map so read-modify-write flows behave. */
-const backing = new Map<string, unknown>()
+const syncBacking = new Map<string, unknown>()
+const localBacking = new Map<string, unknown>()
 
 describe("ProviderManager", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    backing.clear()
-    storage.get.mockImplementation(async (key: string) => backing.get(key))
-    storage.set.mockImplementation(async (key: string, value: unknown) => {
-      backing.set(key, value)
+    syncBacking.clear()
+    localBacking.clear()
+    stores.sync.get.mockImplementation(async (key: string) =>
+      syncBacking.get(key)
+    )
+    stores.sync.set.mockImplementation(async (key: string, value: unknown) => {
+      syncBacking.set(key, value)
     })
-    storage.remove.mockImplementation(async (key: string) => {
-      backing.delete(key)
+    stores.sync.remove.mockImplementation(async (key: string) => {
+      syncBacking.delete(key)
+    })
+    stores.local.get.mockImplementation(async (key: string) =>
+      localBacking.get(key)
+    )
+    stores.local.set.mockImplementation(async (key: string, value: unknown) => {
+      localBacking.set(key, value)
+    })
+    stores.local.remove.mockImplementation(async (key: string) => {
+      localBacking.delete(key)
     })
   })
 
@@ -42,8 +64,103 @@ describe("ProviderManager", () => {
     ])
   })
 
+  it("stores provider API keys locally and keeps sync config secret-free", async () => {
+    const providers = [
+      ...DEFAULT_PROVIDERS,
+      {
+        id: "custom:openai:secure",
+        type: ProviderType.OPENAI,
+        name: "Remote",
+        enabled: true,
+        baseUrl: "https://example.com/v1",
+        apiKey: "sk-local-only"
+      }
+    ]
+
+    await ProviderManager.saveProviders(providers)
+
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      "custom:openai:secure": "sk-local-only"
+    })
+    expect(syncBacking.get(ProviderStorageKey.CONFIG)).toEqual(
+      providers.map(({ apiKey: _apiKey, ...provider }) => provider)
+    )
+    expect(
+      JSON.stringify(syncBacking.get(ProviderStorageKey.CONFIG))
+    ).not.toContain("sk-local-only")
+    await expect(
+      ProviderManager.getProviderConfig("custom:openai:secure")
+    ).resolves.toMatchObject({ apiKey: "sk-local-only" })
+  })
+
+  it("migrates legacy synced API keys to local storage before purging them", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, [
+      ...DEFAULT_PROVIDERS,
+      {
+        id: "custom:openai:legacy",
+        type: ProviderType.OPENAI,
+        name: "Legacy remote",
+        enabled: true,
+        baseUrl: "https://example.com/v1",
+        apiKey: "sk-legacy"
+      }
+    ])
+
+    const providers = await ProviderManager.getProviders()
+
+    expect(
+      providers.find((provider) => provider.id === "custom:openai:legacy")
+    ).toMatchObject({ apiKey: "sk-legacy" })
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({
+      "custom:openai:legacy": "sk-legacy"
+    })
+    expect(
+      JSON.stringify(syncBacking.get(ProviderStorageKey.CONFIG))
+    ).not.toContain("sk-legacy")
+    expect(stores.local.set.mock.invocationCallOrder[0]).toBeLessThan(
+      stores.sync.set.mock.invocationCallOrder[0]
+    )
+  })
+
+  it("does not purge a synced API key when local persistence fails", async () => {
+    const legacyProviders = [
+      ...DEFAULT_PROVIDERS,
+      {
+        id: "custom:openai:retry",
+        type: ProviderType.OPENAI,
+        name: "Retry remote",
+        enabled: true,
+        baseUrl: "https://example.com/v1",
+        apiKey: "sk-retry"
+      }
+    ]
+    syncBacking.set(ProviderStorageKey.CONFIG, legacyProviders)
+    stores.local.set.mockRejectedValueOnce(new Error("local write failed"))
+
+    await expect(ProviderManager.getProviders()).rejects.toThrow(
+      "local write failed"
+    )
+    expect(syncBacking.get(ProviderStorageKey.CONFIG)).toEqual(legacyProviders)
+  })
+
+  it("removes a cleared API key from local storage", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [ProviderId.LM_STUDIO]: "old-key"
+    })
+
+    await ProviderManager.updateProviderConfig(ProviderId.LM_STUDIO, {
+      apiKey: ""
+    })
+
+    expect(localBacking.get(STORAGE_KEYS.PROVIDER.SECRETS)).toEqual({})
+    expect(
+      JSON.stringify(syncBacking.get(ProviderStorageKey.CONFIG))
+    ).not.toContain("old-key")
+  })
+
   it("removes stale OpenAI config that is no longer in the provider UI", async () => {
-    storage.get.mockImplementation(async (key: string) => {
+    stores.sync.get.mockImplementation(async (key: string) => {
       if (key === ProviderStorageKey.CONFIG) {
         return [
           DEFAULT_PROVIDERS[0],
@@ -74,7 +191,7 @@ describe("ProviderManager", () => {
     expect(providers.map((provider) => provider.id)).toContain(
       ProviderId.LM_STUDIO
     )
-    expect(storage.set).toHaveBeenCalledWith(
+    expect(stores.sync.set).toHaveBeenCalledWith(
       ProviderStorageKey.CONFIG,
       expect.not.arrayContaining([
         expect.objectContaining({ id: ProviderId.OPENAI })
@@ -83,7 +200,7 @@ describe("ProviderManager", () => {
   })
 
   it("keeps custom providers through the sanitizer", async () => {
-    backing.set(ProviderStorageKey.CONFIG, [
+    syncBacking.set(ProviderStorageKey.CONFIG, [
       ...DEFAULT_PROVIDERS,
       {
         id: "custom:openai:abc123",
@@ -99,55 +216,55 @@ describe("ProviderManager", () => {
   })
 
   it("migrates the old global Ollama URL into canonical provider config on first read", async () => {
-    backing.set("provider-base-url", "http://old-device:11434")
+    syncBacking.set("provider-base-url", "http://old-device:11434")
 
     const providers = await ProviderManager.getProviders()
 
     expect(
       providers.find((provider) => provider.id === ProviderId.OLLAMA)?.baseUrl
     ).toBe("http://old-device:11434")
-    expect(backing.has("provider-base-url")).toBe(false)
+    expect(syncBacking.has("provider-base-url")).toBe(false)
   })
 
   it("keeps an explicit canonical URL over stale legacy/global values", async () => {
-    backing.set(ProviderStorageKey.CONFIG, [
+    syncBacking.set(ProviderStorageKey.CONFIG, [
       {
         ...DEFAULT_PROVIDERS[0],
         baseUrl: "http://canonical:11434"
       },
       ...DEFAULT_PROVIDERS.slice(1)
     ])
-    backing.set("ollama-base-url", "http://legacy:11434")
-    backing.set("provider-base-url", "http://global:11434")
+    syncBacking.set("ollama-base-url", "http://legacy:11434")
+    syncBacking.set("provider-base-url", "http://global:11434")
 
     const providers = await ProviderManager.getProviders()
 
     expect(
       providers.find((provider) => provider.id === ProviderId.OLLAMA)?.baseUrl
     ).toBe("http://canonical:11434")
-    expect(backing.has("ollama-base-url")).toBe(false)
-    expect(backing.has("provider-base-url")).toBe(false)
+    expect(syncBacking.has("ollama-base-url")).toBe(false)
+    expect(syncBacking.has("provider-base-url")).toBe(false)
   })
 
   it("updates only canonical provider config for Ollama URL changes", async () => {
-    backing.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS])
 
     await ProviderManager.updateProviderConfig(ProviderId.OLLAMA, {
       baseUrl: "http://new-host:11434"
     })
 
-    const providers = backing.get(
+    const providers = syncBacking.get(
       ProviderStorageKey.CONFIG
     ) as typeof DEFAULT_PROVIDERS
     expect(
       providers.find((provider) => provider.id === ProviderId.OLLAMA)?.baseUrl
     ).toBe("http://new-host:11434")
-    expect(backing.has("ollama-base-url")).toBe(false)
-    expect(backing.has("provider-base-url")).toBe(false)
+    expect(syncBacking.has("ollama-base-url")).toBe(false)
+    expect(syncBacking.has("provider-base-url")).toBe(false)
   })
 
   it("drops untouched beta defaults but preserves configured ones as custom", async () => {
-    backing.set(ProviderStorageKey.CONFIG, [
+    syncBacking.set(ProviderStorageKey.CONFIG, [
       ...DEFAULT_PROVIDERS,
       {
         id: ProviderId.VLLM,
@@ -300,7 +417,7 @@ describe("ProviderManager", () => {
 
     it("resolves bare-name collisions preferring enabled providers", async () => {
       const customId = "custom:openai:vllm"
-      backing.set(ProviderStorageKey.CONFIG, [
+      syncBacking.set(ProviderStorageKey.CONFIG, [
         ...DEFAULT_PROVIDERS,
         {
           id: customId,
@@ -319,7 +436,7 @@ describe("ProviderManager", () => {
     })
 
     it("migrates the legacy flat map to scoped keys once", async () => {
-      backing.set(ProviderStorageKey.MODEL_MAPPINGS, {
+      syncBacking.set(ProviderStorageKey.MODEL_MAPPINGS, {
         llama3: ProviderId.LM_STUDIO,
         qwen3: "custom:openai:vllm"
       })
@@ -331,21 +448,23 @@ describe("ProviderManager", () => {
         providerId: "custom:openai:vllm"
       })
       // Legacy key deleted; scoped map holds provider-prefixed keys.
-      expect(backing.has(ProviderStorageKey.MODEL_MAPPINGS)).toBe(false)
-      expect(backing.get(ProviderStorageKey.MODEL_MAPPINGS_V2)).toMatchObject({
+      expect(syncBacking.has(ProviderStorageKey.MODEL_MAPPINGS)).toBe(false)
+      expect(
+        syncBacking.get(ProviderStorageKey.MODEL_MAPPINGS_V2)
+      ).toMatchObject({
         [`${ProviderId.LM_STUDIO}::llama3`]: ProviderId.LM_STUDIO
       })
     })
 
     it("remaps scoped beta-provider mappings to migrated custom ids", async () => {
-      backing.set(ProviderStorageKey.MODEL_MAPPINGS_V2, {
+      syncBacking.set(ProviderStorageKey.MODEL_MAPPINGS_V2, {
         [`${ProviderId.VLLM}::qwen3`]: ProviderId.VLLM
       })
 
       expect(await ProviderManager.getModelMapping("qwen3")).toEqual({
         providerId: "custom:openai:legacy-vllm"
       })
-      expect(backing.get(ProviderStorageKey.MODEL_MAPPINGS_V2)).toEqual({
+      expect(syncBacking.get(ProviderStorageKey.MODEL_MAPPINGS_V2)).toEqual({
         "custom:openai:legacy-vllm::qwen3": "custom:openai:legacy-vllm"
       })
     })

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -9,6 +9,7 @@ import {
   hydrateProviderSecrets,
   persistProviderConfigs,
   persistProviderConfigsUnlocked,
+  recoverProviderPersistenceUnlocked,
   withProviderPersistenceLock
 } from "./provider-secret-store"
 import {
@@ -208,6 +209,7 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
 
 /** Caller must hold the provider-persistence lock. */
 const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
+  await recoverProviderPersistenceUnlocked()
   let stored = await plasmoGlobalStorage.get<ProviderConfig[]>(
     ProviderStorageKey.CONFIG
   )

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -10,6 +10,7 @@ import {
   persistProviderConfigs,
   persistProviderConfigsUnlocked,
   recoverProviderPersistenceUnlocked,
+  recoverProviderResetUnlocked,
   withProviderPersistenceLock
 } from "./provider-secret-store"
 import {
@@ -209,6 +210,7 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
 
 /** Caller must hold the provider-persistence lock. */
 const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
+  await recoverProviderResetUnlocked()
   await recoverProviderPersistenceUnlocked()
   let stored = await plasmoGlobalStorage.get<ProviderConfig[]>(
     ProviderStorageKey.CONFIG

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -7,7 +7,9 @@ import { clearModelCapabilityOverridesForProvider } from "./model-capability-ove
 import {
   containsLegacySyncedSecrets,
   hydrateProviderSecrets,
-  persistProviderConfigs
+  persistProviderConfigs,
+  persistProviderConfigsUnlocked,
+  withProviderPersistenceLock
 } from "./provider-secret-store"
 import {
   type CustomProviderWire,
@@ -204,106 +206,111 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
   }
 }
 
+/** Caller must hold the provider-persistence lock. */
+const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
+  let stored = await plasmoGlobalStorage.get<ProviderConfig[]>(
+    ProviderStorageKey.CONFIG
+  )
+  if (!stored || stored.length === 0) {
+    stored = [...DEFAULT_PROVIDERS]
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  const containsLegacySecrets = containsLegacySyncedSecrets(stored)
+  stored = await hydrateProviderSecrets(stored)
+  if (containsLegacySecrets) {
+    // Idempotent migration: local credentials are written first, then the
+    // legacy secret-bearing sync payload is replaced with public config.
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  const sanitized = sanitizeStoredProviders(stored)
+  if (sanitized.removed.length > 0 || sanitized.migrated.length > 0) {
+    logger.info(
+      "Sanitized provider configs not present in the built-in provider UI",
+      "ProviderManager",
+      {
+        removed: sanitized.removed.map((provider) => provider.id),
+        migrated: sanitized.migrated
+      }
+    )
+    stored = sanitized.providers
+  }
+
+  // Merge new defaults if they are missing from stored config
+  const currentStored = stored ?? []
+  const missing = DEFAULT_PROVIDERS.filter(
+    (d) => !currentStored.find((s) => s.id === d.id)
+  )
+
+  // One-time migration of the pre-provider-config Ollama base URL: adopt
+  // it into the stored config, persist, and delete the legacy key so this
+  // read stops happening on every getProviders call.
+  try {
+    const legacyStoredUrl = await plasmoGlobalStorage.get<string>(
+      LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL
+    )
+    const globalStoredUrl = await plasmoGlobalStorage.get<string>(
+      STORAGE_KEYS.PROVIDER.BASE_URL
+    )
+    const legacyUrl = legacyStoredUrl?.trim()
+      ? legacyStoredUrl
+      : globalStoredUrl?.trim()
+        ? globalStoredUrl
+        : undefined
+
+    if (legacyUrl) {
+      const defaultProviderIndex = stored.findIndex(
+        (p) => p.id === ProviderId.OLLAMA
+      )
+      const currentBaseUrl = stored[defaultProviderIndex]?.baseUrl
+      const defaultBaseUrl = DEFAULT_PROVIDERS.find(
+        (provider) => provider.id === ProviderId.OLLAMA
+      )?.baseUrl
+      if (
+        defaultProviderIndex !== -1 &&
+        legacyUrl !== currentBaseUrl &&
+        (!currentBaseUrl || currentBaseUrl === defaultBaseUrl)
+      ) {
+        stored = [...stored]
+        stored[defaultProviderIndex] = {
+          ...stored[defaultProviderIndex],
+          baseUrl: legacyUrl
+        }
+        await persistProviderConfigsUnlocked(stored)
+      }
+    }
+    if (legacyStoredUrl !== undefined || globalStoredUrl !== undefined) {
+      await plasmoGlobalStorage.remove(LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL)
+      await plasmoGlobalStorage.remove(STORAGE_KEYS.PROVIDER.BASE_URL)
+    }
+  } catch (e) {
+    logger.warn(
+      "Failed to migrate legacy provider URL in getProviders",
+      "ProviderManager",
+      { error: e }
+    )
+  }
+
+  if (missing.length > 0) {
+    const merged = [...stored, ...missing]
+    await persistProviderConfigsUnlocked(merged)
+    return merged
+  }
+
+  if (sanitized.removed.length > 0 || sanitized.migrated.length > 0) {
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  return stored
+}
+
 /**
  * Manages persistence and retrieval of provider configurations.
  */
 export const ProviderManager = {
   async getProviders(): Promise<ProviderConfig[]> {
-    let stored = await plasmoGlobalStorage.get<ProviderConfig[]>(
-      ProviderStorageKey.CONFIG
-    )
-    if (!stored || stored.length === 0) {
-      stored = [...DEFAULT_PROVIDERS]
-      await ProviderManager.saveProviders(stored)
-    }
-
-    const containsLegacySecrets = containsLegacySyncedSecrets(stored)
-    stored = await hydrateProviderSecrets(stored)
-    if (containsLegacySecrets) {
-      // Idempotent migration: local credentials are written first, then the
-      // legacy secret-bearing sync payload is replaced with public config.
-      await ProviderManager.saveProviders(stored)
-    }
-
-    const sanitized = sanitizeStoredProviders(stored)
-    if (sanitized.removed.length > 0 || sanitized.migrated.length > 0) {
-      logger.info(
-        "Sanitized provider configs not present in the built-in provider UI",
-        "ProviderManager",
-        {
-          removed: sanitized.removed.map((provider) => provider.id),
-          migrated: sanitized.migrated
-        }
-      )
-      stored = sanitized.providers
-    }
-
-    // Merge new defaults if they are missing from stored config
-    const currentStored = stored ?? []
-    const missing = DEFAULT_PROVIDERS.filter(
-      (d) => !currentStored.find((s) => s.id === d.id)
-    )
-
-    // One-time migration of the pre-provider-config Ollama base URL: adopt
-    // it into the stored config, persist, and delete the legacy key so this
-    // read stops happening on every getProviders call.
-    try {
-      const legacyStoredUrl = await plasmoGlobalStorage.get<string>(
-        LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL
-      )
-      const globalStoredUrl = await plasmoGlobalStorage.get<string>(
-        STORAGE_KEYS.PROVIDER.BASE_URL
-      )
-      const legacyUrl = legacyStoredUrl?.trim()
-        ? legacyStoredUrl
-        : globalStoredUrl?.trim()
-          ? globalStoredUrl
-          : undefined
-
-      if (legacyUrl) {
-        const defaultProviderIndex = stored.findIndex(
-          (p) => p.id === ProviderId.OLLAMA
-        )
-        const currentBaseUrl = stored[defaultProviderIndex]?.baseUrl
-        const defaultBaseUrl = DEFAULT_PROVIDERS.find(
-          (provider) => provider.id === ProviderId.OLLAMA
-        )?.baseUrl
-        if (
-          defaultProviderIndex !== -1 &&
-          legacyUrl !== currentBaseUrl &&
-          (!currentBaseUrl || currentBaseUrl === defaultBaseUrl)
-        ) {
-          stored = [...stored]
-          stored[defaultProviderIndex] = {
-            ...stored[defaultProviderIndex],
-            baseUrl: legacyUrl
-          }
-          await ProviderManager.saveProviders(stored)
-        }
-      }
-      if (legacyStoredUrl !== undefined || globalStoredUrl !== undefined) {
-        await plasmoGlobalStorage.remove(LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL)
-        await plasmoGlobalStorage.remove(STORAGE_KEYS.PROVIDER.BASE_URL)
-      }
-    } catch (e) {
-      logger.warn(
-        "Failed to migrate legacy provider URL in getProviders",
-        "ProviderManager",
-        { error: e }
-      )
-    }
-
-    if (missing.length > 0) {
-      const merged = [...stored, ...missing]
-      await ProviderManager.saveProviders(merged)
-      return merged
-    }
-
-    if (sanitized.removed.length > 0 || sanitized.migrated.length > 0) {
-      await ProviderManager.saveProviders(stored)
-    }
-
-    return stored
+    return withProviderPersistenceLock(getProvidersUnlocked)
   },
 
   async getProviderConfig(id: string): Promise<ProviderConfig | undefined> {
@@ -322,29 +329,35 @@ export const ProviderManager = {
     id: string,
     updates: Partial<ProviderConfig>
   ): Promise<void> {
-    const providers = await ProviderManager.getProviders()
-    const index = providers.findIndex((p) => p.id === id)
-    if (index !== -1) {
-      if (updates.baseUrl !== undefined) {
-        validateProviderBaseUrl(updates.baseUrl)
-      }
-      const previousBaseUrl = providers[index].baseUrl
-      const updatedConfig = { ...providers[index], ...updates }
-      providers[index] = updatedConfig
-      await ProviderManager.saveProviders(providers)
+    if (updates.baseUrl !== undefined) {
+      validateProviderBaseUrl(updates.baseUrl)
+    }
+    let previousBaseUrl: string | undefined
+    let updated = false
 
-      // A different endpoint may be a different server — probe results no
-      // longer describe it.
-      if (
-        updates.baseUrl !== undefined &&
-        updates.baseUrl !== previousBaseUrl
-      ) {
-        await clearCapabilityProbesForProvider(id).catch((e) => {
-          logger.warn("Failed to clear capability probes", "ProviderManager", {
-            error: e
-          })
+    await withProviderPersistenceLock(async () => {
+      const providers = await getProvidersUnlocked()
+      const index = providers.findIndex((p) => p.id === id)
+      if (index === -1) return
+
+      previousBaseUrl = providers[index].baseUrl
+      providers[index] = { ...providers[index], ...updates }
+      await persistProviderConfigsUnlocked(providers)
+      updated = true
+    })
+
+    // A different endpoint may be a different server — probe results no
+    // longer describe it.
+    if (
+      updated &&
+      updates.baseUrl !== undefined &&
+      updates.baseUrl !== previousBaseUrl
+    ) {
+      await clearCapabilityProbesForProvider(id).catch((e) => {
+        logger.warn("Failed to clear capability probes", "ProviderManager", {
+          error: e
         })
-      }
+      })
     }
   },
 
@@ -474,8 +487,10 @@ export const ProviderManager = {
         : {})
     }
 
-    const providers = await ProviderManager.getProviders()
-    await ProviderManager.saveProviders([...providers, config])
+    await withProviderPersistenceLock(async () => {
+      const providers = await getProvidersUnlocked()
+      await persistProviderConfigsUnlocked([...providers, config])
+    })
     return config
   },
 
@@ -486,10 +501,12 @@ export const ProviderManager = {
         kind: "validation"
       })
     }
-    const providers = await ProviderManager.getProviders()
-    await ProviderManager.saveProviders(
-      providers.filter((p) => String(p.id) !== id)
-    )
+    await withProviderPersistenceLock(async () => {
+      const providers = await getProvidersUnlocked()
+      await persistProviderConfigsUnlocked(
+        providers.filter((p) => String(p.id) !== id)
+      )
+    })
     await ProviderManager.removeModelMappingsForProvider(id)
     await clearCapabilityProbesForProvider(id).catch(() => undefined)
     await clearModelCapabilityOverridesForProvider(id).catch(() => undefined)

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -5,6 +5,11 @@ import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { clearCapabilityProbesForProvider } from "./capability-probe"
 import { clearModelCapabilityOverridesForProvider } from "./model-capability-overrides"
 import {
+  containsLegacySyncedSecrets,
+  hydrateProviderSecrets,
+  persistProviderConfigs
+} from "./provider-secret-store"
+import {
   type CustomProviderWire,
   isCustomProviderId,
   makeCustomProviderId,
@@ -212,6 +217,14 @@ export const ProviderManager = {
       await ProviderManager.saveProviders(stored)
     }
 
+    const containsLegacySecrets = containsLegacySyncedSecrets(stored)
+    stored = await hydrateProviderSecrets(stored)
+    if (containsLegacySecrets) {
+      // Idempotent migration: local credentials are written first, then the
+      // legacy secret-bearing sync payload is replaced with public config.
+      await ProviderManager.saveProviders(stored)
+    }
+
     const sanitized = sanitizeStoredProviders(stored)
     if (sanitized.removed.length > 0 || sanitized.migrated.length > 0) {
       logger.info(
@@ -299,7 +312,7 @@ export const ProviderManager = {
   },
 
   async saveProviders(providers: ProviderConfig[]): Promise<void> {
-    await plasmoGlobalStorage.set(ProviderStorageKey.CONFIG, providers)
+    await persistProviderConfigs(providers)
   },
 
   /**

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -6,6 +6,13 @@ import {
 import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
 
 type ProviderSecretMap = Record<string, string>
+type ProviderPersistenceSnapshot = {
+  publicConfigs: ProviderConfig[]
+  secrets: ProviderSecretMap
+}
+
+const PROVIDER_PERSISTENCE_LOCK = "ollama-client:provider-persistence"
+let persistenceQueue = Promise.resolve()
 
 const hasOwnApiKey = (provider: ProviderConfig): boolean =>
   Object.hasOwn(provider, "apiKey")
@@ -22,6 +29,25 @@ const extractSecrets = (providers: ProviderConfig[]): ProviderSecretMap => {
     if (apiKey) secrets[String(provider.id)] = apiKey
   }
   return secrets
+}
+
+const enqueuePersistence = (operation: () => Promise<void>): Promise<void> => {
+  const queued = persistenceQueue.then(operation, operation)
+  persistenceQueue = queued.then(
+    () => undefined,
+    () => undefined
+  )
+  return queued
+}
+
+const withPersistenceLock = (operation: () => Promise<void>): Promise<void> => {
+  const lockManager = globalThis.navigator?.locks
+  if (lockManager) {
+    return lockManager
+      .request(PROVIDER_PERSISTENCE_LOCK, operation)
+      .then(() => undefined)
+  }
+  return enqueuePersistence(operation)
 }
 
 export const hydrateProviderSecrets = async (
@@ -52,12 +78,21 @@ export const containsLegacySyncedSecrets = (
 export const persistProviderConfigs = async (
   providers: ProviderConfig[]
 ): Promise<void> => {
-  await plasmoDeviceStorage.set(
-    STORAGE_KEYS.PROVIDER.SECRETS,
-    extractSecrets(providers)
-  )
-  await plasmoGlobalStorage.set(
-    ProviderStorageKey.CONFIG,
-    providers.map(stripSecrets)
-  )
+  // Snapshot before waiting: callers may mutate their form state while an
+  // earlier save owns the cross-context lock.
+  const snapshot: ProviderPersistenceSnapshot = {
+    secrets: extractSecrets(providers),
+    publicConfigs: providers.map(stripSecrets)
+  }
+
+  await withPersistenceLock(async () => {
+    await plasmoDeviceStorage.set(
+      STORAGE_KEYS.PROVIDER.SECRETS,
+      snapshot.secrets
+    )
+    await plasmoGlobalStorage.set(
+      ProviderStorageKey.CONFIG,
+      snapshot.publicConfigs
+    )
+  })
 }

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -1,7 +1,8 @@
 import { STORAGE_KEYS } from "@/lib/constants"
 import {
   plasmoDeviceStorage,
-  plasmoGlobalStorage
+  plasmoGlobalStorage,
+  removePlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
 import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
 import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
@@ -16,6 +17,10 @@ type ProviderPersistenceJournal = {
   previousSecrets: ProviderSecretMap
   nextSecrets: ProviderSecretMap
   nextPublicConfigs: ProviderConfig[]
+}
+type ProviderResetJournal = {
+  version: 1
+  keys: string[]
 }
 
 const PROVIDER_PERSISTENCE_LOCK = "ollama-client:provider-persistence"
@@ -66,6 +71,44 @@ export const hydrateProviderSecrets = async (
 export const containsLegacySyncedSecrets = (
   providers: ProviderConfig[]
 ): boolean => providers.some(hasOwnApiKey)
+
+/** Caller must hold the provider-persistence lock. */
+export const recoverProviderResetUnlocked = async (): Promise<void> => {
+  const journal = await plasmoDeviceStorage.get<ProviderResetJournal>(
+    STORAGE_KEYS.PROVIDER.RESET_JOURNAL
+  )
+  if (!journal) return
+
+  for (const key of journal.keys) {
+    await removePlasmoStoredValue(key)
+  }
+  await plasmoDeviceStorage.remove(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)
+}
+
+/**
+ * Durably clear provider storage. The journal remains until every removal
+ * succeeds, so a later provider read or write can finish interrupted cleanup.
+ * Caller must hold the provider-persistence lock.
+ */
+export const resetProviderStorageUnlocked = async (
+  keys: string[]
+): Promise<void> => {
+  const resetKeys = [
+    ProviderStorageKey.CONFIG,
+    ...keys.filter(
+      (key) =>
+        key !== ProviderStorageKey.CONFIG &&
+        key !== STORAGE_KEYS.PROVIDER.RESET_JOURNAL
+    )
+  ]
+  const journal: ProviderResetJournal = {
+    version: 1,
+    keys: [...new Set(resetKeys)]
+  }
+
+  await plasmoDeviceStorage.set(STORAGE_KEYS.PROVIDER.RESET_JOURNAL, journal)
+  await recoverProviderResetUnlocked()
+}
 
 /** Caller must hold the provider-persistence lock. */
 export const recoverProviderPersistenceUnlocked = async (): Promise<void> => {
@@ -146,6 +189,7 @@ export const persistProviderConfigs = async (
   // earlier save owns the cross-context lock.
   const snapshot = providers.map((provider) => ({ ...provider }))
   await withProviderPersistenceLock(async () => {
+    await recoverProviderResetUnlocked()
     await recoverProviderPersistenceUnlocked()
     await persistProviderConfigsUnlocked(snapshot)
   })

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -1,0 +1,63 @@
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  plasmoDeviceStorage,
+  plasmoGlobalStorage
+} from "@/lib/plasmo-global-storage"
+import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
+
+type ProviderSecretMap = Record<string, string>
+
+const hasOwnApiKey = (provider: ProviderConfig): boolean =>
+  Object.hasOwn(provider, "apiKey")
+
+const stripSecrets = (provider: ProviderConfig): ProviderConfig => {
+  const { apiKey: _apiKey, ...publicConfig } = provider
+  return publicConfig
+}
+
+const extractSecrets = (providers: ProviderConfig[]): ProviderSecretMap => {
+  const secrets: ProviderSecretMap = {}
+  for (const provider of providers) {
+    const apiKey = provider.apiKey?.trim()
+    if (apiKey) secrets[String(provider.id)] = apiKey
+  }
+  return secrets
+}
+
+export const hydrateProviderSecrets = async (
+  providers: ProviderConfig[]
+): Promise<ProviderConfig[]> => {
+  const secrets =
+    (await plasmoDeviceStorage.get<ProviderSecretMap>(
+      STORAGE_KEYS.PROVIDER.SECRETS
+    )) ?? {}
+
+  return providers.map((provider) => {
+    // During migration, legacy sync value wins. This also preserves an explicit
+    // empty value so saving it clears an existing local credential.
+    if (hasOwnApiKey(provider)) return provider
+    const apiKey = secrets[String(provider.id)]
+    return apiKey ? { ...provider, apiKey } : provider
+  })
+}
+
+export const containsLegacySyncedSecrets = (
+  providers: ProviderConfig[]
+): boolean => providers.some(hasOwnApiKey)
+
+/**
+ * Persist credentials before public config. A failed local write leaves sync
+ * untouched; a failed sync write is safe to retry and cannot lose credentials.
+ */
+export const persistProviderConfigs = async (
+  providers: ProviderConfig[]
+): Promise<void> => {
+  await plasmoDeviceStorage.set(
+    STORAGE_KEYS.PROVIDER.SECRETS,
+    extractSecrets(providers)
+  )
+  await plasmoGlobalStorage.set(
+    ProviderStorageKey.CONFIG,
+    providers.map(stripSecrets)
+  )
+}

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -4,6 +4,7 @@ import {
   plasmoGlobalStorage
 } from "@/lib/plasmo-global-storage"
 import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
+import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
 
 type ProviderSecretMap = Record<string, string>
 type ProviderPersistenceSnapshot = {
@@ -12,7 +13,6 @@ type ProviderPersistenceSnapshot = {
 }
 
 const PROVIDER_PERSISTENCE_LOCK = "ollama-client:provider-persistence"
-let persistenceQueue = Promise.resolve()
 
 const hasOwnApiKey = (provider: ProviderConfig): boolean =>
   Object.hasOwn(provider, "apiKey")
@@ -31,29 +31,9 @@ const extractSecrets = (providers: ProviderConfig[]): ProviderSecretMap => {
   return secrets
 }
 
-const enqueuePersistence = (operation: () => Promise<void>): Promise<void> => {
-  const queued = persistenceQueue.then(operation, operation)
-  persistenceQueue = queued.then(
-    () => undefined,
-    () => undefined
-  )
-  return queued
-}
-
 export const withProviderPersistenceLock = <T>(
   operation: () => Promise<T>
-): Promise<T> => {
-  const lockManager = globalThis.navigator?.locks
-  if (lockManager) {
-    return lockManager
-      .request(PROVIDER_PERSISTENCE_LOCK, operation)
-      .then((result) => result)
-  }
-  let result: T
-  return enqueuePersistence(async () => {
-    result = await operation()
-  }).then(() => result)
-}
+): Promise<T> => withStorageWriteLock(PROVIDER_PERSISTENCE_LOCK, operation)
 
 export const hydrateProviderSecrets = async (
   providers: ProviderConfig[]

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -11,8 +11,19 @@ type ProviderPersistenceSnapshot = {
   publicConfigs: ProviderConfig[]
   secrets: ProviderSecretMap
 }
+type ProviderPersistenceJournal = {
+  version: 1
+  previousSecrets: ProviderSecretMap
+  nextSecrets: ProviderSecretMap
+  nextPublicConfigs: ProviderConfig[]
+}
 
 const PROVIDER_PERSISTENCE_LOCK = "ollama-client:provider-persistence"
+
+const configsMatch = (
+  left: ProviderConfig[] | undefined,
+  right: ProviderConfig[]
+): boolean => JSON.stringify(left) === JSON.stringify(right)
 
 const hasOwnApiKey = (provider: ProviderConfig): boolean =>
   Object.hasOwn(provider, "apiKey")
@@ -56,6 +67,24 @@ export const containsLegacySyncedSecrets = (
   providers: ProviderConfig[]
 ): boolean => providers.some(hasOwnApiKey)
 
+/** Caller must hold the provider-persistence lock. */
+export const recoverProviderPersistenceUnlocked = async (): Promise<void> => {
+  const journal = await plasmoDeviceStorage.get<ProviderPersistenceJournal>(
+    STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+  )
+  if (!journal) return
+
+  const syncedConfig = await plasmoGlobalStorage.get<ProviderConfig[]>(
+    ProviderStorageKey.CONFIG
+  )
+  const recoveredSecrets = configsMatch(syncedConfig, journal.nextPublicConfigs)
+    ? journal.nextSecrets
+    : journal.previousSecrets
+
+  await plasmoDeviceStorage.set(STORAGE_KEYS.PROVIDER.SECRETS, recoveredSecrets)
+  await plasmoDeviceStorage.remove(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
+}
+
 /**
  * Persist credentials before public config. A failed local write leaves sync
  * untouched; a failed sync write is safe to retry and cannot lose credentials.
@@ -67,12 +96,47 @@ export const persistProviderConfigsUnlocked = async (
     secrets: extractSecrets(providers),
     publicConfigs: providers.map(stripSecrets)
   }
+  const previousSecrets =
+    (await plasmoDeviceStorage.get<ProviderSecretMap>(
+      STORAGE_KEYS.PROVIDER.SECRETS
+    )) ?? {}
+  const journal: ProviderPersistenceJournal = {
+    version: 1,
+    previousSecrets,
+    nextSecrets: snapshot.secrets,
+    nextPublicConfigs: snapshot.publicConfigs
+  }
 
-  await plasmoDeviceStorage.set(STORAGE_KEYS.PROVIDER.SECRETS, snapshot.secrets)
-  await plasmoGlobalStorage.set(
-    ProviderStorageKey.CONFIG,
-    snapshot.publicConfigs
+  await plasmoDeviceStorage.set(
+    STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL,
+    journal
   )
+  await plasmoDeviceStorage.set(STORAGE_KEYS.PROVIDER.SECRETS, snapshot.secrets)
+
+  try {
+    await plasmoGlobalStorage.set(
+      ProviderStorageKey.CONFIG,
+      snapshot.publicConfigs
+    )
+  } catch (syncError) {
+    try {
+      await plasmoDeviceStorage.set(
+        STORAGE_KEYS.PROVIDER.SECRETS,
+        previousSecrets
+      )
+      await plasmoDeviceStorage.remove(
+        STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
+      )
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [syncError, rollbackError],
+        "Provider config write and credential rollback both failed"
+      )
+    }
+    throw syncError
+  }
+
+  await plasmoDeviceStorage.remove(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
 }
 
 export const persistProviderConfigs = async (
@@ -81,7 +145,8 @@ export const persistProviderConfigs = async (
   // Snapshot before waiting: callers may mutate their form state while an
   // earlier save owns the cross-context lock.
   const snapshot = providers.map((provider) => ({ ...provider }))
-  await withProviderPersistenceLock(() =>
-    persistProviderConfigsUnlocked(snapshot)
-  )
+  await withProviderPersistenceLock(async () => {
+    await recoverProviderPersistenceUnlocked()
+    await persistProviderConfigsUnlocked(snapshot)
+  })
 }

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -40,14 +40,19 @@ const enqueuePersistence = (operation: () => Promise<void>): Promise<void> => {
   return queued
 }
 
-const withPersistenceLock = (operation: () => Promise<void>): Promise<void> => {
+export const withProviderPersistenceLock = <T>(
+  operation: () => Promise<T>
+): Promise<T> => {
   const lockManager = globalThis.navigator?.locks
   if (lockManager) {
     return lockManager
       .request(PROVIDER_PERSISTENCE_LOCK, operation)
-      .then(() => undefined)
+      .then((result) => result)
   }
-  return enqueuePersistence(operation)
+  let result: T
+  return enqueuePersistence(async () => {
+    result = await operation()
+  }).then(() => result)
 }
 
 export const hydrateProviderSecrets = async (
@@ -75,24 +80,28 @@ export const containsLegacySyncedSecrets = (
  * Persist credentials before public config. A failed local write leaves sync
  * untouched; a failed sync write is safe to retry and cannot lose credentials.
  */
-export const persistProviderConfigs = async (
+export const persistProviderConfigsUnlocked = async (
   providers: ProviderConfig[]
 ): Promise<void> => {
-  // Snapshot before waiting: callers may mutate their form state while an
-  // earlier save owns the cross-context lock.
   const snapshot: ProviderPersistenceSnapshot = {
     secrets: extractSecrets(providers),
     publicConfigs: providers.map(stripSecrets)
   }
 
-  await withPersistenceLock(async () => {
-    await plasmoDeviceStorage.set(
-      STORAGE_KEYS.PROVIDER.SECRETS,
-      snapshot.secrets
-    )
-    await plasmoGlobalStorage.set(
-      ProviderStorageKey.CONFIG,
-      snapshot.publicConfigs
-    )
-  })
+  await plasmoDeviceStorage.set(STORAGE_KEYS.PROVIDER.SECRETS, snapshot.secrets)
+  await plasmoGlobalStorage.set(
+    ProviderStorageKey.CONFIG,
+    snapshot.publicConfigs
+  )
+}
+
+export const persistProviderConfigs = async (
+  providers: ProviderConfig[]
+): Promise<void> => {
+  // Snapshot before waiting: callers may mutate their form state while an
+  // earlier save owns the cross-context lock.
+  const snapshot = providers.map((provider) => ({ ...provider }))
+  await withProviderPersistenceLock(() =>
+    persistProviderConfigsUnlocked(snapshot)
+  )
 }

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -243,6 +243,7 @@ describe("S2 — reset actually wipes data", () => {
     // Provider public config and device-local secrets must both be reset.
     expect(allKeys).toContain(ProviderStorageKey.CONFIG)
     expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
+    expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
     expect(allKeys).toContain(ProviderStorageKey.MODEL_MAPPINGS)
 
     // The other reset bug: Object.values() on a top-level *string* key

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -244,6 +244,7 @@ describe("S2 — reset actually wipes data", () => {
     expect(allKeys).toContain(ProviderStorageKey.CONFIG)
     expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
     expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
+    expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)
     expect(allKeys).toContain(ProviderStorageKey.MODEL_MAPPINGS)
 
     // The other reset bug: Object.values() on a top-level *string* key

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -9,7 +9,12 @@ import {
   it,
   vi
 } from "vitest"
-import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
+import {
+  SQLITE_DB_KEY,
+  SQLITE_DB_NAME,
+  SQLITE_DB_STORE,
+  STORAGE_KEYS
+} from "@/lib/constants"
 import { OpenAICompatibleProvider } from "@/lib/providers/openai-compatible"
 import {
   ProviderId,
@@ -235,9 +240,9 @@ describe("S2 — reset actually wipes data", () => {
     const map = getAllResetKeys()
     const allKeys = Object.values(map).flat()
 
-    // The bug this guards: ProviderStorageKey.CONFIG (holds API keys) was in
-    // no reset map, so "reset provider data" left stored keys behind.
+    // Provider public config and device-local secrets must both be reset.
     expect(allKeys).toContain(ProviderStorageKey.CONFIG)
+    expect(allKeys).toContain(STORAGE_KEYS.PROVIDER.SECRETS)
     expect(allKeys).toContain(ProviderStorageKey.MODEL_MAPPINGS)
 
     // The other reset bug: Object.values() on a top-level *string* key

--- a/src/lib/storage/__tests__/storage-write-lock.test.ts
+++ b/src/lib/storage/__tests__/storage-write-lock.test.ts
@@ -20,39 +20,11 @@ describe("withStorageWriteLock", () => {
     expect(request).toHaveBeenCalledWith("k", expect.any(Function))
   })
 
-  it("falls back to an in-process queue that serializes writes", async () => {
-    // No navigator.locks → in-process queue path.
-    vi.stubGlobal("navigator", {})
-
-    const order: string[] = []
-    const makeOp = (id: string) => async () => {
-      order.push(`start:${id}`)
-      await Promise.resolve()
-      await Promise.resolve()
-      order.push(`end:${id}`)
-    }
-
-    await Promise.all([
-      withStorageWriteLock("same", makeOp("a")),
-      withStorageWriteLock("same", makeOp("b"))
-    ])
-
-    // Serialized: a fully completes before b starts.
-    expect(order).toEqual(["start:a", "end:a", "start:b", "end:b"])
-  })
-
-  it("keeps the queue alive after a rejecting operation", async () => {
+  it("fails closed when navigator.locks is unavailable", async () => {
     vi.stubGlobal("navigator", {})
 
     await expect(
-      withStorageWriteLock("chain", async () => {
-        throw new Error("boom")
-      })
-    ).rejects.toThrow("boom")
-
-    // A later write on the same lock still runs.
-    await expect(withStorageWriteLock("chain", async () => "ok")).resolves.toBe(
-      "ok"
-    )
+      withStorageWriteLock("same", async () => "never runs")
+    ).rejects.toThrow("Cross-context storage locking is unavailable")
   })
 })

--- a/src/lib/storage/storage-key-registry.ts
+++ b/src/lib/storage/storage-key-registry.ts
@@ -9,6 +9,11 @@ export interface StorageKeyMetadata {
 }
 
 export const STORAGE_KEY_REGISTRY: Record<string, StorageKeyMetadata> = {
+  [STORAGE_KEYS.PROVIDER.SECRETS]: {
+    key: STORAGE_KEYS.PROVIDER.SECRETS,
+    scope: "device-local",
+    reason: "Provider credentials must never sync between browser profiles."
+  },
   [STORAGE_KEYS.PROVIDER.BASE_URL]: {
     key: STORAGE_KEYS.PROVIDER.BASE_URL,
     scope: "sync-safe",

--- a/src/lib/storage/storage-key-registry.ts
+++ b/src/lib/storage/storage-key-registry.ts
@@ -14,6 +14,11 @@ export const STORAGE_KEY_REGISTRY: Record<string, StorageKeyMetadata> = {
     scope: "device-local",
     reason: "Provider credentials must never sync between browser profiles."
   },
+  [STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL]: {
+    key: STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL,
+    scope: "device-local",
+    reason: "Temporary recovery state for cross-area provider config commits."
+  },
   [STORAGE_KEYS.PROVIDER.BASE_URL]: {
     key: STORAGE_KEYS.PROVIDER.BASE_URL,
     scope: "sync-safe",

--- a/src/lib/storage/storage-key-registry.ts
+++ b/src/lib/storage/storage-key-registry.ts
@@ -19,6 +19,11 @@ export const STORAGE_KEY_REGISTRY: Record<string, StorageKeyMetadata> = {
     scope: "device-local",
     reason: "Temporary recovery state for cross-area provider config commits."
   },
+  [STORAGE_KEYS.PROVIDER.RESET_JOURNAL]: {
+    key: STORAGE_KEYS.PROVIDER.RESET_JOURNAL,
+    scope: "device-local",
+    reason: "Durable recovery state for interrupted provider-data resets."
+  },
   [STORAGE_KEYS.PROVIDER.BASE_URL]: {
     key: STORAGE_KEYS.PROVIDER.BASE_URL,
     scope: "sync-safe",

--- a/src/lib/storage/storage-write-lock.ts
+++ b/src/lib/storage/storage-write-lock.ts
@@ -9,33 +9,13 @@
  * per-origin and shared across every context of the extension, so a lock taken
  * in the options page blocks the side panel and vice versa.
  *
- * Where the Web Locks API is unavailable (test/legacy environments) this falls
- * back to a per-context in-memory queue — still correct within one context,
- * which is all a single-context environment has.
+ * Supported extension targets provide Web Locks. If the API is unavailable,
+ * fail closed: an in-memory queue would only protect one JavaScript realm and
+ * would silently reintroduce lost updates between extension contexts.
  */
 
-type LockGrantedCallback = () => Promise<unknown>
 interface LockManagerLike {
   request<T>(name: string, callback: () => Promise<T>): Promise<T>
-}
-
-const inProcessQueues = new Map<string, Promise<unknown>>()
-
-const enqueueInProcess = <T>(
-  name: string,
-  operation: () => Promise<T>
-): Promise<T> => {
-  const previous = inProcessQueues.get(name) ?? Promise.resolve()
-  const result = previous.then(operation, operation)
-  // Keep the chain alive regardless of whether an individual op rejects.
-  inProcessQueues.set(
-    name,
-    result.then(
-      () => undefined,
-      () => undefined
-    )
-  )
-  return result
 }
 
 const getLockManager = (): LockManagerLike | null => {
@@ -53,8 +33,10 @@ export const withStorageWriteLock = <T>(
   operation: () => Promise<T>
 ): Promise<T> => {
   const locks = getLockManager()
-  if (locks) {
-    return locks.request(name, operation as LockGrantedCallback) as Promise<T>
+  if (!locks) {
+    return Promise.reject(
+      new Error("Cross-context storage locking is unavailable")
+    )
   }
-  return enqueueInProcess(name, operation)
+  return locks.request(name, operation)
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,27 @@ import { afterEach, beforeEach, vi } from "vitest"
 import "@testing-library/jest-dom"
 import "fake-indexeddb/auto"
 
+const testWebLockQueues = new Map<string, Promise<unknown>>()
+const requestTestWebLock = vi.fn(
+  (name: string, callback: () => Promise<unknown>): Promise<unknown> => {
+    const previous = testWebLockQueues.get(name) ?? Promise.resolve()
+    const result = previous.then(callback, callback)
+    testWebLockQueues.set(
+      name,
+      result.then(
+        () => undefined,
+        () => undefined
+      )
+    )
+    return result
+  }
+)
+
+Object.defineProperty(globalThis.navigator, "locks", {
+  configurable: true,
+  value: { request: requestTestWebLock }
+})
+
 // Mock chrome extension APIs
 global.chrome = {
   runtime: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     description: "__MSG_extDescription__",
     default_locale: "en",
     version: packageJson.version,
+    ...(browser === "firefox" ? {} : { minimum_chrome_version: "88" }),
     homepage_url: packageJson.homepage,
     icons: {
       16: "assets/icon.png",


### PR DESCRIPTION
## Summary

- store provider API keys in device-local extension storage
- keep synced provider configuration free of credentials
- migrate legacy synced keys with local-first, retry-safe ordering
- hydrate credentials only at provider configuration read boundaries
- clear local credentials during provider reset and provider removal
- add regression coverage for migration, failure recovery, clearing, and reset behavior

## Why

Provider configuration previously persisted API keys in sync storage. That could copy remote-provider credentials between browser profiles and exposed secrets through synced configuration dumps.

Migration writes credentials locally before replacing the legacy sync payload. If the local write fails, the original synced value remains untouched so credentials are not lost.

## Impact

Existing provider configurations migrate automatically on first read. Provider consumers and settings UI continue receiving hydrated configuration, while persistent sync data contains only public provider fields. No user action is required.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 1,932 tests passed
- Chrome MV3 production build
- Firefox MV2 production build
- strict i18n drift check
- docs production build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps provider API keys in device-local storage. The main changes are:

- Separates local credentials from synced provider configuration.
- Migrates legacy synced credentials with journal-based recovery.
- Serializes provider reads, writes, updates, removals, and resets.
- Hydrates credentials at provider configuration read boundaries.
- Adds tests for concurrency, rollback, migration, clearing, and reset recovery.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Provider writes and complete read-modify-write operations now use the same cross-context lock.
- Persistence journals recover interrupted commits and rollbacks.
- Reset journals replay incomplete provider cleanup before later reads or writes.
- Tests cover overlapping saves, failed storage operations, credential clearing, and interrupted resets.
- No blocking issues remain in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/providers/provider-secret-store.ts | Adds local credential storage, cross-context locking, persistence rollback, and reset recovery. |
| src/lib/providers/manager.ts | Hydrates credentials on reads and locks complete provider read-modify-write operations. |
| src/hooks/use-reset-app-storage.ts | Coordinates provider and full resets with the provider persistence lock. |
| src/lib/storage/storage-write-lock.ts | Requires cross-context Web Locks instead of using a single-context fallback. |
| wxt.config.ts | Sets the minimum Chrome version required by the updated runtime behavior. |

<sub>Reviews (7): Last reviewed commit: ["fix(storage): recover interrupted resets"](https://github.com/shishir435/ollama-client/commit/6e8e39232548df2e2fdb853a94020716b0b2dfed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45210439)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->