### PR TITLE
fix(backup): handle plasmo-encoded storage values in export and import

### DIFF
--- a/src/features/knowledge/components/data-migration-settings.tsx
+++ b/src/features/knowledge/components/data-migration-settings.tsx
@@ -20,7 +20,6 @@ import { Button } from "@/components/ui/button"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
 import { useToast } from "@/hooks/use-toast"
 import { backupService, type ImportResult } from "@/lib/backup-service"
-import { MESSAGE_KEYS } from "@/lib/constants/keys"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { formatBackupFilenameTimestamp } from "@/lib/format-utils"
 import { logger } from "@/lib/logger"
@@ -132,10 +131,17 @@ export const DataMigrationSettings = () => {
     // Vector/knowledge DB failures are non-fatal for the reload decision.
     const restoredChatHistory = importResult?.database.ok
     if (restoredChatHistory) {
-      browser.runtime
-        .sendMessage({ type: MESSAGE_KEYS.APP.RELOAD })
-        .catch(() => {})
-      window.location.reload()
+      // Restart the whole extension: service worker and every page. The
+      // import bumped the SQLite import generation, so any context that
+      // keeps running with the old generation (background worker, an open
+      // sidepanel) has all of its chat saves silently skipped by the
+      // stale-writer guard. A page-level reload fan-out cannot guarantee
+      // delivery — runtime.reload() can.
+      try {
+        browser.runtime.reload()
+      } catch {
+        window.location.reload()
+      }
     }
   }
 

--- a/src/hooks/use-reset-app-storage.ts
+++ b/src/hooks/use-reset-app-storage.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react"
-import { MESSAGE_KEYS } from "@/lib/constants"
+import { browser } from "wxt/browser"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { getAllResetKeys } from "@/lib/get-all-reset-keys"
 import { logger } from "@/lib/logger"
@@ -12,7 +12,6 @@ import {
   resetProviderStorageUnlocked,
   withProviderPersistenceLock
 } from "@/lib/providers/provider-secret-store"
-import { sendRuntimeMessage } from "@/lib/runtime-messages"
 import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
 export type ResetKey = keyof ReturnType<typeof getAllResetKeys> | "all"
@@ -54,11 +53,17 @@ export const useResetAppStorage = () => {
       }
 
       if (key === "all" || key === "CHAT_SESSIONS") {
-        // Tell other extension pages to reload so they pick up the fresh state.
-        sendRuntimeMessage(MESSAGE_KEYS.APP.RELOAD).catch(() => {
-          /* not available in test */
-        })
-        setTimeout(() => window.location.reload(), 100)
+        // Restart the whole extension so every context — including the
+        // background worker, which has no APP.RELOAD listener — reinitializes
+        // with the new import generation. Contexts left running with the old
+        // generation have all chat saves silently skipped.
+        setTimeout(() => {
+          try {
+            browser.runtime.reload()
+          } catch {
+            window.location.reload()
+          }
+        }, 100)
         return "Resetting..."
       }
 

--- a/src/lib/__tests__/backup-service.test.ts
+++ b/src/lib/__tests__/backup-service.test.ts
@@ -157,6 +157,50 @@ describe("backupService", () => {
       expect(JSON.stringify({ syncData, localData })).not.toContain("secret")
     })
 
