### PR TITLE
Redact private data from diagnostic logs

### DIFF
--- a/src/contents/__tests__/content-debug.test.ts
+++ b/src/contents/__tests__/content-debug.test.ts
@@ -9,7 +9,7 @@ describe("content debug logging", () => {
   })
 
   it("is disabled by default", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {})
 
     contentDebugLog("hidden")
 
@@ -21,11 +21,14 @@ describe("content debug logging", () => {
     ;(
       window as unknown as { __OLLAMA_CLIENT_CONTENT_DEBUG__?: boolean }
     ).__OLLAMA_CLIENT_CONTENT_DEBUG__ = true
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {})
 
     contentDebugLog("visible", { ok: true })
 
     expect(isContentDebugEnabled()).toBe(true)
-    expect(consoleSpy).toHaveBeenCalledWith("visible", { ok: true })
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[ContentDebug] visible"),
+      { details: [{ ok: true }] }
+    )
   })
 })

--- a/src/contents/__tests__/content-debug.test.ts
+++ b/src/contents/__tests__/content-debug.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { contentDebugLog, isContentDebugEnabled } from "../content-debug"
+import {
+  contentDebugError,
+  contentDebugLog,
+  isContentDebugEnabled
+} from "../content-debug"
 
 describe("content debug logging", () => {
   afterEach(() => {
@@ -29,6 +33,23 @@ describe("content debug logging", () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("[ContentDebug] visible"),
       { details: [{ ok: true }] }
+    )
+  })
+
+  it("always reports manual helper failures through the redacted logger", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    contentDebugError(
+      "Manual test failed with password='correct horse battery staple'",
+      new Error("Bearer manual-test-secret")
+    )
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain(
+      "correct horse battery staple"
+    )
+    expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain(
+      "manual-test-secret"
     )
   })
 })

--- a/src/contents/content-debug.ts
+++ b/src/contents/content-debug.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger"
+
 interface ContentDebugWindow extends Window {
   __OLLAMA_CLIENT_CONTENT_DEBUG__?: boolean
 }
@@ -9,6 +11,9 @@ export const isContentDebugEnabled = (): boolean =>
 
 export const contentDebugLog = (...args: unknown[]): void => {
   if (isContentDebugEnabled()) {
-    console.log(...args)
+    const [message, ...details] = args
+    logger.info(String(message ?? "Content debug event"), "ContentDebug", {
+      details
+    })
   }
 }

--- a/src/contents/content-debug.ts
+++ b/src/contents/content-debug.ts
@@ -17,3 +17,7 @@ export const contentDebugLog = (...args: unknown[]): void => {
     })
   }
 }
+
+export const contentDebugError = (message: string, error: unknown): void => {
+  logger.error(message, "ContentDebug", { error })
+}

--- a/src/contents/debug-init.ts
+++ b/src/contents/debug-init.ts
@@ -76,7 +76,7 @@ const installDebugHelpers = (): void => {
         )
       }
     } catch (error) {
-      console.error("[Manual Test] Error:", error)
+      contentDebugLog("[Manual Test] Error:", { error })
     }
   }
 
@@ -98,7 +98,7 @@ const installDebugHelpers = (): void => {
         result.logEntry.detectedPatterns
       )
     } catch (error) {
-      console.error("[Manual Test] Error:", error)
+      contentDebugLog("[Manual Test] Error:", { error })
     }
   }
 

--- a/src/contents/debug-init.ts
+++ b/src/contents/debug-init.ts
@@ -6,7 +6,7 @@
  * test entry points. They never affect user-facing behavior.
  */
 
-import { contentDebugLog } from "./content-debug"
+import { contentDebugError, contentDebugLog } from "./content-debug"
 
 interface ContentScriptWindow extends Window {
   __providerContentScript?: boolean
@@ -76,7 +76,7 @@ const installDebugHelpers = (): void => {
         )
       }
     } catch (error) {
-      contentDebugLog("[Manual Test] Error:", { error })
+      contentDebugError("[Manual Test] Transcript failed", error)
     }
   }
 
