### PR TITLE
spike(sqlite): opfs-sahpool phase 1 — physical import + incremental writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
+    "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "benchmark:build": "pnpm generate:resources && WXT_BENCHMARK=1 WXT_OUTPUT_DIR=build/chrome-mv3-benchmark wxt build",
     "benchmark:build:firefox": "pnpm generate:resources && WXT_BENCHMARK=1 WXT_OUTPUT_DIR=build/firefox-mv2-benchmark wxt build -b firefox --mv2 --mode production",
     "benchmark:browser": "tsx tools/benchmark-browser-persistence.ts",
+    "spike:owner-gates": "tsx tools/spike-owner-gates.ts",
     "verify": "pnpm typecheck && pnpm lint:check && pnpm test:run && pnpm check:generated",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.15
         version: 2.4.15
+      '@sqlite.org/sqlite-wasm':
+        specifier: 3.53.0-build1
+        version: 3.53.0-build1
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -2437,6 +2440,10 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@sqlite.org/sqlite-wasm@3.53.0-build1':
+    resolution: {integrity: sha512-PfWPWN2n+/37doa8oh2/oUXk4OOsRYZsxc1W1sDXIGb/Pu5Yrb+f2eyYpgQMGITVX7HVgxhs9P18Rc6I97ym/g==}
+    engines: {node: '>=22'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -8772,6 +8779,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sqlite.org/sqlite-wasm@3.53.0-build1': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,3 +7,11 @@ import { initializeBackgroundStartup } from "@/background/startup"
 initializeBackgroundStartup()
 registerPortRouter()
 registerMessageRouter()
+
+// Dev-only section 9.4 spike host (offscreen OPFS owner). The flag is false
+// in store builds, so this branch and its chunk are eliminated entirely.
+if (typeof __SPIKE_OPFS_OWNER__ !== "undefined" && __SPIKE_OPFS_OWNER__) {
+  void import("@/spike/opfs/background-owner-host").then((module) =>
+    module.registerSpikeOwnerHost()
+  )
+}

--- a/src/entrypoints/spike-opfs/index.html
+++ b/src/entrypoints/spike-opfs/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>OPFS SAHPool Spike</title>
+  <style>
+    body { margin: 24px; font-family: ui-monospace, monospace; max-width: 900px; }
+    h1 { font-size: 18px; }
+    .row { margin: 8px 0; display: flex; gap: 8px; align-items: center; }
+    label { min-width: 80px; }
+    button { padding: 4px 12px; }
+    #status { color: #666; min-height: 1.2em; }
+    #warning { color: #b45309; }
+    pre { background: #f4f4f5; padding: 12px; overflow-x: auto; white-space: pre-wrap; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #18181b; color: #e4e4e7; }
+      pre { background: #27272a; }
+      #status { color: #a1a1aa; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Section 9.4 spike: sqlite-wasm + opfs-sahpool (dev-only page)</h1>
+  <p>
+    Builds the section 9.8 fixtures with sql.js in this page, physically
+    imports the exported bytes into an official sqlite-wasm database behind
+    the <code>opfs-sahpool</code> VFS in one dedicated worker, then measures
+    incremental durable writes. Spike code — not a product surface.
+  </p>
+  <div class="row">
+    <label for="scale">Scale</label>
+    <select id="scale">
+      <option value="small" selected>small (500 chats / 10k messages)</option>
+      <option value="medium">medium (1k chats / 20k messages)</option>
+      <option value="binary">binary (medium + 62.5 MiB attachments)</option>
+      <option value="tree">tree (500 branched chats / 41k messages)</option>
+      <option value="large">large (10k chats / 200k messages)</option>
+    </select>
+  </div>
+  <div class="row">
+    <label for="iterations">Iterations</label>
+    <input id="iterations" type="number" min="1" max="20" value="3">
+  </div>
+  <p id="warning" hidden>
+    Warning: the large fixture allocates multiple GiB in this page while
+    sql.js builds it and may crash the tab.
+  </p>
+  <div class="row">
+    <button id="run" type="button">Run</button>
+    <button id="copy" type="button" disabled>Copy JSON</button>
+    <button id="cleanup" type="button">Wipe spike OPFS files</button>
+  </div>
+  <p id="status"></p>
+  <pre id="output"></pre>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/src/entrypoints/spike-opfs/main.ts
+++ b/src/entrypoints/spike-opfs/main.ts
@@ -1,0 +1,214 @@
+import type { SqlJsStatic } from "sql.js"
+import initSqlJs from "sql.js/dist/sql-wasm.js"
+import {
+  createFixture,
+  SCALES,
+  type ScaleName
+} from "@/lib/sqlite/benchmark/persistence-benchmark-core"
+import type {
+  SpikeResponse,
+  SpikeRunRequest,
+  SpikeScaleResult
+} from "@/spike/opfs/protocol"
+
+const scaleSelect = document.getElementById("scale") as HTMLSelectElement
+const iterationsInput = document.getElementById(
+  "iterations"
+) as HTMLInputElement
+const runButton = document.getElementById("run") as HTMLButtonElement
+const copyButton = document.getElementById("copy") as HTMLButtonElement
+const cleanupButton = document.getElementById("cleanup") as HTMLButtonElement
+const statusLine = document.getElementById("status") as HTMLParagraphElement
+const warningLine = document.getElementById("warning") as HTMLParagraphElement
+const output = document.getElementById("output") as HTMLPreElement
+
+const setStatus = (message: string): void => {
+  statusLine.textContent = message
+}
+
+const sampleMemoryBytes = (): number | null => {
+  const memory = (
+    performance as Performance & {
+      memory?: { usedJSHeapSize?: number }
+    }
+  ).memory
+  return typeof memory?.usedJSHeapSize === "number"
+    ? memory.usedJSHeapSize
+    : null
+}
+
+const toMiB = (bytes: number): number => bytes / (1024 * 1024)
+
+let worker: Worker | undefined
+let requestId = 0
+const pending = new Map<
+  number,
+  { resolve: (response: SpikeResponse) => void }
+>()
+
+const getWorker = (): Worker => {
+  if (!worker) {
+    worker = new Worker(
+      new URL("../../spike/opfs/sahpool-worker.ts", import.meta.url),
+      { type: "module" }
+    )
+    worker.onmessage = (event: MessageEvent<SpikeResponse>) => {
+      const entry = pending.get(event.data.id)
+      if (!entry) return
+      pending.delete(event.data.id)
+      entry.resolve(event.data)
+    }
+    worker.onerror = (event) => {
+      const error = `Worker error: ${event.message || "unknown"}`
+      for (const [id, entry] of pending) {
+        pending.delete(id)
+        entry.resolve({ id, ok: false, error })
+      }
+    }
+  }
+  return worker
+}
+
+const callWorker = (
+  request: Omit<SpikeRunRequest, "id"> | { type: "cleanup" },
+  transfer: Transferable[] = []
+): Promise<SpikeResponse> => {
+  requestId += 1
+  const id = requestId
+  return new Promise((resolve) => {
+    pending.set(id, { resolve })
+    getWorker().postMessage({ ...request, id }, transfer)
+  })
+}
+
+let sqlPromise: Promise<SqlJsStatic> | undefined
+
+const initSql = (): Promise<SqlJsStatic> => {
+  if (!sqlPromise) {
+    sqlPromise = (async () => {
+      const wasmUrl =
+        globalThis.chrome?.runtime?.getURL?.("assets/sql-wasm.wasm") ??
+        new URL("/assets/sql-wasm.wasm", location.origin).toString()
+      const response = await fetch(wasmUrl)
+      const wasmBinary = await response.arrayBuffer()
+      return (
+        initSqlJs as unknown as (config: {
+          wasmBinary: Uint8Array
+        }) => Promise<SqlJsStatic>
+      )({ wasmBinary: new Uint8Array(wasmBinary) })
+    })()
+  }
+  return sqlPromise
+}
+
+scaleSelect.addEventListener("change", () => {
+  warningLine.hidden = scaleSelect.value !== "large"
+})
+
+runButton.addEventListener("click", async () => {
+  const scaleName = scaleSelect.value as ScaleName
+  const iterations = Number(iterationsInput.value)
+  if (!Number.isInteger(iterations) || iterations < 1) {
+    setStatus("Iterations must be a positive integer")
+    return
+  }
+
+  runButton.disabled = true
+  copyButton.disabled = true
+  output.textContent = ""
+  try {
+    const memoryBefore = sampleMemoryBytes()
+    setStatus("Loading sql.js WASM…")
+    const SQL = await initSql()
+    const scale = SCALES[scaleName]
+
+    setStatus(`Building ${scaleName} fixture with sql.js…`)
+    const buildStartedAt = performance.now()
+    const fixture = createFixture(SQL, scale)
+    const fixtureBuildMs = performance.now() - buildStartedAt
+
+    setStatus("Exporting fixture bytes…")
+    const exportStartedAt = performance.now()
+    const fixtureBytes = fixture.export()
+    const initialExportMs = performance.now() - exportStartedAt
+    fixture.close()
+
+    setStatus(
+      `Importing ${toMiB(fixtureBytes.byteLength).toFixed(1)} MiB into opfs-sahpool and measuring…`
+    )
+    const buffer = fixtureBytes.buffer.slice(
+      fixtureBytes.byteOffset,
+      fixtureBytes.byteOffset + fixtureBytes.byteLength
+    ) as ArrayBuffer
+    const response = await callWorker(
+      {
+        type: "run",
+        scaleName,
+        iterations,
+        expectedSessions: scale.chats,
+        expectedMessages: scale.messages,
+        hasTree: Boolean(scale.tree),
+        bytes: buffer
+      },
+      [buffer]
+    )
+    if (!response.ok) throw new Error(response.error)
+    if (!response.result) throw new Error("Worker returned no result")
+
+    const memoryAfter = sampleMemoryBytes()
+    const result: SpikeScaleResult = {
+      scale: scaleName,
+      chats: scale.chats,
+      messages: scale.messages,
+      iterations,
+      fixtureMiB: toMiB(fixtureBytes.byteLength),
+      fixtureBuildMs,
+      initialExportMs,
+      ...(scale.tree ? { treePlan: scale.tree } : {}),
+      ...response.result,
+      memoryDeltaMiB:
+        memoryBefore !== null && memoryAfter !== null
+          ? toMiB(memoryAfter - memoryBefore)
+          : null,
+      memoryMetric: memoryBefore === null ? null : "page-usedJSHeapSize"
+    }
+
+    output.textContent = JSON.stringify(
+      {
+        measuredAt: new Date().toISOString(),
+        userAgent: navigator.userAgent,
+        topology:
+          "sqlite-wasm opfs-sahpool in one dedicated worker; incremental transactional writes",
+        results: [result]
+      },
+      null,
+      2
+    )
+    copyButton.disabled = false
+    setStatus("Done")
+  } catch (error) {
+    setStatus(`Failed: ${error instanceof Error ? error.message : error}`)
+  } finally {
+    runButton.disabled = false
+  }
+})
+
+copyButton.addEventListener("click", async () => {
+  await navigator.clipboard.writeText(output.textContent ?? "")
+  setStatus("Copied")
+})
+
+cleanupButton.addEventListener("click", async () => {
+  cleanupButton.disabled = true
+  try {
+    const response = await callWorker({ type: "cleanup" })
+    if (!response.ok) throw new Error(response.error)
+    setStatus("Benchmark databases deleted")
+  } catch (error) {
+    setStatus(
+      `Cleanup failed: ${error instanceof Error ? error.message : error}`
+    )
+  } finally {
+    cleanupButton.disabled = false
+  }
+})

--- a/src/entrypoints/spike-opfs/main.ts
+++ b/src/entrypoints/spike-opfs/main.ts
@@ -115,6 +115,7 @@ runButton.addEventListener("click", async () => {
 
   runButton.disabled = true
   copyButton.disabled = true
+  cleanupButton.disabled = true
   output.textContent = ""
   try {
     const memoryBefore = sampleMemoryBytes()
@@ -190,16 +191,22 @@ runButton.addEventListener("click", async () => {
     setStatus(`Failed: ${error instanceof Error ? error.message : error}`)
   } finally {
     runButton.disabled = false
+    cleanupButton.disabled = false
   }
 })
 
 copyButton.addEventListener("click", async () => {
-  await navigator.clipboard.writeText(output.textContent ?? "")
-  setStatus("Copied")
+  try {
+    await navigator.clipboard.writeText(output.textContent ?? "")
+    setStatus("Copied")
+  } catch (error) {
+    setStatus(`Copy failed: ${error instanceof Error ? error.message : error}`)
+  }
 })
 
 cleanupButton.addEventListener("click", async () => {
   cleanupButton.disabled = true
+  runButton.disabled = true
   try {
     const response = await callWorker({ type: "cleanup" })
     if (!response.ok) throw new Error(response.error)
@@ -210,5 +217,6 @@ cleanupButton.addEventListener("click", async () => {
     )
   } finally {
     cleanupButton.disabled = false
+    runButton.disabled = false
   }
 })

--- a/src/entrypoints/spike-owner-offscreen/index.html
+++ b/src/entrypoints/spike-owner-offscreen/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Spike OPFS Owner</title>
+</head>
+<body>
+  <!-- Section 9.4 spike: hidden offscreen document hosting the single
+       SQLite OPFS owner worker. Dev builds only. -->
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/src/entrypoints/spike-owner-offscreen/main.ts
+++ b/src/entrypoints/spike-owner-offscreen/main.ts
@@ -48,7 +48,12 @@ const ensureWorker = (): Worker => {
       if (event.data.ok) entry.resolve(event.data.result)
       else entry.reject(new Error(event.data.error ?? "Unknown worker error"))
     }
-    worker.onerror = () => rejectAllPending("Owner worker crashed")
+    worker.onerror = () => {
+      // Drop the dead worker so the next RPC spawns a fresh generation;
+      // otherwise every later call would hang until the client timeout.
+      worker = null
+      rejectAllPending("Owner worker crashed")
+    }
   }
   return worker
 }

--- a/src/entrypoints/spike-owner-offscreen/main.ts
+++ b/src/entrypoints/spike-owner-offscreen/main.ts
@@ -1,0 +1,94 @@
+import {
+  type OwnerRpcMessage,
+  SPIKE_OWNER_RPC
+} from "@/spike/opfs/owner-protocol"
+
+// Section 9.4 spike phase 2: the offscreen owner document. Hosts the one
+// SQLite worker and answers spike-owner-rpc runtime messages from every
+// other extension context. Nothing else in the extension may open the
+// spike database.
+
+const ownerId = crypto.randomUUID()
+let worker: Worker | null = null
+let workerGeneration = 0
+let requestId = 0
+const pending = new Map<
+  number,
+  {
+    resolve: (value: unknown) => void
+    reject: (reason: Error) => void
+  }
+>()
+
+const rejectAllPending = (reason: string): void => {
+  for (const [id, entry] of pending) {
+    pending.delete(id)
+    entry.reject(new Error(reason))
+  }
+}
+
+const ensureWorker = (): Worker => {
+  if (!worker) {
+    worker = new Worker(
+      new URL("../../spike/opfs/owner-worker.ts", import.meta.url),
+      { type: "module" }
+    )
+    workerGeneration += 1
+    worker.onmessage = (
+      event: MessageEvent<{
+        id: number
+        ok: boolean
+        result?: unknown
+        error?: string
+      }>
+    ) => {
+      const entry = pending.get(event.data.id)
+      if (!entry) return
+      pending.delete(event.data.id)
+      if (event.data.ok) entry.resolve(event.data.result)
+      else entry.reject(new Error(event.data.error ?? "Unknown worker error"))
+    }
+    worker.onerror = () => rejectAllPending("Owner worker crashed")
+  }
+  return worker
+}
+
+const callWorker = (op: string, payload: unknown): Promise<unknown> => {
+  requestId += 1
+  const id = requestId
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject })
+    ensureWorker().postMessage({ id, op, payload })
+  })
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  const rpc = message as OwnerRpcMessage | undefined
+  if (rpc?.type !== SPIKE_OWNER_RPC) return false
+
+  ;(async () => {
+    if (rpc.op === "ownerInfo") {
+      sendResponse({ ok: true, result: { ownerId, workerGeneration } })
+      return
+    }
+    if (rpc.op === "terminateWorker") {
+      // Gate 4/5 hook: simulate a worker crash. Pending calls fail, the next
+      // op spawns a fresh worker generation which must recover from OPFS.
+      worker?.terminate()
+      worker = null
+      rejectAllPending("Owner worker terminated by test")
+      sendResponse({ ok: true, result: { ownerId, workerGeneration } })
+      return
+    }
+    try {
+      const result = await callWorker(rpc.op, rpc.payload)
+      sendResponse({ ok: true, result })
+    } catch (error) {
+      sendResponse({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  })()
+  return true
+})

--- a/src/entrypoints/spike-owner/index.html
+++ b/src/entrypoints/spike-owner/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>OPFS Owner Spike Client</title>
+  <style>
+    body { margin: 24px; font-family: ui-monospace, monospace; max-width: 900px; }
+    h1 { font-size: 18px; }
+    .row { margin: 8px 0; display: flex; gap: 8px; align-items: center; }
+    button { padding: 4px 12px; }
+    #status { color: #666; min-height: 1.2em; }
+    pre { background: #f4f4f5; padding: 12px; overflow-x: auto; white-space: pre-wrap; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #18181b; color: #e4e4e7; }
+      pre { background: #27272a; }
+      #status { color: #a1a1aa; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Section 9.4 spike: single-owner client (dev-only page)</h1>
+  <p>
+    Every button routes through the offscreen owner document via runtime
+    messaging — this page never opens the database. The gate runner
+    (<code>pnpm spike:owner-gates</code>) drives <code>window.__spikeOwner</code>
+    directly; the buttons exist for manual poking.
+  </p>
+  <div class="row">
+    <button id="info" type="button">Owner info</button>
+    <button id="append" type="button">Append message</button>
+    <button id="counts" type="button">Counts</button>
+    <button id="kill-worker" type="button">Terminate worker</button>
+    <button id="close-owner" type="button">Close owner document</button>
+    <button id="reset" type="button">Reset spike tables</button>
+  </div>
+  <p id="status"></p>
+  <pre id="output"></pre>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/src/entrypoints/spike-owner/main.ts
+++ b/src/entrypoints/spike-owner/main.ts
@@ -1,0 +1,106 @@
+import {
+  type OwnerOp,
+  type OwnerRpcResponse,
+  SPIKE_OWNER_CLOSE,
+  SPIKE_OWNER_ENSURE,
+  SPIKE_OWNER_RPC
+} from "@/spike/opfs/owner-protocol"
+
+// Section 9.4 spike phase 2: extension-page client of the single owner.
+// Exposes window.__spikeOwner / window.__spikeOwnerControl for the Playwright
+// gate runner; the buttons are for manual use.
+
+const statusLine = document.getElementById("status") as HTMLParagraphElement
+const output = document.getElementById("output") as HTMLPreElement
+
+const setStatus = (message: string): void => {
+  statusLine.textContent = message
+}
+
+const show = (value: unknown): void => {
+  output.textContent = JSON.stringify(value, null, 2)
+}
+
+const RPC_TIMEOUT_MS = 30_000
+
+const withTimeout = async <T>(work: Promise<T>): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Owner RPC timed out")),
+          RPC_TIMEOUT_MS
+        )
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const ensureOwner = async (): Promise<void> => {
+  const response = (await withTimeout(
+    chrome.runtime.sendMessage({ type: SPIKE_OWNER_ENSURE })
+  )) as OwnerRpcResponse | undefined
+  if (!response) throw new Error("Ensure-owner message dropped")
+  if (!response.ok) throw new Error(response.error)
+}
+
+const ownerRpc = async (op: OwnerOp, payload?: unknown): Promise<unknown> => {
+  await ensureOwner()
+  const response = (await withTimeout(
+    chrome.runtime.sendMessage({ type: SPIKE_OWNER_RPC, op, payload })
+  )) as OwnerRpcResponse | undefined
+  if (!response) throw new Error("Owner RPC message dropped")
+  if (!response.ok) throw new Error(response.error)
+  return response.result
+}
+
+const closeOwner = async (): Promise<unknown> => {
+  const response = (await withTimeout(
+    chrome.runtime.sendMessage({ type: SPIKE_OWNER_CLOSE })
+  )) as OwnerRpcResponse | undefined
+  if (!response) throw new Error("Close-owner message dropped")
+  if (!response.ok) throw new Error(response.error)
+  return response
+}
+
+declare global {
+  interface Window {
+    __spikeOwner: (op: OwnerOp, payload?: unknown) => Promise<unknown>
+    __spikeOwnerControl: {
+      ensure: () => Promise<void>
+      close: () => Promise<unknown>
+    }
+  }
+}
+
+window.__spikeOwner = ownerRpc
+window.__spikeOwnerControl = { ensure: ensureOwner, close: closeOwner }
+
+const wire = (id: string, action: () => Promise<unknown>): void => {
+  const button = document.getElementById(id) as HTMLButtonElement
+  button.addEventListener("click", async () => {
+    button.disabled = true
+    setStatus(`Running ${id}…`)
+    try {
+      show(await action())
+      setStatus("Done")
+    } catch (error) {
+      setStatus(`Failed: ${error instanceof Error ? error.message : error}`)
+    } finally {
+      button.disabled = false
+    }
+  })
+}
+
+wire("info", () => ownerRpc("ownerInfo"))
+wire("append", () =>
+  ownerRpc("append", { writer: "manual", seq: Date.now() % 100000 })
+)
+wire("counts", () => ownerRpc("counts"))
+wire("kill-worker", () => ownerRpc("terminateWorker"))
+wire("close-owner", () => closeOwner())
+wire("reset", () => ownerRpc("reset"))

--- a/src/lib/sqlite/benchmark/persistence-benchmark-core.ts
+++ b/src/lib/sqlite/benchmark/persistence-benchmark-core.ts
@@ -87,7 +87,7 @@ const measure = async (work: () => void | Promise<void>): Promise<number> => {
   return performance.now() - startedAt
 }
 
-const summarize = (samples: number[]): SampleSummary => {
+export const summarize = (samples: number[]): SampleSummary => {
   const sorted = [...samples].sort((left, right) => left - right)
   const percentile = (value: number) =>
     sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * value) - 1)]

--- a/src/spike/opfs/background-owner-host.ts
+++ b/src/spike/opfs/background-owner-host.ts
@@ -1,0 +1,103 @@
+import {
+  SPIKE_OWNER_BG_WRITE,
+  SPIKE_OWNER_CLOSE,
+  SPIKE_OWNER_ENSURE,
+  SPIKE_OWNER_RPC
+} from "./owner-protocol"
+
+// Section 9.4 spike phase 2: background side of the single-owner topology.
+// The service worker never opens the database; it only guarantees that the
+// offscreen owner document exists and can issue writes through it while all
+// visible extension pages are closed (gate 3). Registered from
+// src/background/index.ts behind a dev-only build flag.
+
+const OFFSCREEN_URL = "spike-owner-offscreen.html"
+
+let creating: Promise<void> | null = null
+
+const hasOwnerDocument = async (): Promise<boolean> => {
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: ["OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType]
+  })
+  return contexts.length > 0
+}
+
+const ensureOwner = async (): Promise<void> => {
+  if (await hasOwnerDocument()) return
+  // Chrome allows one offscreen document per extension and rejects concurrent
+  // createDocument calls, so creation is serialized behind one promise.
+  if (!creating) {
+    creating = chrome.offscreen
+      .createDocument({
+        url: OFFSCREEN_URL,
+        reasons: ["WORKERS" as chrome.offscreen.Reason],
+        justification:
+          "Development spike: hosts the single SQLite OPFS owner worker"
+      })
+      .catch((error: unknown) => {
+        // A concurrent path may have created it already.
+        if (!String(error).includes("Only a single offscreen")) throw error
+      })
+      .finally(() => {
+        creating = null
+      })
+  }
+  await creating
+}
+
+// Gate 3: a durable write initiated by background code itself while no
+// extension page is open. This is a direct function (also exposed on
+// globalThis for the gate runner) because chrome.runtime.sendMessage never
+// delivers to the sender's own context — background code cannot message
+// itself, it calls the owner client directly.
+const backgroundWrite = async (payload: unknown): Promise<unknown> => {
+  await ensureOwner()
+  return chrome.runtime.sendMessage({
+    type: SPIKE_OWNER_RPC,
+    op: "upsertCheckpoint",
+    payload
+  })
+}
+
+export const registerSpikeOwnerHost = (): void => {
+  ;(
+    globalThis as {
+      __spikeOwnerBgWrite?: (payload: unknown) => Promise<unknown>
+    }
+  ).__spikeOwnerBgWrite = backgroundWrite
+
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    const type = (message as { type?: string } | undefined)?.type
+
+    if (type === SPIKE_OWNER_ENSURE) {
+      ensureOwner()
+        .then(() => sendResponse({ ok: true }))
+        .catch((error: unknown) =>
+          sendResponse({ ok: false, error: String(error) })
+        )
+      return true
+    }
+
+    if (type === SPIKE_OWNER_CLOSE) {
+      chrome.offscreen
+        .closeDocument()
+        .then(() => sendResponse({ ok: true }))
+        .catch((error: unknown) =>
+          sendResponse({ ok: false, error: String(error) })
+        )
+      return true
+    }
+
+    if (type === SPIKE_OWNER_BG_WRITE) {
+      // Same write, reachable from extension pages via messaging.
+      backgroundWrite((message as { payload?: unknown }).payload)
+        .then((response) => sendResponse(response))
+        .catch((error: unknown) =>
+          sendResponse({ ok: false, error: String(error) })
+        )
+      return true
+    }
+
+    return false
+  })
+}

