### PR TITLE
Restrict runtime messages by sender surface

### DIFF
--- a/src/background/__tests__/index.test.ts
+++ b/src/background/__tests__/index.test.ts
@@ -11,6 +11,7 @@ const listeners = {
 
 const mockBrowser = {
   runtime: {
+    id: "test-extension-id",
     onConnect: {
       addListener: vi.fn((fn) => listeners.onConnect.push(fn))
     },
@@ -23,7 +24,7 @@ const mockBrowser = {
     onStartup: {
       addListener: vi.fn((fn) => listeners.onStartup.push(fn))
     },
-    getURL: vi.fn()
+    getURL: vi.fn((path: string) => `chrome-extension://test/${path}`)
   },
   windows: {
     create: vi.fn()
@@ -33,6 +34,17 @@ const mockBrowser = {
       addListener: vi.fn()
     }
   }
+}
+
+const extensionSender = {
+  id: "test-extension-id",
+  url: "chrome-extension://test/sidepanel.html"
+}
+
+const contentScriptSender = {
+  id: "test-extension-id",
+  tab: { id: 42 },
+  url: "https://example.com/page"
 }
 
 vi.mock("@/lib/browser-api", () => ({
@@ -133,17 +145,71 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       const sendResponse = vi.fn()
 
-      onMessage({ type: MESSAGE_KEYS.PROVIDER.GET_MODELS }, {}, sendResponse)
+      onMessage(
+        { type: MESSAGE_KEYS.PROVIDER.GET_MODELS },
+        extensionSender,
+        sendResponse
+      )
 
       expect(handleGetModels).toHaveBeenCalledWith(sendResponse)
+    })
+
+    it("allows content scripts to use an allowlisted message", () => {
+      const onMessage = listeners.onMessage[0]
+      const sendResponse = vi.fn()
+
+      onMessage(
+        { type: MESSAGE_KEYS.PROVIDER.GET_MODELS },
+        contentScriptSender,
+        sendResponse
+      )
+
+      expect(handleGetModels).toHaveBeenCalledWith(sendResponse)
+    })
+
+    it("rejects privileged messages from content scripts", () => {
+      const onMessage = listeners.onMessage[0]
+      const sendResponse = vi.fn()
+
+      expect(
+        onMessage(
+          { type: MESSAGE_KEYS.PROVIDER.DELETE_MODEL, payload: "model" },
+          contentScriptSender,
+          sendResponse
+        )
+      ).toBe(true)
+
+      expect(handleDeleteModel).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: { status: 403, message: "Message not allowed from this context" }
+      })
+    })
+
+    it("rejects non-selection ports from content scripts", () => {
+      const onConnect = listeners.onConnect[0]
+      const port = {
+        name: "request-id",
+        sender: contentScriptSender,
+        onMessage: { addListener: vi.fn() },
+        onDisconnect: { addListener: vi.fn() },
+        disconnect: vi.fn()
+      }
+
+      onConnect(port)
+
+      expect(port.disconnect).toHaveBeenCalledOnce()
+      expect(port.onMessage.addListener).not.toHaveBeenCalled()
     })
 
     it("should route CHAT_WITH_MODEL via port", () => {
       const onConnect = listeners.onConnect[0]
       const port = {
         name: "test-port",
+        sender: extensionSender,
         onMessage: { addListener: vi.fn() },
-        onDisconnect: { addListener: vi.fn() }
+        onDisconnect: { addListener: vi.fn() },
+        disconnect: vi.fn()
       }
 
       onConnect(port)
@@ -161,8 +227,10 @@ describe("Background Script Entry Point", () => {
       const onConnect = listeners.onConnect[0]
       const port = {
         name: MESSAGE_KEYS.PROVIDER.PULL_MODEL,
+        sender: extensionSender,
         onMessage: { addListener: vi.fn() },
-        onDisconnect: { addListener: vi.fn() }
+        onDisconnect: { addListener: vi.fn() },
+        disconnect: vi.fn()
       }
 
       onConnect(port)
@@ -182,7 +250,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.SHOW_MODEL_DETAILS, payload: "model" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleShowModelDetails).toHaveBeenCalled()
@@ -197,7 +265,9 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       const sendResponse = vi.fn()
 
-      expect(onMessage({ type, payload: null }, {}, sendResponse)).toBe(true)
+      expect(
+        onMessage({ type, payload: null }, extensionSender, sendResponse)
+      ).toBe(true)
       expect(sendResponse).toHaveBeenCalledWith({
         success: false,
         error: { status: 400, message: "Invalid message payload" }
@@ -208,7 +278,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.SCRAPE_MODEL, query: "q" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleScrapeModel).toHaveBeenCalled()
@@ -218,7 +288,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.SCRAPE_MODEL_VARIANTS, name: "m" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleScrapeModelVariants).toHaveBeenCalled()
@@ -228,7 +298,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.UPDATE_BASE_URL, payload: "url" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleUpdateBaseUrl).toHaveBeenCalled()
@@ -236,7 +306,11 @@ describe("Background Script Entry Point", () => {
 
     it("should route GET_LOADED_MODELS", () => {
       const onMessage = listeners.onMessage[0]
-      onMessage({ type: MESSAGE_KEYS.PROVIDER.GET_LOADED_MODELS }, {}, vi.fn())
+      onMessage(
+        { type: MESSAGE_KEYS.PROVIDER.GET_LOADED_MODELS },
+        extensionSender,
+        vi.fn()
+      )
       expect(handleGetLoadedModels).toHaveBeenCalled()
     })
 
@@ -244,7 +318,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.UNLOAD_MODEL, payload: "m" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleUnloadModel).toHaveBeenCalled()
@@ -254,7 +328,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.WARMUP_MODEL, payload: { model: "m" } },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleWarmupModel).toHaveBeenCalled()
@@ -264,7 +338,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.DELETE_MODEL, payload: "m" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleDeleteModel).toHaveBeenCalled()
@@ -274,7 +348,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.GET_PROVIDER_VERSION },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(handleGetProviderVersion).toHaveBeenCalled()
@@ -284,7 +358,7 @@ describe("Background Script Entry Point", () => {
       const onMessage = listeners.onMessage[0]
       onMessage(
         { type: MESSAGE_KEYS.PROVIDER.CHECK_EMBEDDING_MODEL, payload: "m" },
-        {},
+        extensionSender,
         vi.fn()
       )
       expect(checkEmbeddingModelExists).toHaveBeenCalled()

--- a/src/background/__tests__/runtime-sender-authorization.test.ts
+++ b/src/background/__tests__/runtime-sender-authorization.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+import {
+  classifyRuntimeSender,
+  isRuntimeMessageAllowed,
+  isRuntimePortAllowed,
+  isRuntimePortMessageAllowed,
+  type RuntimeSenderLike
+} from "@/background/runtime-sender-authorization"
+import { MESSAGE_KEYS } from "@/lib/constants"
+
+const extensionId = "extension-id"
+const extensionUrlPrefix = "chrome-extension://extension-id/"
+const extensionPage = {
+  id: extensionId,
+  url: `${extensionUrlPrefix}sidepanel.html`
+}
+const contentScript = {
+  id: extensionId,
+  tab: { id: 42 },
+  url: "https://example.com/page"
+}
+
+const messageAllowed = (
+  type: string,
+  sender: RuntimeSenderLike = contentScript
+) => isRuntimeMessageAllowed(type, sender, extensionId, extensionUrlPrefix)
+
+const portAllowed = (
+  portName: string,
+  sender: RuntimeSenderLike = contentScript
+) => isRuntimePortAllowed(portName, sender, extensionId, extensionUrlPrefix)
+
+const portMessageAllowed = (
+  portName: string,
+  messageType: string,
+  sender: RuntimeSenderLike = contentScript
+) =>
+  isRuntimePortMessageAllowed(
+    portName,
+    messageType,
+    sender,
+    extensionId,
+    extensionUrlPrefix
+  )
+
+describe("runtime sender authorization", () => {
+  it("classifies extension pages, content scripts, and foreign senders", () => {
+    expect(
+      classifyRuntimeSender(extensionPage, extensionId, extensionUrlPrefix)
+    ).toBe("extension-page")
+    expect(
+      classifyRuntimeSender(contentScript, extensionId, extensionUrlPrefix)
+    ).toBe("content-script")
+    expect(
+      classifyRuntimeSender({ id: "foreign" }, extensionId, extensionUrlPrefix)
+    ).toBe("untrusted")
+    expect(classifyRuntimeSender({}, extensionId, extensionUrlPrefix)).toBe(
+      "untrusted"
+    )
+  })
+
+  it("keeps extension pages privileged when opened in a browser tab", () => {
+    expect(
+      classifyRuntimeSender(
+        {
+          id: extensionId,
+          tab: { id: 9 },
+          url: `${extensionUrlPrefix}options.html`
+        },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe("extension-page")
+    expect(
+      classifyRuntimeSender(
+        {
+          id: extensionId,
+          tab: { id: 10 },
+          origin: "chrome-extension://extension-id"
+        },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe("extension-page")
+  })
+
+  it("allows extension pages to use the internal runtime API", () => {
+    expect(
+      messageAllowed(MESSAGE_KEYS.PROVIDER.DELETE_MODEL, extensionPage)
+    ).toBe(true)
+    expect(portAllowed("request-id", extensionPage)).toBe(true)
+    expect(
+      portMessageAllowed(
+        "request-id",
+        MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
+        extensionPage
+      )
+    ).toBe(true)
+    expect(
+      portMessageAllowed(MESSAGE_KEYS.PROVIDER.PULL_MODEL, "", extensionPage)
+    ).toBe(true)
+  })
+
+  it("gives content scripts only the narrow message allowlist", () => {
+    expect(messageAllowed(MESSAGE_KEYS.PROVIDER.GET_MODELS)).toBe(true)
+    expect(messageAllowed(MESSAGE_KEYS.OLLAMA.GET_MODELS)).toBe(true)
+    expect(messageAllowed(MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT)).toBe(
+      true
+    )
+    expect(messageAllowed(MESSAGE_KEYS.PROVIDER.DELETE_MODEL)).toBe(false)
+    expect(messageAllowed(MESSAGE_KEYS.PROVIDER.CONFIRM_TOOL)).toBe(false)
+  })
+
+  it("binds content-script messages to the selection-action port", () => {
+    const portName = MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION
+    expect(portAllowed(portName)).toBe(true)
+    expect(
+      portMessageAllowed(portName, MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION)
+    ).toBe(true)
+    expect(
+      portMessageAllowed(
+        portName,
+        MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION
+      )
+    ).toBe(true)
+    expect(
+      portMessageAllowed(portName, MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL)
+    ).toBe(false)
+    expect(portAllowed(MESSAGE_KEYS.BROWSER.SELECTION_BRIDGE_PORT)).toBe(false)
+  })
+
+  it("rejects every message and port from foreign senders", () => {
+    const foreign = {
+      id: "foreign",
+      tab: { id: 7 },
+      url: "https://example.com"
+    }
+    expect(messageAllowed(MESSAGE_KEYS.PROVIDER.GET_MODELS, foreign)).toBe(
+      false
+    )
+    expect(
+      portAllowed(MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION, foreign)
+    ).toBe(false)
+    expect(
+      portMessageAllowed(
+        MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
+        MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
+        foreign
+      )
+    ).toBe(false)
+  })
+})

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -23,6 +23,10 @@ import { notifyJobComplete } from "@/background/lib/notify"
 import { postSelectionToSidePanels } from "@/background/lib/selection-bridge"
 import { resolveToolConfirmation } from "@/background/lib/tool-confirmation-registry"
 import { safeSendResponse } from "@/background/lib/utils"
+import {
+  classifyRuntimeSender,
+  isRuntimeMessageAllowed
+} from "@/background/runtime-sender-authorization"
 import { browser, isChromiumBased } from "@/lib/browser-api"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { getErrorMessage } from "@/lib/error-utils"
@@ -34,11 +38,33 @@ import type {
   SendResponseFunction
 } from "@/types"
 
+const extensionUrlPrefix = browser.runtime.getURL("")
+
 const respondInvalidPayload = (sendResponse: SendResponseFunction) =>
   safeSendResponse(sendResponse, {
     success: false,
     error: { status: 400, message: "Invalid message payload" }
   })
+
+const respondForbidden = (
+  type: string,
+  sender: Runtime.MessageSender,
+  sendResponse: SendResponseFunction
+) => {
+  logger.warn("Blocked unauthorized runtime message", "RuntimeAuthorization", {
+    type,
+    surface: classifyRuntimeSender(
+      sender,
+      browser.runtime.id,
+      extensionUrlPrefix
+    ),
+    tabId: sender.tab?.id
+  })
+  safeSendResponse(sendResponse, {
+    success: false,
+    error: { status: 403, message: "Message not allowed from this context" }
+  })
+}
 
 const openSidePanelForSelection = (tab?: {
   windowId?: number
@@ -137,6 +163,23 @@ export const registerMessageRouter = () => {
   ): true | undefined => {
     const response = sendResponse as SendResponseFunction
     const message = rawMessage as ChromeMessage
+
+    if (
+      typeof message?.type !== "string" ||
+      !isRuntimeMessageAllowed(
+        message.type,
+        sender,
+        browser.runtime.id,
+        extensionUrlPrefix
+      )
+    ) {
+      respondForbidden(
+        typeof message?.type === "string" ? message.type : "invalid",
+        sender,
+        response
+      )
+      return true
+    }
 
     switch (message.type) {
       case MESSAGE_KEYS.PROVIDER.GET_MODELS:

--- a/src/background/port-router.ts
+++ b/src/background/port-router.ts
@@ -6,6 +6,11 @@ import {
   registerSelectionBridgePort,
   unregisterSelectionBridgePort
 } from "@/background/lib/selection-bridge"
+import {
+  classifyRuntimeSender,
+  isRuntimePortAllowed,
+  isRuntimePortMessageAllowed
+} from "@/background/runtime-sender-authorization"
 import type { SelectionActionMessage } from "@/features/selection-actions/types"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
@@ -18,11 +23,36 @@ import type {
   PortStatusFunction
 } from "@/types"
 
+const extensionUrlPrefix = browser.runtime.getURL("")
+
 let portConnectionSeq = 0
 
 export const registerPortRouter = () => {
   browser.runtime.onConnect.addListener((rawPort) => {
     const port = rawPort as unknown as ChromePort
+    const sender = rawPort.sender ?? {}
+
+    if (
+      !isRuntimePortAllowed(
+        port.name,
+        sender,
+        browser.runtime.id,
+        extensionUrlPrefix
+      )
+    ) {
+      logger.warn("Blocked unauthorized runtime port", "RuntimeAuthorization", {
+        portName: port.name,
+        surface: classifyRuntimeSender(
+          sender,
+          browser.runtime.id,
+          extensionUrlPrefix
+        ),
+        tabId: sender.tab?.id
+      })
+      port.disconnect()
+      return
+    }
+
     let isPortClosed = false
     let currentAbortKey: string | undefined
     // Port names are shared constants; give each live connection its own
@@ -45,6 +75,34 @@ export const registerPortRouter = () => {
 
     port.onMessage.addListener(async (message) => {
       const msg = message as ChromeMessage
+      const messageType = typeof msg?.type === "string" ? msg.type : ""
+      if (
+        !isRuntimePortMessageAllowed(
+          port.name,
+          messageType,
+          sender,
+          browser.runtime.id,
+          extensionUrlPrefix
+        )
+      ) {
+        logger.warn(
+          "Blocked unauthorized runtime port message",
+          "RuntimeAuthorization",
+          {
+            portName: port.name,
+            type: messageType || "invalid",
+            surface: classifyRuntimeSender(
+              sender,
+              browser.runtime.id,
+              extensionUrlPrefix
+            ),
+            tabId: sender.tab?.id
+          }
+        )
+        port.disconnect()
+        return
+      }
+
       if (msg.type === MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL) {
         currentAbortKey = (msg as ChatWithModelMessage).payload?.requestId
         await handleChatWithModel(
@@ -82,6 +140,33 @@ export const registerPortRouter = () => {
     ) {
       port.onMessage.addListener(async (message) => {
         const msg = message as ChromeMessage
+        const messageType = typeof msg?.type === "string" ? msg.type : ""
+        if (
+          !isRuntimePortMessageAllowed(
+            port.name,
+            messageType,
+            sender,
+            browser.runtime.id,
+            extensionUrlPrefix
+          )
+        ) {
+          logger.warn(
+            "Blocked unauthorized model-pull message",
+            "RuntimeAuthorization",
+            {
+              portName: port.name,
+              type: messageType || "invalid",
+              surface: classifyRuntimeSender(
+                sender,
+                browser.runtime.id,
+                extensionUrlPrefix
+              ),
+              tabId: sender.tab?.id
+            }
+          )
+          port.disconnect()
+          return
+        }
         await handleModelPull(msg as ModelPullMessage, port, getPortStatus)
       })
     }

--- a/src/background/runtime-sender-authorization.ts
+++ b/src/background/runtime-sender-authorization.ts
@@ -1,0 +1,85 @@
+import { MESSAGE_KEYS } from "@/lib/constants"
+
+export type RuntimeSenderSurface =
+  | "extension-page"
+  | "content-script"
+  | "untrusted"
+
+export interface RuntimeSenderLike {
+  id?: string
+  origin?: string
+  tab?: { id?: number }
+  url?: string
+}
+
+const CONTENT_SCRIPT_MESSAGE_ALLOWLIST = new Set<string>([
+  MESSAGE_KEYS.PROVIDER.GET_MODELS,
+  MESSAGE_KEYS.OLLAMA.GET_MODELS,
+  MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT
+])
+
+const CONTENT_SCRIPT_PORT_ALLOWLIST = new Set<string>([
+  MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION
+])
+
+const CONTENT_SCRIPT_PORT_MESSAGE_ALLOWLIST = new Set<string>([
+  MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
+  MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION
+])
+
+export const classifyRuntimeSender = (
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string
+): RuntimeSenderSurface => {
+  if (!extensionId || sender.id !== extensionId) return "untrusted"
+  if (
+    sender.url?.startsWith(extensionUrlPrefix) ||
+    (sender.origin && extensionUrlPrefix.startsWith(`${sender.origin}/`))
+  ) {
+    return "extension-page"
+  }
+  return sender.tab ? "content-script" : "extension-page"
+}
+
+export const isRuntimeMessageAllowed = (
+  type: string,
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string
+): boolean => {
+  const surface = classifyRuntimeSender(sender, extensionId, extensionUrlPrefix)
+  if (surface === "extension-page") return true
+  if (surface === "content-script")
+    return CONTENT_SCRIPT_MESSAGE_ALLOWLIST.has(type)
+  return false
+}
+
+export const isRuntimePortAllowed = (
+  portName: string,
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string
+): boolean => {
+  const surface = classifyRuntimeSender(sender, extensionId, extensionUrlPrefix)
+  if (surface === "extension-page") return true
+  if (surface === "content-script")
+    return CONTENT_SCRIPT_PORT_ALLOWLIST.has(portName)
+  return false
+}
+
+export const isRuntimePortMessageAllowed = (
+  portName: string,
+  messageType: string,
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string
+): boolean => {
+  const surface = classifyRuntimeSender(sender, extensionId, extensionUrlPrefix)
+  if (surface === "extension-page") return true
+  if (surface !== "content-script") return false
+  return (
+    CONTENT_SCRIPT_PORT_ALLOWLIST.has(portName) &&
+    CONTENT_SCRIPT_PORT_MESSAGE_ALLOWLIST.has(messageType)
+  )
+}


### PR DESCRIPTION
## Summary

- classify runtime senders as extension pages, content scripts, or untrusted
- restrict content scripts to the small set of messages and ports they require
- reject unauthorized one-shot requests with a structured 403 response
- disconnect unauthorized ports and bind selection-action port messages to their expected protocol
- preserve extension-page behavior, including options pages opened in tabs and model-pull ports with port-specific message shapes

## Security model

Runtime identity and extension-owned URL/origin determine the sender surface. Foreign or missing senders are denied. Content scripts can request model metadata, add a page selection to chat, and use the selection-action port; privileged provider, storage, and tool routes remain extension-page-only.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` (245 files, 1,964 tests)
- `pnpm build`
- `pnpm build:firefox`
- pre-push i18n and docs builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restricts background runtime messaging based on the sender surface. The main changes are:

- Classify senders as extension pages, content scripts, or untrusted contexts.
- Limit content scripts to explicit message and selection-action protocols.
- Return structured forbidden responses for unauthorized one-shot messages.
- Disconnect unauthorized ports and port messages.
- Add authorization and router integration tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Authorization is enforced before one-shot dispatch, at port connection, and for each port message.
- Existing extension-page and model-pull message shapes remain supported.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/background/runtime-sender-authorization.ts | Adds sender classification and explicit content-script allowlists for messages, ports, and port messages. |
| src/background/message-router.ts | Adds authorization before one-shot message dispatch and returns structured forbidden responses. |
| src/background/port-router.ts | Checks authorization when ports connect and again before each port message reaches a handler. |
| src/background/__tests__/runtime-sender-authorization.test.ts | Covers sender classification and the new message and port authorization rules. |
| src/background/__tests__/index.test.ts | Updates router fixtures and tests allowed and rejected runtime traffic. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Runtime sender] --> B{Extension ID matches?}
    B -- No --> U[Reject or disconnect]
    B -- Yes --> C{Extension URL or origin?}
    C -- Yes --> E[Allow extension-page protocol]
    C -- No --> D{Sender has a tab?}
    D -- No --> E
    D -- Yes --> S[Content-script surface]
    S --> M{Message allowlisted?}
    M -- Yes --> R[Route request]
    M -- No --> F[Return 403]
    S --> P{Selection-action port?}
    P -- No --> U
    P -- Yes --> Q{Port message allowlisted?}
    Q -- Yes --> H[Route selection action]
    Q -- No --> U
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Runtime sender] --> B{Extension ID matches?}
    B -- No --> U[Reject or disconnect]
    B -- Yes --> C{Extension URL or origin?}
    C -- Yes --> E[Allow extension-page protocol]
    C -- No --> D{Sender has a tab?}
    D -- No --> E
    D -- Yes --> S[Content-script surface]
    S --> M{Message allowlisted?}
    M -- Yes --> R[Route request]
    M -- No --> F[Return 403]
    S --> P{Selection-action port?}
    P -- No --> U
    P -- Yes --> Q{Port message allowlisted?}
    Q -- Yes --> H[Route selection action]
    Q -- No --> U
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): authorize message senders"](https://github.com/shishir435/ollama-client/commit/0002def6dca37310efa04595e30c6750fd7ba964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45243807)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->