@@ -98,7 +98,7 @@ const installDebugHelpers = (): void => {
         result.logEntry.detectedPatterns
       )
     } catch (error) {
-      contentDebugLog("[Manual Test] Error:", { error })
+      contentDebugError("[Manual Test] Extraction failed", error)
     }
   }
 

--- a/src/features/chat/hooks/__tests__/use-chat.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat.test.ts
@@ -735,7 +735,10 @@ describe("useChat", () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("Failed to embed messages"),
       expect.objectContaining({
-        error: expect.any(Error)
+        error: expect.objectContaining({
+          name: "Error",
+          message: "Embedding failed"
+        })
       })
     )
     consoleSpy.mockRestore()

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -156,7 +156,7 @@ export const useChatStream = ({
           done: msg.done,
           error: msg.error
         })
-        logger.debug("MSG", "useChatStream", JSON.stringify(msg, null, 3))
+        logger.debug("MSG", "useChatStream", msg)
       }
       if (firstChunk) {
         setIsStreaming(true)

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -83,6 +83,33 @@ describe("privacy-safe logger", () => {
     })
   })
 
+  it("fully redacts quoted secrets containing spaces", () => {
+    const result = redactLogValue({
+      note: [
+        "password='correct horse battery staple'",
+        'api_key="quoted api secret"',
+        String.raw`client_secret="escaped \"quote\" secret"`,
+        "token=unquoted-secret safe=value"
+      ].join(" ")
+    })
+    const serialized = JSON.stringify(result)
+
+    expect(serialized).not.toContain("correct horse battery staple")
+    expect(serialized).not.toContain("quoted api secret")
+    expect(serialized).not.toContain('escaped \\"quote\\" secret')
+    expect(serialized).not.toContain("unquoted-secret")
+    expect(serialized).toContain("safe=value")
+  })
+
+  it("turns invalid dates into an unreadable marker without throwing", () => {
+    expect(() =>
+      redactLogValue({ createdAt: new Date(Number.NaN) })
+    ).not.toThrow()
+    expect(redactLogValue({ createdAt: new Date(Number.NaN) })).toEqual({
+      createdAt: "[Unreadable]"
+    })
+  })
+
   it("sends only redacted snapshots to the console sink", () => {
     const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {})
     const logger = new Logger(LogLevel.DEBUG)

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { REDACTED_LOG_VALUE, redactLogValue } from "@/lib/log-redaction"
+import { Logger, LogLevel } from "@/lib/logger"
+
+describe("privacy-safe logger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("recursively redacts case-varied credentials and private content", () => {
+    const input = {
+      safe: "kept",
+      Api_Key: "api-secret",
+      nested: {
+        AUTHORIZATION: "Bearer auth-secret",
+        refreshToken: "refresh-secret",
+        requestBody: { messages: [{ content: "private prompt" }] },
+        messages: [{ content: "private message" }],
+        pageContent: "private page",
+        file_content: "private file"
+      },
+      customHeaders: {
+        "X-Tenant": "tenant-secret",
+        "X-Custom-Auth": "custom-secret"
+      }
+    }
+
+    expect(redactLogValue(input)).toEqual({
+      safe: "kept",
+      Api_Key: REDACTED_LOG_VALUE,
+      nested: {
+        AUTHORIZATION: REDACTED_LOG_VALUE,
+        refreshToken: REDACTED_LOG_VALUE,
+        requestBody: REDACTED_LOG_VALUE,
+        messages: REDACTED_LOG_VALUE,
+        pageContent: REDACTED_LOG_VALUE,
+        file_content: REDACTED_LOG_VALUE
+      },
+      customHeaders: {
+        "X-Tenant": REDACTED_LOG_VALUE,
+        "X-Custom-Auth": REDACTED_LOG_VALUE
+      }
+    })
+  })
+
+  it("sanitizes errors, URLs, free-form credentials, and cycles", () => {
+    const error = new Error(
+      "Request failed with Bearer bearer-secret and sk-1234567890secret"
+    )
+    const value: Record<string, unknown> = {
+      error,
+      endpoint: "https://user:pass@example.com/path?api_key=query-secret",
+      note: "authorization=inline-secret cookie=cookie-secret"
+    }
+    value.self = value
+
+    const result = redactLogValue(value) as Record<string, unknown>
+    const serialized = JSON.stringify(result)
+
+    expect(serialized).not.toContain("bearer-secret")
+    expect(serialized).not.toContain("1234567890secret")
+    expect(serialized).not.toContain("user:pass")
+    expect(serialized).not.toContain("query-secret")
+    expect(serialized).not.toContain("inline-secret")
+    expect(serialized).not.toContain("cookie-secret")
+    expect((result.error as { name: string }).name).toBe("Error")
+    expect(result.self).toBe("[Circular]")
+  })
+
+  it("parses serialized structured data before redacting it", () => {
+    expect(
+      redactLogValue(
+        JSON.stringify({
+          status: 400,
+          apiKey: "serialized-secret",
+          messages: [{ content: "serialized prompt" }]
+        })
+      )
+    ).toEqual({
+      status: 400,
+      apiKey: REDACTED_LOG_VALUE,
+      messages: REDACTED_LOG_VALUE
+    })
+  })
+
+  it("sends only redacted snapshots to the console sink", () => {
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {})
+    const logger = new Logger(LogLevel.DEBUG)
+    const data = {
+      apiKey: "sink-secret",
+      status: 401,
+      headers: { Authorization: "Bearer header-secret" }
+    }
+
+    logger.info("Failed with token=message-secret", "Provider", data, "session")
+    data.apiKey = "mutated-later"
+
+    expect(consoleInfo).toHaveBeenCalledTimes(1)
+    const [message, safeData] = consoleInfo.mock.calls[0]
+    expect(message).not.toContain("message-secret")
+    expect(safeData).toEqual({
+      apiKey: REDACTED_LOG_VALUE,
+      status: 401,
+      headers: { Authorization: REDACTED_LOG_VALUE }
+    })
+    expect(JSON.stringify(consoleInfo.mock.calls)).not.toContain("sink-secret")
+    expect(JSON.stringify(consoleInfo.mock.calls)).not.toContain(
+      "header-secret"
+    )
+    expect(JSON.stringify(consoleInfo.mock.calls)).not.toContain(
+      "mutated-later"
+    )
+  })
+
+  it("does not inspect data below the configured log level", () => {
+    const logger = new Logger(LogLevel.ERROR)
+    const value = Object.defineProperty({}, "apiKey", {
+      enumerable: true,
+      get: () => {
+        throw new Error("should not be read")
+      }
+    })
+
+    expect(() => logger.debug("skipped", "Test", value)).not.toThrow()
+  })
+})