--- a/src/spike/opfs/owner-protocol.ts
+++ b/src/spike/opfs/owner-protocol.ts
@@ -1,0 +1,49 @@
+// Section 9.4 spike phase 2: wire types for the single-owner topology.
+// Clients (extension pages, background) send runtime messages; the offscreen
+// document owns the only SQLite worker and answers spike-owner-rpc messages.
+// Throwaway spike code: keep it isolated from production modules.
+
+export const SPIKE_OWNER_ENSURE = "spike-owner-ensure"
+export const SPIKE_OWNER_CLOSE = "spike-owner-close"
+export const SPIKE_OWNER_BG_WRITE = "spike-owner-bg-write"
+export const SPIKE_OWNER_RPC = "spike-owner-rpc"
+
+export type OwnerOp =
+  | "ownerInfo"
+  | "terminateWorker"
+  | "append"
+  | "counts"
+  | "upsertCheckpoint"
+  | "readCheckpoint"
+  | "beginHang"
+  | "reset"
+
+export interface OwnerRpcMessage {
+  type: typeof SPIKE_OWNER_RPC
+  op: OwnerOp
+  payload?: unknown
+}
+
+export interface AppendPayload {
+  writer: string
+  seq: number
+}
+
+export interface CheckpointPayload {
+  requestId: string
+  state: string
+}
+
+export interface CountsResult {
+  total: number
+  byWriter: Record<string, number>
+}
+
+export interface OwnerInfoResult {
+  ownerId: string
+  workerGeneration: number
+}
+
+export type OwnerRpcResponse =
+  | { ok: true; result: unknown }
+  | { ok: false; error: string }

