### PR TITLE
Centralize provider capability truth

### DIFF
--- a/src/background/__tests__/rpc-server.test.ts
+++ b/src/background/__tests__/rpc-server.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   list: vi.fn(),
   testConnection: vi.fn(),
   listModels: vi.fn(),
+  upsert: vi.fn(),
+  remove: vi.fn(),
+  probeModelCapabilities: vi.fn(),
   info: vi.fn(),
   error: vi.fn()
 }))
@@ -12,7 +15,10 @@ vi.mock("@/lib/providers/provider-rpc-service", () => ({
   ProviderRpcService: {
     list: mocks.list,
     testConnection: mocks.testConnection,
-    listModels: mocks.listModels
+    listModels: mocks.listModels,
+    upsert: mocks.upsert,
+    remove: mocks.remove,
+    probeModelCapabilities: mocks.probeModelCapabilities
   }
 }))
 
@@ -60,6 +66,20 @@ beforeEach(() => {
     latencyMs: 4
   })
   mocks.listModels.mockResolvedValue({ models: [], failures: [] })
+  mocks.upsert.mockResolvedValue({
+    provider: {
+      id: "custom:openai:test",
+      type: "openai",
+      enabled: true,
+      name: "Test",
+      hasApiKey: false
+    }
+  })
+  mocks.remove.mockResolvedValue({ removedProviderId: "custom:openai:test" })
+  mocks.probeModelCapabilities.mockResolvedValue({
+    toolCalling: true,
+    probedAt: 1
+  })
 })
 
 describe("RPC server", () => {
@@ -169,6 +189,34 @@ describe("RPC server", () => {
     expect(sendResponse.mock.calls[0][0]).toMatchObject({
       ok: false,
       error: { code: RpcErrorCode.Forbidden, status: 403 }
+    })
+  })
+
+  it("dispatches capability probes only through the typed command", async () => {
+    const envelope = request(RpcMethod.ProvidersProbeModelCapabilities, {
+      providerId: "custom:openai:test",
+      modelName: "tool-model"
+    })
+    const sendResponse = vi.fn()
+
+    await handleRpcRequest(
+      envelope,
+      extensionSender,
+      extensionId,
+      extensionPrefix,
+      sendResponse
+    )
+
+    expect(mocks.probeModelCapabilities).toHaveBeenCalledWith(
+      {
+        providerId: "custom:openai:test",
+        modelName: "tool-model"
+      },
+      expect.anything()
+    )
+    expect(sendResponse.mock.calls[0][0]).toMatchObject({
+      ok: true,
+      result: { toolCalling: true, probedAt: 1 }
     })
   })
 

--- a/src/background/lib/__tests__/resolve-model-tools.test.ts
+++ b/src/background/lib/__tests__/resolve-model-tools.test.ts
@@ -172,6 +172,57 @@ describe("resolveModelTools", () => {
     expect(resolved?.tools.map((t) => t.name)).toContain("capture_screenshot")
   })
 
+  it("falls back to catalog metadata when model details return null", async () => {
+    definitions = [...baseDefinitions, captureScreenshotTool]
+    const getModelDetails = vi.fn(async () => null)
+    const getModels = vi.fn(async () => [
+      {
+        name: "remote-vl",
+        model: "remote-vl",
+        modified_at: "",
+        size: 0,
+        digest: "",
+        details: {
+          parent_model: "",
+          format: "",
+          family: "",
+          families: [],
+          parameter_size: "",
+          quantization_level: ""
+        },
+        capabilityHints: {
+          modalities: ["text", "image"],
+          supportedParameters: ["tools"]
+        }
+      }
+    ])
+    const provider: LLMProvider = {
+      ...providerWithDetails(getModelDetails),
+      id: "custom:openai:remote",
+      config: {
+        id: "custom:openai:remote",
+        type: "openai" as never,
+        name: "Remote",
+        enabled: true,
+        baseUrl: "https://example.test/v1"
+      },
+      capabilities: {
+        modelDiscovery: true
+      } as LLMProvider["capabilities"],
+      getModels
+    }
+
+    const resolved = await resolveModelTools(
+      "remote-vl",
+      "custom:openai:remote",
+      provider
+    )
+
+    expect(getModelDetails).toHaveBeenCalledOnce()
+    expect(getModels).toHaveBeenCalledOnce()
+    expect(resolved).toEqual({ tools: definitions, mode: "native" })
+  })
+
   it("returns no tools for a non-tool-calling model without the fallback opt-in", async () => {
     const nonToolModel = providerWithDetails(
       vi.fn(async () => ({ capabilities: ["completion"] }))

--- a/src/background/lib/resolve-model-tools.ts
+++ b/src/background/lib/resolve-model-tools.ts
@@ -70,47 +70,62 @@ export const resolveModelTools = async (
   const cached = capabilityTagsCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
     metadata = cached
-  } else if (provider.getModelDetails) {
-    try {
-      const details = await provider.getModelDetails(model)
-      metadata = {
-        tags: (details as { capabilities?: string[] } | null)?.capabilities
-      }
-      capabilityTagsCache.set(cacheKey, {
-        ...metadata,
-        expiresAt: Date.now() + CAPABILITY_TAGS_CACHE_TTL_MS
-      })
-    } catch (error) {
-      logger.debug(
-        "Failed to read model details for tool gating",
-        "resolveModelTools",
-        {
-          error
+  } else {
+    let resolvedMetadata = false
+    if (provider.getModelDetails) {
+      try {
+        const details = await provider.getModelDetails(model)
+        const tags = (details as { capabilities?: string[] } | null)
+          ?.capabilities
+        if (tags?.length) {
+          metadata = { tags }
+          resolvedMetadata = true
         }
-      )
-    }
-  } else if (provider.capabilities?.modelDiscovery && provider.getModels) {
-    try {
-      const servedModel = (await provider.getModels()).find(
-        (candidate) => candidate.name === model
-      )
-      metadata = {
-        tags: undefined,
-        modelType: servedModel?.capabilityHints?.modelType,
-        contextLength: servedModel?.capabilityHints?.contextLength,
-        modalities: servedModel?.capabilityHints?.modalities,
-        supportedParameters: servedModel?.capabilityHints?.supportedParameters
+      } catch (error) {
+        logger.debug(
+          "Failed to read model details for tool gating",
+          "resolveModelTools",
+          { error }
+        )
       }
+    }
+
+    // OpenAI-compatible providers expose a null-returning detail method. A
+    // missing detail verdict must fall through to their richer model catalog.
+    if (
+      !resolvedMetadata &&
+      provider.capabilities?.modelDiscovery &&
+      provider.getModels
+    ) {
+      try {
+        const servedModel = (await provider.getModels()).find(
+          (candidate) => candidate.name === model
+        )
+        if (servedModel) {
+          metadata = {
+            tags: undefined,
+            modelType: servedModel.capabilityHints?.modelType,
+            contextLength: servedModel.capabilityHints?.contextLength,
+            modalities: servedModel.capabilityHints?.modalities,
+            supportedParameters:
+              servedModel.capabilityHints?.supportedParameters
+          }
+          resolvedMetadata = true
+        }
+      } catch (error) {
+        logger.debug(
+          "Failed to read model catalog metadata for tool gating",
+          "resolveModelTools",
+          { error }
+        )
+      }
+    }
+
+    if (resolvedMetadata) {
       capabilityTagsCache.set(cacheKey, {
         ...metadata,
         expiresAt: Date.now() + CAPABILITY_TAGS_CACHE_TTL_MS
       })
-    } catch (error) {
-      logger.debug(
-        "Failed to read model catalog metadata for tool gating",
-        "resolveModelTools",
-        { error }
-      )
     }
   }
 

--- a/src/background/lib/resolve-model-tools.ts
+++ b/src/background/lib/resolve-model-tools.ts
@@ -22,6 +22,10 @@ const CAPABILITY_TAGS_CACHE_TTL_MS = 60_000
 
 interface CapabilityTagsCacheEntry {
   tags: string[] | undefined
+  modelType?: string
+  contextLength?: number
+  modalities?: string[]
+  supportedParameters?: string[]
   expiresAt: number
 }
 
@@ -60,17 +64,20 @@ export const resolveModelTools = async (
   const providerUrl = resolveProviderBaseUrl(provider.config)
   const cacheKey = `${resolvedProviderId}::${providerUrl}::${model}`
 
-  let ollamaCapabilities: string[] | undefined
+  let metadata: Omit<CapabilityTagsCacheEntry, "expiresAt"> = {
+    tags: undefined
+  }
   const cached = capabilityTagsCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
-    ollamaCapabilities = cached.tags
+    metadata = cached
   } else if (provider.getModelDetails) {
     try {
       const details = await provider.getModelDetails(model)
-      ollamaCapabilities = (details as { capabilities?: string[] } | null)
-        ?.capabilities
+      metadata = {
+        tags: (details as { capabilities?: string[] } | null)?.capabilities
+      }
       capabilityTagsCache.set(cacheKey, {
-        tags: ollamaCapabilities,
+        ...metadata,
         expiresAt: Date.now() + CAPABILITY_TAGS_CACHE_TTL_MS
       })
     } catch (error) {
@@ -82,6 +89,29 @@ export const resolveModelTools = async (
         }
       )
     }
+  } else if (provider.capabilities?.modelDiscovery && provider.getModels) {
+    try {
+      const servedModel = (await provider.getModels()).find(
+        (candidate) => candidate.name === model
+      )
+      metadata = {
+        tags: undefined,
+        modelType: servedModel?.capabilityHints?.modelType,
+        contextLength: servedModel?.capabilityHints?.contextLength,
+        modalities: servedModel?.capabilityHints?.modalities,
+        supportedParameters: servedModel?.capabilityHints?.supportedParameters
+      }
+      capabilityTagsCache.set(cacheKey, {
+        ...metadata,
+        expiresAt: Date.now() + CAPABILITY_TAGS_CACHE_TTL_MS
+      })
+    } catch (error) {
+      logger.debug(
+        "Failed to read model catalog metadata for tool gating",
+        "resolveModelTools",
+        { error }
+      )
+    }
   }
 
   const [override, probed] = await Promise.all([
@@ -90,7 +120,11 @@ export const resolveModelTools = async (
   ])
   const capabilities = getModelCapabilities({
     providerId: resolvedProviderId,
-    ollamaCapabilities,
+    ollamaCapabilities: metadata.tags,
+    lmStudioModelType: metadata.modelType,
+    contextLength: metadata.contextLength,
+    modalities: metadata.modalities,
+    supportedParameters: metadata.supportedParameters,
     override,
     probed
   })

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -29,7 +29,13 @@ const handlers = {
   [RpcMethod.ProvidersTestConnection]: async (request, signal) =>
     ProviderRpcService.testConnection(request, signal),
   [RpcMethod.ProvidersListModels]: async (request, signal) =>
-    ProviderRpcService.listModels(request, signal)
+    ProviderRpcService.listModels(request, signal),
+  [RpcMethod.ProvidersUpsert]: async (request) =>
+    ProviderRpcService.upsert(request),
+  [RpcMethod.ProvidersRemove]: async (request) =>
+    ProviderRpcService.remove(request),
+  [RpcMethod.ProvidersProbeModelCapabilities]: async (request, signal) =>
+    ProviderRpcService.probeModelCapabilities(request, signal)
 } satisfies RpcHandlers
 
 const activeRequests = new Map<string, AbortController>()

--- a/src/features/model/components/model-menu.tsx
+++ b/src/features/model/components/model-menu.tsx
@@ -29,16 +29,10 @@ import { DEFAULT_PROVIDER_ID, MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { Check, ChevronDown, RotateCcw, Settings } from "@/lib/lucide-icon"
 import { getModelCapabilities } from "@/lib/providers/capabilities"
-import {
-  type CapabilityProbeResult,
-  probeReasoning,
-  probeToolCalling,
-  probeVision,
-  setCapabilityProbe
-} from "@/lib/providers/capability-probe"
-import { ProviderFactory } from "@/lib/providers/factory"
 import { getProviderDisplayName } from "@/lib/providers/registry"
 import { cn } from "@/lib/utils"
+import { extensionRpcClient } from "@/protocol/extension-client"
+import { RpcMethod } from "@/protocol/rpc"
 import {
   formatFileSize,
   getModelIcon,
@@ -175,6 +169,9 @@ export const ModelMenu = ({
         ollamaCapabilities: targetTags,
         lmStudioModelType: targetModelData?.capabilityHints?.modelType,
         contextLength: targetModelData?.capabilityHints?.contextLength,
+        modalities: targetModelData?.capabilityHints?.modalities,
+        supportedParameters:
+          targetModelData?.capabilityHints?.supportedParameters,
         probed: getProbe(capabilityTarget.providerId, capabilityTarget.model)
       })
     : null
@@ -186,6 +183,9 @@ export const ModelMenu = ({
         ollamaCapabilities: targetTags,
         lmStudioModelType: targetModelData?.capabilityHints?.modelType,
         contextLength: targetModelData?.capabilityHints?.contextLength,
+        modalities: targetModelData?.capabilityHints?.modalities,
+        supportedParameters:
+          targetModelData?.capabilityHints?.supportedParameters,
         override: getOverride(
           capabilityTarget.providerId,
           capabilityTarget.model
@@ -407,44 +407,13 @@ export const ModelMenu = ({
             clearOverride(capabilityTarget.providerId, capabilityTarget.model)
           }
           onProbe={async () => {
-            const provider = await ProviderFactory.getProvider(
-              capabilityTarget.providerId
+            return extensionRpcClient.call(
+              RpcMethod.ProvidersProbeModelCapabilities,
+              {
+                providerId: capabilityTarget.providerId,
+                modelName: capabilityTarget.model
+              }
             )
-            // Probe each capability independently — one failing must not discard
-            // the others' results.
-            const [tool, reasoning, vision] = await Promise.allSettled([
-              probeToolCalling(provider, capabilityTarget.model),
-              probeReasoning(provider, capabilityTarget.model),
-              probeVision(provider, capabilityTarget.model)
-            ])
-            if (
-              tool.status === "rejected" &&
-              reasoning.status === "rejected" &&
-              vision.status === "rejected"
-            ) {
-              throw tool.reason
-            }
-            const merged: CapabilityProbeResult = { probedAt: Date.now() }
-            if (tool.status === "fulfilled") {
-              merged.toolCalling = tool.value.toolCalling
-            }
-            if (reasoning.status === "fulfilled") {
-              merged.reasoning = reasoning.value.reasoning
-            }
-            // Vision is positive-only: adopt a verdict only when the probe
-            // reached one, so an inconclusive read never overrides metadata.
-            if (
-              vision.status === "fulfilled" &&
-              typeof vision.value.vision === "boolean"
-            ) {
-              merged.vision = vision.value.vision
-            }
-            await setCapabilityProbe(
-              capabilityTarget.providerId,
-              capabilityTarget.model,
-              merged
-            )
-            return merged
           }}
         />
       )}

--- a/src/features/model/hooks/use-model-capability-overrides.ts
+++ b/src/features/model/hooks/use-model-capability-overrides.ts
@@ -74,6 +74,8 @@ export const useModelCapabilityOverrides = () => {
         ollamaCapabilities,
         lmStudioModelType: model.capabilityHints?.modelType,
         contextLength: model.capabilityHints?.contextLength,
+        modalities: model.capabilityHints?.modalities,
+        supportedParameters: model.capabilityHints?.supportedParameters,
         override: getOverride(providerId, model.name),
         probed: getProbe(providerId, model.name)
       })

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -5,7 +5,6 @@ import { DEFAULT_PROVIDER_ID } from "@/lib/constants"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { isAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { ProviderManager } from "@/lib/providers/manager"
 import {
   providerProfileRequiresApiKey,
   resolveProviderServiceProfile
@@ -18,6 +17,7 @@ import {
   type ProviderServiceProfile
 } from "@/lib/providers/types"
 import { extensionRpcClient } from "@/protocol/extension-client"
+import type { PublicProviderConfig } from "@/protocol/provider-rpc"
 import { RpcMethod } from "@/protocol/rpc"
 import { useProviderHealth } from "./use-provider-health"
 
@@ -26,6 +26,14 @@ const LOCAL_PROVIDER_IDS = [
   ProviderId.LM_STUDIO,
   ProviderId.LLAMA_CPP
 ]
+
+type ProviderSettingsConfig = ProviderConfig & {
+  hasApiKey?: boolean
+}
+
+const toSettingsConfig = (
+  provider: PublicProviderConfig
+): ProviderSettingsConfig => provider as unknown as ProviderSettingsConfig
 
 const isLocalhostEndpoint = (baseUrl?: string) => {
   const url = baseUrl?.trim()
@@ -59,7 +67,7 @@ const getCspCompatibilityHint = (baseUrl?: string) => {
 
 export const useProviderSettingsState = () => {
   const { t } = useTranslation()
-  const [providers, setProviders] = useState<ProviderConfig[]>([])
+  const [providers, setProviders] = useState<ProviderSettingsConfig[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedId, setSelectedId] = useState<string>(DEFAULT_PROVIDER_ID)
   const [testingConnection, setTestingConnection] = useState(false)
@@ -68,14 +76,20 @@ export const useProviderSettingsState = () => {
     message: string
   } | null>(null)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+  const [apiKeyEditedProviderIds, setApiKeyEditedProviderIds] = useState<
+    Set<string>
+  >(new Set())
 
   const providerHealth = useProviderHealth(providers)
 
   const loadProviders = useCallback(async () => {
     setLoading(true)
     try {
-      const data = await ProviderManager.getProviders()
-      setProviders(data)
+      const { providers: data } = await extensionRpcClient.call(
+        RpcMethod.ProvidersList,
+        {}
+      )
+      setProviders(data.map(toSettingsConfig))
     } catch (error) {
       logger.error("Failed to load providers", "ProviderSettings", { error })
     } finally {
@@ -106,6 +120,21 @@ export const useProviderSettingsState = () => {
   const isRemoteEndpoint =
     Boolean(activeConfig?.baseUrl?.trim()) &&
     !isLocalhostEndpoint(activeConfig?.baseUrl)
+  const apiKeyWasEdited = activeConfig
+    ? apiKeyEditedProviderIds.has(String(activeConfig.id))
+    : false
+
+  const configForRpc = useCallback(
+    (config: ProviderSettingsConfig): ProviderConfig => {
+      const { hasApiKey: _hasApiKey, ...withoutPublicMarker } = config
+      if (apiKeyEditedProviderIds.has(String(config.id))) {
+        return withoutPublicMarker
+      }
+      const { apiKey: _apiKey, ...publicConfig } = withoutPublicMarker
+      return publicConfig as ProviderConfig
+    },
+    [apiKeyEditedProviderIds]
+  )
 
   const handleTestConnection = async () => {
     if (!activeConfig) return
@@ -126,7 +155,8 @@ export const useProviderSettingsState = () => {
       providerProfileRequiresApiKey(
         resolveProviderServiceProfile(activeConfig)
       ) &&
-      !activeConfig.apiKey?.trim()
+      !activeConfig.apiKey?.trim() &&
+      (!activeConfig.hasApiKey || apiKeyWasEdited)
     ) {
       const message = t("settings.providers.test_connection.api_key_required", {
         name: activeConfig.name
@@ -145,7 +175,7 @@ export const useProviderSettingsState = () => {
     try {
       const result = await extensionRpcClient.call(
         RpcMethod.ProvidersTestConnection,
-        { target: "draft", config: activeConfig }
+        { target: "draft", config: configForRpc(activeConfig) }
       )
       logger.debug("Provider connection RPC succeeded", "ProviderSettings", {
         count: result.modelCount
@@ -228,8 +258,23 @@ export const useProviderSettingsState = () => {
 
   const handleSave = async (config: ProviderConfig) => {
     try {
-      await ProviderManager.updateProviderConfig(config.id, config)
-      setProviders((prev) => prev.map((p) => (p.id === config.id ? config : p)))
+      const { provider: saved } = await extensionRpcClient.call(
+        RpcMethod.ProvidersUpsert,
+        {
+          target: "existing",
+          config: configForRpc(config)
+        }
+      )
+      setProviders((prev) =>
+        prev.map((provider) =>
+          provider.id === config.id ? toSettingsConfig(saved) : provider
+        )
+      )
+      setApiKeyEditedProviderIds((previous) => {
+        const next = new Set(previous)
+        next.delete(String(config.id))
+        return next
+      })
       setHasUnsavedChanges(false)
       toast({
         title: t("settings.saved"),
@@ -253,7 +298,10 @@ export const useProviderSettingsState = () => {
     serviceProfile?: ProviderServiceProfile
   }): Promise<boolean> => {
     try {
-      const config = await ProviderManager.addCustomProvider(input)
+      const { provider: config } = await extensionRpcClient.call(
+        RpcMethod.ProvidersUpsert,
+        { target: "new", provider: input }
+      )
       await loadProviders()
       setSelectedId(String(config.id))
       toast({
@@ -279,7 +327,9 @@ export const useProviderSettingsState = () => {
 
   const removeProvider = async (id: string) => {
     try {
-      await ProviderManager.removeCustomProvider(id)
+      await extensionRpcClient.call(RpcMethod.ProvidersRemove, {
+        providerId: id
+      })
       await loadProviders()
       if (selectedId === id) setSelectedId(DEFAULT_PROVIDER_ID)
     } catch (error) {
@@ -297,6 +347,11 @@ export const useProviderSettingsState = () => {
 
   const updateConfig = (updates: Partial<ProviderConfig>) => {
     if (!activeConfig) return
+    if (Object.hasOwn(updates, "apiKey")) {
+      setApiKeyEditedProviderIds((previous) =>
+        new Set(previous).add(String(activeConfig.id))
+      )
+    }
     const updated = { ...activeConfig, ...updates }
     setProviders((prev) =>
       prev.map((p) => (p.id === activeConfig.id ? updated : p))
@@ -312,7 +367,10 @@ export const useProviderSettingsState = () => {
       prev.map((p) => (p.id === activeConfig.id ? updated : p))
     )
     try {
-      await ProviderManager.updateProviderConfig(activeConfig.id, { enabled })
+      await extensionRpcClient.call(RpcMethod.ProvidersUpsert, {
+        target: "existing",
+        config: configForRpc(updated)
+      })
     } catch (error) {
       logger.error("Failed to auto-save toggle", "ProviderSettings", { error })
     }
@@ -323,10 +381,10 @@ export const useProviderSettingsState = () => {
 
     const timeoutId = setTimeout(async () => {
       try {
-        await ProviderManager.updateProviderConfig(
-          activeConfig.id,
-          activeConfig
-        )
+        await extensionRpcClient.call(RpcMethod.ProvidersUpsert, {
+          target: "existing",
+          config: configForRpc(activeConfig)
+        })
         setHasUnsavedChanges(false)
         logger.debug(
           `Auto-saved configuration for ${activeConfig.name}`,
@@ -338,7 +396,7 @@ export const useProviderSettingsState = () => {
     }, 2000)
 
     return () => clearTimeout(timeoutId)
-  }, [activeConfig, hasUnsavedChanges])
+  }, [activeConfig, configForRpc, hasUnsavedChanges])
 
   const headerStatusConfigs = [
     {

--- a/src/features/model/hooks/use-selected-model-capabilities.ts
+++ b/src/features/model/hooks/use-selected-model-capabilities.ts
@@ -49,6 +49,8 @@ export const useSelectedModelCapabilities = (): SelectedModelCapabilities => {
     ollamaCapabilities,
     lmStudioModelType: model?.capabilityHints?.modelType,
     contextLength: model?.capabilityHints?.contextLength,
+    modalities: model?.capabilityHints?.modalities,
+    supportedParameters: model?.capabilityHints?.supportedParameters,
     override: getOverride(providerId, selectedModel)
   })
 

--- a/src/lib/providers/__tests__/capabilities.test.ts
+++ b/src/lib/providers/__tests__/capabilities.test.ts
@@ -285,4 +285,24 @@ describe("getModelCapabilities", () => {
       confidence: "high"
     })
   })
+
+  it("treats empty catalog arrays as missing evidence", () => {
+    const input = {
+      providerId: "custom:openai:openrouter",
+      modalities: [] as string[],
+      supportedParameters: [] as string[]
+    }
+    const caps = getModelCapabilities(input)
+    const states = getModelCapabilityStates(input)
+
+    expect(caps.source).toBe("provider-default")
+    expect(caps.confidence).toBe("low")
+    expect(states.vision.status).toBe("unknown")
+    expect(states.reasoning.status).toBe("unknown")
+    expect(states.toolCalling).toEqual({
+      status: "supported",
+      source: "provider-default",
+      confidence: "low"
+    })
+  })
 })

--- a/src/lib/providers/__tests__/capabilities.test.ts
+++ b/src/lib/providers/__tests__/capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   getModelCapabilities,
+  getModelCapabilityStates,
   getProviderCapabilities,
   PROVIDER_CAPABILITIES
 } from "@/lib/providers/capabilities"
@@ -249,6 +250,39 @@ describe("getModelCapabilities", () => {
       embeddings: false,
       modelDiscovery: true,
       toolCalling: true
+    })
+  })
+
+  it("keeps unknown separate from unsupported in the new capability contract", () => {
+    const states = getModelCapabilityStates({
+      providerId: "unknown-provider"
+    })
+
+    expect(states.vision.status).toBe("unknown")
+    expect(states.reasoning.status).toBe("unknown")
+  })
+
+  it("uses hosted catalog metadata as high-confidence capability evidence", () => {
+    const input = {
+      providerId: "custom:openai:openrouter",
+      modalities: ["text", "image"],
+      supportedParameters: ["tools", "reasoning"]
+    }
+    const caps = getModelCapabilities(input)
+    const states = getModelCapabilityStates(input)
+
+    expect(caps).toMatchObject({
+      text: true,
+      vision: true,
+      toolCalling: true,
+      reasoning: true,
+      source: "model-metadata",
+      confidence: "high"
+    })
+    expect(states.toolCalling).toEqual({
+      status: "supported",
+      source: "model-metadata",
+      confidence: "high"
     })
   })
 })

--- a/src/lib/providers/__tests__/contract.test.ts
+++ b/src/lib/providers/__tests__/contract.test.ts
@@ -212,6 +212,42 @@ describe("provider contracts", () => {
     ).rejects.toThrow("OpenAI Error (401): nope")
   })
 
+  it("normalizes hosted model-catalog capability metadata", async () => {
+    const provider = new OpenAICompatibleProvider({
+      id: "custom:openai:openrouter",
+      name: "OpenRouter",
+      type: ProviderType.OPENAI,
+      enabled: true,
+      baseUrl: "https://openrouter.test/api/v1"
+    })
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "multimodal-model",
+            context_length: 131072,
+            architecture: {
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"]
+            },
+            supported_parameters: ["tools", "reasoning"]
+          }
+        ]
+      })
+    )
+
+    await expect(provider.getModels()).resolves.toEqual([
+      expect.objectContaining({
+        name: "multimodal-model",
+        capabilityHints: {
+          contextLength: 131072,
+          modalities: ["text", "image"],
+          supportedParameters: ["tools", "reasoning"]
+        }
+      })
+    ])
+  })
+
   it("LM Studio prefers /api/v0/models rich metadata and falls back to OpenAI models", async () => {
     const provider = new LMStudioProvider({
       id: ProviderId.LM_STUDIO,
@@ -268,7 +304,11 @@ describe("provider contracts", () => {
           {
             id: "llama-cpp-model",
             created: 1_700_000_000,
-            meta: { n_params: 7_000_000_000, size: 1234 }
+            meta: {
+              n_params: 7_000_000_000,
+              n_ctx_train: 32768,
+              size: 1234
+            }
           }
         ]
       })
@@ -278,6 +318,7 @@ describe("provider contracts", () => {
       expect.objectContaining({
         name: "llama-cpp-model",
         size: 1234,
+        capabilityHints: { contextLength: 32768 },
         details: expect.objectContaining({ parameter_size: "7B" })
       })
     ])

--- a/src/lib/providers/__tests__/provider-rpc-service.test.ts
+++ b/src/lib/providers/__tests__/provider-rpc-service.test.ts
@@ -2,14 +2,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   getProviders: vi.fn(),
+  getProviderConfig: vi.fn(),
+  updateProviderConfig: vi.fn(),
+  addCustomProvider: vi.fn(),
+  removeCustomProvider: vi.fn(),
   getProvider: vi.fn(),
-  getProviderWithConfig: vi.fn()
+  getProviderWithConfig: vi.fn(),
+  probeToolCalling: vi.fn(),
+  probeReasoning: vi.fn(),
+  probeVision: vi.fn(),
+  setCapabilityProbe: vi.fn()
 }))
 
 vi.mock("../manager", () => ({
   ProviderManager: {
-    getProviders: mocks.getProviders
+    getProviders: mocks.getProviders,
+    getProviderConfig: mocks.getProviderConfig,
+    updateProviderConfig: mocks.updateProviderConfig,
+    addCustomProvider: mocks.addCustomProvider,
+    removeCustomProvider: mocks.removeCustomProvider
   }
+}))
+
+vi.mock("../capability-probe", () => ({
+  probeToolCalling: mocks.probeToolCalling,
+  probeReasoning: mocks.probeReasoning,
+  probeVision: mocks.probeVision,
+  setCapabilityProbe: mocks.setCapabilityProbe
 }))
 
 vi.mock("../factory", () => ({
@@ -58,7 +77,17 @@ const model = (name: string) => ({
 })
 
 beforeEach(() => {
+  vi.clearAllMocks()
   mocks.getProviders.mockResolvedValue(configs)
+  mocks.getProviderConfig.mockImplementation(async (id: string) =>
+    configs.find((config) => config.id === id)
+  )
+  mocks.addCustomProvider.mockImplementation(async (input) => ({
+    id: "custom:openai:new",
+    type: ProviderType.OPENAI,
+    enabled: true,
+    ...input
+  }))
   mocks.getProvider.mockImplementation(async (id: string) => ({
     id,
     getModels: async () => [model(`${id}-model`)]
@@ -67,6 +96,12 @@ beforeEach(() => {
     id: config.id,
     getModels: async () => [model("draft-model")]
   }))
+  mocks.probeToolCalling.mockResolvedValue({
+    toolCalling: true,
+    probedAt: 1
+  })
+  mocks.probeReasoning.mockResolvedValue({ reasoning: false, probedAt: 2 })
+  mocks.probeVision.mockResolvedValue({ vision: true, probedAt: 3 })
 })
 
 describe("ProviderRpcService", () => {
@@ -94,6 +129,35 @@ describe("ProviderRpcService", () => {
       modelCount: 1
     })
     expect(result).not.toHaveProperty("apiKey")
+  })
+
+  it("keeps a stored credential background-only when testing an edited draft", async () => {
+    await ProviderRpcService.testConnection({
+      target: "draft",
+      config: {
+        ...configs[0],
+        apiKey: undefined,
+        baseUrl: "https://edited.example.test/v1"
+      }
+    })
+
+    expect(mocks.getProviderWithConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://edited.example.test/v1",
+        apiKey: "private-key"
+      })
+    )
+  })
+
+  it("does not restore a stored credential after the user explicitly clears it", async () => {
+    await ProviderRpcService.testConnection({
+      target: "draft",
+      config: { ...configs[0], apiKey: "" }
+    })
+
+    expect(mocks.getProviderWithConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "" })
+    )
   })
 
   it("merges custom models and reports partial failures without query side effects", async () => {
@@ -146,5 +210,46 @@ describe("ProviderRpcService", () => {
 
     await expect(pending).rejects.toMatchObject({ name: "AbortError" })
     expect(getModels).toHaveBeenCalledWith(controller.signal)
+  })
+
+  it("upserts and removes providers without returning credentials", async () => {
+    const created = await ProviderRpcService.upsert({
+      target: "new",
+      provider: {
+        name: "New remote",
+        baseUrl: "https://example.test/v1",
+        wire: "openai",
+        apiKey: "private-new-key"
+      }
+    })
+
+    expect(created.provider).toMatchObject({
+      id: "custom:openai:new",
+      hasApiKey: true
+    })
+    expect(created.provider).not.toHaveProperty("apiKey")
+
+    await expect(
+      ProviderRpcService.remove({ providerId: "custom:openai:new" })
+    ).resolves.toEqual({ removedProviderId: "custom:openai:new" })
+    expect(mocks.removeCustomProvider).toHaveBeenCalledWith("custom:openai:new")
+  })
+
+  it("probes capabilities in background and persists partial evidence", async () => {
+    const result = await ProviderRpcService.probeModelCapabilities({
+      providerId: "custom:openai:remote",
+      modelName: "vision-model"
+    })
+
+    expect(result).toMatchObject({
+      toolCalling: true,
+      reasoning: false,
+      vision: true
+    })
+    expect(mocks.setCapabilityProbe).toHaveBeenCalledWith(
+      "custom:openai:remote",
+      "vision-model",
+      result
+    )
   })
 })

--- a/src/lib/providers/capabilities.ts
+++ b/src/lib/providers/capabilities.ts
@@ -19,6 +19,19 @@ export type ModelCapabilitySource =
  */
 export type ModelCapabilityConfidence = "high" | "medium" | "low"
 
+export type CapabilityStatus = "supported" | "unsupported" | "unknown"
+
+export interface ModelCapabilityState {
+  status: CapabilityStatus
+  source: ModelCapabilitySource
+  confidence: ModelCapabilityConfidence
+}
+
+export type ModelCapabilityStates = Record<
+  "text" | "vision" | "embeddings" | "toolCalling" | "reasoning",
+  ModelCapabilityState
+>
+
 export interface ModelCapabilities {
   text: boolean
   vision: boolean
@@ -69,6 +82,10 @@ export interface ModelCapabilityInput {
   lmStudioModelType?: string
   /** Context window length in tokens, when known. */
   contextLength?: number
+  /** Modalities reported by model catalogs such as OpenRouter. */
+  modalities?: string[]
+  /** Supported request parameters reported by the model catalog. */
+  supportedParameters?: string[]
   /** User-set capability override for this model, if any. */
   override?: ModelCapabilityOverride | null
   /**
@@ -142,6 +159,37 @@ const detectModelCapabilities = (
       contextLength: input.contextLength,
       source: "model-metadata",
       confidence: "medium"
+    }
+  }
+
+  const modalities = input.modalities?.map((value) => value.toLowerCase())
+  const supportedParameters = input.supportedParameters?.map((value) =>
+    value.toLowerCase()
+  )
+  if (modalities !== undefined || supportedParameters !== undefined) {
+    const supportsAnyParameter = (...names: string[]) =>
+      names.some((name) => supportedParameters?.includes(name))
+    return {
+      text:
+        modalities?.includes("text") ??
+        (providerCaps?.chat === true || modalities === undefined),
+      vision: modalities?.includes("image") ?? false,
+      embeddings: providerCaps?.embeddings ?? false,
+      toolCalling:
+        supportedParameters !== undefined
+          ? supportsAnyParameter("tools", "tool_choice")
+          : (providerCaps?.toolCalling ?? false),
+      reasoning:
+        supportedParameters !== undefined
+          ? supportsAnyParameter(
+              "reasoning",
+              "reasoning_effort",
+              "include_reasoning"
+            )
+          : false,
+      contextLength: input.contextLength,
+      source: "model-metadata",
+      confidence: "high"
     }
   }
 
@@ -220,6 +268,93 @@ export const getModelCapabilities = (
   }
 
   return merged
+}
+
+const capabilityStatus = (value: boolean): CapabilityStatus =>
+  value ? "supported" : "unsupported"
+
+/**
+ * Source-aware capability contract for new consumers. Existing UI can keep
+ * using `getModelCapabilities` booleans during migration; new RPC/enforcement
+ * code can distinguish a real negative from missing evidence.
+ */
+export const getModelCapabilityStates = (
+  input: ModelCapabilityInput
+): ModelCapabilityStates => {
+  const resolved = getModelCapabilities(input)
+  const flags = [
+    "text",
+    "vision",
+    "embeddings",
+    "toolCalling",
+    "reasoning"
+  ] as const
+  const states = {} as ModelCapabilityStates
+  const tagsAvailable = Boolean(input.ollamaCapabilities?.length)
+  const modalitiesAvailable = input.modalities !== undefined
+  const parametersAvailable = input.supportedParameters !== undefined
+  const lmTypeAvailable = Boolean(input.lmStudioModelType)
+  const providerCaps = getProviderCapabilities(input.providerId)
+
+  for (const flag of flags) {
+    const override = input.override?.[flag]
+    if (typeof override === "boolean") {
+      states[flag] = {
+        status: capabilityStatus(override),
+        source: "user-override",
+        confidence: "high"
+      }
+      continue
+    }
+
+    const probed =
+      flag === "toolCalling" || flag === "reasoning" || flag === "vision"
+        ? input.probed?.[flag]
+        : undefined
+    if (typeof probed === "boolean") {
+      states[flag] = {
+        status: capabilityStatus(probed),
+        source: "probed",
+        confidence: "medium"
+      }
+      continue
+    }
+
+    const metadataOwnsFlag =
+      tagsAvailable ||
+      (modalitiesAvailable && (flag === "text" || flag === "vision")) ||
+      (parametersAvailable &&
+        (flag === "toolCalling" || flag === "reasoning")) ||
+      (lmTypeAvailable &&
+        (flag === "text" || flag === "vision" || flag === "embeddings"))
+    if (metadataOwnsFlag) {
+      states[flag] = {
+        status: capabilityStatus(resolved[flag]),
+        source: "model-metadata",
+        confidence: resolved.confidence
+      }
+      continue
+    }
+
+    const providerValue =
+      flag === "text"
+        ? providerCaps?.chat
+        : flag === "embeddings"
+          ? providerCaps?.embeddings
+          : flag === "toolCalling"
+            ? providerCaps?.toolCalling
+            : undefined
+    states[flag] = {
+      status:
+        typeof providerValue === "boolean"
+          ? capabilityStatus(providerValue)
+          : "unknown",
+      source: "provider-default",
+      confidence: "low"
+    }
+  }
+
+  return states
 }
 
 export const OPENAI_COMPATIBLE_PROVIDER_CAPABILITIES: ProviderCapabilities = {

--- a/src/lib/providers/capabilities.ts
+++ b/src/lib/providers/capabilities.ts
@@ -162,10 +162,15 @@ const detectModelCapabilities = (
     }
   }
 
-  const modalities = input.modalities?.map((value) => value.toLowerCase())
-  const supportedParameters = input.supportedParameters?.map((value) =>
-    value.toLowerCase()
-  )
+  // Empty catalog arrays are frequently placeholders, not authoritative
+  // negatives. Treat them as missing evidence and fall back to probes,
+  // overrides, or provider defaults.
+  const modalities = input.modalities?.length
+    ? input.modalities.map((value) => value.toLowerCase())
+    : undefined
+  const supportedParameters = input.supportedParameters?.length
+    ? input.supportedParameters.map((value) => value.toLowerCase())
+    : undefined
   if (modalities !== undefined || supportedParameters !== undefined) {
     const supportsAnyParameter = (...names: string[]) =>
       names.some((name) => supportedParameters?.includes(name))
@@ -291,8 +296,8 @@ export const getModelCapabilityStates = (
   ] as const
   const states = {} as ModelCapabilityStates
   const tagsAvailable = Boolean(input.ollamaCapabilities?.length)
-  const modalitiesAvailable = input.modalities !== undefined
-  const parametersAvailable = input.supportedParameters !== undefined
+  const modalitiesAvailable = Boolean(input.modalities?.length)
+  const parametersAvailable = Boolean(input.supportedParameters?.length)
   const lmTypeAvailable = Boolean(input.lmStudioModelType)
   const providerCaps = getProviderCapabilities(input.providerId)
 

--- a/src/lib/providers/capability-probe.ts
+++ b/src/lib/providers/capability-probe.ts
@@ -38,6 +38,23 @@ const STORAGE_KEY = STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_PROBES
 
 const PROBE_TIMEOUT_MS = 30_000
 
+const createProbeAbortScope = (externalSignal?: AbortSignal) => {
+  const controller = new AbortController()
+  const abortFromCaller = () => controller.abort(externalSignal?.reason)
+  if (externalSignal?.aborted) abortFromCaller()
+  else
+    externalSignal?.addEventListener("abort", abortFromCaller, { once: true })
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  return {
+    signal: controller.signal,
+    abort: () => controller.abort(),
+    cleanup: () => {
+      clearTimeout(timeout)
+      externalSignal?.removeEventListener("abort", abortFromCaller)
+    }
+  }
+}
+
 /**
  * Web Locks name serializing read-modify-write on the probe map across every
  * extension context. Each write reads the whole map, patches one key, and
@@ -140,10 +157,10 @@ const PROBE_TOOL = {
  */
 export const probeToolCalling = async (
   provider: LLMProvider,
-  modelName: string
+  modelName: string,
+  externalSignal?: AbortSignal
 ): Promise<CapabilityProbeResult> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  const scope = createProbeAbortScope(externalSignal)
 
   let sawToolCall = false
   let streamError: string | undefined
@@ -169,10 +186,10 @@ export const probeToolCalling = async (
         if (chunk.toolCalls && chunk.toolCalls.length > 0) {
           sawToolCall = true
           // The answer is in — cut the stream instead of letting the model run.
-          controller.abort()
+          scope.abort()
         }
       },
-      controller.signal
+      scope.signal
     )
   } catch (error) {
     // Abort-after-success is expected; anything else only matters if we never
@@ -185,7 +202,7 @@ export const probeToolCalling = async (
       throw error
     }
   } finally {
-    clearTimeout(timeout)
+    scope.cleanup()
   }
 
   // A failed request proves nothing about the model — surface it instead of
@@ -210,10 +227,10 @@ const THINKING_UNSUPPORTED = /does not support think/i
  */
 export const probeReasoning = async (
   provider: LLMProvider,
-  modelName: string
+  modelName: string,
+  externalSignal?: AbortSignal
 ): Promise<CapabilityProbeResult> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  const scope = createProbeAbortScope(externalSignal)
 
   let sawThinking = false
   let streamError: string | undefined
@@ -238,10 +255,10 @@ export const probeReasoning = async (
         if (chunk.thinkingDelta && chunk.thinkingDelta.length > 0) {
           sawThinking = true
           // Signal is in — cut the stream instead of paying for the full answer.
-          controller.abort()
+          scope.abort()
         }
       },
-      controller.signal
+      scope.signal
     )
   } catch (error) {
     if (!sawThinking) {
@@ -257,7 +274,7 @@ export const probeReasoning = async (
       throw error
     }
   } finally {
-    clearTimeout(timeout)
+    scope.cleanup()
   }
 
   if (!sawThinking && streamError) {
@@ -290,10 +307,10 @@ const IMAGE_UNSUPPORTED = /image|vision|multimodal|missing data/i
  */
 export const probeVision = async (
   provider: LLMProvider,
-  modelName: string
+  modelName: string,
+  externalSignal?: AbortSignal
 ): Promise<CapabilityProbeResult> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  const scope = createProbeAbortScope(externalSignal)
 
   let answer = ""
   let streamError: string | undefined
@@ -327,7 +344,7 @@ export const probeVision = async (
         if (chunk.delta) answer += chunk.delta
         if (chunk.content) answer += chunk.content
       },
-      controller.signal
+      scope.signal
     )
   } catch (error) {
     logger.debug("Vision probe request failed", "capabilityProbe", {
@@ -340,7 +357,7 @@ export const probeVision = async (
     }
     throw error
   } finally {
-    clearTimeout(timeout)
+    scope.cleanup()
   }
 
   // A server that flat-out rejects image input is a clean negative.

--- a/src/lib/providers/llama-cpp.ts
+++ b/src/lib/providers/llama-cpp.ts
@@ -16,6 +16,7 @@ interface LlamaCppModel {
   size?: number | string
   meta?: {
     n_params?: number
+    n_ctx_train?: number
     size?: number | string
   }
 }
@@ -129,7 +130,10 @@ export class LlamaCppProvider extends OpenAICompatibleProvider {
             families: [],
             parameter_size: paramSize,
             quantization_level: ""
-          }
+          },
+          ...(meta.n_ctx_train && {
+            capabilityHints: { contextLength: meta.n_ctx_train }
+          })
         }
       })
     } catch (e) {

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -240,7 +240,16 @@ export class OpenAICompatibleProvider implements LLMProvider {
       }
       const data = await response.json()
       return (
-        (data.data as { id: string }[])?.map((m) => ({
+        (
+          data.data as Array<{
+            id: string
+            context_length?: number
+            architecture?: {
+              input_modalities?: string[]
+            }
+            supported_parameters?: string[]
+          }>
+        )?.map((m) => ({
           name: m.id,
           model: m.id,
           modified_at: new Date().toISOString(),
@@ -253,7 +262,20 @@ export class OpenAICompatibleProvider implements LLMProvider {
             families: [],
             parameter_size: "",
             quantization_level: ""
-          }
+          },
+          ...((m.context_length ||
+            m.architecture?.input_modalities ||
+            m.supported_parameters) && {
+            capabilityHints: {
+              ...(m.context_length ? { contextLength: m.context_length } : {}),
+              ...(m.architecture?.input_modalities && {
+                modalities: [...new Set(m.architecture.input_modalities)]
+              }),
+              ...(m.supported_parameters && {
+                supportedParameters: m.supported_parameters
+              })
+            }
+          })
         })) || []
       )
     } catch (e) {

--- a/src/lib/providers/provider-rpc-service.ts
+++ b/src/lib/providers/provider-rpc-service.ts
@@ -3,12 +3,24 @@ import type {
   ProvidersListModelsRequest,
   ProvidersListModelsResult,
   ProvidersListResult,
+  ProvidersProbeModelCapabilitiesRequest,
+  ProvidersProbeModelCapabilitiesResult,
+  ProvidersRemoveRequest,
+  ProvidersRemoveResult,
+  ProvidersUpsertRequest,
+  ProvidersUpsertResult,
   ProviderTestConnectionRequest,
   ProviderTestConnectionResult,
   PublicProviderConfig
 } from "@/protocol/provider-rpc"
 import type { ProviderModel } from "@/types/model"
 
+import {
+  probeReasoning,
+  probeToolCalling,
+  probeVision,
+  setCapabilityProbe
+} from "./capability-probe"
 import { ProviderFactory } from "./factory"
 import { ProviderManager } from "./manager"
 import type { ProviderConfig } from "./types"
@@ -67,9 +79,19 @@ export const ProviderRpcService = {
     const startedAt = performance.now()
     const provider =
       request.target === "draft"
-        ? await ProviderFactory.getProviderWithConfig(
-            request.config as ProviderConfig
-          )
+        ? await (async () => {
+            const draft = request.config as ProviderConfig
+            const stored =
+              draft.apiKey === undefined
+                ? await ProviderManager.getProviderConfig(String(draft.id))
+                : undefined
+            return ProviderFactory.getProviderWithConfig({
+              ...draft,
+              ...(draft.apiKey === undefined && stored?.apiKey
+                ? { apiKey: stored.apiKey }
+                : {})
+            })
+          })()
         : await ProviderFactory.getProvider(request.providerId)
     const models = await provider.getModels(signal)
     return {
@@ -78,6 +100,60 @@ export const ProviderRpcService = {
       modelCount: models.length,
       latencyMs: Math.max(0, performance.now() - startedAt)
     }
+  },
+
+  async upsert(
+    request: ProvidersUpsertRequest
+  ): Promise<ProvidersUpsertResult> {
+    if (request.target === "new") {
+      const config = await ProviderManager.addCustomProvider(
+        request.provider as Parameters<
+          typeof ProviderManager.addCustomProvider
+        >[0]
+      )
+      return { provider: toPublicConfig(config) }
+    }
+
+    const id = String(request.config.id)
+    const existing = await ProviderManager.getProviderConfig(id)
+    if (!existing) {
+      throw createAppError(`Provider ${id} not found`, {
+        kind: "provider",
+        status: 404,
+        providerId: id,
+        userMessage: "Provider configuration was not found"
+      })
+    }
+    if (request.config.type !== existing.type) {
+      throw createAppError("A provider's wire protocol cannot be changed", {
+        kind: "validation",
+        status: 400,
+        providerId: id,
+        userMessage:
+          "Provider protocol cannot be changed. Add a new provider instead."
+      })
+    }
+    await ProviderManager.updateProviderConfig(
+      id,
+      request.config as ProviderConfig
+    )
+    const saved = await ProviderManager.getProviderConfig(id)
+    if (!saved) {
+      throw createAppError(`Provider ${id} disappeared after update`, {
+        kind: "provider",
+        status: 500,
+        providerId: id,
+        userMessage: "Provider configuration could not be saved"
+      })
+    }
+    return { provider: toPublicConfig(saved) }
+  },
+
+  async remove(
+    request: ProvidersRemoveRequest
+  ): Promise<ProvidersRemoveResult> {
+    await ProviderManager.removeCustomProvider(request.providerId)
+    return { removedProviderId: request.providerId }
   },
 
   async listModels(
@@ -135,5 +211,43 @@ export const ProviderRpcService = {
       left.providerId.localeCompare(right.providerId)
     )
     return { models, failures }
+  },
+
+  async probeModelCapabilities(
+    request: ProvidersProbeModelCapabilitiesRequest,
+    signal?: AbortSignal
+  ): Promise<ProvidersProbeModelCapabilitiesResult> {
+    const provider = await ProviderFactory.getProvider(request.providerId)
+    const [tool, reasoning, vision] = await Promise.allSettled([
+      probeToolCalling(provider, request.modelName, signal),
+      probeReasoning(provider, request.modelName, signal),
+      probeVision(provider, request.modelName, signal)
+    ])
+    if (
+      tool.status === "rejected" &&
+      reasoning.status === "rejected" &&
+      vision.status === "rejected"
+    ) {
+      throw tool.reason
+    }
+
+    const result: ProvidersProbeModelCapabilitiesResult = {
+      probedAt: Date.now()
+    }
+    if (tool.status === "fulfilled") {
+      result.toolCalling = tool.value.toolCalling
+    }
+    if (reasoning.status === "fulfilled") {
+      result.reasoning = reasoning.value.reasoning
+    }
+    if (
+      vision.status === "fulfilled" &&
+      typeof vision.value.vision === "boolean"
+    ) {
+      result.vision = vision.value.vision
+    }
+    signal?.throwIfAborted()
+    await setCapabilityProbe(request.providerId, request.modelName, result)
+    return result
   }
 }

--- a/src/protocol/provider-rpc.ts
+++ b/src/protocol/provider-rpc.ts
@@ -64,7 +64,9 @@ const ProviderModelSchema = z
     capabilityHints: z
       .object({
         modelType: z.string().optional(),
-        contextLength: z.number().optional()
+        contextLength: z.number().optional(),
+        modalities: z.array(z.string()).max(50).optional(),
+        supportedParameters: z.array(z.string()).max(100).optional()
       })
       .optional()
   })
@@ -90,6 +92,42 @@ const ProviderModelSchema = z
 export const ProvidersListRequestSchema = z.object({}).strict()
 export const ProvidersListResultSchema = z
   .object({ providers: z.array(PublicProviderConfigSchema) })
+  .strict()
+
+const NewProviderInputSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    baseUrl: z.string().min(1).max(4096),
+    wire: z.enum(["ollama", "openai", "anthropic"]),
+    apiKey: z.string().max(32_768).optional(),
+    customModels: z.array(z.string().min(1).max(500)).max(500).optional(),
+    serviceProfile: ProviderServiceProfileSchema.optional()
+  })
+  .strict()
+
+export const ProvidersUpsertRequestSchema = z.discriminatedUnion("target", [
+  z
+    .object({
+      target: z.literal("existing"),
+      config: ProviderConfigInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      target: z.literal("new"),
+      provider: NewProviderInputSchema
+    })
+    .strict()
+])
+export const ProvidersUpsertResultSchema = z
+  .object({ provider: PublicProviderConfigSchema })
+  .strict()
+
+export const ProvidersRemoveRequestSchema = z
+  .object({ providerId: z.string().min(1).max(200) })
+  .strict()
+export const ProvidersRemoveResultSchema = z
+  .object({ removedProviderId: z.string() })
   .strict()
 
 export const ProviderTestConnectionRequestSchema = z.discriminatedUnion(
@@ -138,8 +176,31 @@ export const ProvidersListModelsResultSchema = z
   })
   .strict()
 
+export const ProvidersProbeModelCapabilitiesRequestSchema = z
+  .object({
+    providerId: z.string().min(1).max(200),
+    modelName: z.string().min(1).max(500)
+  })
+  .strict()
+export const ProvidersProbeModelCapabilitiesResultSchema = z
+  .object({
+    toolCalling: z.boolean().optional(),
+    reasoning: z.boolean().optional(),
+    vision: z.boolean().optional(),
+    probedAt: z.number().int().nonnegative()
+  })
+  .strict()
+
 export type ProvidersListRequest = z.input<typeof ProvidersListRequestSchema>
 export type ProvidersListResult = z.infer<typeof ProvidersListResultSchema>
+export type ProvidersUpsertRequest = z.input<
+  typeof ProvidersUpsertRequestSchema
+>
+export type ProvidersUpsertResult = z.infer<typeof ProvidersUpsertResultSchema>
+export type ProvidersRemoveRequest = z.input<
+  typeof ProvidersRemoveRequestSchema
+>
+export type ProvidersRemoveResult = z.infer<typeof ProvidersRemoveResultSchema>
 export type ProviderTestConnectionRequest = z.input<
   typeof ProviderTestConnectionRequestSchema
 >
@@ -151,6 +212,12 @@ export type ProvidersListModelsRequest = z.input<
 >
 export type ProvidersListModelsResult = z.infer<
   typeof ProvidersListModelsResultSchema
+>
+export type ProvidersProbeModelCapabilitiesRequest = z.input<
+  typeof ProvidersProbeModelCapabilitiesRequestSchema
+>
+export type ProvidersProbeModelCapabilitiesResult = z.infer<
+  typeof ProvidersProbeModelCapabilitiesResultSchema
 >
 
 export interface RpcMap {
@@ -165,6 +232,18 @@ export interface RpcMap {
   [RpcMethod.ProvidersListModels]: RpcDefinition<
     ProvidersListModelsRequest,
     ProvidersListModelsResult
+  >
+  [RpcMethod.ProvidersUpsert]: RpcDefinition<
+    ProvidersUpsertRequest,
+    ProvidersUpsertResult
+  >
+  [RpcMethod.ProvidersRemove]: RpcDefinition<
+    ProvidersRemoveRequest,
+    ProvidersRemoveResult
+  >
+  [RpcMethod.ProvidersProbeModelCapabilities]: RpcDefinition<
+    ProvidersProbeModelCapabilitiesRequest,
+    ProvidersProbeModelCapabilitiesResult
   >
 }
 

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -5,6 +5,12 @@ import {
   ProvidersListModelsResultSchema,
   ProvidersListRequestSchema,
   ProvidersListResultSchema,
+  ProvidersProbeModelCapabilitiesRequestSchema,
+  ProvidersProbeModelCapabilitiesResultSchema,
+  ProvidersRemoveRequestSchema,
+  ProvidersRemoveResultSchema,
+  ProvidersUpsertRequestSchema,
+  ProvidersUpsertResultSchema,
   ProviderTestConnectionRequestSchema,
   ProviderTestConnectionResultSchema
 } from "./provider-rpc"
@@ -41,5 +47,26 @@ export const RPC_METHOD_DEFINITIONS = {
     allowedSources: extensionPagesOnly,
     timeoutMs: 30_000,
     operation: "query"
+  },
+  [RpcMethod.ProvidersUpsert]: {
+    request: ProvidersUpsertRequestSchema,
+    response: ProvidersUpsertResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 10_000,
+    operation: "command"
+  },
+  [RpcMethod.ProvidersRemove]: {
+    request: ProvidersRemoveRequestSchema,
+    response: ProvidersRemoveResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 10_000,
+    operation: "command"
+  },
+  [RpcMethod.ProvidersProbeModelCapabilities]: {
+    request: ProvidersProbeModelCapabilitiesRequestSchema,
+    response: ProvidersProbeModelCapabilitiesResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 35_000,
+    operation: "command"
   }
 } as const satisfies Record<RpcMethod, RpcMethodDefinition>

--- a/src/protocol/rpc.ts
+++ b/src/protocol/rpc.ts
@@ -8,7 +8,10 @@ export const RPC_CANCEL_MESSAGE_TYPE = "app-rpc-cancel" as const
 export enum RpcMethod {
   ProvidersList = "providers.list",
   ProvidersTestConnection = "providers.testConnection",
-  ProvidersListModels = "providers.listModels"
+  ProvidersListModels = "providers.listModels",
+  ProvidersUpsert = "providers.upsert",
+  ProvidersRemove = "providers.remove",
+  ProvidersProbeModelCapabilities = "providers.probeModelCapabilities"
 }
 
 export enum RpcErrorCode {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -25,6 +25,10 @@ export type ProviderModel = {
     modelType?: string
     /** Context window in tokens, when the list endpoint reports it. */
     contextLength?: number
+    /** Input/output modalities reported by hosted model catalogs. */
+    modalities?: string[]
+    /** Request parameters explicitly supported by the served model. */
+    supportedParameters?: string[]
   }
 }
 


### PR DESCRIPTION
## What changed

- add typed provider upsert, remove, and model-capability probe RPC commands
- move provider settings reads and mutations behind the background RPC boundary so saved API keys remain background-owned
- add source-aware supported, unsupported, and unknown model capability states
- normalize hosted model-catalog modalities, context length, and supported parameters
- preserve LM Studio, llama.cpp, Ollama, OpenRouter, generic OpenAI-compatible, and Anthropic fallback behavior
- use the same capability metadata for background tool and vision gating
- propagate RPC cancellation through empirical capability probes

## Why

Capability truth was split across provider defaults, React-side probes, provider metadata, and background tool gating. Provider settings also still read secret-bearing configuration directly in the UI despite the typed provider RPC foundation.

This consolidates provider operations and capability evidence behind one validated background boundary while retaining compatibility for existing boolean consumers.

## Impact

- capability detection becomes consistent across model UI and runtime tool enforcement
- custom provider config mutations use typed RPC
- saved provider credentials no longer need to enter provider settings state
- richer OpenRouter/OpenAI and llama.cpp metadata reduces manual overrides
- explicit user overrides and empirical probes remain supported

## Validation

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test:run` — 249 files, 2,015 tests
- `pnpm build`
- `pnpm docs:build`
- strict i18n drift check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes provider configuration and model capability handling behind the background RPC boundary. The main changes are:

- Typed RPC commands for provider updates, removal, model discovery, and capability probes.
- Background-owned provider credentials and settings mutations.
- Source-aware capability states with shared metadata for UI and runtime gating.
- Normalized hosted catalog metadata for modalities, context length, and supported parameters.
- Cancellation support for empirical capability probes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Catalog metadata is now consulted when model details return no capability verdict.
- Empty metadata arrays now fall back to defaults or unknown states instead of disabling capabilities.
- Tests cover both updated paths.
- No blocking issues remain in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/background/lib/resolve-model-tools.ts | Falls back from missing model details to catalog metadata and uses the resulting hints for tool gating. |
| src/lib/providers/capabilities.ts | Adds source-aware capability states and treats empty catalog arrays as missing evidence. |
| src/lib/providers/provider-rpc-service.ts | Adds background-owned provider mutations and cancellable capability probes without returning saved credentials. |
| src/protocol/provider-rpc.ts | Defines validated request and response schemas for the new provider RPC operations. |
| src/features/model/hooks/use-provider-settings-state.ts | Moves provider settings reads and mutations to RPC while preserving stored credentials that were not edited. |

<sub>Reviews (2): Last reviewed commit: ["fix(providers): honor capability evidenc..."](https://github.com/shishir435/ollama-client/commit/4fbf3e90b50a8c67194c15393e0d584f8755b2f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45312835)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->