--- a/src/lib/log-redaction.ts
+++ b/src/lib/log-redaction.ts
@@ -51,6 +51,19 @@ const PRIVATE_CONTENT_KEYS = new Set([
 
 const PRIVATE_CONTAINER_KEYS = new Set(["customheaders", "headers"])
 
+const SENSITIVE_TEXT_KEY_PATTERN =
+  "(?:api[-_ ]?key|access[-_ ]?token|auth(?:orization)?|bearer[-_ ]?token|client[-_ ]?secret|cookie|credential|password|private[-_ ]?key|proxy[-_ ]?authorization|refresh[-_ ]?token|secret(?:[-_ ]?key)?|token|x[-_ ]?api[-_ ]?key)"
+
+const QUOTED_SECRET_PATTERN = new RegExp(
+  `(["']?${SENSITIVE_TEXT_KEY_PATTERN}["']?\\s*[:=]\\s*)(["'])((?:\\\\[\\s\\S]|(?!\\2)[\\s\\S])*)\\2`,
+  "gi"
+)
+
+const UNQUOTED_SECRET_PATTERN = new RegExp(
+  `(["']?${SENSITIVE_TEXT_KEY_PATTERN}["']?\\s*[:=]\\s*)([^\\s,"'}]+)`,
+  "gi"
+)
+
 const isSecretKey = (key: string): boolean => {
   const normalized = normalizeKey(key)
   return (
@@ -91,10 +104,8 @@ export const redactLogText = (value: string): string => {
   return urlRedacted
     .replace(/\b(Bearer|Basic)\s+[^\s,;]+/gi, `$1 ${REDACTED_LOG_VALUE}`)
     .replace(/\bsk-[a-z0-9_-]{8,}\b/gi, REDACTED_LOG_VALUE)
-    .replace(
-      /(["']?(?:api[-_ ]?key|access[-_ ]?token|auth(?:orization)?|bearer[-_ ]?token|client[-_ ]?secret|cookie|credential|password|private[-_ ]?key|proxy[-_ ]?authorization|refresh[-_ ]?token|secret(?:[-_ ]?key)?|token|x[-_ ]?api[-_ ]?key)["']?\s*[:=]\s*["']?)([^\s,"'}]+)/gi,
-      `$1${REDACTED_LOG_VALUE}`
-    )
+    .replace(QUOTED_SECRET_PATTERN, `$1$2${REDACTED_LOG_VALUE}$2`)
+    .replace(UNQUOTED_SECRET_PATTERN, `$1${REDACTED_LOG_VALUE}`)
     .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1")
 }
 
@@ -182,7 +193,10 @@ export const redactLogValue = (
   seen.add(value)
 
   if (value instanceof Error) return redactError(value, seen)
-  if (value instanceof Date) return value.toISOString()
+  if (value instanceof Date)
+    return Number.isNaN(value.getTime())
+      ? UNREADABLE_LOG_VALUE
+      : value.toISOString()
   if (value instanceof URL) return redactLogText(value.toString())
   if (Array.isArray(value))
     return value.map((item) => redactLogValue(item, seen))

--- a/src/lib/log-redaction.ts
+++ b/src/lib/log-redaction.ts
@@ -1,0 +1,199 @@
+export const REDACTED_LOG_VALUE = "[REDACTED]"
+const CIRCULAR_LOG_VALUE = "[Circular]"
+const UNREADABLE_LOG_VALUE = "[Unreadable]"
+
+const normalizeKey = (key: string): string =>
+  key.toLowerCase().replace(/[^a-z0-9]/g, "")
+
+const SECRET_KEYS = new Set([
+  "accesskey",
+  "accesstoken",
+  "apikey",
+  "auth",
+  "authtoken",
+  "authorization",
+  "bearertoken",
+  "clientsecret",
+  "cookie",
+  "credentials",
+  "password",
+  "privatekey",
+  "proxyauthorization",
+  "refreshtoken",
+  "secret",
+  "secretkey",
+  "setcookie",
+  "token",
+  "xapikey"
+])
+
+const PRIVATE_CONTENT_KEYS = new Set([
+  "body",
+  "content",
+  "delta",
+  "document",
+  "filecontent",
+  "input",
+  "messages",
+  "output",
+  "pagecontent",
+  "prompt",
+  "prompts",
+  "query",
+  "reasoning",
+  "requestbody",
+  "responsebody",
+  "systemprompt",
+  "text",
+  "thinking",
+  "transcript"
+])
+
+const PRIVATE_CONTAINER_KEYS = new Set(["customheaders", "headers"])
+
+const isSecretKey = (key: string): boolean => {
+  const normalized = normalizeKey(key)
+  return (
+    SECRET_KEYS.has(normalized) ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("password") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("token")
+  )
+}
+
+const isPrivateContentKey = (key: string): boolean =>
+  PRIVATE_CONTENT_KEYS.has(normalizeKey(key))
+
+const isPrivateContainerKey = (key: string): boolean =>
+  PRIVATE_CONTAINER_KEYS.has(normalizeKey(key))
+
+const redactUrl = (value: string): string => {
+  if (!/^https?:\/\//i.test(value)) return value
+  try {
+    const url = new URL(value)
+    if (url.username || url.password) {
+      url.username = ""
+      url.password = ""
+    }
+    for (const key of url.searchParams.keys()) {
+      if (isSecretKey(key)) url.searchParams.set(key, REDACTED_LOG_VALUE)
+    }
+    return url.toString()
+  } catch {
+    return value
+  }
+}
+
+/** Redact credentials that can appear outside a structured object. */
+export const redactLogText = (value: string): string => {
+  const urlRedacted = redactUrl(value)
+  return urlRedacted
+    .replace(/\b(Bearer|Basic)\s+[^\s,;]+/gi, `$1 ${REDACTED_LOG_VALUE}`)
+    .replace(/\bsk-[a-z0-9_-]{8,}\b/gi, REDACTED_LOG_VALUE)
+    .replace(
+      /(["']?(?:api[-_ ]?key|access[-_ ]?token|auth(?:orization)?|bearer[-_ ]?token|client[-_ ]?secret|cookie|credential|password|private[-_ ]?key|proxy[-_ ]?authorization|refresh[-_ ]?token|secret(?:[-_ ]?key)?|token|x[-_ ]?api[-_ ]?key)["']?\s*[:=]\s*["']?)([^\s,"'}]+)/gi,
+      `$1${REDACTED_LOG_VALUE}`
+    )
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1")
+}
+
+const redactLogStringValue = (
+  value: string,
+  seen: WeakSet<object>
+): unknown => {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    try {
+      return redactLogValue(JSON.parse(trimmed), seen)
+    } catch {
+      // Not valid JSON; apply ordinary text redaction below.
+    }
+  }
+  return redactLogText(value)
+}
+
+const redactPrivateContainer = (value: unknown): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return REDACTED_LOG_VALUE
+  }
+
+  try {
+    return Object.fromEntries(
+      Object.keys(value).map((key) => [key, REDACTED_LOG_VALUE])
+    )
+  } catch {
+    return REDACTED_LOG_VALUE
+  }
+}
+
+const redactError = (error: Error, seen: WeakSet<object>): unknown => {
+  const result: Record<string, unknown> = {
+    name: redactLogText(error.name),
+    message: redactLogText(error.message)
+  }
+  if (error.stack) result.stack = redactLogText(error.stack)
+  if (error.cause !== undefined)
+    result.cause = redactLogValue(error.cause, seen)
+
+  for (const key of Object.keys(error)) {
+    if (key in result) continue
+    result[key] = redactProperty(key, error[key as keyof Error], seen)
+  }
+  return result
+}
+
+const redactProperty = (
+  key: string,
+  value: unknown,
+  seen: WeakSet<object>
+): unknown => {
+  if (isSecretKey(key) || isPrivateContentKey(key)) return REDACTED_LOG_VALUE
+  if (isPrivateContainerKey(key)) return redactPrivateContainer(value)
+  return redactLogValue(value, seen)
+}
+
+/**
+ * Create a privacy-safe, eager snapshot for a console or diagnostic sink.
+ * The input is never mutated and object references are never forwarded.
+ */
+export const redactLogValue = (
+  value: unknown,
+  seen = new WeakSet<object>()
+): unknown => {
+  if (typeof value === "string") return redactLogStringValue(value, seen)
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return value
+  }
+  if (typeof value === "symbol") return value.toString()
+  if (typeof value === "function")
+    return `[Function ${value.name || "anonymous"}]`
+
+  if (seen.has(value)) return CIRCULAR_LOG_VALUE
+  seen.add(value)
+
+  if (value instanceof Error) return redactError(value, seen)
+  if (value instanceof Date) return value.toISOString()
+  if (value instanceof URL) return redactLogText(value.toString())
+  if (Array.isArray(value))
+    return value.map((item) => redactLogValue(item, seen))
+
+  try {
+    const result: Record<string, unknown> = {}
+    for (const [key, nestedValue] of Object.entries(value)) {
+      result[key] = redactProperty(key, nestedValue, seen)
+    }
+    return result
+  } catch {
+    return UNREADABLE_LOG_VALUE
+  }
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,5 @@
+import { redactLogText, redactLogValue } from "@/lib/log-redaction"
+
 /**
  * Log levels for the application
  * Higher values = more severe
@@ -63,23 +65,24 @@ export class Logger {
 
     const levelName = LOG_LEVEL_NAMES[level]
     const timestamp = new Date().toISOString()
-    const contextStr = context ? `[${context}]` : ""
-    const sessionStr = sessionId ? `[Session:${sessionId}]` : ""
-    const formatted = `${timestamp} ${levelName.toUpperCase()} ${contextStr}${sessionStr} ${message}`
+    const contextStr = context ? `[${redactLogText(context)}]` : ""
+    const sessionStr = sessionId ? `[Session:${redactLogText(sessionId)}]` : ""
+    const formatted = `${timestamp} ${levelName.toUpperCase()} ${contextStr}${sessionStr} ${redactLogText(message)}`
+    const safeData = data === undefined ? "" : redactLogValue(data)
 
     switch (level) {
       case LogLevel.DEBUG:
       case LogLevel.VERBOSE:
-        console.log(formatted, data ?? "")
+        console.log(formatted, safeData)
         break
       case LogLevel.INFO:
-        console.info(formatted, data ?? "")
+        console.info(formatted, safeData)
         break
       case LogLevel.WARN:
-        console.warn(formatted, data ?? "")
+        console.warn(formatted, safeData)
         break
       case LogLevel.ERROR:
-        console.error(formatted, data ?? "")
+        console.error(formatted, safeData)
         break
     }
   }


### PR DESCRIPTION
## What changed

- add one recursive redaction boundary before every logger console sink
- redact case-varied credential fields, headers, request/response bodies, prompts, page/file content, reasoning data, and serialized structured payloads
- scrub bearer/basic credentials, API-key patterns, URL user info, and sensitive query parameters from free-form text
- snapshot errors and structured data eagerly, with safe handling for cycles and unreadable objects
- route content-script debug output through the central logger and remove the pre-stringified stream payload
- add regression coverage for nested secrets, custom headers, errors, URLs, cycles, mutation after logging, skipped log levels, and serialized payloads

## Why

Provider credentials and private user content could previously reach browser DevTools through arbitrary logger data or direct content-script console calls. Redaction at the sink makes privacy independent of individual call-site discipline while preserving useful status and error metadata.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 1,952 tests
- `pnpm build`
- `pnpm build:firefox`
- pre-push i18n drift check and docs build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds privacy-safe redaction for diagnostic logging. The main changes are:

- Recursive redaction before each console sink.
- Credential and private-content scrubbing for structured and free-form data.
- Eager snapshots for errors, cycles, dates, and mutable objects.
- Centralized content-script debug logging.
- Tests for sensitive values, URLs, errors, cycles, and skipped log levels.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The latest changes address the previously reported logging failures.
- No additional blocking issue meets the follow-up review scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/log-redaction.ts | Adds recursive redaction for structured values, errors, URLs, serialized data, and free-form credentials. |
| src/lib/logger.ts | Applies eager redaction to messages, context, session identifiers, and data before console output. |
| src/contents/content-debug.ts | Routes content-script diagnostics through the central logger and adds unconditional error reporting. |
| src/contents/debug-init.ts | Uses the redacted error path for manual transcript and extraction helper failures. |
| src/features/chat/hooks/use-chat-stream.ts | Passes stream messages as structured data so the logger can redact them recursively. |

<sub>Reviews (2): Last reviewed commit: ["fix(logging): close redaction edge cases"](https://github.com/shishir435/ollama-client/commit/8e625575fff848fc713f5b94d5af8f2be346e834) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45238808)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->