--- a/src/spike/opfs/owner-worker.ts
+++ b/src/spike/opfs/owner-worker.ts
@@ -1,0 +1,179 @@
+/// <reference lib="webworker" />
+import sqlite3InitModule, {
+  type Database,
+  type SAHPoolUtil,
+  type Sqlite3Static
+} from "@sqlite.org/sqlite-wasm"
+import sqliteWasmUrl from "@sqlite.org/sqlite-wasm/sqlite3.wasm?url"
+import type {
+  AppendPayload,
+  CheckpointPayload,
+  CountsResult,
+  OwnerOp
+} from "./owner-protocol"
+
+// Section 9.4 spike phase 2: the single database-owner worker. Hosted by the
+// offscreen document only — no other context may open this database. The
+// database handle stays open for the worker's lifetime; a terminated worker
+// mid-transaction must roll back via the journal on the next open (gate 5).
+
+const DB_PATH = "/spike-owner.sqlite"
+
+const SPIKE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS spike_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  writer TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  timestamp INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS spike_checkpoints (
+  requestId TEXT PRIMARY KEY,
+  state TEXT NOT NULL,
+  updatedAt INTEGER NOT NULL
+);
+`
+
+interface WorkerRequest {
+  id: number
+  op: OwnerOp
+  payload?: unknown
+}
+
+let dbPromise: Promise<Database> | null = null
+
+const openDatabase = (): Promise<Database> => {
+  if (!dbPromise) {
+    dbPromise = (async () => {
+      // The published typings declare init() without arguments, but the
+      // runtime accepts an Emscripten module config; locateFile is required
+      // so the bundled wasm asset resolves inside the worker chunk.
+      const sqlite3 = await (
+        sqlite3InitModule as unknown as (config: {
+          locateFile: () => string
+          print: (message: string) => void
+          printErr: (message: string) => void
+        }) => Promise<Sqlite3Static>
+      )({
+        locateFile: () => sqliteWasmUrl,
+        print: () => {},
+        printErr: (message: string) => console.error("[sqlite3]", message)
+      })
+      const pool: SAHPoolUtil = await sqlite3.installOpfsSAHPoolVfs({
+        // Distinct pool/directory from the phase-1 measurement worker so the
+        // two spikes never contend for the same SAH handles.
+        name: "spike-owner-pool",
+        initialCapacity: 6
+      })
+      const db = new pool.OpfsSAHPoolDb(DB_PATH)
+      db.exec(SPIKE_SCHEMA)
+      return db
+    })()
+  }
+  return dbPromise
+}
+
+const queryNumber = (db: Database, sql: string): number => {
+  let value = 0
+  db.exec({
+    sql,
+    callback: (row) => {
+      value = Number((row as unknown[])[0])
+    }
+  })
+  return value
+}
+
+const counts = (db: Database): CountsResult => {
+  const byWriter: Record<string, number> = {}
+  db.exec({
+    sql: "SELECT writer, COUNT(*) FROM spike_messages GROUP BY writer",
+    callback: (row) => {
+      const [writer, count] = row as unknown[]
+      byWriter[String(writer)] = Number(count)
+    }
+  })
+  return {
+    total: queryNumber(db, "SELECT COUNT(*) FROM spike_messages"),
+    byWriter
+  }
+}
+
+const handle = async (op: OwnerOp, payload: unknown): Promise<unknown> => {
+  const db = await openDatabase()
+
+  switch (op) {
+    case "append": {
+      const { writer, seq } = payload as AppendPayload
+      db.exec({
+        sql: `INSERT INTO spike_messages (writer, seq, content, timestamp)
+              VALUES (?, ?, ?, ?)`,
+        bind: [writer, seq, `message ${writer}#${seq}`, Date.now()]
+      })
+      return counts(db)
+    }
+    case "counts":
+      return counts(db)
+    case "upsertCheckpoint": {
+      const { requestId, state } = payload as CheckpointPayload
+      const updatedAt = Date.now()
+      db.exec({
+        sql: `INSERT OR REPLACE INTO spike_checkpoints (requestId, state, updatedAt)
+              VALUES (?, ?, ?)`,
+        bind: [requestId, state, updatedAt]
+      })
+      return { updatedAt }
+    }
+    case "readCheckpoint": {
+      const { requestId } = payload as { requestId: string }
+      let checkpoint: { state: string; updatedAt: number } | null = null
+      db.exec({
+        sql: "SELECT state, updatedAt FROM spike_checkpoints WHERE requestId = ?",
+        bind: [requestId],
+        callback: (row) => {
+          const [state, updatedAt] = row as unknown[]
+          checkpoint = { state: String(state), updatedAt: Number(updatedAt) }
+        }
+      })
+      return checkpoint
+    }
+    case "beginHang": {
+      // Gate 5 setup: leave an uncommitted transaction open. The driver then
+      // terminates this worker; the journal must roll the insert back when
+      // the next worker generation reopens the database.
+      db.exec("BEGIN IMMEDIATE")
+      db.exec({
+        sql: `INSERT INTO spike_messages (writer, seq, content, timestamp)
+              VALUES (?, ?, ?, ?)`,
+        bind: ["hanging-txn", 0, "must roll back", Date.now()]
+      })
+      return { uncommittedTotal: counts(db).total }
+    }
+    case "reset": {
+      try {
+        db.exec("ROLLBACK")
+      } catch {
+        // no open transaction
+      }
+      db.exec("DELETE FROM spike_messages")
+      db.exec("DELETE FROM spike_checkpoints")
+      return counts(db)
+    }
+    default:
+      throw new Error(`Unknown owner op: ${op}`)
+  }
+}
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const { id, op, payload } = event.data
+  try {
+    const result = await handle(op, payload)
+    self.postMessage({ id, ok: true, result })
+  } catch (error) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}