+    it("decodes plasmo-encoded values so nested secrets are stripped", async () => {
+      // @plasmohq/storage persists values as JSON strings; raw
+      // chrome.storage reads therefore return encoded strings, and
+      // sanitization must not pass secrets through inside them.
+      ;(chrome.storage.sync.get as any).mockResolvedValue({
+        [ProviderStorageKey.CONFIG]: JSON.stringify([
+          {
+            id: "remote",
+            name: "Remote",
+            type: "openai",
+            enabled: true,
+            baseUrl: "https://example.com/v1",
+            apiKey: "encoded-secret"
+          }
+        ]),
+        [STORAGE_KEYS.THEME.PREFERENCE]: JSON.stringify("dark")
+      })
+
+      await backupService.exportAll()
+
+      const zipInstance = vi.mocked(JSZip).mock.instances[0]
+      const syncCall = (zipInstance.file as any).mock.calls.find(
+        (call: any) => call[0] === "sync-storage.json"
+      )
+      const syncData = JSON.parse(syncCall[1])
+
+      const providerValue = syncData[ProviderStorageKey.CONFIG]
+      expect(typeof providerValue).toBe("string")
+      expect(providerValue).not.toContain("encoded-secret")
+      expect(JSON.parse(providerValue)).toEqual([
+        {
+          id: "remote",
+          name: "Remote",
+          type: "openai",
+          enabled: true,
+          baseUrl: "https://example.com/v1"
+        }
+      ])
+      // Plain scalar values keep their encoded form byte-for-byte.
+      expect(syncData[STORAGE_KEYS.THEME.PREFERENCE]).toBe(
+        JSON.stringify("dark")
+      )
+    })
+
     it("should flush live SQLite contexts before reading persisted bytes", async () => {
       await backupService.exportAll()
 
@@ -413,6 +457,76 @@ describe("backupService", () => {
       expect(
         JSON.stringify(vi.mocked(plasmoGlobalStorage.set).mock.calls)
       ).not.toContain("legacy-plaintext-key")
+    })
+
+    it("imports provider config stored in plasmo-encoded string form", async () => {
+      // Real v2 backups export raw chrome.storage values, where
+      // @plasmohq/storage keeps provider configs as a JSON string. Import
+      // must accept that form — this is the exact shape user backups have.
+      const provider = {
+        id: "custom:openai:remote",
+        name: "Remote",
+        type: "openai",
+        enabled: true,
+        baseUrl: "https://example.com/v1"
+      }
+      const mockFile = (content: string) => ({
+        async: vi.fn().mockResolvedValue(content)
+      })
+      vi.mocked(JSZip.loadAsync).mockResolvedValue({
+        file: vi.fn().mockImplementation((name) => {
+          if (name === "manifest.json")
+            return mockFile(JSON.stringify({ ...mockManifest, version: 2 }))
+          if (name === "sync-storage.json")
+            return mockFile(
+              JSON.stringify({
+                [ProviderStorageKey.CONFIG]: JSON.stringify([provider])
+              })
+            )
+          if (name === "local-storage.json") return mockFile("{}")
+          return null
+        })
+      } as any)
+
+      const result = await backupService.importAll(
+        new File([], "encoded-provider.zip")
+      )
+
+      expect(result.syncStorage.ok).toBe(true)
+      expect(result.localStorage.ok).toBe(true)
+      expect(plasmoGlobalStorage.set).toHaveBeenCalledWith(
+        ProviderStorageKey.CONFIG,
+        [provider]
+      )
+    })
+
+    it("rejects provider config strings that are not valid JSON", async () => {
+      const mockFile = (content: string) => ({
+        async: vi.fn().mockResolvedValue(content)
+      })
+      vi.mocked(JSZip.loadAsync).mockResolvedValue({
+        file: vi.fn().mockImplementation((name) => {
+          if (name === "manifest.json")
+            return mockFile(JSON.stringify({ ...mockManifest, version: 2 }))
+          if (name === "sync-storage.json")
+            return mockFile(
+              JSON.stringify({
+                [ProviderStorageKey.CONFIG]: "not-json{"
+              })
+            )
+          if (name === "local-storage.json") return mockFile("{}")
+          return null
+        })
+      } as any)
+
+      const result = await backupService.importAll(
+        new File([], "corrupt-provider.zip")
+      )
+
+      expect(result.syncStorage.ok).toBe(false)
+      expect(result.syncStorage.error).toContain(
+        "Invalid provider configuration"
+      )
     })
 
     it("should report failures for individual components", async () => {

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -76,9 +76,22 @@ const preparePortableStorageImport = (
   providerConfigs?: ProviderConfig[]
 } => {
   const settings = { ...data }
-  const providerConfigValue = settings[ProviderStorageKey.CONFIG]
+  let providerConfigValue = settings[ProviderStorageKey.CONFIG]
   delete settings[ProviderStorageKey.CONFIG]
   if (providerConfigValue === undefined) return { settings }
+
+  // Backups written from raw chrome.storage reads carry the value in
+  // @plasmohq/storage's encoded form: a JSON string, not an array. Accept
+  // both so existing user backups import.
+  if (typeof providerConfigValue === "string") {
+    try {
+      providerConfigValue = JSON.parse(providerConfigValue)
+    } catch {
+      throw createAppError("Invalid provider configuration in backup", {
+        kind: "validation"
+      })
+    }
+  }
 
   const parsedProviderConfigs =
     ProviderConfigsBackupSchema.safeParse(providerConfigValue)

--- a/src/lib/storage/backup-storage-policy.ts
+++ b/src/lib/storage/backup-storage-policy.ts
@@ -79,6 +79,21 @@ const sanitizePortableValue = (value: unknown): unknown => {
   return sanitized
 }
 
+// @plasmohq/storage JSON-stringifies every value it persists, so raw
+// chrome.storage reads return encoded strings. Sanitization cannot strip
+// secrets it cannot see inside a string, so encoded values are decoded
+// before sanitizing and re-encoded after to preserve the stored format.
+const decodePlasmoValue = (
+  value: unknown
+): { decoded: unknown; wasEncoded: boolean } => {
+  if (typeof value !== "string") return { decoded: value, wasEncoded: false }
+  try {
+    return { decoded: JSON.parse(value), wasEncoded: true }
+  } catch {
+    return { decoded: value, wasEncoded: false }
+  }
+}
+
 export const selectPortableStorageData = (
   storageData: Record<string, unknown>,
   options: { allowLegacyKeys?: boolean } = {}
@@ -95,7 +110,9 @@ export const selectPortableStorageData = (
       rejectedKeys.push(key)
       continue
     }
-    data[key] = sanitizePortableValue(value)
+    const { decoded, wasEncoded } = decodePlasmoValue(value)
+    const sanitized = sanitizePortableValue(decoded)
+    data[key] = wasEncoded ? JSON.stringify(sanitized) : sanitized
   }
 
   return { data, rejectedKeys }


### PR DESCRIPTION
## Summary

Fixes the import failure seen in real backups: **Preferences (Sync)** and **Local Storage** both fail with *"Invalid provider configuration in backup"* while SQLite/Dexie import fine.

**Root cause:** `@plasmohq/storage` persists every value as a JSON string. Backup export reads raw `chrome.storage`, so the provider-config value lands in the backup as an encoded **string** — but `preparePortableStorageImport` validates it against an **array** schema. Every backup that contains provider configs fails the Preferences/Local Storage sections, 100% of the time. Existing tests missed it because they mock `chrome.storage.get` with already-parsed arrays; the real plasmo encoding never appeared in a test.

**Second bug, same cause (export side):** `sanitizePortableValue` can't strip secrets it can't see inside a string. A pre-migration profile whose sync payload still carries `apiKey` would export credentials **verbatim** into the backup zip.

## Fix

- **Import**: accept the plasmo-encoded string form of provider configs — parse before schema validation, still reject malformed JSON. Existing user backups (like the one in the report) now import.
- **Export** (`selectPortableStorageData`): decode plasmo-encoded values → sanitize → re-encode, preserving the stored format byte-for-byte for scalars. Secrets inside encoded provider configs are now stripped.

## Tests

- encoded export round-trip: secret stripped, value stays string-encoded, scalar values byte-identical
- encoded import path: provider config as JSON string imports and persists parsed
- malformed encoded string: still rejected with the validation error
- full `src/lib` suite: 813 passed

## Verification

User-reported repro: v2 backup with provider configs → before: Preferences+Local Storage failed; after: schema validates the parsed array. Chat history (SQLite), vectors, knowledge sets were unaffected before and after.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes backup handling for Plasmo-encoded storage values. The main changes are:

- Decodes values before removing nested secrets during export.
- Accepts encoded provider configurations during import.
- Adds tests for encoded values and malformed provider data.
- Reloads the extension after chat-history import or reset.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated import path validates decoded provider data.
- Export sanitization now reaches secrets inside encoded values.
- The reload changes use the extension runtime API with a page fallback.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/storage/backup-storage-policy.ts | Decodes encoded storage values before sanitization and restores their encoded form for export. |
| src/lib/backup-service.ts | Parses encoded provider configurations before validating and importing them. |
| src/lib/__tests__/backup-service.test.ts | Adds coverage for encoded export sanitization, encoded imports, and malformed provider data. |
| src/features/knowledge/components/data-migration-settings.tsx | Reloads the extension after a successful chat-history import. |
| src/hooks/use-reset-app-storage.ts | Reloads the extension after resetting chat storage. |

<sub>Reviews (2): Last reviewed commit: ["fix(backup): restart whole extension aft..."](https://github.com/shishir435/ollama-client/commit/e73f99f7f644a884c38d735f225ac8f448b38306) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45435861)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->