--- a/src/spike/opfs/owner-worker.ts
+++ b/src/spike/opfs/owner-worker.ts
@@ -164,8 +164,8 @@ const handle = async (op: OwnerOp, payload: unknown): Promise<unknown> => {
   }
 }
 
-self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const { id, op, payload } = event.data
+const processRequest = async (request: WorkerRequest): Promise<void> => {
+  const { id, op, payload } = request
   try {
     const result = await handle(op, payload)
     self.postMessage({ id, ok: true, result })
@@ -176,4 +176,13 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       error: error instanceof Error ? error.message : String(error)
     })
   }
+}
+
+// The owner serializes all database operations through one chain — async
+// handlers would otherwise interleave at await points and break the
+// single-writer ordering the topology exists to guarantee.
+let operationChain: Promise<void> = Promise.resolve()
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  operationChain = operationChain.then(() => processRequest(event.data))
 }

--- a/src/spike/opfs/protocol.ts
+++ b/src/spike/opfs/protocol.ts
@@ -1,0 +1,58 @@
+import type {
+  SampleSummary,
+  ScaleName,
+  TreePlan
+} from "@/lib/sqlite/benchmark/persistence-benchmark-core"
+
+// Section 9.4 spike wire types between the spike page and the dedicated
+// sqlite-wasm opfs-sahpool worker. Throwaway spike code: keep it isolated
+// from production modules.
+
+export interface SpikeRunRequest {
+  id: number
+  type: "run"
+  scaleName: ScaleName
+  iterations: number
+  expectedSessions: number
+  expectedMessages: number
+  hasTree: boolean
+  // sql.js-exported database bytes; transferred, not copied.
+  bytes: ArrayBuffer
+}
+
+export interface SpikeCleanupRequest {
+  id: number
+  type: "cleanup"
+}
+
+export type SpikeRequest = SpikeRunRequest | SpikeCleanupRequest
+
+export interface SpikeWorkerResult {
+  importDbMs: number
+  importedBytes: number
+  rowCountsOk: boolean
+  journalMode: string
+  coldOpenMs: SampleSummary
+  first50SessionsMs: SampleSummary
+  warm50MessagesMs: SampleSummary
+  activePath50Ms?: SampleSummary
+  durableAppendMs: SampleSummary
+  checkpointChurn20Ms: SampleSummary
+}
+
+export interface SpikeScaleResult extends SpikeWorkerResult {
+  scale: ScaleName
+  chats: number
+  messages: number
+  iterations: number
+  fixtureMiB: number
+  fixtureBuildMs: number
+  initialExportMs: number
+  treePlan?: TreePlan
+  memoryDeltaMiB: number | null
+  memoryMetric: string | null
+}
+
+export type SpikeResponse =
+  | { id: number; ok: true; result?: SpikeWorkerResult }
+  | { id: number; ok: false; error: string }

--- a/src/spike/opfs/sahpool-worker.ts
+++ b/src/spike/opfs/sahpool-worker.ts
@@ -1,0 +1,247 @@
+/// <reference lib="webworker" />
+import sqlite3InitModule, {
+  type Database,
+  type SAHPoolUtil,
+  type Sqlite3Static
+} from "@sqlite.org/sqlite-wasm"
+import sqliteWasmUrl from "@sqlite.org/sqlite-wasm/sqlite3.wasm?url"
+import {
+  ACTIVE_PATH_SQL,
+  summarize
+} from "@/lib/sqlite/benchmark/persistence-benchmark-core"
+import type {
+  SpikeRequest,
+  SpikeResponse,
+  SpikeRunRequest,
+  SpikeWorkerResult
+} from "./protocol"
+
+// Section 9.4 spike: official sqlite-wasm with the opfs-sahpool VFS inside
+// one dedicated worker. This measures the candidate persistence topology's
+// physical import and incremental durable writes — the two properties the
+// current full-blob sql.js topology lacks.
+
+const DB_PATH = "/spike-benchmark.sqlite"
+const CHECKPOINT_BATCH = 20
+
+const measure = async (work: () => void | Promise<void>): Promise<number> => {
+  const startedAt = performance.now()
+  await work()
+  return performance.now() - startedAt
+}
+
+let sqlitePromise: Promise<{
+  sqlite3: Sqlite3Static
+  pool: SAHPoolUtil
+}> | null = null
+
+const initSqlite = (): NonNullable<typeof sqlitePromise> => {
+  if (!sqlitePromise) {
+    sqlitePromise = (async () => {
+      // The published typings declare init() without arguments, but the
+      // runtime accepts an Emscripten module config; locateFile is required
+      // here so the bundled wasm asset resolves inside the worker chunk.
+      const sqlite3 = await (
+        sqlite3InitModule as unknown as (config: {
+          locateFile: () => string
+          print: (message: string) => void
+          printErr: (message: string) => void
+        }) => Promise<Sqlite3Static>
+      )({
+        locateFile: () => sqliteWasmUrl,
+        print: () => {},
+        printErr: (message: string) => console.error("[sqlite3]", message)
+      })
+      const pool = await sqlite3.installOpfsSAHPoolVfs({
+        name: "spike-opfs-sahpool",
+        // 1 database + journal/temp headroom, per upstream guidance.
+        initialCapacity: 6
+      })
+      return { sqlite3, pool }
+    })()
+  }
+  return sqlitePromise
+}
+
+const queryNumber = (db: Database, sql: string): number => {
+  let value = 0
+  db.exec({
+    sql,
+    callback: (row) => {
+      value = Number((row as unknown[])[0])
+    }
+  })
+  return value
+}
+
+const queryString = (db: Database, sql: string): string => {
+  let value = ""
+  db.exec({
+    sql,
+    callback: (row) => {
+      value = String((row as unknown[])[0])
+    }
+  })
+  return value
+}
+
+const runBenchmark = async (
+  request: SpikeRunRequest
+): Promise<SpikeWorkerResult> => {
+  const { pool } = await initSqlite()
+  const bytes = new Uint8Array(request.bytes)
+
+  pool.unlink(DB_PATH)
+  let importedBytes = 0
+  const importDbMs = await measure(async () => {
+    importedBytes = await pool.importDb(DB_PATH, bytes)
+  })
+
+  const openDb = (): Database => new pool.OpfsSAHPoolDb(DB_PATH)
+
+  let db = openDb()
+  const journalMode = queryString(db, "PRAGMA journal_mode")
+  const rowCountsOk =
+    queryNumber(db, "SELECT COUNT(*) FROM sessions") ===
+      request.expectedSessions &&
+    queryNumber(db, "SELECT COUNT(*) FROM messages") ===
+      request.expectedMessages
+  db.close()
+
+  const coldOpenSamples: number[] = []
+  const firstSessionPageSamples: number[] = []
+  const warmMessagePageSamples: number[] = []
+  const activePathSamples: number[] = []
+  const durableAppendSamples: number[] = []
+  const checkpointChurnSamples: number[] = []
+
+  // One warm-up run is intentionally excluded from reported percentiles,
+  // matching the sql.js benchmark protocol.
+  for (let iteration = -1; iteration < request.iterations; iteration += 1) {
+    let coldDb: Database | undefined
+    const coldOpenMs = await measure(() => {
+      coldDb = openDb()
+    })
+    if (!coldDb) throw new Error("Cold database open failed")
+    db = coldDb
+
+    const firstSessionPageMs = await measure(() => {
+      db.exec(
+        "SELECT id, title, updatedAt FROM sessions ORDER BY updatedAt DESC LIMIT 50"
+      )
+    })
+    const warmMessagePageMs = await measure(() => {
+      db.exec(
+        `SELECT id, role, content, timestamp FROM messages
+         WHERE sessionId = 'benchmark-chat-0'
+         ORDER BY timestamp DESC LIMIT 50`
+      )
+    })
+    let activePathMs = 0
+    if (request.hasTree) {
+      activePathMs = await measure(() => {
+        db.exec(ACTIVE_PATH_SQL)
+      })
+    }
+
+    // Incremental durable append: one row inside one transaction. No full
+    // database export happens anywhere in this path.
+    const durableAppendMs = await measure(() => {
+      db.exec({
+        sql: `INSERT INTO messages (sessionId, role, content, model, timestamp)
+              VALUES (?, ?, ?, ?, ?)`,
+        bind: [
+          "benchmark-chat-0",
+          "user",
+          "durable append",
+          "benchmark-model",
+          Date.now()
+        ]
+      })
+    })
+    db.exec({
+      sql: "DELETE FROM messages WHERE content = ?",
+      bind: ["durable append"]
+    })
+
+    // Streaming-checkpoint churn: repeated upserts of one tool-loop row,
+    // the doc's "repeated assistant-stream checkpoint update" measure.
+    const checkpointState = JSON.stringify({
+      step: "stream",
+      buffer: "y".repeat(2_048)
+    })
+    const checkpointChurnMs = await measure(() => {
+      for (let update = 0; update < CHECKPOINT_BATCH; update += 1) {
+        db.exec({
+          sql: `INSERT OR REPLACE INTO tool_loop_runs
+                (requestId, sessionId, model, providerId, mode, status, state, updatedAt)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          bind: [
+            "spike-checkpoint",
+            "benchmark-chat-0",
+            "benchmark-model",
+            "ollama",
+            "native",
+            "streaming",
+            checkpointState,
+            Date.now() + update
+          ]
+        })
+      }
+    })
+    db.exec({
+      sql: "DELETE FROM tool_loop_runs WHERE requestId = ?",
+      bind: ["spike-checkpoint"]
+    })
+    db.close()
+
+    if (iteration >= 0) {
+      coldOpenSamples.push(coldOpenMs)
+      firstSessionPageSamples.push(firstSessionPageMs)
+      warmMessagePageSamples.push(warmMessagePageMs)
+      if (request.hasTree) activePathSamples.push(activePathMs)
+      durableAppendSamples.push(durableAppendMs)
+      checkpointChurnSamples.push(checkpointChurnMs)
+    }
+  }
+
+  pool.unlink(DB_PATH)
+
+  return {
+    importDbMs,
+    importedBytes,
+    rowCountsOk,
+    journalMode,
+    coldOpenMs: summarize(coldOpenSamples),
+    first50SessionsMs: summarize(firstSessionPageSamples),
+    warm50MessagesMs: summarize(warmMessagePageSamples),
+    ...(request.hasTree
+      ? { activePath50Ms: summarize(activePathSamples) }
+      : {}),
+    durableAppendMs: summarize(durableAppendSamples),
+    checkpointChurn20Ms: summarize(checkpointChurnSamples)
+  }
+}
+
+self.onmessage = async (event: MessageEvent<SpikeRequest>) => {
+  const request = event.data
+  try {
+    if (request.type === "run") {
+      const result = await runBenchmark(request)
+      const response: SpikeResponse = { id: request.id, ok: true, result }
+      self.postMessage(response)
+      return
+    }
+    const { pool } = await initSqlite()
+    await pool.wipeFiles()
+    const response: SpikeResponse = { id: request.id, ok: true }
+    self.postMessage(response)
+  } catch (error) {
+    const response: SpikeResponse = {
+      id: request.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    }
+    self.postMessage(response)
+  }
+}

--- a/src/spike/opfs/sahpool-worker.ts
+++ b/src/spike/opfs/sahpool-worker.ts
@@ -223,8 +223,7 @@ const runBenchmark = async (
   }
 }
 
-self.onmessage = async (event: MessageEvent<SpikeRequest>) => {
-  const request = event.data
+const processRequest = async (request: SpikeRequest): Promise<void> => {
   try {
     if (request.type === "run") {
       const result = await runBenchmark(request)
@@ -244,4 +243,13 @@ self.onmessage = async (event: MessageEvent<SpikeRequest>) => {
     }
     self.postMessage(response)
   }
+}
+
+// Async handlers interleave at await points, so requests are serialized
+// through one chain: a cleanup arriving mid-run must not wipeFiles() under
+// the active database connection.
+let operationChain: Promise<void> = Promise.resolve()
+
+self.onmessage = (event: MessageEvent<SpikeRequest>) => {
+  operationChain = operationChain.then(() => processRequest(event.data))
 }

--- a/src/types/vendor.d.ts
+++ b/src/types/vendor.d.ts
@@ -47,3 +47,10 @@ declare module "pdfjs-dist/build/pdf.worker.min.mjs" {
   const worker: unknown
   export default worker
 }
+
+// Vite `?url` asset import for the official SQLite WASM binary, used by the
+// section 9.4 OPFS spike worker.
+declare module "@sqlite.org/sqlite-wasm/sqlite3.wasm?url" {
+  const url: string
+  export default url
+}

--- a/src/types/vendor.d.ts
+++ b/src/types/vendor.d.ts
@@ -54,3 +54,7 @@ declare module "@sqlite.org/sqlite-wasm/sqlite3.wasm?url" {
   const url: string
   export default url
 }
+
+// Compile-time flag defined in wxt.config.ts vite `define`; true only for
+// WXT_BENCHMARK=1 builds that carry the section 9.4 spike owner host.
+declare const __SPIKE_OPFS_OWNER__: boolean

--- a/tools/benchmark-browser-persistence.ts
+++ b/tools/benchmark-browser-persistence.ts
@@ -36,6 +36,7 @@ interface CliOptions {
   scales: string[]
   iterations: number
   headful: boolean
+  page: string
 }
 
 const parseArgs = (): CliOptions => {
@@ -61,6 +62,11 @@ const parseArgs = (): CliOptions => {
     throw new Error("--iterations must be a positive integer")
   }
 
+  const page = argValue("page") ?? "benchmark.html"
+  if (!["benchmark.html", "spike-opfs.html"].includes(page)) {
+    throw new Error("--page must be benchmark.html or spike-opfs.html")
+  }
+
   return {
     browsers:
       browserArgument === "all"
@@ -68,7 +74,8 @@ const parseArgs = (): CliOptions => {
         : [browserArgument as "chromium" | "firefox"],
     scales,
     iterations,
-    headful: process.argv.includes("--headful")
+    headful: process.argv.includes("--headful"),
+    page
   }
 }
 
@@ -168,9 +175,9 @@ const resolveChromiumExtensionId = async (
 }
 
 const runChromium = async (options: CliOptions): Promise<unknown[]> => {
-  if (!existsSync(resolve(chromeBuildPath, "benchmark.html"))) {
+  if (!existsSync(resolve(chromeBuildPath, options.page))) {
     throw new Error(
-      `Missing ${chromeBuildPath}/benchmark.html — run: pnpm benchmark:build`
+      `Missing ${chromeBuildPath}/${options.page} — run: pnpm benchmark:build`
     )
   }
   const userDataDir = mkdtempSync(`${tmpdir()}/ollama-client-benchmark-`)
@@ -185,7 +192,7 @@ const runChromium = async (options: CliOptions): Promise<unknown[]> => {
     const extensionId = await resolveChromiumExtensionId(context, userDataDir)
     console.error(`[chromium] extension id: ${extensionId}`)
     const page = await context.newPage()
-    await page.goto(`chrome-extension://${extensionId}/benchmark.html`)
+    await page.goto(`chrome-extension://${extensionId}/${options.page}`)
     return await runScalesOnPage(
       page,
       options.scales,
@@ -238,16 +245,16 @@ const startStaticServer = async (
 }
 
 const runFirefox = async (options: CliOptions): Promise<unknown[]> => {
-  if (!existsSync(resolve(firefoxBuildPath, "benchmark.html"))) {
+  if (!existsSync(resolve(firefoxBuildPath, options.page))) {
     throw new Error(
-      `Missing ${firefoxBuildPath}/benchmark.html — run: pnpm benchmark:build:firefox`
+      `Missing ${firefoxBuildPath}/${options.page} — run: pnpm benchmark:build:firefox`
     )
   }
   const server = await startStaticServer(firefoxBuildPath)
   const browser = await firefox.launch({ headless: !options.headful })
   try {
     const page = await browser.newPage()
-    await page.goto(`${server.origin}/benchmark.html`)
+    await page.goto(`${server.origin}/${options.page}`)
     return await runScalesOnPage(
       page,
       options.scales,

--- a/tools/spike-owner-gates.ts
+++ b/tools/spike-owner-gates.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+// Section 9.4 spike phase 2: drives the single-owner topology gates in real
+// packaged Chromium (unpacked MV3 extension, real chrome-extension:// origin).
+//
+// Gates exercised (numbering from PRIVATE_ARCHITECTURE_REBUILD_PLAN.md 9.4):
+//   2. Two extension pages issue concurrent repository commands through the
+//      one owner with no lost update.
+//   3. Background durably writes and rereads a checkpoint while all visible
+//      extension pages are closed.
+//   4. Owner-document close and SQLite-worker termination recover on the next
+//      call without manual reload, preserving durable state.
+//   5. A worker terminated inside an open transaction rolls back to the
+//      pre-transaction state on the next worker generation.
+//
+// Not covered here: forced service-worker termination and full browser
+// restart (manual), packaged Firefox (offscreen API is Chromium-only).
+//
+// Usage: pnpm spike:owner-gates [--headful]
+// Requires: pnpm benchmark:build
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+import { chromium } from "playwright"
+import type { BrowserContext, Page, Worker as PlaywrightWorker } from "playwright"
+
+const chromeBuildPath = resolve("build/chrome-mv3-benchmark")
+const artifactDir = resolve("artifacts/persistence-benchmark")
+const headful = process.argv.includes("--headful")
+
+interface GateResult {
+  gate: string
+  pass: boolean
+  detail: Record<string, unknown>
+}
+
+const results: GateResult[] = []
+
+const record = (
+  gate: string,
+  pass: boolean,
+  detail: Record<string, unknown>
+): void => {
+  results.push({ gate, pass, detail })
+  console.error(`${pass ? "PASS" : "FAIL"} ${gate}`)
+  if (!pass) console.error(JSON.stringify(detail, null, 2))
+}
+
+const findFileRecursive = (dir: string, targetName: string): string => {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = resolve(dir, entry)
+    const stats = statSync(fullPath)
+    if (stats.isFile() && entry === targetName) return fullPath
+    if (stats.isDirectory()) {
+      const found = findFileRecursive(fullPath, targetName)
+      if (found) return found
+    }
+  }
+  return ""
+}
+
+const resolveExtensionId = async (
+  context: BrowserContext,
+  userDataDir: string
+): Promise<string> => {
+  let [serviceWorker] = context.serviceWorkers()
+  if (!serviceWorker) {
+    try {
+      serviceWorker = await context.waitForEvent("serviceworker", {
+        timeout: 10000
+      })
+    } catch {
+      // fall through
+    }
+  }
+  if (serviceWorker) return new URL(serviceWorker.url()).host
+
+  await new Promise((resolvePause) => setTimeout(resolvePause, 1500))
+  for (const fileName of ["Preferences", "Secure Preferences"]) {
+    const preferencesPath = findFileRecursive(userDataDir, fileName)
+    if (!preferencesPath) continue
+    const preferences = JSON.parse(readFileSync(preferencesPath, "utf8")) as {
+      extensions?: { settings?: Record<string, { path?: string }> }
+    }
+    for (const [id, value] of Object.entries(
+      preferences?.extensions?.settings ?? {}
+    )) {
+      if (value?.path === chromeBuildPath) return id
+    }
+  }
+  throw new Error("Failed to resolve Chromium extension id")
+}
+
+const getServiceWorker = async (
+  context: BrowserContext
+): Promise<PlaywrightWorker> => {
+  const [existing] = context.serviceWorkers()
+  if (existing) return existing
+  return context.waitForEvent("serviceworker", { timeout: 15000 })
+}
+
+type Rpc = (op: string, payload?: unknown) => Promise<unknown>
+
+const pageRpc =
+  (page: Page): Rpc =>
+  (op, payload) =>
+    page.evaluate(
+      ([opName, opPayload]) =>
+        (
+          window as unknown as {
+            __spikeOwner: (op: string, payload?: unknown) => Promise<unknown>
+          }
+        ).__spikeOwner(opName as string, opPayload),
+      [op, payload]
+    )
+
+const runGates = async (visible: boolean): Promise<void> => {
+  if (!existsSync(resolve(chromeBuildPath, "spike-owner.html"))) {
+    throw new Error(
+      `Missing ${chromeBuildPath}/spike-owner.html — run: pnpm benchmark:build`
+    )
+  }
+
+  const userDataDir = mkdtempSync(`${tmpdir()}/ollama-client-spike-owner-`)
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: !visible,
+    args: [
+      `--disable-extensions-except=${chromeBuildPath}`,
+      `--load-extension=${chromeBuildPath}`
+    ]
+  })
+
+  try {
+    const extensionId = await resolveExtensionId(context, userDataDir)
+    console.error(`[gates] extension id: ${extensionId}`)
+    const ownerPageUrl = `chrome-extension://${extensionId}/spike-owner.html`
+
+    const pageA = await context.newPage()
+    await pageA.goto(ownerPageUrl)
+    const rpcA = pageRpc(pageA)
+
+    await rpcA("reset")
+    const info = (await rpcA("ownerInfo")) as {
+      ownerId: string
+      workerGeneration: number
+    }
+
+    // ---- Gate 2: concurrent writers through one owner, no lost update ----
+    const pageB = await context.newPage()
+    await pageB.goto(ownerPageUrl)
+    const rpcB = pageRpc(pageB)
+
+    const APPENDS = 100
+    const appendMany = (page: Page, writer: string) =>
+      page.evaluate(
+        async ([writerName, total]) => {
+          const owner = (
+            window as unknown as {
+              __spikeOwner: (op: string, payload?: unknown) => Promise<unknown>
+            }
+          ).__spikeOwner
+          for (let seq = 0; seq < (total as number); seq += 1) {
+            await owner("append", { writer: writerName, seq })
+          }
+        },
+        [writer, APPENDS]
+      )
+
+    await Promise.all([appendMany(pageA, "writer-a"), appendMany(pageB, "writer-b")])
+    const gate2Counts = (await rpcA("counts")) as {
+      total: number
+      byWriter: Record<string, number>
+    }
+    record(
+      "gate2-concurrent-writers",
+      gate2Counts.total === APPENDS * 2 &&
+        gate2Counts.byWriter["writer-a"] === APPENDS &&
+        gate2Counts.byWriter["writer-b"] === APPENDS,
+      { expected: APPENDS * 2, ...gate2Counts }
+    )
+
+    // ---- Gate 3: background write with every visible page closed ----
+    await pageA.close()
+    await pageB.close()
+    const serviceWorker = await getServiceWorker(context)
+    const checkpointState = JSON.stringify({ step: "bg-write", at: Date.now() })
+    // Background code calls the owner client directly — runtime messages are
+    // never delivered back to the sending context, so a SW cannot message
+    // itself the way pages do.
+    const bgWrite = (await serviceWorker.evaluate(
+      async ([state]) =>
+        (
+          globalThis as unknown as {
+            __spikeOwnerBgWrite: (payload: unknown) => Promise<unknown>
+          }
+        ).__spikeOwnerBgWrite({ requestId: "gate3-checkpoint", state }),
+      [checkpointState]
+    )) as { ok: boolean; error?: string } | undefined
+
+    const pageC = await context.newPage()
+    await pageC.goto(ownerPageUrl)
+    const rpcC = pageRpc(pageC)
+    const rereadRaw = await rpcC("readCheckpoint", {
+      requestId: "gate3-checkpoint"
+    })
+    const reread = rereadRaw as { state: string } | null
+    record(
+      "gate3-background-write-pages-closed",
+      Boolean(bgWrite?.ok) && reread?.state === checkpointState,
+      { bgWrite, rereadState: reread?.state?.slice(0, 80) ?? null }
+    )
+
+    // ---- Gate 4a: SQLite worker termination recovers, state durable ----
+    const beforeKill = (await rpcC("counts")) as { total: number }
+    await rpcC("terminateWorker")
+    const afterKill = (await rpcC("counts")) as { total: number }
+    const infoAfterKill = (await rpcC("ownerInfo")) as {
+      ownerId: string
+      workerGeneration: number
+    }
+    record(
+      "gate4a-worker-termination-recovery",
+      afterKill.total === beforeKill.total &&
+        infoAfterKill.workerGeneration === info.workerGeneration + 1 &&
+        infoAfterKill.ownerId === info.ownerId,
+      { beforeKill, afterKill, info, infoAfterKill }
+    )
+
+    // ---- Gate 4b: owner-document close recovers, state durable ----
+    await pageC.evaluate(() =>
+      (
+        window as unknown as {
+          __spikeOwnerControl: { close: () => Promise<unknown> }
+        }
+      ).__spikeOwnerControl.close()
+    )
+    const afterClose = (await rpcC("counts")) as { total: number }
+    const infoAfterClose = (await rpcC("ownerInfo")) as {
+      ownerId: string
+      workerGeneration: number
+    }
+    record(
+      "gate4b-owner-close-recovery",
+      afterClose.total === beforeKill.total &&
+        infoAfterClose.ownerId !== info.ownerId,
+      { afterClose, previousOwner: info.ownerId, newOwner: infoAfterClose.ownerId }
+    )
+
+    // ---- Gate 5: kill worker inside an open transaction; must roll back ----
+    const preHang = (await rpcC("counts")) as { total: number }
+    const hang = (await rpcC("beginHang")) as { uncommittedTotal: number }
+    await rpcC("terminateWorker")
+    const postCrash = (await rpcC("counts")) as { total: number }
+    record(
+      "gate5-transaction-rollback-on-crash",
+      hang.uncommittedTotal === preHang.total + 1 &&
+        postCrash.total === preHang.total,
+      { preHang, hang, postCrash }
+    )
+
+    await rpcC("reset")
+    await pageC.close()
+  } finally {
+    await context.close()
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+const main = async (): Promise<void> => {
+  try {
+    await runGates(headful)
+  } catch (error) {
+    if (
+      headful ||
+      !String(error).includes("Failed to resolve Chromium extension id")
+    ) {
+      throw error
+    }
+    // Headless MV3 service workers can stay lazy; retry once visibly.
+    console.error("[gates] headless bootstrap failed, retrying headful")
+    results.length = 0
+    await runGates(true)
+  }
+
+  const report = {
+    measuredAt: new Date().toISOString(),
+    topology:
+      "MV3 offscreen document owning one sqlite-wasm opfs-sahpool worker; runtime-message RPC",
+    results
+  }
+  mkdirSync(artifactDir, { recursive: true })
+  const outputPath = resolve(artifactDir, `spike-owner-gates-${Date.now()}.json`)
+  writeFileSync(outputPath, JSON.stringify(report, null, 2))
+  console.error(`Report written: ${outputPath}`)
+  console.log(JSON.stringify(report, null, 2))
+
+  if (results.some((result) => !result.pass)) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,17 +22,19 @@ export default defineConfig({
       )
       if (promoIndex !== -1) files.splice(promoIndex, 1)
     },
-    // The persistence benchmark page is a dev tool for the section 9.8
-    // browser measurements. Keep it out of store packages: it only builds in
-    // dev mode or when WXT_BENCHMARK=1 is set explicitly.
+    // The persistence benchmark and OPFS spike pages are dev tools for the
+    // section 9.8/9.4 browser measurements. Keep them out of store packages:
+    // they only build in dev mode or when WXT_BENCHMARK=1 is set explicitly.
     "entrypoints:resolved": (wxt, entrypoints) => {
       const includeBenchmark =
         wxt.config.command === "serve" || process.env.WXT_BENCHMARK === "1"
       if (includeBenchmark) return
-      const benchmarkIndex = entrypoints.findIndex(
-        (entrypoint) => entrypoint.name === "benchmark"
-      )
-      if (benchmarkIndex !== -1) entrypoints.splice(benchmarkIndex, 1)
+      for (const name of ["benchmark", "spike-opfs"]) {
+        const index = entrypoints.findIndex(
+          (entrypoint) => entrypoint.name === name
+        )
+        if (index !== -1) entrypoints.splice(index, 1)
+      }
     }
   },
   manifest: ({ browser }) => ({

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -29,7 +29,12 @@ export default defineConfig({
       const includeBenchmark =
         wxt.config.command === "serve" || process.env.WXT_BENCHMARK === "1"
       if (includeBenchmark) return
-      for (const name of ["benchmark", "spike-opfs"]) {
+      for (const name of [
+        "benchmark",
+        "spike-opfs",
+        "spike-owner",
+        "spike-owner-offscreen"
+      ]) {
         const index = entrypoints.findIndex(
           (entrypoint) => entrypoint.name === name
         )
@@ -71,7 +76,12 @@ export default defineConfig({
       "tabs",
       "scripting",
       "contextMenus",
-      ...(browser === "firefox" ? [] : ["sidePanel", "declarativeNetRequest"])
+      ...(browser === "firefox" ? [] : ["sidePanel", "declarativeNetRequest"]),
+      // Dev-only: the section 9.4 spike's offscreen owner document. Never in
+      // store packages — gated by the same flag as the spike entrypoints.
+      ...(browser !== "firefox" && process.env.WXT_BENCHMARK === "1"
+        ? ["offscreen"]
+        : [])
     ],
     // Optional API permissions requested from the Permissions UI.
     // Declared so they can be requested at runtime via src/lib/permissions.ts;
@@ -122,6 +132,12 @@ export default defineConfig({
 
   vite: () =>
     ({
+      // Compile-time flag for the dev-only section 9.4 spike host in the
+      // background entry; false in store builds so the branch and its
+      // dynamic import are dead-code eliminated.
+      define: {
+        __SPIKE_OPFS_OWNER__: JSON.stringify(process.env.WXT_BENCHMARK === "1")
+      },
       plugins: [
         react({
           babel: {


### PR DESCRIPTION
## Summary

Section 9.4 spike, **phase 1** (stacked on #184 — merge that first; GitHub will retarget this to main).

Official `@sqlite.org/sqlite-wasm` (3.53.0-build1) behind the `opfs-sahpool` VFS in one dedicated module worker, driven by a dev-gated `spike-opfs.html` page through the existing Playwright harness:

```
pnpm benchmark:build && pnpm benchmark:build:firefox
pnpm benchmark:browser --page=spike-opfs.html --scales=small,medium,binary,tree --iterations=3
```

The page builds the section 9.8 fixtures with sql.js, transfers the exported bytes to the worker, which **physically imports them via `poolUtil.importDb`** (session/message row counts verified — gate 1 evidence) and measures cold open, page queries, incremental durable append, and streaming-checkpoint churn (20 tool-loop upserts, ~2 KiB state).

## Results (durable append p50/p95, one 61-byte message)

| Scale | Blob | sql.js full-blob Chromium | **opfs-sahpool Chromium** | sql.js full-blob Firefox | **opfs-sahpool Firefox** |
|---|---:|---:|---:|---:|---:|
| small | 39.7 MiB | 17.4 / 22.5 ms | **1.1 / 1.3 ms** | 99 / 102 ms | **1 / 1 ms** |
| medium | 79.3 MiB | 37.9 / 44.0 ms | **1.1 / 1.2 ms** | 202 / 208 ms | **1 / 1 ms** |
| binary | 141.9 MiB | 63.9 / 72.6 ms | **1.1 / 1.3 ms** | 375 / 387 ms | **2 / 2 ms** |
| tree | 162.4 MiB | 62.9 / 67.0 ms | **1.2 / 1.2 ms** | 413 / 421 ms | **1 / 2 ms** |

Append cost is **flat with database size** — the write amplification is gone. `importDb` runs 6–40 ms for 40–162 MiB. Cold open is sub-millisecond (no full-blob load exists). Checkpoint churn ~1 ms per upsert in both engines. OPFS `createSyncAccessHandle` works in module workers in both Chromium (real extension origin) and Firefox (localhost secure context — packaged `moz-extension://` still phase 2).

## Scope

- Spike code isolated under `src/spike/opfs/` + dev-gated entrypoint; stripped from store builds by the same `entrypoints:resolved` hook (verified absent from `build/chrome-mv3-prod`).
- `@sqlite.org/sqlite-wasm` added as devDependency.
- Driver gains `--page=` to target either measurement page.

**Not in this PR (phase 2):** offscreen-document single-owner topology, service-worker/owner/worker restart recovery (gates 2–5), backup serialization (gate 7), multi-window (gate 8), packaged-Firefox OPFS + quota review (gate 10).

## Test plan

- `pnpm typecheck && pnpm lint:check`; full suite via pre-push
- Spike runs above in real Chromium + Firefox via the harness
- `pnpm build` output verified to contain neither `benchmark.html` nor `spike-opfs.html`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an OPFS SAH-pool persistence spike and a single-owner recovery test path. The main changes are:

- Physical SQLite database import and incremental write benchmarks.
- Dedicated worker serialization for database and cleanup operations.
- An offscreen owner topology with worker restart and transaction recovery gates.
- Browser benchmark page selection and development-only build gating.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Cleanup now waits for active benchmark work to finish.
- Natural owner-worker crashes clear the cached worker so later RPCs can create a fresh generation.
- No blocking issues were found in the updated recovery paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/spike/opfs/sahpool-worker.ts | Adds the SAH-pool benchmark worker and serializes benchmark and cleanup requests. |
| src/entrypoints/spike-owner-offscreen/main.ts | Hosts the database worker, routes owner RPCs, and recreates the worker after crashes. |
| src/spike/opfs/owner-worker.ts | Implements serialized SQLite owner operations and restart-recovery test cases. |
| src/spike/opfs/background-owner-host.ts | Creates the offscreen owner and routes background writes through it. |
| wxt.config.ts | Limits spike entrypoints and permissions to development benchmark builds. |

<sub>Reviews (3): Last reviewed commit: ["fix(spike): recover from natural worker ..."](https://github.com/shishir435/ollama-client/commit/4e45fadeb47b877480fec14840635a10f67199b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45433530)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->