### PR TITLE
Add provider-neutral onboarding and local diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Ollama Client does not include a built-in telemetry pipeline. Your privacy depen
 - Remote providers receive the prompts, context, and files snippets you send to them.
 - Remote search providers receive search queries when web search is enabled and selected.
 - Chat history and RAG data are stored locally by default.
+- Diagnostics are bounded, content-free, previewed locally, and never uploaded automatically.
 
 Do not expose local provider APIs publicly without authentication and network controls.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,12 +11,12 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.0",
-    "astro": "7.0.3",
+    "astro": "7.1.3",
     "postcss": "8.5.10",
     "tailwindcss": "4.3.0"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "7.2.0",
+    "@astrojs/markdown-remark": "7.2.1",
     "@astrojs/mdx": "^7.0.0",
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "^0.41.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "description": "Marketing + docs site for the Ollama Client extension. Built with Astro for Vercel.",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/docs/src/content/docs/concepts/privacy.md
+++ b/docs/src/content/docs/concepts/privacy.md
@@ -18,6 +18,7 @@ These data types are stored locally by the extension:
 - Provider-opaque continuation blocks needed to resume signed or encrypted reasoning
 - Web-search configuration
 - Browser permission state and feature settings
+- A bounded, seven-day local diagnostic event buffer containing technical codes and timing only
 
 Chat history uses SQLite-in-WASM persisted to IndexedDB. Vector storage and
 knowledge sets use local IndexedDB storage.
@@ -73,6 +74,21 @@ context.
 Web search is off unless configured. When enabled, the model can use the selected
 web-search backend through the tool system. API keys are stored locally and are
 not logged by the extension.
+
+## Diagnostics stay local
+
+The extension records up to 200 content-free diagnostic events for seven days,
+with a hard serialized-data ceiling of about 128 KiB. Events are batched before
+device-local browser storage writes to avoid write amplification. The pending
+in-memory batch is separately capped at 50 events and about 32 KiB serialized.
+Events can include an operation name, request ID, status, duration, retry state,
+and support code. They cannot include prompts, responses, file or page content,
+credentials, headers, full endpoints, cookies, or browser history.
+
+In **Help → Diagnostics & support**, you can run local self-tests and preview
+the complete support bundle before copying or downloading it. Nothing is
+uploaded automatically. Clearing diagnostic history removes the local event
+buffer.
 
 ## Reset and backup
 

--- a/docs/src/content/docs/legal/privacy-policy.md
+++ b/docs/src/content/docs/legal/privacy-policy.md
@@ -21,6 +21,7 @@ The extension does **not** run first-party analytics, ad trackers, or telemetry 
 - Optional images attached to chat messages.
 - Optional page content, tab titles/URLs, and selected text when you use browser-context features or when a tool-capable model calls a browser-context tool.
 - Settings and provider configuration values.
+- A bounded local diagnostic event buffer containing technical status codes, request IDs, and timing data, but no prompt or response content.
 
 ## Where data is stored
 
@@ -60,6 +61,9 @@ The extension requests browser permissions for chat UX, optional page extraction
 - You can disable RAG and related indexing features.
 - You can disable browser tab access from settings or the composer context controls.
 - You can reset storage and configuration from the settings page.
+- Diagnostic events expire after seven days, are capped at 300 records, and can be cleared from **Help → Diagnostics & support**.
+
+Diagnostic support bundles are generated and previewed locally. They exclude chats, prompts, responses, uploaded files, page content, embeddings, API keys, headers, cookies, browser history, and full provider endpoints. The extension never uploads a support bundle automatically; you choose whether to copy, download, or share it.
 
 ## Security notes
 

--- a/docs/src/content/docs/legal/privacy-policy.md
+++ b/docs/src/content/docs/legal/privacy-policy.md
@@ -61,7 +61,7 @@ The extension requests browser permissions for chat UX, optional page extraction
 - You can disable RAG and related indexing features.
 - You can disable browser tab access from settings or the composer context controls.
 - You can reset storage and configuration from the settings page.
-- Diagnostic events expire after seven days, are capped at 300 records, and can be cleared from **Help → Diagnostics & support**.
+- Diagnostic events expire after seven days, are capped at 200 records, and can be cleared from **Help → Diagnostics & support**.
 
 Diagnostic support bundles are generated and previewed locally. They exclude chats, prompts, responses, uploaded files, page content, embeddings, API keys, headers, cookies, browser history, and full provider endpoints. The extension never uploads a support bundle automatically; you choose whether to copy, download, or share it.
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "defuddle": "0.9.0",
     "dexie": "^4.4.2",
     "dexie-export-import": "^4.4.0",
-    "dompurify": "^3.4.5",
+    "dompurify": "^3.4.12",
     "highlight.js": "^11.11.1",
     "hnsw": "^1.1.1",
     "i18next": "^26.3.0",
@@ -93,7 +93,7 @@
     "jszip": "^3.10.1",
     "lucide-react": "0.474.0",
     "mammoth": "^1.12.0",
-    "markdown-it": "^14.1.1",
+    "markdown-it": "^14.3.0",
     "markdown-it-container": "^4.0.0",
     "markdown-it-copy-code": "^0.1.3",
     "markdown-it-deflist": "^3.0.0",
@@ -149,6 +149,7 @@
     "geckodriver": "^6.1.1",
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
+    "jsdom": "^24.1.3",
     "knip": "^6.24.0",
     "lint-staged": "^16.4.0",
     "playwright": "^1.60.0",
@@ -179,7 +180,13 @@
   "pnpm": {
     "overrides": {
       "form-data@<4.0.6": ">=4.0.6",
-      "linkify-it@<5.0.1": ">=5.0.1",
+      "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
+      "immutable@>=5.0.0-beta.1 <5.1.8": "5.1.9",
+      "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
+      "linkify-it@<5.0.2": "5.0.2",
+      "markdown-it@<14.2.0": "14.3.0",
+      "sharp@<0.35.0": "0.35.3",
+      "svgo@>=4.0.0 <4.0.2": "4.0.2",
       "vite@>=8.0.0 <8.0.16": ">=8.0.16"
     },
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,13 @@ settings:
 
 overrides:
   form-data@<4.0.6: '>=4.0.6'
-  linkify-it@<5.0.1: '>=5.0.1'
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  linkify-it@<5.0.2: 5.0.2
+  markdown-it@<14.2.0: 14.3.0
+  sharp@<0.35.0: 0.35.3
+  svgo@>=4.0.0 <4.0.2: 4.0.2
   vite@>=8.0.0 <8.0.16: '>=8.0.16'
 
 importers:
@@ -47,8 +53,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(dexie@4.4.2)
       dompurify:
-        specifier: ^3.4.5
-        version: 3.4.5
+        specifier: ^3.4.12
+        version: 3.4.12
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -71,14 +77,14 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
       markdown-it:
-        specifier: ^14.1.1
-        version: 14.1.1
+        specifier: ^14.3.0
+        version: 14.3.0
       markdown-it-container:
         specifier: ^4.0.0
         version: 4.0.0
       markdown-it-copy-code:
         specifier: ^0.1.3
-        version: 0.1.3(markdown-it@14.1.1)
+        version: 0.1.3(markdown-it@14.3.0)
       markdown-it-deflist:
         specifier: ^3.0.0
         version: 3.0.0
@@ -233,6 +239,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^24.1.3
+        version: 24.1.3
       knip:
         specifier: ^6.24.0
         version: 6.24.0
@@ -279,17 +288,17 @@ importers:
   docs:
     dependencies:
       '@astrojs/markdown-remark':
-        specifier: 7.2.0
-        version: 7.2.0
+        specifier: 7.2.1
+        version: 7.2.1
       '@astrojs/mdx':
         specifier: ^7.0.0
-        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       '@astrojs/sitemap':
         specifier: ^3.7.3
         version: 3.7.3
       '@astrojs/starlight':
         specifier: ^0.41.1
-        version: 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+        version: 0.41.1(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
@@ -298,7 +307,7 @@ importers:
         version: 5.2.8
       astro-og-canvas:
         specifier: ^0.12.0
-        version: 0.12.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -307,7 +316,7 @@ importers:
         version: 3.0.0(playwright@1.60.0)
       starlight-typedoc:
         specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
+        version: 0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -319,8 +328,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       astro:
-        specifier: 7.0.3
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       postcss:
         specifier: 8.5.10
         version: 8.5.10
@@ -356,78 +365,88 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@astrojs/compiler-binding-darwin-arm64@0.2.3':
-    resolution: {integrity: sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==}
+  '@astrojs/compiler-binding-darwin-arm64@0.3.1':
+    resolution: {integrity: sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-darwin-x64@0.2.3':
-    resolution: {integrity: sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w==}
+  '@astrojs/compiler-binding-darwin-x64@0.3.1':
+    resolution: {integrity: sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.3':
-    resolution: {integrity: sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg==}
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.1':
+    resolution: {integrity: sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.2.3':
-    resolution: {integrity: sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==}
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.1':
+    resolution: {integrity: sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.2.3':
-    resolution: {integrity: sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw==}
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.1':
+    resolution: {integrity: sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.2.3':
-    resolution: {integrity: sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==}
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.1':
+    resolution: {integrity: sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.2.3':
-    resolution: {integrity: sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA==}
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.1':
+    resolution: {integrity: sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.3':
-    resolution: {integrity: sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ==}
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.1':
+    resolution: {integrity: sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.2.3':
-    resolution: {integrity: sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ==}
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.1':
+    resolution: {integrity: sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@astrojs/compiler-binding@0.2.3':
-    resolution: {integrity: sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw==}
+  '@astrojs/compiler-binding@0.3.1':
+    resolution: {integrity: sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@astrojs/compiler-rs@0.2.3':
-    resolution: {integrity: sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA==}
+  '@astrojs/compiler-rs@0.3.1':
+    resolution: {integrity: sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==}
+    engines: {node: '>=22.12.0'}
 
   '@astrojs/internal-helpers@0.10.0':
     resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
+  '@astrojs/internal-helpers@0.10.1':
+    resolution: {integrity: sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==}
+
   '@astrojs/markdown-remark@7.2.0':
     resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
+  '@astrojs/markdown-remark@7.2.1':
+    resolution: {integrity: sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==}
+
   '@astrojs/markdown-satteri@0.3.2':
     resolution: {integrity: sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==}
+
+  '@astrojs/markdown-satteri@0.3.4':
+    resolution: {integrity: sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==}
 
   '@astrojs/mdx@7.0.0':
     resolution: {integrity: sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==}
@@ -455,8 +474,8 @@ packages:
       '@astrojs/markdown-remark':
         optional: true
 
-  '@astrojs/telemetry@3.3.2':
-    resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
+  '@astrojs/telemetry@3.3.3':
+    resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@babel/code-frame@7.29.0':
@@ -850,9 +869,6 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
@@ -1230,152 +1246,161 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -3059,12 +3084,12 @@ packages:
     peerDependencies:
       astro: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  astro@7.0.3:
-    resolution: {integrity: sha512-CK+G+Tl2DMV1EXCwVG45vyurxf2IfRTklMxDhRKn+tst9Yl8rWXpudL62Fa6zin5Bt968FBvuyASj1aJShROZg==}
+  astro@7.1.3:
+    resolution: {integrity: sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
-      '@astrojs/markdown-remark': 7.2.0
+      '@astrojs/markdown-remark': 7.2.1
     peerDependenciesMeta:
       '@astrojs/markdown-remark':
         optional: true
@@ -3139,8 +3164,8 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3392,6 +3417,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
@@ -3774,8 +3803,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.5:
-    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4253,10 +4282,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -4431,8 +4456,8 @@ packages:
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
-  immutable@5.1.6:
-    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4669,8 +4694,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@24.1.3:
@@ -4863,8 +4888,8 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -4989,7 +5014,7 @@ packages:
   markdown-it-copy-code@0.1.3:
     resolution: {integrity: sha512-8ZgbAtEtXzBw06fPbqYaZ6JswDDRQyXSi2YQ1ghnW1mw2ajpc6KTC8OkpyhBFhKfGzRgUUqATXYo7TT10vsG6w==}
     peerDependencies:
-      markdown-it: '>= 13.0.0'
+      markdown-it: 14.3.0
 
   markdown-it-deflist@3.0.0:
     resolution: {integrity: sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==}
@@ -5012,8 +5037,8 @@ packages:
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -5338,8 +5363,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neotraverse@0.6.18:
-    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
+  neotraverse@1.0.1:
+    resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
     engines: {node: '>= 10'}
 
   next-themes@0.4.6:
@@ -5386,8 +5411,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nwsapi@2.2.23:
-    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   nypm@0.6.6:
     resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
@@ -6087,6 +6112,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6113,9 +6143,14 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -6344,8 +6379,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -6915,10 +6950,6 @@ packages:
   when@3.7.7:
     resolution: {integrity: sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==}
 
-  which-pm-runs@1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
-    engines: {node: '>=4'}
-
   which@1.2.4:
     resolution: {integrity: sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==}
     hasBin: true
@@ -7116,25 +7147,25 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@astrojs/compiler-binding-darwin-arm64@0.2.3':
+  '@astrojs/compiler-binding-darwin-arm64@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-darwin-x64@0.2.3':
+  '@astrojs/compiler-binding-darwin-x64@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.3':
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.2.3':
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.2.3':
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.2.3':
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
@@ -7142,30 +7173,30 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.3':
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.2.3':
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.1':
     optional: true
 
-  '@astrojs/compiler-binding@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-binding@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
-      '@astrojs/compiler-binding-darwin-arm64': 0.2.3
-      '@astrojs/compiler-binding-darwin-x64': 0.2.3
-      '@astrojs/compiler-binding-linux-arm64-gnu': 0.2.3
-      '@astrojs/compiler-binding-linux-arm64-musl': 0.2.3
-      '@astrojs/compiler-binding-linux-x64-gnu': 0.2.3
-      '@astrojs/compiler-binding-linux-x64-musl': 0.2.3
-      '@astrojs/compiler-binding-wasm32-wasi': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@astrojs/compiler-binding-win32-arm64-msvc': 0.2.3
-      '@astrojs/compiler-binding-win32-x64-msvc': 0.2.3
+      '@astrojs/compiler-binding-darwin-arm64': 0.3.1
+      '@astrojs/compiler-binding-darwin-x64': 0.3.1
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.1
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.1
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.1
+      '@astrojs/compiler-binding-linux-x64-musl': 0.3.1
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.1
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.1
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-rs@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@astrojs/compiler-binding': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-binding': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -7174,7 +7205,18 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
+
+  '@astrojs/internal-helpers@0.10.1':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.0
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.0.2
@@ -7203,6 +7245,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@astrojs/markdown-remark@7.2.1':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.1
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@astrojs/markdown-satteri@0.3.2':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
@@ -7210,13 +7274,21 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.4
 
-  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@astrojs/markdown-satteri@0.3.4':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.1
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      satteri: 0.9.4
+
+  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -7242,24 +7314,24 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)':
+  '@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.2
-      '@astrojs/mdx': 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@astrojs/mdx': 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
-      astro-expressive-code: 0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro-expressive-code: 0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.3.0(typescript@5.9.3)
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       klona: 2.0.6
       magic-string: 0.30.21
       mdast-util-directive: 3.1.0
@@ -7275,18 +7347,17 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.0
+      '@astrojs/markdown-remark': 7.2.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@astrojs/telemetry@3.3.2':
+  '@astrojs/telemetry@3.3.3':
     dependencies:
       ci-info: 4.4.0
       dset: 3.1.4
       is-docker: 4.0.0
-      is-wsl: 3.1.1
-      which-pm-runs: 1.1.0
+      package-manager-detector: 1.6.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7690,11 +7761,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
@@ -7937,98 +8003,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-freebsd-wasm32@0.35.3':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@inquirer/ansi@2.0.5':
@@ -9472,25 +9548,25 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
+  astro-expressive-code@0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro-og-canvas@0.12.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
+  astro-og-canvas@0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0):
+  astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
-      '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@astrojs/internal-helpers': 0.10.0
-      '@astrojs/markdown-satteri': 0.3.2
-      '@astrojs/telemetry': 3.3.2
+      '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/internal-helpers': 0.10.1
+      '@astrojs/markdown-satteri': 0.3.4
+      '@astrojs/telemetry': 3.3.3
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
       '@oslojs/encoding': 1.1.0
@@ -9501,7 +9577,7 @@ snapshots:
       ci-info: 4.4.0
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
-      cookie: 1.1.1
+      cookie: 2.0.1
       devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
@@ -9513,39 +9589,36 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
       mrmime: 2.0.1
-      neotraverse: 0.6.18
+      neotraverse: 1.0.1
       obug: 2.1.1
       p-limit: 7.3.0
       p-queue: 9.1.1
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
       picomatch: 4.0.4
-      rehype: 13.0.2
       semver: 7.8.1
       shiki: 4.0.2
       smol-toml: 1.6.1
-      svgo: 4.0.1
+      svgo: 4.0.2
       tinyclip: 0.1.12
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
-      unist-util-visit: 5.1.0
       unstorage: 1.17.5
-      vfile: 6.0.3
       vite: 8.1.2(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.2(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.3.0)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.0
-      sharp: 0.34.5
+      '@astrojs/markdown-remark': 7.2.1
+      sharp: 0.35.3(@types/node@24.12.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9658,7 +9731,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9878,7 +9951,10 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cookie@1.1.1: {}
+  cookie@1.1.1:
+    optional: true
+
+  cookie@2.0.1: {}
 
   copy-anything@2.0.6:
     dependencies:
@@ -9904,7 +9980,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -10251,7 +10327,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.5:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10731,7 +10807,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -10820,10 +10896,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.3:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.4:
     dependencies:
@@ -11128,7 +11200,7 @@ snapshots:
   immer@11.1.8:
     optional: true
 
-  immutable@5.1.6:
+  immutable@5.1.9:
     optional: true
 
   import-fresh@3.3.1:
@@ -11289,7 +11361,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -11303,7 +11375,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.23
+      nwsapi: 2.2.24
       parse5: 7.3.0
       rrweb-cssom: 0.7.1
       saxes: 6.0.0
@@ -11497,7 +11569,7 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -11633,9 +11705,9 @@ snapshots:
 
   markdown-it-container@4.0.0: {}
 
-  markdown-it-copy-code@0.1.3(markdown-it@14.1.1):
+  markdown-it-copy-code@0.1.3(markdown-it@14.3.0):
     dependencies:
-      markdown-it: 14.1.1
+      markdown-it: 14.3.0
 
   markdown-it-deflist@3.0.0: {}
 
@@ -11651,11 +11723,11 @@ snapshots:
 
   markdown-it-task-lists@2.1.1: {}
 
-  markdown-it@14.1.1:
+  markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -11892,7 +11964,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.5
+      dompurify: 3.4.12
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0
@@ -12206,7 +12278,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -12281,7 +12353,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neotraverse@0.6.18: {}
+  neotraverse@1.0.1: {}
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -12327,7 +12399,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nwsapi@2.2.23: {}
+  nwsapi@2.2.24: {}
 
   nypm@0.6.6:
     dependencies:
@@ -13170,7 +13242,7 @@ snapshots:
   sass@1.89.0:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.6
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
@@ -13219,6 +13291,9 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.1: {}
+
+  semver@7.8.5:
+    optional: true
 
   send@1.2.1:
     dependencies:
@@ -13297,36 +13372,38 @@ snapshots:
       - supports-color
       - typescript
 
-  sharp@0.34.5:
+  sharp@0.35.3(@types/node@24.12.4):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 24.12.4
     optional: true
 
   shebang-command@2.0.0:
@@ -13450,9 +13527,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
+  starlight-typedoc@0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      '@astrojs/starlight': 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+      '@astrojs/starlight': 0.41.1(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       github-slugger: 2.0.0
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
@@ -13552,7 +13629,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
@@ -13703,7 +13780,7 @@ snapshots:
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
-      markdown-it: 14.1.1
+      markdown-it: 14.3.0
       minimatch: 10.2.5
       typescript: 5.9.3
       yaml: 2.9.0
@@ -14069,8 +14146,6 @@ snapshots:
   when-exit@2.1.5: {}
 
   when@3.7.7: {}
-
-  which-pm-runs@1.1.0: {}
 
   which@1.2.4:
     dependencies:

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -264,7 +264,7 @@ export const handleRpcRequest = async (
       durationMs: Math.max(0, performance.now() - startedAt)
     })
     if (method !== RpcMethod.DiagnosticsClear) {
-      recordDiagnosticEvent({
+      await recordDiagnosticEvent({
         level:
           status === "error"
             ? "error"

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -1,6 +1,8 @@
 import type { Runtime } from "webextension-polyfill"
 
 import { classifyRuntimeSender } from "@/background/runtime-sender-authorization"
+import { recordDiagnosticEvent } from "@/lib/diagnostics/diagnostic-recorder"
+import { DiagnosticsService } from "@/lib/diagnostics/diagnostics-service"
 import { isAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
@@ -35,13 +37,18 @@ const handlers = {
   [RpcMethod.ProvidersRemove]: async (request) =>
     ProviderRpcService.remove(request),
   [RpcMethod.ProvidersProbeModelCapabilities]: async (request, signal) =>
-    ProviderRpcService.probeModelCapabilities(request, signal)
+    ProviderRpcService.probeModelCapabilities(request, signal),
+  [RpcMethod.DiagnosticsRun]: async (_request, signal) =>
+    DiagnosticsService.run(signal),
+  [RpcMethod.DiagnosticsGetBundle]: async (_request, signal) =>
+    DiagnosticsService.getBundle(signal),
+  [RpcMethod.DiagnosticsClear]: async () => DiagnosticsService.clear()
 } satisfies RpcHandlers
 
 const activeRequests = new Map<string, AbortController>()
 
 const supportCode = (code: RpcErrorCode, requestId: string): string =>
-  `RPC-${code.replaceAll("_", "-").toUpperCase()}-${requestId.slice(0, 8).toUpperCase()}`
+  `OLC-RPC-${code.replaceAll("_", "-").toUpperCase()}-${requestId.slice(0, 8).toUpperCase()}`
 
 const rpcError = (
   code: RpcErrorCode,
@@ -209,6 +216,7 @@ export const handleRpcRequest = async (
 
   let status = "success"
   let errorCode: RpcErrorCode | undefined
+  let diagnosticSupportCode: string | undefined
   try {
     const handler = handlers[method] as (
       value: unknown,
@@ -232,6 +240,7 @@ export const handleRpcRequest = async (
         })
       : normalizeRpcError(error, requestId)
     errorCode = normalized.code
+    diagnosticSupportCode = normalized.supportCode
     sendResponse(response(requestId, { ok: false, error: normalized }))
     if (!cancelled) {
       logger.error("RPC request failed", "RpcServer", {
@@ -254,5 +263,22 @@ export const handleRpcRequest = async (
       errorCode,
       durationMs: Math.max(0, performance.now() - startedAt)
     })
+    if (method !== RpcMethod.DiagnosticsClear) {
+      recordDiagnosticEvent({
+        level:
+          status === "error"
+            ? "error"
+            : status === "cancelled"
+              ? "warn"
+              : "info",
+        code: errorCode ? `RPC_${errorCode.toUpperCase()}` : "RPC_COMPLETED",
+        operation: method,
+        surface: "background",
+        requestId,
+        durationMs: Math.max(0, performance.now() - startedAt),
+        ...(diagnosticSupportCode && { supportCode: diagnosticSupportCode }),
+        ...(errorCode && { metadata: { errorCode } })
+      }).catch(() => undefined)
+    }
   }
 }

--- a/src/components/__tests__/markdown-renderer.test.tsx
+++ b/src/components/__tests__/markdown-renderer.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { MarkdownRenderer } from "../markdown-renderer"

--- a/src/entrypoints/print/main.ts
+++ b/src/entrypoints/print/main.ts
@@ -1,5 +1,6 @@
 import { sanitizeExportFragment } from "@/lib/exporters/export-sanitizer"
 import { consumePrintJob, purgeStalePrintJobs } from "@/lib/exporters/print-job"
+import { getPdfStyles } from "@/lib/exporters/styles"
 
 // The print payload arrives via localStorage, which any extension page can
 // write. Treat it as untrusted: re-sanitize with the same shared config the
@@ -19,12 +20,19 @@ const installCsp = (): void => {
   document.head.appendChild(meta)
 }
 
+const installExportStyles = (): void => {
+  const style = document.createElement("style")
+  style.textContent = getPdfStyles()
+  document.head.appendChild(style)
+}
+
 window.onload = () => {
   const jobId = new URLSearchParams(window.location.search).get("job")
   const job = jobId ? consumePrintJob(jobId) : null
   purgeStalePrintJobs()
 
   if (job) {
+    installExportStyles()
     if (job.filename) document.title = job.filename
     if (!job.allowRemoteImages) installCsp()
     const container = document.getElementById("print-content")

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ConfirmActionDialog } from "@/components/settings/confirm-action-dialog"
 import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messages"
@@ -44,19 +44,38 @@ export const Chat = () => {
   const { isOpen: isSearchOpen, closeSearchDialog } = useSearchDialogStore()
   const { embedMessage } = useAutoEmbedMessages()
   const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null)
+  const pendingSendInFlightRef = useRef(false)
 
   // Omnibox quick-ask ("olc <query>") plumbing lives in its own hook to keep
   // the chat UI decoupled from address-bar integration.
   useOmniboxQuery({ sendMessage, isModelReady })
 
   useEffect(() => {
-    if (!currentSessionId || !isModelReady || !pendingChatSend) return
-    clearPendingChatSend()
+    if (
+      !currentSessionId ||
+      !isModelReady ||
+      isLoading ||
+      isStreaming ||
+      !pendingChatSend ||
+      pendingSendInFlightRef.current
+    ) {
+      return
+    }
+    pendingSendInFlightRef.current = true
     void sendMessage(pendingChatSend)
+      .then((accepted) => {
+        if (accepted) clearPendingChatSend()
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        pendingSendInFlightRef.current = false
+      })
   }, [
     clearPendingChatSend,
     currentSessionId,
     isModelReady,
+    isLoading,
+    isStreaming,
     pendingChatSend,
     sendMessage
   ])

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ConfirmActionDialog } from "@/components/settings/confirm-action-dialog"
 import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messages"
 import { useChat } from "@/features/chat/hooks/use-chat"
 import { useChatKeyboardShortcuts } from "@/features/chat/hooks/use-chat-keyboard-shortcuts"
 import { useOmniboxQuery } from "@/features/chat/hooks/use-omnibox-query"
+import { usePendingChatSend } from "@/features/chat/stores/chat-input-store"
 import { useLoadStream } from "@/features/chat/stores/load-stream-store"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { WelcomeScreen } from "@/sidepanel/components/welcome-screen"
@@ -29,6 +30,7 @@ export const Chat = () => {
     onLoadMore
   } = useChat()
   const { isLoading, isStreaming } = useLoadStream()
+  const { pendingChatSend, clearPendingChatSend } = usePendingChatSend()
   const {
     currentSessionId,
     highlightedMessage,
@@ -46,6 +48,18 @@ export const Chat = () => {
   // Omnibox quick-ask ("olc <query>") plumbing lives in its own hook to keep
   // the chat UI decoupled from address-bar integration.
   useOmniboxQuery({ sendMessage, isModelReady })
+
+  useEffect(() => {
+    if (!currentSessionId || !isModelReady || !pendingChatSend) return
+    clearPendingChatSend()
+    void sendMessage(pendingChatSend)
+  }, [
+    clearPendingChatSend,
+    currentSessionId,
+    isModelReady,
+    pendingChatSend,
+    sendMessage
+  ])
 
   // Handle all keyboard shortcuts
   useChatKeyboardShortcuts({

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { browser } from "@/lib/browser-api"
 import { PROVIDER_MESSAGE_KEYS } from "@/lib/constants/keys"
@@ -221,6 +221,61 @@ describe("useChatStream", () => {
     expect(setIsLoading).toHaveBeenCalledWith(false)
     expect(setIsStreaming).toHaveBeenCalledWith(false)
     expect(mockPort.disconnect).toHaveBeenCalled()
+  })
+
+  it("reports success only after final message persistence resolves", async () => {
+    let resolvePersistence: (() => void) | undefined
+    const persistence = new Promise<void>((resolve) => {
+      resolvePersistence = resolve
+    })
+    const onSuccessfulResponse = vi.fn()
+    setMessages = vi.fn((messages) =>
+      messages.at(-1)?.done ? persistence : undefined
+    )
+    const { result } = renderHook(() =>
+      useChatStream({
+        setMessages,
+        setIsLoading,
+        setIsStreaming,
+        onSuccessfulResponse
+      })
+    )
+    act(() => {
+      result.current.startStream({
+        model: "llama2",
+        messages: [{ role: "user", content: "Hello" }]
+      })
+    })
+    const listener = mockPort.onMessage.addListener.mock.calls[0][0]
+
+    act(() => listener({ delta: "Response" }))
+    act(() => listener({ done: true }))
+    expect(onSuccessfulResponse).not.toHaveBeenCalled()
+
+    resolvePersistence?.()
+    await waitFor(() => expect(onSuccessfulResponse).toHaveBeenCalledOnce())
+  })
+
+  it("does not report provider errors as successful responses", () => {
+    const onSuccessfulResponse = vi.fn()
+    const { result } = renderHook(() =>
+      useChatStream({
+        setMessages,
+        setIsLoading,
+        setIsStreaming,
+        onSuccessfulResponse
+      })
+    )
+    act(() => {
+      result.current.startStream({
+        model: "llama2",
+        messages: [{ role: "user", content: "Hello" }]
+      })
+    })
+    const listener = mockPort.onMessage.addListener.mock.calls[0][0]
+    act(() => listener({ error: { status: 500, message: "failed" } }))
+
+    expect(onSuccessfulResponse).not.toHaveBeenCalled()
   })
 
   it("keeps opaque replay state separate on the assistant message", () => {

--- a/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -15,9 +15,17 @@ type UpdateMessageFn = (
 let capturedSetMessages:
   | ((messages: Array<Record<string, unknown>>) => Promise<void> | void)
   | null = null
+let capturedOnSuccessfulResponse:
+  | ((message: ChatMessage) => Promise<void> | void)
+  | null = null
 
 const embedMessages = vi.fn(async () => undefined)
 const touchMessageActivity = vi.fn(async (_id: number) => undefined)
+const completeOnboarding = vi.fn(async () => true)
+
+vi.mock("@/lib/onboarding/state", () => ({
+  completeOnboardingAfterFirstResponse: () => completeOnboarding()
+}))
 
 vi.mock("@/lib/repositories/chat-history", () => ({
   touchMessageActivity: (id: number) => touchMessageActivity(id)
@@ -25,8 +33,12 @@ vi.mock("@/lib/repositories/chat-history", () => ({
 
 vi.mock("@/features/chat/hooks/use-chat-stream", () => ({
   useChatStream: vi.fn(
-    (config: { setMessages: typeof capturedSetMessages }) => {
+    (config: {
+      setMessages: typeof capturedSetMessages
+      onSuccessfulResponse?: typeof capturedOnSuccessfulResponse
+    }) => {
       capturedSetMessages = config.setMessages
+      capturedOnSuccessfulResponse = config.onSuccessfulResponse ?? null
       return {
         startStream: vi.fn(),
         stopStream: vi.fn()
@@ -62,8 +74,10 @@ const mkOptions = (
 beforeEach(() => {
   vi.useFakeTimers()
   capturedSetMessages = null
+  capturedOnSuccessfulResponse = null
   embedMessages.mockClear()
   touchMessageActivity.mockClear()
+  completeOnboarding.mockClear()
 })
 
 afterEach(() => {
@@ -294,6 +308,19 @@ describe("useChatStreaming", () => {
 
     expect(spies.updateMessage).toHaveBeenCalledTimes(2) // UI + DB flush
     expect(embedMessages).not.toHaveBeenCalled()
+  })
+
+  it("completes onboarding only from explicit successful-response callback", async () => {
+    const { options } = mkOptions()
+    renderHook(() => useChatStreaming(options))
+
+    expect(completeOnboarding).not.toHaveBeenCalled()
+    await capturedOnSuccessfulResponse?.({
+      role: "assistant",
+      content: "hello",
+      done: true
+    })
+    expect(completeOnboarding).toHaveBeenCalledOnce()
   })
 
   it("falls back to the last message in newMessages when the streamed id isn't in the array", async () => {

--- a/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -21,10 +21,11 @@ let capturedOnSuccessfulResponse:
 
 const embedMessages = vi.fn(async () => undefined)
 const touchMessageActivity = vi.fn(async (_id: number) => undefined)
-const completeOnboarding = vi.fn(async () => true)
+const completeOnboarding = vi.fn(async (_sessionId: string | null) => true)
 
 vi.mock("@/lib/onboarding/state", () => ({
-  completeOnboardingAfterFirstResponse: () => completeOnboarding()
+  completeOnboardingAfterFirstResponse: (sessionId: string | null) =>
+    completeOnboarding(sessionId)
 }))
 
 vi.mock("@/lib/repositories/chat-history", () => ({
@@ -312,7 +313,8 @@ describe("useChatStreaming", () => {
 
   it("completes onboarding only from explicit successful-response callback", async () => {
     const { options } = mkOptions()
-    renderHook(() => useChatStreaming(options))
+    const { result } = renderHook(() => useChatStreaming(options))
+    result.current.currentStreamingSessionIdRef.current = "s1"
 
     expect(completeOnboarding).not.toHaveBeenCalled()
     await capturedOnSuccessfulResponse?.({
@@ -320,7 +322,7 @@ describe("useChatStreaming", () => {
       content: "hello",
       done: true
     })
-    expect(completeOnboarding).toHaveBeenCalledOnce()
+    expect(completeOnboarding).toHaveBeenCalledWith("s1")
   })
 
   it("falls back to the last message in newMessages when the streamed id isn't in the array", async () => {

--- a/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
@@ -71,10 +71,12 @@ describe("useChatTurnController", () => {
       })
     )
 
+    let accepted = false
     await act(async () => {
-      await result.current.sendMessage()
+      accepted = await result.current.sendMessage()
     })
 
+    expect(accepted).toBe(true)
     expect(addMessage).toHaveBeenCalledWith(
       "session-1",
       expect.objectContaining({ role: "user", content: "question" })
@@ -157,13 +159,48 @@ describe("useChatTurnController", () => {
       })
     )
 
+    let accepted = true
     await act(async () => {
-      await result.current.sendMessage()
+      accepted = await result.current.sendMessage()
     })
 
+    expect(accepted).toBe(false)
     expect(addMessage).not.toHaveBeenCalled()
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Couldn't start chat" })
     )
+  })
+
+  it("does not accept a queued turn while another turn is active", async () => {
+    loadStreamStore.setState({ isLoading: true, isStreaming: false })
+    const addMessage = vi.fn()
+    const { result } = renderHook(() =>
+      useChatTurnController({
+        config: baseConfig as any,
+        input: "question",
+        setInput: vi.fn(),
+        selectedTabIds: [],
+        contextText: "",
+        tabDocuments: [],
+        messages: [],
+        setIsLoading: vi.fn(),
+        setIsStreaming: vi.fn(),
+        ensureSessionId: vi.fn().mockResolvedValue("session-1"),
+        autoRenameSession: vi.fn(),
+        addMessage,
+        setNextResponseMetrics: vi.fn(),
+        clearNextResponseMetrics: vi.fn(),
+        generateResponse: vi.fn(),
+        toast: vi.fn()
+      })
+    )
+
+    let accepted = true
+    await act(async () => {
+      accepted = await result.current.sendMessage()
+    })
+
+    expect(accepted).toBe(false)
+    expect(addMessage).not.toHaveBeenCalled()
   })
 })

--- a/src/features/chat/hooks/use-chat-response.ts
+++ b/src/features/chat/hooks/use-chat-response.ts
@@ -20,6 +20,7 @@ interface ChatResponseOptions {
     clientContextPrepared?: boolean
   }) => void
   currentStreamingMessageIdRef: { current: number | null }
+  currentStreamingSessionIdRef: { current: string | null }
 }
 
 export const useChatResponse = ({
@@ -28,7 +29,8 @@ export const useChatResponse = ({
   messages,
   addMessage,
   startStream,
-  currentStreamingMessageIdRef
+  currentStreamingMessageIdRef,
+  currentStreamingSessionIdRef
 }: ChatResponseOptions) => {
   const ragSourcesRef = useRef<RagSources | null>(null)
   const promptContextStatsRef = useRef<PromptContextStats | null>(null)
@@ -78,6 +80,7 @@ export const useChatResponse = ({
 
     const assistantId = await addMessage(sessionId, assistantMessage)
     currentStreamingMessageIdRef.current = assistantId
+    currentStreamingSessionIdRef.current = sessionId
 
     startStream({
       model: modelForRequest,

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -33,17 +33,19 @@ interface StreamOptions {
 }
 
 export interface UseChatStreamProps {
-  setMessages: (messages: ChatMessage[]) => void
+  setMessages: (messages: ChatMessage[]) => void | Promise<void>
   setIsLoading: (v: boolean) => void
   setIsStreaming: (v: boolean) => void
   onToken?: (token: string) => void
+  onSuccessfulResponse?: (message: ChatMessage) => void | Promise<void>
 }
 
 export const useChatStream = ({
   setMessages,
   setIsLoading,
   setIsStreaming,
-  onToken
+  onToken,
+  onSuccessfulResponse
 }: UseChatStreamProps) => {
   const DEBUG_THINKING_STREAM = false
   const { t } = useTranslation()
@@ -214,7 +216,7 @@ export const useChatStream = ({
                   error.retryable ? " This may be temporary; try again." : ""
                 }`
               : displayError.message
-          renderAssistant({
+          void renderAssistant({
             ...partial,
             content: chatErrorMessage,
             done: true,
@@ -243,7 +245,16 @@ export const useChatStream = ({
             })
           })
         } else {
-          renderAssistant(result.terminal.message)
+          const message = result.terminal.message
+          Promise.resolve(renderAssistant(message))
+            .then(() => onSuccessfulResponse?.(message))
+            .catch((error) => {
+              logger.debug(
+                "Successful response post-persistence callback failed",
+                "useChatStream",
+                { error }
+              )
+            })
         }
 
         cleanupPort()

--- a/src/features/chat/hooks/use-chat-streaming.ts
+++ b/src/features/chat/hooks/use-chat-streaming.ts
@@ -40,6 +40,7 @@ export const useChatStreaming = ({
   setIsStreaming
 }: ChatStreamingOptions) => {
   const currentStreamingMessageIdRef = useRef<number | null>(null)
+  const currentStreamingSessionIdRef = useRef<string | null>(null)
   const dbUpdateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const livenessIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -153,7 +154,9 @@ export const useChatStreaming = ({
     onSuccessfulResponse: async (message) => {
       if (!message.content.trim()) return
       try {
-        await completeOnboardingAfterFirstResponse()
+        await completeOnboardingAfterFirstResponse(
+          currentStreamingSessionIdRef.current
+        )
       } catch (error) {
         logger.debug("Failed to complete onboarding", "useChatStreaming", {
           error
@@ -167,5 +170,10 @@ export const useChatStreaming = ({
     baseStopStream()
   }
 
-  return { startStream, stopStream, currentStreamingMessageIdRef }
+  return {
+    startStream,
+    stopStream,
+    currentStreamingMessageIdRef,
+    currentStreamingSessionIdRef
+  }
 }

--- a/src/features/chat/hooks/use-chat-streaming.ts
+++ b/src/features/chat/hooks/use-chat-streaming.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react"
 import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messages"
 import { useChatStream } from "@/features/chat/hooks/use-chat-stream"
 import { logger } from "@/lib/logger"
+import { completeOnboardingAfterFirstResponse } from "@/lib/onboarding/state"
 import { touchMessageActivity } from "@/lib/repositories/chat-history"
 import type { ChatMessage } from "@/types"
 
@@ -141,7 +142,6 @@ export const useChatStreaming = ({
         },
         false
       )
-
       if (currentSessionId) {
         embedMessages(newMessages, currentSessionId, false).catch((err) => {
           logger.error("Failed to embed messages", "useChat", { error: err })
@@ -149,7 +149,17 @@ export const useChatStreaming = ({
       }
     },
     setIsLoading,
-    setIsStreaming
+    setIsStreaming,
+    onSuccessfulResponse: async (message) => {
+      if (!message.content.trim()) return
+      try {
+        await completeOnboardingAfterFirstResponse()
+      } catch (error) {
+        logger.debug("Failed to complete onboarding", "useChatStreaming", {
+          error
+        })
+      }
+    }
   })
 
   const stopStream = () => {

--- a/src/features/chat/hooks/use-chat-turn-controller.ts
+++ b/src/features/chat/hooks/use-chat-turn-controller.ts
@@ -95,7 +95,7 @@ export const useChatTurnController = ({
     })
     if (!verdict.proceed) {
       if (verdict.toast) toast(verdict.toast)
-      return
+      return false
     }
 
     setIsLoading(true)
@@ -121,12 +121,12 @@ export const useChatTurnController = ({
         title: "Couldn't start chat",
         description: "Creating the chat failed. Please try again."
       })
-      return
+      return false
     }
     if (!sessionId) {
       setPendingActivityEvents([])
       setIsLoading(false)
-      return
+      return false
     }
 
     const includeContext = selectedTabIds.length > 0 && !!contextText?.trim()
@@ -151,7 +151,7 @@ export const useChatTurnController = ({
         title: "Couldn't send message",
         description: "Saving the message failed. Please try again."
       })
-      return
+      return false
     }
 
     const titleContent = rawInput || files?.[0]?.metadata.fileName || ""
@@ -235,7 +235,7 @@ export const useChatTurnController = ({
         description:
           "The message was saved, but the assistant could not start because context preparation failed."
       })
-      return
+      return true
     }
 
     let { contentWithRAG } = ragResult
@@ -271,7 +271,7 @@ export const useChatTurnController = ({
           usedContextChunks: promptContextStats.usedContextChunks
         }
       })
-      return
+      return true
     }
 
     const messagesForLLM = [
@@ -322,6 +322,7 @@ export const useChatTurnController = ({
       contextPrepared: true
     })
     setPendingActivityEvents([])
+    return true
   }
 
   return { pendingActivityEvents, sendMessage }

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -66,13 +66,17 @@ export const useChat = () => {
   const currentSession = sessions.find((s) => s.id === currentSessionId)
   const messages = currentSession?.messages ?? []
 
-  const { startStream, stopStream, currentStreamingMessageIdRef } =
-    useChatStreaming({
-      currentSessionId,
-      updateMessage,
-      setIsLoading,
-      setIsStreaming
-    })
+  const {
+    startStream,
+    stopStream,
+    currentStreamingMessageIdRef,
+    currentStreamingSessionIdRef
+  } = useChatStreaming({
+    currentSessionId,
+    updateMessage,
+    setIsLoading,
+    setIsStreaming
+  })
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" })
@@ -105,7 +109,8 @@ export const useChat = () => {
       messages,
       addMessage,
       startStream,
-      currentStreamingMessageIdRef
+      currentStreamingMessageIdRef,
+      currentStreamingSessionIdRef
     })
 
   const effectiveConfig = useMemo(() => {

--- a/src/features/chat/stores/__tests__/chat-input-store.test.ts
+++ b/src/features/chat/stores/__tests__/chat-input-store.test.ts
@@ -4,7 +4,7 @@ import { chatInputStore } from "../chat-input-store"
 describe("chatInputStore", () => {
   beforeEach(() => {
     // Reset store to initial state
-    chatInputStore.setState({ input: "" })
+    chatInputStore.setState({ input: "", pendingChatSend: undefined })
   })
 
   it("should initialize with empty input", () => {
@@ -45,5 +45,15 @@ describe("chatInputStore", () => {
     setInput("Replaced")
 
     expect(chatInputStore.getState().input).toBe("Replaced")
+  })
+
+  it("queues and clears a one-time chat send", () => {
+    const { queueChatSend, clearPendingChatSend } = chatInputStore.getState()
+
+    queueChatSend("Test message")
+    expect(chatInputStore.getState().pendingChatSend).toBe("Test message")
+
+    clearPendingChatSend()
+    expect(chatInputStore.getState().pendingChatSend).toBeUndefined()
   })
 })

--- a/src/features/chat/stores/chat-input-store.ts
+++ b/src/features/chat/stores/chat-input-store.ts
@@ -6,8 +6,11 @@ import type { ChatInput } from "@/types"
 interface ComposerState extends ChatInput {
   promptLibraryOpen: boolean
   focused: boolean
+  pendingChatSend?: string
   setPromptLibraryOpen: (open: boolean) => void
   setFocused: (focused: boolean) => void
+  queueChatSend: (input: string) => void
+  clearPendingChatSend: () => void
 }
 
 export const chatInputStore = create<ComposerState>((set) => ({
@@ -16,8 +19,11 @@ export const chatInputStore = create<ComposerState>((set) => ({
   appendInput: (text) => set((state) => ({ input: state.input + text })),
   promptLibraryOpen: false,
   focused: false,
+  pendingChatSend: undefined,
   setPromptLibraryOpen: (promptLibraryOpen) => set({ promptLibraryOpen }),
-  setFocused: (focused) => set({ focused })
+  setFocused: (focused) => set({ focused }),
+  queueChatSend: (pendingChatSend) => set({ pendingChatSend }),
+  clearPendingChatSend: () => set({ pendingChatSend: undefined })
 }))
 
 export const useChatInput = () => {
@@ -37,5 +43,14 @@ export const useComposerUi = () =>
       focused: state.focused,
       setPromptLibraryOpen: state.setPromptLibraryOpen,
       setFocused: state.setFocused
+    }))
+  )
+
+export const usePendingChatSend = () =>
+  chatInputStore(
+    useShallow((state) => ({
+      pendingChatSend: state.pendingChatSend,
+      queueChatSend: state.queueChatSend,
+      clearPendingChatSend: state.clearPendingChatSend
     }))
   )

--- a/src/features/diagnostics/components/__tests__/diagnostics-settings.test.ts
+++ b/src/features/diagnostics/components/__tests__/diagnostics-settings.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import type { DiagnosticsGetBundleResult } from "@/protocol/diagnostics-rpc"
+import { buildDiagnosticIssueUrl } from "../diagnostics-settings"
+
+describe("buildDiagnosticIssueUrl", () => {
+  it("prefills only the safe summary, not event or provider details", () => {
+    const bundle: DiagnosticsGetBundleResult["bundle"] = {
+      format: "ollama-client-support-v1",
+      createdAt: 1,
+      appVersion: "1.2.3",
+      browserFamily: "chromium",
+      osFamily: "linux",
+      capabilities: {},
+      permissions: {},
+      providers: [{ profile: "openrouter", wire: "openai", enabled: true }],
+      storage: { backend: "opfs", messageCount: 20, vectorCount: 4 },
+      events: [
+        {
+          id: crypto.randomUUID(),
+          at: 1,
+          level: "error",
+          code: "RPC_FAILED",
+          operation: "providers.listModels",
+          surface: "background",
+          supportCode: "OLC-RPC-PROVIDER-FAILED-12345678"
+        }
+      ],
+      selfTests: [
+        {
+          id: "provider_discovery",
+          status: "fail",
+          durationMs: 10,
+          code: "OLC-PROVIDER-DISCOVERY-001"
+        }
+      ]
+    }
+
+    const decoded = decodeURIComponent(buildDiagnosticIssueUrl(bundle))
+    expect(decoded).toContain("OLC-PROVIDER-DISCOVERY-001")
+    expect(decoded).not.toContain("openrouter")
+    expect(decoded).not.toContain("messageCount")
+    expect(decoded).not.toContain("OLC-RPC-PROVIDER-FAILED-12345678")
+  })
+})

--- a/src/features/diagnostics/components/diagnostics-settings.tsx
+++ b/src/features/diagnostics/components/diagnostics-settings.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { SettingsCard } from "@/components/settings"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/hooks/use-toast"
+import { openExternalUrl } from "@/lib/browser-api"
+import { EXTERNAL_URLS } from "@/lib/constants"
+import {
+  Activity,
+  Copy,
+  Download,
+  Github,
+  Loader2,
+  Trash2
+} from "@/lib/lucide-icon"
+import type {
+  DiagnosticsGetBundleResult,
+  DiagnosticTestResult
+} from "@/protocol/diagnostics-rpc"
+import { extensionRpcClient } from "@/protocol/extension-client"
+import { RpcMethod } from "@/protocol/rpc"
+
+export const buildDiagnosticIssueUrl = (
+  bundle: DiagnosticsGetBundleResult["bundle"]
+): string => {
+  const failed = bundle.selfTests
+    .filter((test) => test.status === "fail")
+    .map((test) => `- ${test.id}: ${test.code ?? "failed"}`)
+  const body = [
+    "**What happened**",
+    "_Describe the problem here._",
+    "",
+    "**Safe diagnostic summary**",
+    `- Extension: ${bundle.appVersion}`,
+    `- Browser: ${bundle.browserFamily}`,
+    `- OS: ${bundle.osFamily}`,
+    `- Storage backend: ${bundle.storage.backend}`,
+    ...(failed.length > 0 ? failed : ["- Self-tests: passed"]),
+    "",
+    "Review and attach the downloaded support bundle if useful."
+  ].join("\n")
+  const params = new URLSearchParams({
+    title: "[bug] Diagnostics support request",
+    body
+  })
+  return `${EXTERNAL_URLS.GITHUB_ISSUES}/new?${params.toString()}`
+}
+
+export const DiagnosticsSettings = () => {
+  const { t } = useTranslation()
+  const { toast } = useToast()
+  const [running, setRunning] = useState(false)
+  const [tests, setTests] = useState<DiagnosticTestResult[]>([])
+  const [bundle, setBundle] = useState<DiagnosticsGetBundleResult["bundle"]>()
+  const preview = bundle ? JSON.stringify(bundle, null, 2) : ""
+
+  const run = async () => {
+    setRunning(true)
+    try {
+      const result = await extensionRpcClient.call(RpcMethod.DiagnosticsRun, {})
+      setTests(result.tests)
+    } catch {
+      toast({ title: t("diagnostics.failed"), variant: "destructive" })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const loadPreview = async () => {
+    setRunning(true)
+    try {
+      const result = await extensionRpcClient.call(
+        RpcMethod.DiagnosticsGetBundle,
+        {}
+      )
+      setBundle(result.bundle)
+      setTests(result.bundle.selfTests)
+    } catch {
+      toast({ title: t("diagnostics.failed"), variant: "destructive" })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(preview)
+      toast({ title: t("diagnostics.copied") })
+    } catch {
+      toast({ title: t("diagnostics.failed"), variant: "destructive" })
+    }
+  }
+
+  const download = () => {
+    const url = URL.createObjectURL(
+      new Blob([preview], { type: "application/json" })
+    )
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = `ollama-client-support-${bundle?.createdAt ?? Date.now()}.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const clear = async () => {
+    try {
+      await extensionRpcClient.call(RpcMethod.DiagnosticsClear, {})
+      setBundle(undefined)
+      toast({ title: t("diagnostics.cleared") })
+    } catch {
+      toast({ title: t("diagnostics.failed"), variant: "destructive" })
+    }
+  }
+
+  return (
+    <SettingsCard
+      icon={Activity}
+      title={t("diagnostics.title")}
+      description={t("diagnostics.description")}
+      focusId="diagnostics-support">
+      <div className="flex flex-wrap gap-2">
+        <Button disabled={running} onClick={() => void run()}>
+          {running && <Loader2 className="icon-sm animate-spin" />}
+          {t("diagnostics.run")}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={running}
+          onClick={() => void loadPreview()}>
+          {t("diagnostics.preview")}
+        </Button>
+      </div>
+
+      {tests.length > 0 && (
+        <div className="space-y-2" aria-live="polite">
+          {tests.map((test) => (
+            <div
+              key={test.id}
+              className="flex items-center justify-between rounded-control border p-2 text-xs">
+              <span>{t(`diagnostics.tests.${test.id}`)}</span>
+              <div className="flex items-center gap-2">
+                {test.code && (
+                  <code className="select-all text-micro">{test.code}</code>
+                )}
+                <Badge
+                  variant={
+                    test.status === "pass"
+                      ? "secondary"
+                      : test.status === "fail"
+                        ? "destructive"
+                        : "outline"
+                  }>
+                  {t(`diagnostics.status.${test.status}`)}
+                </Badge>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {bundle && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            {t("diagnostics.privacy_notice")}
+          </p>
+          <Textarea
+            value={preview}
+            readOnly
+            className="max-h-80 font-mono text-micro"
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => void copy()}>
+              <Copy className="icon-sm" />
+              {t("diagnostics.copy")}
+            </Button>
+            <Button variant="outline" onClick={download}>
+              <Download className="icon-sm" />
+              {t("diagnostics.download")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => openExternalUrl(buildDiagnosticIssueUrl(bundle))}>
+              <Github className="icon-sm" />
+              {t("diagnostics.open_issue")}
+            </Button>
+            <Button variant="ghost" onClick={() => void clear()}>
+              <Trash2 className="icon-sm" />
+              {t("diagnostics.clear")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </SettingsCard>
+  )
+}

--- a/src/features/selection-actions/__tests__/panel-markdown.test.tsx
+++ b/src/features/selection-actions/__tests__/panel-markdown.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { cleanup, render } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { PanelMarkdown } from "../components/panel-markdown"

--- a/src/features/settings/settings-registry.ts
+++ b/src/features/settings/settings-registry.ts
@@ -102,6 +102,15 @@ type RawSettingsEntry = Omit<SettingsEntry, "tab"> & {
  * only needs the correct `focus` id even if its `tab` is stale.
  */
 const RAW_SETTINGS_REGISTRY: RawSettingsEntry[] = [
+  {
+    id: "diagnostics-support",
+    tab: "help",
+    sectionId: "diagnostics",
+    labelKey: "diagnostics.title",
+    descriptionKey: "diagnostics.description",
+    searchKeys: ["diagnostics.run", "diagnostics.preview"],
+    aliases: ["support bundle", "self test", "support code"]
+  },
   // ---- General -----------------------------------------------------------
   {
     id: "language-select",

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -130,7 +130,15 @@ export const STORAGE_KEYS = {
     PREFERENCE: "light-dark-theme"
   },
   LANGUAGE: "app-language",
-  // One-shot flag: the first-run permissions/privacy intro has been shown.
+  ONBOARDING: {
+    /** Device-local resumable onboarding state. */
+    STATE: "onboarding-state-v2"
+  },
+  DIAGNOSTICS: {
+    /** Device-local, content-free diagnostic ring buffer. */
+    EVENTS: "diagnostic-events-v1"
+  },
+  // Legacy one-shot flag. Read only while migrating onboarding state v2.
   ONBOARDING_PERMISSIONS_SEEN: "onboarding-permissions-seen",
   BROWSER: {
     TABS_ACCESS: "browser-tab-access",

--- a/src/lib/diagnostics/__tests__/diagnostic-recorder.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostic-recorder.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  clearDiagnosticEvents,
+  flushDiagnosticEvents,
+  getDiagnosticEvents,
+  recordDiagnosticEvent
+} from "../diagnostic-recorder"
+
+const storage = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  remove: vi.fn()
+}))
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: storage.get,
+  setPlasmoStoredValue: storage.set,
+  removePlasmoStoredValue: storage.remove
+}))
+
+beforeEach(async () => {
+  await clearDiagnosticEvents()
+  storage.get.mockReset().mockResolvedValue([])
+  storage.set.mockReset().mockResolvedValue(undefined)
+  storage.remove.mockReset().mockResolvedValue(undefined)
+})
+
+describe("diagnostic recorder", () => {
+  it("stores only allowlisted technical metadata", async () => {
+    await recordDiagnosticEvent({
+      level: "error",
+      code: "RPC_PROVIDER_FAILED",
+      operation: "providers.listModels",
+      surface: "background",
+      metadata: {
+        count: 2,
+        status: "failed",
+        prompt: "private prompt",
+        result: "contains private words"
+      }
+    })
+    await flushDiagnosticEvents()
+
+    expect(storage.set).toHaveBeenCalledWith(STORAGE_KEYS.DIAGNOSTICS.EVENTS, [
+      expect.objectContaining({
+        metadata: { count: 2, status: "failed" }
+      })
+    ])
+  })
+
+  it("batches multiple events into one storage write", async () => {
+    await recordDiagnosticEvent({
+      level: "info",
+      code: "RPC_COMPLETED",
+      operation: "providers.list",
+      surface: "background"
+    })
+    await recordDiagnosticEvent({
+      level: "info",
+      code: "RPC_COMPLETED",
+      operation: "providers.listModels",
+      surface: "background"
+    })
+
+    expect(storage.set).not.toHaveBeenCalled()
+    await expect(getDiagnosticEvents()).resolves.toHaveLength(2)
+
+    await flushDiagnosticEvents()
+    expect(storage.set).toHaveBeenCalledOnce()
+    expect(storage.set.mock.calls[0]?.[1]).toHaveLength(2)
+  })
+
+  it("keeps the pending in-memory batch small during an event burst", async () => {
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        recordDiagnosticEvent({
+          level: "info",
+          code: "RPC_COMPLETED",
+          operation: `providers.test-${index}`,
+          surface: "background",
+          metadata: { result: "x".repeat(100) }
+        })
+      )
+    )
+
+    const events = await getDiagnosticEvents()
+    expect(events.length).toBeLessThanOrEqual(50)
+    expect(JSON.stringify(events).length).toBeLessThanOrEqual(32 * 1024)
+  })
+
+  it("drops invalid, expired, and excess records", async () => {
+    const now = Date.now()
+    storage.get.mockResolvedValue([
+      { secret: "not an event" },
+      {
+        id: crypto.randomUUID(),
+        at: now - 8 * 24 * 60 * 60 * 1000,
+        level: "info",
+        code: "OLD",
+        operation: "test",
+        surface: "background"
+      },
+      {
+        id: crypto.randomUUID(),
+        at: now,
+        level: "info",
+        code: "CURRENT",
+        operation: "test",
+        surface: "background"
+      }
+    ])
+
+    await expect(getDiagnosticEvents(now)).resolves.toMatchObject([
+      { code: "CURRENT" }
+    ])
+  })
+
+  it("caps retained diagnostics by count and serialized size", async () => {
+    const now = Date.now()
+    storage.get.mockResolvedValue(
+      Array.from({ length: 250 }, (_, index) => ({
+        id: crypto.randomUUID(),
+        at: now + index,
+        level: "info",
+        code: "RPC_COMPLETED",
+        operation: "providers.listModels",
+        surface: "background",
+        metadata: { result: "x".repeat(1_000) }
+      }))
+    )
+
+    const events = await getDiagnosticEvents(now + 250)
+    expect(events.length).toBeLessThanOrEqual(200)
+    expect(JSON.stringify(events).length).toBeLessThanOrEqual(128 * 1024)
+    expect(events.at(-1)?.at).toBe(now + 249)
+  })
+})

--- a/src/lib/diagnostics/__tests__/diagnostic-recorder.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostic-recorder.test.ts
@@ -13,6 +13,11 @@ const storage = vi.hoisted(() => ({
   set: vi.fn(),
   remove: vi.fn()
 }))
+const sessionStorage = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  remove: vi.fn()
+}))
 vi.mock("@/lib/plasmo-global-storage", () => ({
   getPlasmoStoredValue: storage.get,
   setPlasmoStoredValue: storage.set,
@@ -20,10 +25,27 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
 }))
 
 beforeEach(async () => {
-  await clearDiagnosticEvents()
+  let sessionValues: Record<string, unknown> = {}
+  Object.assign(chrome.storage, { session: sessionStorage })
+  sessionStorage.get.mockReset().mockImplementation(async (key: string) => ({
+    [key]: sessionValues[key]
+  }))
+  sessionStorage.set.mockReset().mockImplementation(async (items) => {
+    sessionValues = { ...sessionValues, ...items }
+  })
+  sessionStorage.remove.mockReset().mockImplementation(async (key: string) => {
+    delete sessionValues[key]
+  })
   storage.get.mockReset().mockResolvedValue([])
   storage.set.mockReset().mockResolvedValue(undefined)
   storage.remove.mockReset().mockResolvedValue(undefined)
+  await clearDiagnosticEvents()
+  sessionStorage.get.mockClear()
+  sessionStorage.set.mockClear()
+  sessionStorage.remove.mockClear()
+  storage.get.mockClear()
+  storage.set.mockClear()
+  storage.remove.mockClear()
 })
 
 describe("diagnostic recorder", () => {
@@ -64,11 +86,41 @@ describe("diagnostic recorder", () => {
     })
 
     expect(storage.set).not.toHaveBeenCalled()
+    expect(sessionStorage.set).toHaveBeenCalledTimes(2)
     await expect(getDiagnosticEvents()).resolves.toHaveLength(2)
 
     await flushDiagnosticEvents()
     expect(storage.set).toHaveBeenCalledOnce()
     expect(storage.set.mock.calls[0]?.[1]).toHaveLength(2)
+  })
+
+  it("serializes clear after an in-flight flush", async () => {
+    let releaseWrite: (() => void) | undefined
+    storage.set.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWrite = resolve
+        })
+    )
+    await recordDiagnosticEvent({
+      level: "info",
+      code: "RPC_COMPLETED",
+      operation: "providers.list",
+      surface: "background"
+    })
+
+    const flush = flushDiagnosticEvents()
+    await vi.waitFor(() => expect(storage.set).toHaveBeenCalledOnce())
+    const clear = clearDiagnosticEvents()
+    expect(storage.remove).not.toHaveBeenCalled()
+
+    releaseWrite?.()
+    await flush
+    await clear
+    expect(storage.remove).toHaveBeenCalledOnce()
+    expect(storage.set.mock.invocationCallOrder[0]).toBeLessThan(
+      storage.remove.mock.invocationCallOrder[0]
+    )
   })
 
   it("keeps the pending in-memory batch small during an event burst", async () => {

--- a/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  countMessages: vi.fn(),
+  vectorCount: vi.fn(),
+  providers: vi.fn(),
+  listModels: vi.fn(),
+  backend: vi.fn(),
+  txBegin: vi.fn(),
+  txRollback: vi.fn(),
+  query: vi.fn(),
+  events: vi.fn(),
+  record: vi.fn(),
+  clear: vi.fn()
+}))
+
+vi.mock("@/lib/repositories/chat-history", () => ({
+  countMessages: mocks.countMessages
+}))
+vi.mock("@/lib/embeddings/db", () => ({
+  vectorDb: { vectors: { count: mocks.vectorCount } }
+}))
+vi.mock("@/lib/providers/manager", () => ({
+  ProviderManager: { getProviders: mocks.providers }
+}))
+vi.mock("@/lib/providers/provider-rpc-service", () => ({
+  ProviderRpcService: { listModels: mocks.listModels }
+}))
+vi.mock("@/lib/persistence/backend", () => ({
+  readPersistenceBackend: mocks.backend
+}))
+vi.mock("@/lib/persistence/client", () => ({
+  rpcTxBegin: mocks.txBegin,
+  rpcTxRollback: mocks.txRollback,
+  rpcQuery: mocks.query
+}))
+vi.mock("../diagnostic-recorder", () => ({
+  getDiagnosticEvents: mocks.events,
+  recordDiagnosticEvent: mocks.record,
+  clearDiagnosticEvents: mocks.clear
+}))
+
+import { DiagnosticsService } from "../diagnostics-service"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  chrome.runtime.getManifest = vi.fn(() => ({ version: "1.2.3" })) as never
+  mocks.countMessages.mockResolvedValue(12)
+  mocks.vectorCount.mockResolvedValue(4)
+  mocks.providers.mockResolvedValue([
+    {
+      id: "private-id",
+      name: "Private deployment",
+      type: "openai",
+      enabled: true,
+      baseUrl: "https://secret.example/private/path?token=secret",
+      apiKey: "sk-secret",
+      serviceProfile: "openrouter"
+    }
+  ])
+  mocks.listModels.mockResolvedValue({
+    models: [{ name: "private-model" }],
+    failures: []
+  })
+  mocks.backend.mockResolvedValue("opfs")
+  mocks.txBegin.mockResolvedValue(undefined)
+  mocks.txRollback.mockResolvedValue(undefined)
+  mocks.query.mockResolvedValue([{ ok: 1 }])
+  mocks.events.mockResolvedValue([])
+  mocks.record.mockResolvedValue(undefined)
+  mocks.clear.mockResolvedValue(undefined)
+})
+
+describe("DiagnosticsService", () => {
+  it("runs a rollback-only repository smoke test and provider discovery", async () => {
+    const result = await DiagnosticsService.run()
+
+    expect(result.tests.map((test) => test.id)).toEqual(
+      expect.arrayContaining([
+        "chat_repository",
+        "provider_discovery",
+        "migration"
+      ])
+    )
+    expect(mocks.txBegin).toHaveBeenCalledOnce()
+    expect(mocks.query).toHaveBeenCalledWith(
+      "SELECT 1 AS ok",
+      undefined,
+      expect.stringMatching(/^diagnostic-/)
+    )
+    expect(mocks.txRollback).toHaveBeenCalledOnce()
+    expect(mocks.listModels).toHaveBeenCalledWith(
+      { enabledOnly: true },
+      undefined
+    )
+  })
+
+  it("exports provider classes without identities, endpoints, models, or secrets", async () => {
+    const { bundle } = await DiagnosticsService.getBundle()
+    const serialized = JSON.stringify(bundle)
+
+    expect(bundle.providers).toEqual([
+      { profile: "openrouter", wire: "openai", enabled: true }
+    ])
+    expect(serialized).not.toContain("private-id")
+    expect(serialized).not.toContain("Private deployment")
+    expect(serialized).not.toContain("secret.example")
+    expect(serialized).not.toContain("private-model")
+    expect(serialized).not.toContain("sk-secret")
+  })
+
+  it("surfaces legacy persistence as a recoverable migration action", async () => {
+    mocks.backend.mockResolvedValue("legacy")
+    const result = await DiagnosticsService.run()
+
+    expect(result.tests.find((test) => test.id === "migration")).toMatchObject({
+      status: "action",
+      code: "OLC-STORAGE-MIGRATION-001"
+    })
+  })
+})

--- a/src/lib/diagnostics/diagnostic-recorder.ts
+++ b/src/lib/diagnostics/diagnostic-recorder.ts
@@ -1,0 +1,158 @@
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  getPlasmoStoredValue,
+  removePlasmoStoredValue,
+  setPlasmoStoredValue
+} from "@/lib/plasmo-global-storage"
+import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
+import {
+  type DiagnosticEvent,
+  DiagnosticEventSchema
+} from "@/protocol/diagnostics-rpc"
+
+const MAX_EVENTS = 200
+const MAX_SERIALIZED_CHARS = 128 * 1024
+const MAX_PENDING_EVENTS = 50
+const MAX_PENDING_SERIALIZED_CHARS = 32 * 1024
+const EVENT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const FLUSH_DELAY_MS = 15_000
+const DIAGNOSTIC_LOCK = "diagnostic-events-v1-write"
+const SAFE_METADATA_KEYS = new Set([
+  "browserApi",
+  "capability",
+  "count",
+  "errorCode",
+  "phase",
+  "result",
+  "schemaVersion",
+  "source",
+  "status"
+])
+
+type DiagnosticInput = Omit<DiagnosticEvent, "id" | "at" | "metadata"> & {
+  metadata?: Record<string, unknown>
+}
+
+let pendingEvents: DiagnosticEvent[] = []
+let flushTimer: ReturnType<typeof setTimeout> | undefined
+
+const safeMetadata = (
+  metadata: Record<string, unknown> | undefined
+): DiagnosticEvent["metadata"] => {
+  if (!metadata) return undefined
+  const entries = Object.entries(metadata).flatMap(([key, value]) => {
+    if (!SAFE_METADATA_KEYS.has(key)) return []
+    if (
+      value !== null &&
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      return []
+    }
+    if (typeof value === "string" && !/^[a-zA-Z0-9_.:-]{1,100}$/.test(value)) {
+      return []
+    }
+    return [[key, value] as const]
+  })
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+const compactEvents = (
+  events: DiagnosticEvent[],
+  now: number,
+  maxEvents = MAX_EVENTS,
+  maxSerializedChars = MAX_SERIALIZED_CHARS
+) => {
+  const compacted = events
+    .filter((event) => now - event.at <= EVENT_TTL_MS)
+    .slice(-maxEvents)
+  while (
+    compacted.length > 0 &&
+    JSON.stringify(compacted).length > maxSerializedChars
+  ) {
+    compacted.shift()
+  }
+  return compacted
+}
+
+const readStoredEvents = async (): Promise<DiagnosticEvent[]> => {
+  const raw = await getPlasmoStoredValue<unknown>(
+    STORAGE_KEYS.DIAGNOSTICS.EVENTS
+  )
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((event) => {
+    const parsed = DiagnosticEventSchema.safeParse(event)
+    return parsed.success ? [parsed.data] : []
+  })
+}
+
+export const getDiagnosticEvents = async (
+  now = Date.now()
+): Promise<DiagnosticEvent[]> =>
+  compactEvents([...(await readStoredEvents()), ...pendingEvents], now)
+
+export const flushDiagnosticEvents = async (): Promise<void> => {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = undefined
+  }
+  if (pendingEvents.length === 0) return
+
+  const batch = pendingEvents
+  pendingEvents = []
+  try {
+    await withStorageWriteLock(DIAGNOSTIC_LOCK, async () => {
+      const stored = await readStoredEvents()
+      await setPlasmoStoredValue(
+        STORAGE_KEYS.DIAGNOSTICS.EVENTS,
+        compactEvents([...stored, ...batch], Date.now())
+      )
+    })
+  } catch (error) {
+    pendingEvents = compactEvents(
+      [...batch, ...pendingEvents],
+      Date.now(),
+      MAX_PENDING_EVENTS,
+      MAX_PENDING_SERIALIZED_CHARS
+    )
+    throw error
+  }
+}
+
+const scheduleFlush = () => {
+  if (flushTimer) return
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined
+    void flushDiagnosticEvents().catch(() => undefined)
+  }, FLUSH_DELAY_MS)
+}
+
+export const recordDiagnosticEvent = async (
+  input: DiagnosticInput
+): Promise<void> => {
+  const event = DiagnosticEventSchema.parse({
+    ...input,
+    id: crypto.randomUUID(),
+    at: Date.now(),
+    metadata: safeMetadata(input.metadata)
+  })
+  pendingEvents = compactEvents(
+    [...pendingEvents, event],
+    event.at,
+    MAX_PENDING_EVENTS,
+    MAX_PENDING_SERIALIZED_CHARS
+  )
+  scheduleFlush()
+}
+
+export const clearDiagnosticEvents = async (): Promise<void> => {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = undefined
+  }
+  pendingEvents = []
+  await withStorageWriteLock(DIAGNOSTIC_LOCK, () =>
+    removePlasmoStoredValue(STORAGE_KEYS.DIAGNOSTICS.EVENTS)
+  )
+}

--- a/src/lib/diagnostics/diagnostic-recorder.ts
+++ b/src/lib/diagnostics/diagnostic-recorder.ts
@@ -17,6 +17,7 @@ const MAX_PENDING_SERIALIZED_CHARS = 32 * 1024
 const EVENT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const FLUSH_DELAY_MS = 15_000
 const DIAGNOSTIC_LOCK = "diagnostic-events-v1-write"
+const PENDING_STORAGE_KEY = "diagnostic-pending-events-v1"
 const SAFE_METADATA_KEYS = new Set([
   "browserApi",
   "capability",
@@ -33,8 +34,21 @@ type DiagnosticInput = Omit<DiagnosticEvent, "id" | "at" | "metadata"> & {
   metadata?: Record<string, unknown>
 }
 
-let pendingEvents: DiagnosticEvent[] = []
+let fallbackPendingEvents: DiagnosticEvent[] = []
 let flushTimer: ReturnType<typeof setTimeout> | undefined
+
+type SessionStorageArea = {
+  get: (key: string) => Promise<Record<string, unknown>>
+  set: (items: Record<string, unknown>) => Promise<void>
+  remove: (key: string) => Promise<void>
+}
+
+const getSessionStorage = (): SessionStorageArea | undefined =>
+  (
+    chrome.storage as typeof chrome.storage & {
+      session?: SessionStorageArea
+    }
+  ).session
 
 const safeMetadata = (
   metadata: Record<string, unknown> | undefined
@@ -64,9 +78,13 @@ const compactEvents = (
   maxEvents = MAX_EVENTS,
   maxSerializedChars = MAX_SERIALIZED_CHARS
 ) => {
-  const compacted = events
-    .filter((event) => now - event.at <= EVENT_TTL_MS)
-    .slice(-maxEvents)
+  const compacted = Array.from(
+    new Map(
+      events
+        .filter((event) => now - event.at <= EVENT_TTL_MS)
+        .map((event) => [event.id, event])
+    ).values()
+  ).slice(-maxEvents)
   while (
     compacted.length > 0 &&
     JSON.stringify(compacted).length > maxSerializedChars
@@ -87,37 +105,65 @@ const readStoredEvents = async (): Promise<DiagnosticEvent[]> => {
   })
 }
 
+const parseEvents = (raw: unknown): DiagnosticEvent[] => {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((event) => {
+    const parsed = DiagnosticEventSchema.safeParse(event)
+    return parsed.success ? [parsed.data] : []
+  })
+}
+
+const readPendingEvents = async (): Promise<DiagnosticEvent[]> => {
+  const sessionStorage = getSessionStorage()
+  if (!sessionStorage) return fallbackPendingEvents
+  const stored = await sessionStorage.get(PENDING_STORAGE_KEY)
+  return parseEvents(stored[PENDING_STORAGE_KEY])
+}
+
+const writePendingEvents = async (events: DiagnosticEvent[]): Promise<void> => {
+  const sessionStorage = getSessionStorage()
+  if (!sessionStorage) {
+    fallbackPendingEvents = events
+    return
+  }
+  await sessionStorage.set({ [PENDING_STORAGE_KEY]: events })
+}
+
+const clearPendingEvents = async (): Promise<void> => {
+  fallbackPendingEvents = []
+  await getSessionStorage()?.remove(PENDING_STORAGE_KEY)
+}
+
 export const getDiagnosticEvents = async (
   now = Date.now()
 ): Promise<DiagnosticEvent[]> =>
-  compactEvents([...(await readStoredEvents()), ...pendingEvents], now)
+  withStorageWriteLock(DIAGNOSTIC_LOCK, async () =>
+    compactEvents(
+      [...(await readStoredEvents()), ...(await readPendingEvents())],
+      now
+    )
+  )
 
 export const flushDiagnosticEvents = async (): Promise<void> => {
   if (flushTimer) {
     clearTimeout(flushTimer)
     flushTimer = undefined
   }
-  if (pendingEvents.length === 0) return
-
-  const batch = pendingEvents
-  pendingEvents = []
-  try {
-    await withStorageWriteLock(DIAGNOSTIC_LOCK, async () => {
+  await withStorageWriteLock(DIAGNOSTIC_LOCK, async () => {
+    const batch = await readPendingEvents()
+    if (batch.length === 0) return
+    try {
       const stored = await readStoredEvents()
       await setPlasmoStoredValue(
         STORAGE_KEYS.DIAGNOSTICS.EVENTS,
         compactEvents([...stored, ...batch], Date.now())
       )
-    })
-  } catch (error) {
-    pendingEvents = compactEvents(
-      [...batch, ...pendingEvents],
-      Date.now(),
-      MAX_PENDING_EVENTS,
-      MAX_PENDING_SERIALIZED_CHARS
-    )
-    throw error
-  }
+      await clearPendingEvents()
+    } catch (error) {
+      await writePendingEvents(batch)
+      throw error
+    }
+  })
 }
 
 const scheduleFlush = () => {
@@ -137,12 +183,17 @@ export const recordDiagnosticEvent = async (
     at: Date.now(),
     metadata: safeMetadata(input.metadata)
   })
-  pendingEvents = compactEvents(
-    [...pendingEvents, event],
-    event.at,
-    MAX_PENDING_EVENTS,
-    MAX_PENDING_SERIALIZED_CHARS
-  )
+  await withStorageWriteLock(DIAGNOSTIC_LOCK, async () => {
+    const pendingEvents = await readPendingEvents()
+    await writePendingEvents(
+      compactEvents(
+        [...pendingEvents, event],
+        event.at,
+        MAX_PENDING_EVENTS,
+        MAX_PENDING_SERIALIZED_CHARS
+      )
+    )
+  })
   scheduleFlush()
 }
 
@@ -151,8 +202,8 @@ export const clearDiagnosticEvents = async (): Promise<void> => {
     clearTimeout(flushTimer)
     flushTimer = undefined
   }
-  pendingEvents = []
-  await withStorageWriteLock(DIAGNOSTIC_LOCK, () =>
-    removePlasmoStoredValue(STORAGE_KEYS.DIAGNOSTICS.EVENTS)
-  )
+  await withStorageWriteLock(DIAGNOSTIC_LOCK, async () => {
+    await clearPendingEvents()
+    await removePlasmoStoredValue(STORAGE_KEYS.DIAGNOSTICS.EVENTS)
+  })
 }

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -1,0 +1,221 @@
+import { vectorDb } from "@/lib/embeddings/db"
+import { readPersistenceBackend } from "@/lib/persistence/backend"
+import { rpcQuery, rpcTxBegin, rpcTxRollback } from "@/lib/persistence/client"
+import { ProviderManager } from "@/lib/providers/manager"
+import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
+import { countMessages } from "@/lib/repositories/chat-history"
+import type {
+  DiagnosticsGetBundleResult,
+  DiagnosticsRunResult,
+  DiagnosticTestResult
+} from "@/protocol/diagnostics-rpc"
+
+import {
+  clearDiagnosticEvents,
+  getDiagnosticEvents,
+  recordDiagnosticEvent
+} from "./diagnostic-recorder"
+
+const elapsed = (startedAt: number) =>
+  Math.max(0, performance.now() - startedAt)
+
+const runTest = async (
+  id: string,
+  test: () => Promise<
+    Record<string, string | number | boolean | null> | undefined
+  >
+): Promise<DiagnosticTestResult> => {
+  const startedAt = performance.now()
+  try {
+    const metadata = await test()
+    return {
+      id,
+      status: "pass",
+      durationMs: elapsed(startedAt),
+      ...(metadata && { metadata })
+    }
+  } catch {
+    return {
+      id,
+      status: "fail",
+      durationMs: elapsed(startedAt),
+      code: `OLC-${id.replaceAll("_", "-").toUpperCase()}-001`
+    }
+  }
+}
+
+const storageRoundTrip = async (
+  area: chrome.storage.StorageArea
+): Promise<undefined> => {
+  const key = `diagnostic-self-test-${crypto.randomUUID()}`
+  const value = crypto.randomUUID()
+  try {
+    await area.set({ [key]: value })
+    const read = await area.get(key)
+    if (read[key] !== value) throw new Error("storage roundtrip mismatch")
+  } finally {
+    await area.remove(key)
+  }
+  return undefined
+}
+
+const capabilities = () => ({
+  tabs: Boolean(chrome.tabs),
+  permissions: Boolean(chrome.permissions),
+  sessions: Boolean(chrome.sessions),
+  declarativeNetRequest: Boolean(chrome.declarativeNetRequest),
+  offscreen: Boolean(chrome.offscreen)
+})
+
+const permissions = async (): Promise<Record<string, boolean>> => {
+  if (!chrome.permissions?.getAll) return {}
+  const granted = await chrome.permissions.getAll()
+  const names = new Set(granted.permissions ?? [])
+  return {
+    tabs: names.has("tabs"),
+    sessions: names.has("sessions"),
+    history: names.has("history"),
+    bookmarks: names.has("bookmarks"),
+    notifications: names.has("notifications")
+  }
+}
+
+const browserFamily = () => {
+  const ua = navigator.userAgent
+  if (/Firefox/i.test(ua)) return "firefox"
+  if (/Edg/i.test(ua)) return "edge"
+  if (/Chrom/i.test(ua)) return "chromium"
+  return "other"
+}
+
+const osFamily = () => {
+  const ua = navigator.userAgent
+  if (/Windows/i.test(ua)) return "windows"
+  if (/Mac OS|Macintosh/i.test(ua)) return "macos"
+  if (/Linux/i.test(ua)) return "linux"
+  return "other"
+}
+
+const runMigrationTest = async (): Promise<DiagnosticTestResult> => {
+  const result = await runTest("migration", async () => ({
+    result: await readPersistenceBackend()
+  }))
+  if (result.status === "pass" && result.metadata?.result === "legacy") {
+    return {
+      ...result,
+      status: "action",
+      code: "OLC-STORAGE-MIGRATION-001"
+    }
+  }
+  return result
+}
+
+export const DiagnosticsService = {
+  async run(signal?: AbortSignal): Promise<DiagnosticsRunResult> {
+    const tests = await Promise.all([
+      runTest("runtime_version", async () => {
+        const version = chrome.runtime.getManifest().version
+        if (!version) throw new Error("missing version")
+        return { result: "available" }
+      }),
+      runTest("browser_apis", async () => ({
+        count: Object.values(capabilities()).filter(Boolean).length
+      })),
+      runTest("permissions", async () => ({
+        count: Object.values(await permissions()).filter(Boolean).length
+      })),
+      runTest("sync_storage", () => storageRoundTrip(chrome.storage.sync)),
+      runTest("local_storage", () => storageRoundTrip(chrome.storage.local)),
+      runTest("chat_repository", async () => {
+        const token = `diagnostic-${crypto.randomUUID()}`
+        let began = false
+        try {
+          await rpcTxBegin(token)
+          began = true
+          const rows = await rpcQuery("SELECT 1 AS ok", undefined, token)
+          if (rows[0]?.ok !== 1) throw new Error("transaction smoke mismatch")
+        } finally {
+          if (began) await rpcTxRollback(token)
+        }
+        const count = await countMessages()
+        return { count }
+      }),
+      runTest("vector_store", async () => ({
+        count: await vectorDb.vectors.count()
+      })),
+      runTest("provider_discovery", async () => {
+        const result = await ProviderRpcService.listModels(
+          {
+            enabledOnly: true
+          },
+          signal
+        )
+        return {
+          count: result.models.length,
+          status: result.failures.length > 0 ? "partial" : "pass"
+        }
+      }),
+      runMigrationTest()
+    ])
+    signal?.throwIfAborted()
+    await recordDiagnosticEvent({
+      level: tests.every((test) => test.status === "pass") ? "info" : "warn",
+      code: "DIAGNOSTICS_SELF_TEST_COMPLETED",
+      operation: "diagnostics.run",
+      surface: "background",
+      metadata: {
+        count: tests.length,
+        result: tests.some((test) => test.status === "fail")
+          ? "failure"
+          : tests.some((test) => test.status === "action")
+            ? "action"
+            : "pass"
+      }
+    })
+    return { tests }
+  },
+
+  async getBundle(signal?: AbortSignal): Promise<DiagnosticsGetBundleResult> {
+    const [
+      providers,
+      events,
+      selfTests,
+      permissionState,
+      messageCount,
+      vectorCount
+    ] = await Promise.all([
+      ProviderManager.getProviders(),
+      getDiagnosticEvents(),
+      this.run(signal).then((result) => result.tests),
+      permissions(),
+      countMessages(),
+      vectorDb.vectors.count()
+    ])
+    signal?.throwIfAborted()
+    const backend = await readPersistenceBackend()
+    return {
+      bundle: {
+        format: "ollama-client-support-v1",
+        createdAt: Date.now(),
+        appVersion: chrome.runtime.getManifest().version,
+        browserFamily: browserFamily(),
+        osFamily: osFamily(),
+        capabilities: capabilities(),
+        permissions: permissionState,
+        providers: providers.map((provider) => ({
+          profile: String(provider.serviceProfile ?? "generic"),
+          wire: String(provider.type),
+          enabled: provider.enabled
+        })),
+        storage: { backend, messageCount, vectorCount },
+        events,
+        selfTests
+      }
+    }
+  },
+
+  async clear() {
+    await clearDiagnosticEvents()
+    return { cleared: true as const }
+  }
+}

--- a/src/lib/exporters/__tests__/export-sanitizer.test.ts
+++ b/src/lib/exporters/__tests__/export-sanitizer.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it } from "vitest"
 
 import {
@@ -44,10 +46,11 @@ describe("sanitizeExportFragment", () => {
     expect(clean).toContain('href="mailto:x@y.z"')
   })
 
-  it("keeps the export stylesheet", () => {
+  it("drops untrusted stylesheet elements", () => {
     const clean = sanitizeExportFragment("<style>.x{color:red}</style><p>t</p>")
-    expect(clean).toContain("<style>")
-    expect(clean).toContain(".x{color:red}")
+    expect(clean).not.toContain("<style>")
+    expect(clean).not.toContain(".x{color:red}")
+    expect(clean).toContain("<p>t</p>")
   })
 
   it("replaces remote images with a placeholder by default", () => {

--- a/src/lib/exporters/export-sanitizer.ts
+++ b/src/lib/exporters/export-sanitizer.ts
@@ -120,16 +120,16 @@ export interface ExportSanitizeOptions {
 /**
  * Sanitize the COMPLETE assembled print/export fragment. The print page reads
  * this fragment out of localStorage — writable by any extension page — so it
- * re-sanitizes on its side too; both ends share this one config. `<style>` is
- * allowed because the export carries its own stylesheet; when remote images
- * are blocked, the print page's CSP meta also covers CSS `url()` loads.
+ * re-sanitizes on its side too; both ends share this one config. App-owned
+ * print CSS is installed separately so untrusted payloads cannot inject style
+ * elements. When remote images are blocked, print CSP also covers CSS loads.
  */
 export const sanitizeExportFragment = (
   html: string,
   options?: ExportSanitizeOptions
 ): string => {
   const safe = DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: [...EXPORT_ALLOWED_TAGS, "style", "hr"],
+    ALLOWED_TAGS: [...EXPORT_ALLOWED_TAGS, "hr"],
     ALLOWED_ATTR: EXPORT_ALLOWED_ATTR,
     ALLOWED_URI_REGEXP: EXPORT_ALLOWED_URI_REGEXP
   })

--- a/src/lib/exporters/pdf-exporter.ts
+++ b/src/lib/exporters/pdf-exporter.ts
@@ -8,7 +8,6 @@ import type { ChatMessage, ChatSession, ImageAttachment } from "@/types"
 import { escapeHtml, sanitizeExportFragment } from "./export-sanitizer"
 import { createMarkdownParser, parseMessageContent } from "./markdown-utils"
 import { type PrintJobPayload, printJobKey } from "./print-job"
-import { getPdfStyles } from "./styles"
 import type { Exporter, ExportOptions } from "./types"
 
 /**
@@ -111,7 +110,6 @@ export const pdfExporter: Exporter = {
     const md = createMarkdownParser()
     const title = session.title || t("sessions.export.default_title")
     const html = `
-      ${getPdfStyles()}
       <div class="chat-container">
         <h1 class="chat-title">${escapeHtml(title)}</h1>
         ${(session.messages ?? []).map((msg) => renderMessage(msg, t, md)).join("")}
@@ -128,7 +126,6 @@ export const pdfExporter: Exporter = {
   exportAllSessions: async (sessions: ChatSession[], t: TFunction) => {
     const md = createMarkdownParser()
     const html = `
-      ${getPdfStyles()}
       <div class="chat-container">
         <h1 class="chat-title">${escapeHtml(t("sessions.export.all_sessions_title"))}</h1>
         ${sessions
@@ -153,7 +150,6 @@ export const pdfExporter: Exporter = {
   ) => {
     const md = createMarkdownParser()
     const html = `
-      ${getPdfStyles()}
       <div class="chat-container">
         ${renderMessage(message, t, md)}
       </div>

--- a/src/lib/exporters/styles.ts
+++ b/src/lib/exporters/styles.ts
@@ -1,7 +1,6 @@
 // No remote @import here: the export stylesheet must not fetch third-party
 // resources (fonts included) — printing a chat should leave no network trace.
 export const getPdfStyles = () => `
-<style>
   * {
     box-sizing: border-box;
   }
@@ -243,5 +242,4 @@ export const getPdfStyles = () => `
       word-wrap: break-word;
     }
   }
-</style>
 `

--- a/src/lib/onboarding/__tests__/state.test.ts
+++ b/src/lib/onboarding/__tests__/state.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  completeOnboardingAfterFirstResponse,
+  getOnboardingState,
+  selectOnboardingModel,
+  updateOnboardingState
+} from "../state"
+
+const storage = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn()
+}))
+
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: storage.get,
+  setPlasmoStoredValue: storage.set
+}))
+
+beforeEach(() => {
+  storage.get.mockReset()
+  storage.set.mockReset().mockResolvedValue(undefined)
+})
+
+describe("onboarding state", () => {
+  it("migrates the legacy seen flag to complete", async () => {
+    storage.get.mockImplementation(async (key: string) =>
+      key === STORAGE_KEYS.ONBOARDING_PERMISSIONS_SEEN ? true : undefined
+    )
+
+    await expect(getOnboardingState()).resolves.toMatchObject({
+      version: 2,
+      stage: "complete"
+    })
+  })
+
+  it("starts new profiles at privacy", async () => {
+    storage.get.mockResolvedValue(undefined)
+    await expect(getOnboardingState()).resolves.toEqual({
+      version: 2,
+      stage: "privacy"
+    })
+  })
+
+  it("completes only from test-chat", async () => {
+    storage.get.mockResolvedValue({ version: 2, stage: "privacy" })
+    await expect(completeOnboardingAfterFirstResponse()).resolves.toBe(false)
+
+    storage.get.mockResolvedValue({
+      version: 2,
+      stage: "test-chat",
+      providerId: "ollama",
+      modelRef: { providerId: "ollama", modelId: "qwen3" }
+    })
+    await expect(completeOnboardingAfterFirstResponse()).resolves.toBe(true)
+    expect(storage.set).toHaveBeenLastCalledWith(
+      STORAGE_KEYS.ONBOARDING.STATE,
+      expect.objectContaining({ stage: "complete" })
+    )
+  })
+
+  it("persists provider-qualified model selection", async () => {
+    storage.get.mockResolvedValue({
+      version: 2,
+      stage: "model-choice",
+      providerId: "openrouter",
+      testSessionId: "22222222-2222-4222-8222-222222222222"
+    })
+    await selectOnboardingModel({
+      providerId: "openrouter",
+      modelId: "vendor/model"
+    })
+    expect(storage.set).toHaveBeenCalledWith(
+      STORAGE_KEYS.ONBOARDING.STATE,
+      expect.objectContaining({
+        stage: "test-chat",
+        modelRef: { providerId: "openrouter", modelId: "vendor/model" },
+        testSessionId: undefined
+      })
+    )
+  })
+
+  it("does not reopen completed onboarding", async () => {
+    storage.get.mockResolvedValue({
+      version: 2,
+      stage: "complete",
+      completedAt: 1
+    })
+    await expect(
+      updateOnboardingState({ stage: "provider-choice" })
+    ).resolves.toMatchObject({ stage: "complete" })
+  })
+})

--- a/src/lib/onboarding/__tests__/state.test.ts
+++ b/src/lib/onboarding/__tests__/state.test.ts
@@ -45,19 +45,45 @@ describe("onboarding state", () => {
 
   it("completes only from test-chat", async () => {
     storage.get.mockResolvedValue({ version: 2, stage: "privacy" })
-    await expect(completeOnboardingAfterFirstResponse()).resolves.toBe(false)
+    await expect(
+      completeOnboardingAfterFirstResponse(
+        "11111111-1111-4111-8111-111111111111"
+      )
+    ).resolves.toBe(false)
 
     storage.get.mockResolvedValue({
       version: 2,
       stage: "test-chat",
       providerId: "ollama",
-      modelRef: { providerId: "ollama", modelId: "qwen3" }
+      modelRef: { providerId: "ollama", modelId: "qwen3" },
+      testSessionId: "11111111-1111-4111-8111-111111111111"
     })
-    await expect(completeOnboardingAfterFirstResponse()).resolves.toBe(true)
+    await expect(
+      completeOnboardingAfterFirstResponse(
+        "11111111-1111-4111-8111-111111111111"
+      )
+    ).resolves.toBe(true)
     expect(storage.set).toHaveBeenLastCalledWith(
       STORAGE_KEYS.ONBOARDING.STATE,
       expect.objectContaining({ stage: "complete" })
     )
+  })
+
+  it("does not complete from another chat session", async () => {
+    storage.get.mockResolvedValue({
+      version: 2,
+      stage: "test-chat",
+      providerId: "ollama",
+      modelRef: { providerId: "ollama", modelId: "qwen3" },
+      testSessionId: "11111111-1111-4111-8111-111111111111"
+    })
+
+    await expect(
+      completeOnboardingAfterFirstResponse(
+        "22222222-2222-4222-8222-222222222222"
+      )
+    ).resolves.toBe(false)
+    expect(storage.set).not.toHaveBeenCalled()
   })
 
   it("persists provider-qualified model selection", async () => {

--- a/src/lib/onboarding/state.ts
+++ b/src/lib/onboarding/state.ts
@@ -1,0 +1,119 @@
+import { z } from "zod"
+
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  getPlasmoStoredValue,
+  setPlasmoStoredValue
+} from "@/lib/plasmo-global-storage"
+import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
+import type { SelectedModelRef } from "@/types/model"
+
+export const OnboardingStageSchema = z.enum([
+  "privacy",
+  "provider-choice",
+  "provider-connection",
+  "model-choice",
+  "test-chat",
+  "complete"
+])
+
+export type OnboardingStage = z.infer<typeof OnboardingStageSchema>
+
+export const OnboardingStateSchema = z
+  .object({
+    version: z.literal(2),
+    stage: OnboardingStageSchema,
+    providerId: z.string().min(1).max(200).optional(),
+    modelRef: z
+      .object({
+        providerId: z.string().min(1).max(200),
+        modelId: z.string().min(1).max(500)
+      })
+      .strict()
+      .optional(),
+    testSessionId: z.string().uuid().optional(),
+    completedAt: z.number().int().nonnegative().optional(),
+    skippedAt: z.number().int().nonnegative().optional()
+  })
+  .strict()
+
+export type OnboardingState = z.infer<typeof OnboardingStateSchema>
+
+export const INITIAL_ONBOARDING_STATE: OnboardingState = {
+  version: 2,
+  stage: "privacy"
+}
+
+const ONBOARDING_LOCK = "onboarding-state-v2-write"
+
+const readStoredState = async (): Promise<OnboardingState | undefined> => {
+  const raw = await getPlasmoStoredValue<unknown>(STORAGE_KEYS.ONBOARDING.STATE)
+  const parsed = OnboardingStateSchema.safeParse(raw)
+  return parsed.success ? parsed.data : undefined
+}
+
+/**
+ * Read resumable onboarding state. Profiles that completed the legacy intro
+ * are treated as complete so an upgrade never forces established users back
+ * through first-run setup.
+ */
+export const getOnboardingState = async (): Promise<OnboardingState> => {
+  const current = await readStoredState()
+  if (current) return current
+
+  const legacySeen = await getPlasmoStoredValue<boolean>(
+    STORAGE_KEYS.ONBOARDING_PERMISSIONS_SEEN
+  )
+  const migrated: OnboardingState = legacySeen
+    ? { version: 2, stage: "complete", completedAt: Date.now() }
+    : INITIAL_ONBOARDING_STATE
+  await setPlasmoStoredValue(STORAGE_KEYS.ONBOARDING.STATE, migrated)
+  return migrated
+}
+
+export const updateOnboardingState = async (
+  update: Partial<Omit<OnboardingState, "version">>
+): Promise<OnboardingState> =>
+  withStorageWriteLock(ONBOARDING_LOCK, async () => {
+    const current = await getOnboardingState()
+    if (current.stage === "complete") return current
+    const next = OnboardingStateSchema.parse({
+      ...current,
+      ...update,
+      version: 2
+    })
+    await setPlasmoStoredValue(STORAGE_KEYS.ONBOARDING.STATE, next)
+    return next
+  })
+
+export const selectOnboardingProvider = (providerId: string) =>
+  updateOnboardingState({
+    stage: "provider-connection",
+    providerId,
+    modelRef: undefined
+  })
+
+export const selectOnboardingModel = (modelRef: SelectedModelRef) =>
+  updateOnboardingState({
+    stage: "test-chat",
+    providerId: modelRef.providerId,
+    modelRef,
+    testSessionId: undefined
+  })
+
+/** Called only after a final assistant message has been durably written. */
+export const completeOnboardingAfterFirstResponse =
+  async (): Promise<boolean> =>
+    withStorageWriteLock(ONBOARDING_LOCK, async () => {
+      const current = await getOnboardingState()
+      if (current.stage !== "test-chat") return false
+      await setPlasmoStoredValue(STORAGE_KEYS.ONBOARDING.STATE, {
+        ...current,
+        stage: "complete",
+        completedAt: Date.now()
+      } satisfies OnboardingState)
+      return true
+    })
+
+export const skipOnboarding = () =>
+  updateOnboardingState({ stage: "complete", skippedAt: Date.now() })

--- a/src/lib/onboarding/state.ts
+++ b/src/lib/onboarding/state.ts
@@ -102,18 +102,25 @@ export const selectOnboardingModel = (modelRef: SelectedModelRef) =>
   })
 
 /** Called only after a final assistant message has been durably written. */
-export const completeOnboardingAfterFirstResponse =
-  async (): Promise<boolean> =>
-    withStorageWriteLock(ONBOARDING_LOCK, async () => {
-      const current = await getOnboardingState()
-      if (current.stage !== "test-chat") return false
-      await setPlasmoStoredValue(STORAGE_KEYS.ONBOARDING.STATE, {
-        ...current,
-        stage: "complete",
-        completedAt: Date.now()
-      } satisfies OnboardingState)
-      return true
-    })
+export const completeOnboardingAfterFirstResponse = async (
+  sessionId: string | null
+): Promise<boolean> =>
+  withStorageWriteLock(ONBOARDING_LOCK, async () => {
+    const current = await getOnboardingState()
+    if (
+      current.stage !== "test-chat" ||
+      !sessionId ||
+      current.testSessionId !== sessionId
+    ) {
+      return false
+    }
+    await setPlasmoStoredValue(STORAGE_KEYS.ONBOARDING.STATE, {
+      ...current,
+      stage: "complete",
+      completedAt: Date.now()
+    } satisfies OnboardingState)
+    return true
+  })
 
 export const skipOnboarding = () =>
   updateOnboardingState({ stage: "complete", skippedAt: Date.now() })

--- a/src/lib/storage/storage-key-registry.ts
+++ b/src/lib/storage/storage-key-registry.ts
@@ -124,6 +124,16 @@ export const STORAGE_KEY_REGISTRY: Record<string, StorageKeyMetadata> = {
     reason:
       "One-shot first-run intro flag; optional permissions are per-device, so each browser shows it once."
   },
+  [STORAGE_KEYS.ONBOARDING.STATE]: {
+    key: STORAGE_KEYS.ONBOARDING.STATE,
+    scope: "device-local",
+    reason: "Onboarding progress and provider detection are per-device."
+  },
+  [STORAGE_KEYS.DIAGNOSTICS.EVENTS]: {
+    key: STORAGE_KEYS.DIAGNOSTICS.EVENTS,
+    scope: "device-local",
+    reason: "Sanitized support diagnostics describe this browser profile only."
+  },
   [STORAGE_KEYS.BROWSER.TABS_ACCESS]: {
     key: STORAGE_KEYS.BROWSER.TABS_ACCESS,
     scope: "sync-safe",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "Die Hintergrundanfrage ist fehlgeschlagen. Bitte versuche es erneut."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Schritt {{current}} von {{total}}",
     "continue": "Weiter",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "Der Seitenzugriff erlaubt der Erweiterung, von dir angefragte Websites zu lesen. Nichts wird gesendet, außer du konfigurierst einen Remote-Anbieter."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Berechtigungen öffnen",
       "dismiss": "Später"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Anbieter verbinden",
       "description": "Prüfe jetzt den Standard-Ollama-Endpunkt. Du kannst ihn ändern oder später einen anderen Anbieter einrichten.",
       "connected": "Verbunden. {{count}} Modell(e) gefunden.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "The background request failed. Please try again."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Step {{current}} of {{total}}",
     "continue": "Continue",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "Page access lets the extension read sites you ask about. Nothing is sent anywhere unless you configure a remote provider."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Open Permissions",
       "dismiss": "Maybe later"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Connect a provider",
       "description": "Check the default Ollama endpoint now. You can change it or configure another provider later.",
       "connected": "Connected. Found {{count}} model(s).",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "La solicitud en segundo plano falló. Inténtalo de nuevo."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Paso {{current}} de {{total}}",
     "continue": "Continuar",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "El acceso a páginas permite que la extensión lea los sitios que solicites. No se envía nada salvo que configures un proveedor remoto."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Abrir permisos",
       "dismiss": "Quizás más tarde"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Conectar un proveedor",
       "description": "Comprueba ahora el endpoint predeterminado de Ollama. Puedes cambiarlo o configurar otro proveedor después.",
       "connected": "Conectado. Se encontraron {{count}} modelo(s).",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "La requête en arrière-plan a échoué. Réessayez."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Étape {{current}} sur {{total}}",
     "continue": "Continuer",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "L’accès aux pages permet à l’extension de lire les sites que vous demandez. Rien n’est envoyé sauf si vous configurez un fournisseur distant."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Ouvrir les autorisations",
       "dismiss": "Plus tard"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Connecter un fournisseur",
       "description": "Vérifiez maintenant le point d’accès Ollama par défaut. Vous pourrez le modifier ou configurer un autre fournisseur plus tard.",
       "connected": "Connecté. {{count}} modèle(s) trouvé(s).",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "बैकग्राउंड अनुरोध विफल रहा। कृपया फिर कोशिश करें।"
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "चरण {{current}} / {{total}}",
     "continue": "जारी रखें",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "पेज एक्सेस से एक्सटेंशन आपके कहे हुए साइट पढ़ सकता है। रिमोट प्रदाता कॉन्फ़िगर किए बिना कुछ भी बाहर नहीं भेजा जाता।"
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "अनुमतियाँ खोलें",
       "dismiss": "बाद में"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "प्रदाता कनेक्ट करें",
       "description": "अभी डिफ़ॉल्ट Ollama एंडपॉइंट जाँचें। इसे बदल सकते हैं या बाद में दूसरा प्रदाता सेट कर सकते हैं।",
       "connected": "कनेक्ट हुआ। {{count}} मॉडल मिले।",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "La richiesta in background non è riuscita. Riprova."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Passaggio {{current}} di {{total}}",
     "continue": "Continua",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "L’accesso alle pagine consente all’estensione di leggere i siti richiesti. Nulla viene inviato a meno che non configuri un provider remoto."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Apri autorizzazioni",
       "dismiss": "Più tardi"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Connetti un provider",
       "description": "Verifica ora l’endpoint Ollama predefinito. Puoi cambiarlo o configurare un altro provider in seguito.",
       "connected": "Connesso. Trovati {{count}} modelli.",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "バックグラウンドのリクエストに失敗しました。もう一度お試しください。"
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "{{total}} ステップ中 {{current}}",
     "continue": "続ける",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "ページアクセスにより、依頼したサイトを拡張機能が読み取れます。リモートプロバイダーを設定しない限り、外部には送信されません。"
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "権限を開く",
       "dismiss": "後で"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "プロバイダーを接続",
       "description": "既定の Ollama エンドポイントを確認します。後で変更したり、別のプロバイダーを設定したりできます。",
       "connected": "接続しました。{{count}} 個のモデルが見つかりました。",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "Фоновый запрос завершился ошибкой. Повторите попытку."
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "Шаг {{current}} из {{total}}",
     "continue": "Продолжить",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "Доступ к страницам позволяет расширению читать запрошенные вами сайты. Ничего не отправляется, если вы не настроили удалённого провайдера."
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "Открыть разрешения",
       "dismiss": "Позже"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "Подключить провайдера",
       "description": "Проверьте стандартный адрес Ollama. Его можно изменить или позже настроить другого провайдера.",
       "connected": "Подключено. Найдено моделей: {{count}}.",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -1829,10 +1829,47 @@
       "internal": "后台请求失败。请重试。"
     }
   },
+  "diagnostics": {
+    "title": "Diagnostics & support",
+    "description": "Run local self-tests and preview a privacy-safe support bundle. Nothing uploads automatically.",
+    "run": "Run diagnostics",
+    "preview": "Preview support bundle",
+    "copy": "Copy bundle",
+    "download": "Download bundle",
+    "open_issue": "Open GitHub issue",
+    "clear": "Clear diagnostic history",
+    "copied": "Support bundle copied",
+    "cleared": "Diagnostic history cleared",
+    "failed": "Diagnostics request failed",
+    "privacy_notice": "Review before sharing. Bundle excludes chats, prompts, files, page content, credentials, cookies, and full endpoints.",
+    "status": {
+      "pass": "Pass",
+      "fail": "Fail",
+      "action": "Action needed",
+      "unsupported": "Unsupported"
+    },
+    "tests": {
+      "runtime_version": "Runtime version",
+      "browser_apis": "Browser APIs",
+      "permissions": "Browser permissions",
+      "sync_storage": "Sync storage",
+      "local_storage": "Local storage",
+      "chat_repository": "Chat repository",
+      "vector_store": "Vector store",
+      "provider_discovery": "Provider and model discovery",
+      "migration": "Persistence migration"
+    }
+  },
   "onboarding": {
     "step": "第 {{current}} 步，共 {{total}} 步",
     "continue": "继续",
     "privacy": {
+      "title": "Private by default",
+      "description": "Choose where your conversations are processed. Ollama Client has no product telemetry.",
+      "local_storage": "Chats and settings are stored in this browser profile.",
+      "no_telemetry": "Prompts, responses, and errors are not uploaded to an Ollama Client server.",
+      "remote_policy": "Remote providers receive requests directly and apply their own data policies.",
+      "permissions_jit": "Optional browser access is requested only when you use a related feature.",
       "host_access": "页面访问权限让扩展读取您指定的网站。除非配置远程提供商，否则不会向外发送任何内容。"
     },
     "permissions": {
@@ -1843,7 +1880,30 @@
       "open": "打开权限",
       "dismiss": "以后再说"
     },
+    "model": {
+      "title": "Choose a chat model",
+      "description": "Embedding-only models are hidden. You can change this choice later.",
+      "none": "Connection succeeded, but no chat models were found. Install or configure a model, then retry.",
+      "placeholder": "Select a model",
+      "use": "Use this model"
+    },
+    "test_chat": {
+      "title": "Send your first message",
+      "description": "Close setup and send the sample below. Setup completes only after the response is saved.",
+      "prompt": "Say hello in one sentence and tell me which model you are.",
+      "cost": "A remote request may incur a small provider charge.",
+      "open_chat": "Open chat"
+    },
     "provider": {
+      "choose_title": "Choose a provider",
+      "choose_description": "Local providers keep processing on your device. Remote providers receive the content you send.",
+      "local": "Local provider",
+      "remote": "Remote provider",
+      "key_configured": "API key configured",
+      "connect_title": "Check provider connection",
+      "connect_description": "Connect to {{provider}} and discover its available models.",
+      "remote_disclosure": "This check contacts the remote provider directly. No prompt is sent.",
+      "connection_failed": "Connection failed. Use this support code when asking for help.",
       "title": "连接提供商",
       "description": "立即检查默认 Ollama 端点。您可以修改它，也可以稍后配置其他提供商。",
       "connected": "已连接。找到 {{count}} 个模型。",

--- a/src/options/components/settings-page.tsx
+++ b/src/options/components/settings-page.tsx
@@ -31,6 +31,7 @@ import { SocialLinkButton } from "@/components/social-link-button"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { ChatDisplaySettings, SpeechSettings } from "@/features/chat/components"
 import { ContextSettings } from "@/features/context/components/context-settings"
+import { DiagnosticsSettings } from "@/features/diagnostics/components/diagnostics-settings"
 import { DataMigrationSettings } from "@/features/knowledge/components/data-migration-settings"
 import { ContentExtractionSettings } from "@/features/model/components/content-extraction-settings"
 import { EmbeddingSettings } from "@/features/model/components/embedding-settings"
@@ -181,6 +182,7 @@ export const SettingsPage = () => {
     ),
     help: (
       <SectionStack>
+        <DiagnosticsSettings />
         <Guides />
         <SocialHandles />
       </SectionStack>

--- a/src/protocol/diagnostics-rpc.ts
+++ b/src/protocol/diagnostics-rpc.ts
@@ -1,0 +1,127 @@
+import { z } from "zod"
+
+import type { RpcDefinition } from "./rpc"
+import { RpcMethod } from "./rpc"
+
+export const DiagnosticTestResultSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(["pass", "fail", "action", "unsupported"]),
+    durationMs: z.number().nonnegative(),
+    code: z.string().optional(),
+    metadata: z
+      .record(
+        z.string(),
+        z.union([z.string(), z.number(), z.boolean(), z.null()])
+      )
+      .optional()
+  })
+  .strict()
+
+export const DiagnosticEventSchema = z
+  .object({
+    id: z.string().uuid(),
+    at: z.number().int().nonnegative(),
+    level: z.enum(["info", "warn", "error"]),
+    code: z.string().regex(/^[A-Z0-9_-]{1,100}$/),
+    operation: z.string().regex(/^[a-zA-Z0-9_.:-]{1,100}$/),
+    surface: z.enum(["sidepanel", "options", "background", "content"]),
+    requestId: z.string().uuid().optional(),
+    providerProfile: z
+      .string()
+      .regex(/^[a-zA-Z0-9_.:-]{1,100}$/)
+      .optional(),
+    wireProtocol: z
+      .string()
+      .regex(/^[a-zA-Z0-9_.:-]{1,100}$/)
+      .optional(),
+    status: z.number().int().optional(),
+    durationMs: z.number().nonnegative().optional(),
+    retryable: z.boolean().optional(),
+    supportCode: z
+      .string()
+      .regex(/^[A-Z0-9_-]{1,120}$/)
+      .optional(),
+    metadata: z
+      .record(
+        z.string(),
+        z.union([z.string(), z.number(), z.boolean(), z.null()])
+      )
+      .optional()
+  })
+  .strict()
+
+export const DiagnosticsRunRequestSchema = z.object({}).strict()
+export const DiagnosticsRunResultSchema = z
+  .object({ tests: z.array(DiagnosticTestResultSchema).max(30) })
+  .strict()
+
+export const DiagnosticsGetBundleRequestSchema = z.object({}).strict()
+export const DiagnosticsGetBundleResultSchema = z
+  .object({
+    bundle: z
+      .object({
+        format: z.literal("ollama-client-support-v1"),
+        createdAt: z.number().int().nonnegative(),
+        appVersion: z.string(),
+        browserFamily: z.string(),
+        osFamily: z.string(),
+        capabilities: z.record(z.string(), z.boolean()),
+        permissions: z.record(z.string(), z.boolean()),
+        providers: z.array(
+          z.object({
+            profile: z.string(),
+            wire: z.string(),
+            enabled: z.boolean()
+          })
+        ),
+        storage: z.object({
+          backend: z.string(),
+          messageCount: z.number().int().nonnegative(),
+          vectorCount: z.number().int().nonnegative()
+        }),
+        events: z.array(DiagnosticEventSchema),
+        selfTests: z.array(DiagnosticTestResultSchema)
+      })
+      .strict()
+  })
+  .strict()
+
+export const DiagnosticsClearRequestSchema = z.object({}).strict()
+export const DiagnosticsClearResultSchema = z
+  .object({ cleared: z.literal(true) })
+  .strict()
+
+export type DiagnosticsRunRequest = z.infer<typeof DiagnosticsRunRequestSchema>
+export type DiagnosticsRunResult = z.infer<typeof DiagnosticsRunResultSchema>
+export type DiagnosticsGetBundleRequest = z.infer<
+  typeof DiagnosticsGetBundleRequestSchema
+>
+export type DiagnosticsGetBundleResult = z.infer<
+  typeof DiagnosticsGetBundleResultSchema
+>
+export type DiagnosticsClearRequest = z.infer<
+  typeof DiagnosticsClearRequestSchema
+>
+export type DiagnosticsClearResult = z.infer<
+  typeof DiagnosticsClearResultSchema
+>
+export type DiagnosticEvent = z.infer<typeof DiagnosticEventSchema>
+export type DiagnosticTestResult = z.infer<typeof DiagnosticTestResultSchema>
+
+declare module "./provider-rpc" {
+  interface RpcMap {
+    [RpcMethod.DiagnosticsRun]: RpcDefinition<
+      DiagnosticsRunRequest,
+      DiagnosticsRunResult
+    >
+    [RpcMethod.DiagnosticsGetBundle]: RpcDefinition<
+      DiagnosticsGetBundleRequest,
+      DiagnosticsGetBundleResult
+    >
+    [RpcMethod.DiagnosticsClear]: RpcDefinition<
+      DiagnosticsClearRequest,
+      DiagnosticsClearResult
+    >
+  }
+}

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -1,6 +1,15 @@
 import type { z } from "zod"
 
 import {
+  DiagnosticsClearRequestSchema,
+  DiagnosticsClearResultSchema,
+  DiagnosticsGetBundleRequestSchema,
+  DiagnosticsGetBundleResultSchema,
+  DiagnosticsRunRequestSchema,
+  DiagnosticsRunResultSchema
+} from "./diagnostics-rpc"
+
+import {
   ProvidersListModelsRequestSchema,
   ProvidersListModelsResultSchema,
   ProvidersListRequestSchema,
@@ -67,6 +76,27 @@ export const RPC_METHOD_DEFINITIONS = {
     response: ProvidersProbeModelCapabilitiesResultSchema,
     allowedSources: extensionPagesOnly,
     timeoutMs: 35_000,
+    operation: "command"
+  },
+  [RpcMethod.DiagnosticsRun]: {
+    request: DiagnosticsRunRequestSchema,
+    response: DiagnosticsRunResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 30_000,
+    operation: "command"
+  },
+  [RpcMethod.DiagnosticsGetBundle]: {
+    request: DiagnosticsGetBundleRequestSchema,
+    response: DiagnosticsGetBundleResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 30_000,
+    operation: "query"
+  },
+  [RpcMethod.DiagnosticsClear]: {
+    request: DiagnosticsClearRequestSchema,
+    response: DiagnosticsClearResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 5_000,
     operation: "command"
   }
 } as const satisfies Record<RpcMethod, RpcMethodDefinition>

--- a/src/protocol/rpc.ts
+++ b/src/protocol/rpc.ts
@@ -11,7 +11,10 @@ export enum RpcMethod {
   ProvidersListModels = "providers.listModels",
   ProvidersUpsert = "providers.upsert",
   ProvidersRemove = "providers.remove",
-  ProvidersProbeModelCapabilities = "providers.probeModelCapabilities"
+  ProvidersProbeModelCapabilities = "providers.probeModelCapabilities",
+  DiagnosticsRun = "diagnostics.run",
+  DiagnosticsGetBundle = "diagnostics.getBundle",
+  DiagnosticsClear = "diagnostics.clear"
 }
 
 export enum RpcErrorCode {

--- a/src/sidepanel/components/__tests__/first-run-permissions-dialog.test.tsx
+++ b/src/sidepanel/components/__tests__/first-run-permissions-dialog.test.tsx
@@ -1,10 +1,27 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RpcMethod } from "@/protocol/rpc"
 import { FirstRunPermissionsDialog } from "../first-run-permissions-dialog"
 
-const store = vi.hoisted(() => ({ get: vi.fn(), set: vi.fn() }))
-vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: { get: store.get, set: store.set }
+const onboarding = vi.hoisted(() => ({
+  get: vi.fn(),
+  update: vi.fn(),
+  selectProvider: vi.fn(),
+  selectModel: vi.fn(),
+  skip: vi.fn()
+}))
+vi.mock("@/lib/onboarding/state", () => ({
+  getOnboardingState: onboarding.get,
+  updateOnboardingState: onboarding.update,
+  selectOnboardingProvider: onboarding.selectProvider,
+  selectOnboardingModel: onboarding.selectModel,
+  skipOnboarding: onboarding.skip
+}))
+
+const rpc = vi.hoisted(() => ({ call: vi.fn() }))
+vi.mock("@/protocol/extension-client", () => ({
+  extensionRpcClient: rpc
 }))
 
 const api = vi.hoisted(() => ({
@@ -16,69 +33,185 @@ vi.mock("@/lib/browser-api", () => ({
   runtime: { getURL: api.getURL }
 }))
 
-const providers = vi.hoisted(() => ({
-  getProviderConfig: vi.fn(),
-  updateProviderConfig: vi.fn()
+vi.mock("@/lib/providers/selected-model", () => ({
+  saveSelectedModelRef: vi.fn()
 }))
-vi.mock("@/lib/providers/manager", () => ({
-  ProviderManager: providers
+
+const chat = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  setCurrentSessionId: vi.fn(),
+  queueChatSend: vi.fn()
+}))
+vi.mock("@/features/sessions/stores/chat-session-store", () => ({
+  useChatSessions: () => ({
+    createSession: chat.createSession,
+    setCurrentSessionId: chat.setCurrentSessionId
+  })
+}))
+vi.mock("@/features/chat/stores/chat-input-store", () => ({
+  usePendingChatSend: () => ({ queueChatSend: chat.queueChatSend })
 }))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() })
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
-  store.set.mockResolvedValue(undefined)
-  providers.getProviderConfig.mockResolvedValue({
-    id: "ollama",
-    type: "ollama",
-    enabled: true,
-    name: "Ollama",
-    baseUrl: "http://localhost:11434"
+  onboarding.get.mockResolvedValue({ version: 2, stage: "privacy" })
+  onboarding.update.mockImplementation(
+    async ({ stage }: { stage: string }) => ({
+      version: 2,
+      stage
+    })
+  )
+  onboarding.selectProvider.mockResolvedValue(undefined)
+  onboarding.selectModel.mockResolvedValue(undefined)
+  onboarding.skip.mockResolvedValue(undefined)
+  chat.createSession.mockResolvedValue("11111111-1111-4111-8111-111111111111")
+  rpc.call.mockImplementation(async (method: RpcMethod) => {
+    if (method === RpcMethod.ProvidersList) {
+      return {
+        providers: [
+          {
+            id: "ollama",
+            type: "ollama",
+            enabled: true,
+            name: "Ollama",
+            baseUrl: "http://localhost:11434",
+            hasApiKey: false
+          }
+        ]
+      }
+    }
+    if (method === RpcMethod.ProvidersTestConnection) {
+      return {
+        providerId: "ollama",
+        reachable: true,
+        modelCount: 1,
+        latencyMs: 1
+      }
+    }
+    return {
+      models: [
+        {
+          name: "qwen3",
+          model: "qwen3",
+          modified_at: "",
+          size: 0,
+          digest: "",
+          providerId: "ollama",
+          details: {
+            parent_model: "",
+            format: "gguf",
+            family: "qwen",
+            families: ["qwen"],
+            parameter_size: "",
+            quantization_level: ""
+          }
+        }
+      ],
+      failures: []
+    }
   })
-  providers.updateProviderConfig.mockResolvedValue(undefined)
 })
 
 describe("FirstRunPermissionsDialog", () => {
-  it("shows on first run and deep-links to the Permissions tab", async () => {
-    store.get.mockResolvedValue(undefined)
+  it("shows resumable privacy onboarding for a new profile", async () => {
     render(<FirstRunPermissionsDialog />)
 
     await waitFor(() =>
-      expect(screen.getByText("onboarding.permissions.title")).toBeTruthy()
+      expect(screen.getByText("onboarding.privacy.title")).toBeTruthy()
+    )
+    fireEvent.click(screen.getByText("onboarding.continue"))
+    expect(onboarding.update).toHaveBeenCalledWith({
+      stage: "provider-choice"
+    })
+  })
+
+  it("stays hidden for completed onboarding", async () => {
+    onboarding.get.mockResolvedValue({
+      version: 2,
+      stage: "complete",
+      completedAt: 1
+    })
+    render(<FirstRunPermissionsDialog />)
+
+    await waitFor(() => expect(onboarding.get).toHaveBeenCalled())
+    expect(screen.queryByText("onboarding.privacy.title")).toBeNull()
+    expect(rpc.call).not.toHaveBeenCalled()
+  })
+
+  it("selects and tests providers through background RPC", async () => {
+    render(<FirstRunPermissionsDialog />)
+    await waitFor(() =>
+      expect(screen.getByText("onboarding.privacy.title")).toBeTruthy()
     )
 
     fireEvent.click(screen.getByText("onboarding.continue"))
-    fireEvent.click(screen.getByText("onboarding.provider.skip"))
-    fireEvent.click(screen.getByText("onboarding.permissions.open"))
-
-    expect(store.set).toHaveBeenCalledWith("onboarding-permissions-seen", true)
-    expect(api.openOptionsInTab).toHaveBeenCalledWith(
-      "chrome-extension://test/options.html?tab=privacy"
-    )
-  })
-
-  it("stays hidden once the flag is set", async () => {
-    store.get.mockResolvedValue(true)
-    render(<FirstRunPermissionsDialog />)
-
-    await waitFor(() => expect(store.get).toHaveBeenCalled())
-    expect(screen.queryByText("onboarding.permissions.title")).toBeNull()
-  })
-
-  it("marks the intro seen when dismissed", async () => {
-    store.get.mockResolvedValue(undefined)
-    render(<FirstRunPermissionsDialog />)
+    fireEvent.click(await screen.findByText("Ollama"))
+    await screen.findByText("onboarding.provider.connect_title")
+    fireEvent.click(screen.getByText("settings.providers.test"))
 
     await waitFor(() =>
-      expect(screen.getByText("onboarding.permissions.dismiss")).toBeTruthy()
+      expect(rpc.call).toHaveBeenCalledWith(RpcMethod.ProvidersTestConnection, {
+        target: "stored",
+        providerId: "ollama"
+      })
     )
+    expect(rpc.call).toHaveBeenCalledWith(RpcMethod.ProvidersListModels, {
+      providerId: "ollama"
+    })
+  })
 
-    fireEvent.click(screen.getByText("onboarding.permissions.dismiss"))
+  it("records explicit skip without treating dialog close as completion", async () => {
+    render(<FirstRunPermissionsDialog />)
+    await screen.findByText("onboarding.privacy.title")
+    fireEvent.click(screen.getByText("onboarding.provider.skip"))
+    expect(onboarding.skip).toHaveBeenCalledOnce()
+  })
 
-    expect(store.set).toHaveBeenCalledWith("onboarding-permissions-seen", true)
-    expect(api.openOptionsInTab).not.toHaveBeenCalled()
+  it("creates a chat and prefills the onboarding prompt", async () => {
+    onboarding.get.mockResolvedValue({
+      version: 2,
+      stage: "test-chat",
+      providerId: "ollama",
+      modelRef: { providerId: "ollama", modelId: "qwen3" }
+    })
+    render(<FirstRunPermissionsDialog />)
+
+    fireEvent.click(await screen.findByText("onboarding.test_chat.open_chat"))
+
+    await waitFor(() => expect(chat.createSession).toHaveBeenCalledOnce())
+    expect(onboarding.update).toHaveBeenCalledWith({
+      testSessionId: "11111111-1111-4111-8111-111111111111"
+    })
+    expect(chat.queueChatSend).toHaveBeenCalledWith(
+      "onboarding.test_chat.prompt"
+    )
+  })
+
+  it("resumes the existing onboarding chat without creating a duplicate", async () => {
+    const testSessionId = "22222222-2222-4222-8222-222222222222"
+    onboarding.get.mockResolvedValue({
+      version: 2,
+      stage: "test-chat",
+      providerId: "ollama",
+      modelRef: { providerId: "ollama", modelId: "qwen3" },
+      testSessionId
+    })
+    render(<FirstRunPermissionsDialog />)
+
+    fireEvent.click(await screen.findByText("onboarding.test_chat.open_chat"))
+
+    expect(chat.setCurrentSessionId).toHaveBeenCalledWith(testSessionId)
+    expect(chat.createSession).not.toHaveBeenCalled()
+    expect(chat.queueChatSend).toHaveBeenCalledWith(
+      "onboarding.test_chat.prompt"
+    )
   })
 })

--- a/src/sidepanel/components/first-run-permissions-dialog.tsx
+++ b/src/sidepanel/components/first-run-permissions-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
@@ -10,240 +10,456 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { openOptionsInTab, runtime } from "@/lib/browser-api"
-import { STORAGE_KEYS } from "@/lib/constants"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { usePendingChatSend } from "@/features/chat/stores/chat-input-store"
+import {
+  AddProviderDialog,
+  type AddProviderDialogProps
+} from "@/features/model/components/add-provider-dialog"
+import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
+import { useToast } from "@/hooks/use-toast"
+import { openOptionsInTab, runtime } from "@/lib/browser-api"
+import {
+  ArrowLeft,
+  Bot,
   CircleCheck,
+  Globe,
   Loader2,
-  Lock,
   Server,
   ShieldCheck,
   TriangleAlert
 } from "@/lib/lucide-icon"
 import {
-  checkProviderConnection,
-  OLLAMA_CORS_COMMAND,
-  type ProviderConnectionResult
-} from "@/lib/onboarding/provider-connection"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
-import { ProviderManager } from "@/lib/providers/manager"
-import { ProviderId } from "@/lib/providers/types"
+  getOnboardingState,
+  type OnboardingStage,
+  selectOnboardingModel,
+  selectOnboardingProvider,
+  skipOnboarding,
+  updateOnboardingState
+} from "@/lib/onboarding/state"
+import { saveSelectedModelRef } from "@/lib/providers/selected-model"
+import { extensionRpcClient } from "@/protocol/extension-client"
+import type {
+  ProvidersListModelsResult,
+  PublicProviderConfig
+} from "@/protocol/provider-rpc"
+import { RpcMethod } from "@/protocol/rpc"
 
-type Step = "privacy" | "provider" | "permissions"
+const STAGES: OnboardingStage[] = [
+  "privacy",
+  "provider-choice",
+  "provider-connection",
+  "model-choice",
+  "test-chat"
+]
 
-const failureKey = (
-  result: Exclude<ProviderConnectionResult, { kind: "connected" }>
-): string => `onboarding.provider.errors.${result.kind}`
+const isLocalProvider = (provider: PublicProviderConfig) =>
+  provider.type === "ollama" ||
+  /^(https?:\/\/)?(localhost|127\.0\.0\.1|\[::1\])/i.test(
+    provider.baseUrl ?? ""
+  )
 
-/**
- * First-run three-beat: local privacy contract, provider connection check, then
- * optional permissions. Provider failures stay in-app and actionable instead
- * of sending a new user straight to external docs.
- */
+const chatModelsOnly = (models: ProvidersListModelsResult["models"]) =>
+  models.filter((model) => {
+    const type = model.capabilityHints?.modelType?.toLowerCase()
+    return type !== "embedding" && !/\bembed(ding)?\b/i.test(model.name)
+  })
+
 export const FirstRunPermissionsDialog = () => {
   const { t } = useTranslation()
+  const { toast } = useToast()
+  const { queueChatSend } = usePendingChatSend()
+  const { createSession, setCurrentSessionId } = useChatSessions()
   const [open, setOpen] = useState(false)
-  const [step, setStep] = useState<Step>("privacy")
-  const [baseUrl, setBaseUrl] = useState("http://localhost:11434")
-  const [checking, setChecking] = useState(false)
-  const [connection, setConnection] = useState<ProviderConnectionResult | null>(
-    null
+  const [stage, setStage] = useState<OnboardingStage>("privacy")
+  const [providers, setProviders] = useState<PublicProviderConfig[]>([])
+  const [providerId, setProviderId] = useState<string>()
+  const [models, setModels] = useState<ProvidersListModelsResult["models"]>([])
+  const [modelId, setModelId] = useState("")
+  const [testSessionId, setTestSessionId] = useState<string>()
+  const [busy, setBusy] = useState(false)
+  const [addProviderOpen, setAddProviderOpen] = useState(false)
+  const [errorSupportCode, setErrorSupportCode] = useState<string>()
+  const [connectionError, setConnectionError] = useState<{
+    messageKey?: string
+    fallback: string
+  }>()
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === providerId),
+    [providerId, providers]
   )
 
   useEffect(() => {
     let active = true
-    plasmoGlobalStorage
-      .get<boolean>(STORAGE_KEYS.ONBOARDING_PERMISSIONS_SEEN)
-      .then((seen) => {
+    const load = async () => {
+      try {
+        const state = await getOnboardingState()
         if (!active) return
-        if (!seen) setOpen(true)
-      })
-      .catch(() => undefined)
-    ProviderManager.getProviderConfig(ProviderId.OLLAMA)
-      .then((config) => {
-        if (active && config?.baseUrl) setBaseUrl(config.baseUrl)
-      })
-      .catch(() => undefined)
+        setProviderId(state.providerId)
+        setModelId(state.modelRef?.modelId ?? "")
+        setTestSessionId(state.testSessionId)
+        setStage(state.stage)
+        if (state.stage === "complete") return
+        setOpen(true)
+        const result = await extensionRpcClient.call(
+          RpcMethod.ProvidersList,
+          {}
+        )
+        if (active) setProviders(result.providers)
+        if (state.stage === "model-choice" && state.providerId) {
+          const modelResult = await extensionRpcClient.call(
+            RpcMethod.ProvidersListModels,
+            { providerId: state.providerId }
+          )
+          if (active) setModels(chatModelsOnly(modelResult.models))
+        }
+      } catch {
+        if (active) setOpen(true)
+      }
+    }
+    void load()
     return () => {
       active = false
     }
   }, [])
 
-  const finish = () => {
-    void plasmoGlobalStorage.set(STORAGE_KEYS.ONBOARDING_PERMISSIONS_SEEN, true)
-    setOpen(false)
+  const persistStage = async (next: OnboardingStage) => {
+    setStage(next)
+    await updateOnboardingState({ stage: next })
+  }
+
+  const chooseProvider = async (id: string) => {
+    setProviderId(id)
+    setErrorSupportCode(undefined)
+    setConnectionError(undefined)
+    await selectOnboardingProvider(id)
+    setStage("provider-connection")
   }
 
   const testConnection = async () => {
-    setChecking(true)
-    setConnection(null)
-    const current = await ProviderManager.getProviderConfig(ProviderId.OLLAMA)
-    if (!current) {
-      setConnection({ kind: "unavailable" })
-      setChecking(false)
-      return
-    }
-    const result = await checkProviderConnection({
-      ...current,
-      baseUrl: baseUrl.trim()
-    })
-    if (result.kind === "connected") {
-      await ProviderManager.updateProviderConfig(ProviderId.OLLAMA, {
-        baseUrl: baseUrl.trim()
+    if (!providerId) return
+    setBusy(true)
+    setErrorSupportCode(undefined)
+    setConnectionError(undefined)
+    try {
+      await extensionRpcClient.call(RpcMethod.ProvidersTestConnection, {
+        target: "stored",
+        providerId
       })
+      const result = await extensionRpcClient.call(
+        RpcMethod.ProvidersListModels,
+        { providerId }
+      )
+      setModels(chatModelsOnly(result.models))
+      await persistStage("model-choice")
+    } catch (error) {
+      const safeError = error as {
+        messageKey?: string
+        userMessage?: string
+        context?: unknown
+      }
+      setErrorSupportCode(
+        safeError.context
+          ? String(safeError.context)
+          : "OLC-PROVIDER-CONNECTION-001"
+      )
+      setConnectionError({
+        messageKey: safeError.messageKey,
+        fallback:
+          safeError.userMessage ?? t("onboarding.provider.connection_failed")
+      })
+    } finally {
+      setBusy(false)
     }
-    setConnection(result)
-    setChecking(false)
+  }
+
+  const chooseModel = async () => {
+    if (!providerId || !modelId) return
+    const ref = { providerId, modelId }
+    await saveSelectedModelRef(ref)
+    await selectOnboardingModel(ref)
+    setStage("test-chat")
+  }
+
+  const openTestChat = async () => {
+    let sessionId = testSessionId
+    if (sessionId) {
+      setCurrentSessionId(sessionId)
+    } else {
+      sessionId = await createSession()
+      setTestSessionId(sessionId)
+      await updateOnboardingState({ testSessionId: sessionId })
+    }
+    queueChatSend(t("onboarding.test_chat.prompt"))
+    setOpen(false)
   }
 
   const openProviderSetup = () => {
     void openOptionsInTab(
-      runtime.getURL("options.html?tab=models&focus=provider-base-url")
+      runtime.getURL("options.html?tab=models&focus=provider-settings")
     )
   }
 
-  const openPermissions = () => {
-    finish()
-    void openOptionsInTab(runtime.getURL("options.html?tab=privacy"))
+  const addProvider: AddProviderDialogProps["onAdd"] = async (provider) => {
+    try {
+      const result = await extensionRpcClient.call(RpcMethod.ProvidersUpsert, {
+        target: "new",
+        provider
+      })
+      setProviders((current) => [...current, result.provider])
+      await chooseProvider(result.provider.id)
+      return true
+    } catch (error) {
+      const safeError = error as { userMessage?: string; context?: unknown }
+      const supportCode = safeError.context
+        ? String(safeError.context)
+        : "OLC-PROVIDER-CONNECTION-001"
+      setErrorSupportCode(supportCode)
+      toast({
+        title: t("onboarding.provider.connection_failed"),
+        description: `${safeError.userMessage ?? t("errors.rpc.provider_failed")} (${supportCode})`,
+        variant: "destructive"
+      })
+      return false
+    }
   }
 
-  const stepIndex = step === "privacy" ? 1 : step === "provider" ? 2 : 3
+  const goBack = async () => {
+    const index = STAGES.indexOf(stage)
+    const next = STAGES[Math.max(0, index - 1)]
+    await persistStage(next)
+  }
+
+  const stepIndex = Math.max(1, STAGES.indexOf(stage) + 1)
   const Icon =
-    step === "privacy" ? ShieldCheck : step === "provider" ? Server : Lock
+    stage === "privacy"
+      ? ShieldCheck
+      : stage === "provider-choice"
+        ? Bot
+        : stage === "provider-connection"
+          ? Server
+          : CircleCheck
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) finish()
-      }}>
-      <DialogContent>
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex size-9 items-center justify-center rounded-control bg-app-primary-soft text-app-agent">
-              <Icon className="icon-md" />
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+        }}>
+        <DialogContent>
+          <DialogHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex size-9 items-center justify-center rounded-control bg-app-primary-soft text-app-agent">
+                <Icon className="icon-md" />
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {t("onboarding.step", { current: stepIndex, total: 5 })}
+              </span>
             </div>
-            <span className="text-xs text-muted-foreground">
-              {t("onboarding.step", { current: stepIndex, total: 3 })}
-            </span>
-          </div>
 
-          {step === "privacy" && (
-            <>
-              <DialogTitle>{t("onboarding.permissions.title")}</DialogTitle>
-              <DialogDescription>
-                {t("onboarding.permissions.privacy")}
-              </DialogDescription>
-              <DialogDescription>
-                {t("onboarding.privacy.host_access")}
-              </DialogDescription>
-            </>
-          )}
+            {stage === "privacy" && (
+              <>
+                <DialogTitle>{t("onboarding.privacy.title")}</DialogTitle>
+                <DialogDescription>
+                  {t("onboarding.privacy.description")}
+                </DialogDescription>
+                <ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+                  <li>{t("onboarding.privacy.local_storage")}</li>
+                  <li>{t("onboarding.privacy.no_telemetry")}</li>
+                  <li>{t("onboarding.privacy.remote_policy")}</li>
+                  <li>{t("onboarding.privacy.permissions_jit")}</li>
+                </ul>
+              </>
+            )}
 
-          {step === "provider" && (
-            <>
-              <DialogTitle>{t("onboarding.provider.title")}</DialogTitle>
-              <DialogDescription>
-                {t("onboarding.provider.description")}
-              </DialogDescription>
-              <div className="space-y-2 pt-2">
-                <label className="text-xs font-medium" htmlFor="onboarding-url">
-                  {t("settings.providers.base_url")}
-                </label>
-                <Input
-                  id="onboarding-url"
-                  value={baseUrl}
-                  onChange={(event) => {
-                    setBaseUrl(event.target.value)
-                    setConnection(null)
-                  }}
-                />
-                {connection?.kind === "connected" && (
-                  <div className="flex gap-2 rounded-control bg-success/10 p-2 text-xs text-success">
-                    <CircleCheck className="icon-sm shrink-0" />
-                    <span>
-                      {t("onboarding.provider.connected", {
-                        count: connection.modelCount
-                      })}
-                    </span>
+            {stage === "provider-choice" && (
+              <>
+                <DialogTitle>
+                  {t("onboarding.provider.choose_title")}
+                </DialogTitle>
+                <DialogDescription>
+                  {t("onboarding.provider.choose_description")}
+                </DialogDescription>
+                <div className="grid max-h-72 gap-2 overflow-y-auto pt-2 sm:grid-cols-2">
+                  {providers.map((provider) => {
+                    const local = isLocalProvider(provider)
+                    const ProviderIcon = local ? Server : Globe
+                    return (
+                      <button
+                        type="button"
+                        key={provider.id}
+                        className="rounded-control border p-3 text-left hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => void chooseProvider(provider.id)}>
+                        <div className="flex items-center gap-2 font-medium">
+                          <ProviderIcon className="icon-sm" />
+                          {provider.name}
+                        </div>
+                        <div className="mt-1 text-micro text-muted-foreground">
+                          {t(
+                            local
+                              ? "onboarding.provider.local"
+                              : "onboarding.provider.remote"
+                          )}
+                          {!local && provider.hasApiKey
+                            ? ` · ${t("onboarding.provider.key_configured")}`
+                            : ""}
+                        </div>
+                      </button>
+                    )
+                  })}
+                  <button
+                    type="button"
+                    className="rounded-control border border-dashed p-3 text-left hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => setAddProviderOpen(true)}>
+                    <div className="flex items-center gap-2 font-medium">
+                      <Globe className="icon-sm" />
+                      {t("settings.providers.add.title")}
+                    </div>
+                    <div className="mt-1 text-micro text-muted-foreground">
+                      {t("settings.providers.add.description")}
+                    </div>
+                  </button>
+                </div>
+              </>
+            )}
+
+            {stage === "provider-connection" && (
+              <>
+                <DialogTitle>
+                  {t("onboarding.provider.connect_title")}
+                </DialogTitle>
+                <DialogDescription>
+                  {t("onboarding.provider.connect_description", {
+                    provider: selectedProvider?.name ?? providerId
+                  })}
+                </DialogDescription>
+                {selectedProvider && !isLocalProvider(selectedProvider) && (
+                  <div className="rounded-control bg-warning/10 p-2 text-xs text-warning-foreground">
+                    {t("onboarding.provider.remote_disclosure")}
                   </div>
                 )}
-                {connection && connection.kind !== "connected" && (
-                  <div className="space-y-2 rounded-control bg-destructive/10 p-2 text-xs text-destructive">
+                {errorSupportCode && (
+                  <div className="space-y-1 rounded-control bg-destructive/10 p-2 text-xs text-destructive">
                     <div className="flex gap-2">
                       <TriangleAlert className="icon-sm shrink-0" />
-                      <span>{t(failureKey(connection))}</span>
+                      {connectionError?.messageKey
+                        ? t(connectionError.messageKey)
+                        : (connectionError?.fallback ??
+                          t("onboarding.provider.connection_failed"))}
                     </div>
-                    {(connection.kind === "cors" ||
-                      connection.kind === "unavailable") && (
-                      <code className="block select-all overflow-x-auto rounded-control bg-background p-1.5 text-micro text-foreground">
-                        {OLLAMA_CORS_COMMAND}
-                      </code>
-                    )}
+                    <code className="select-all">{errorSupportCode}</code>
                   </div>
                 )}
-              </div>
-            </>
-          )}
+              </>
+            )}
 
-          {step === "permissions" && (
-            <>
-              <DialogTitle>
-                {t("onboarding.permissions.optional_title")}
-              </DialogTitle>
-              <DialogDescription>
-                {t("onboarding.permissions.body")}
-              </DialogDescription>
-            </>
-          )}
-        </DialogHeader>
+            {stage === "model-choice" && (
+              <>
+                <DialogTitle>{t("onboarding.model.title")}</DialogTitle>
+                <DialogDescription>
+                  {t("onboarding.model.description")}
+                </DialogDescription>
+                {models.length === 0 ? (
+                  <div className="rounded-control bg-warning/10 p-2 text-xs">
+                    {t("onboarding.model.none")}
+                  </div>
+                ) : (
+                  <Select
+                    value={modelId}
+                    onValueChange={(value) => setModelId(value ?? "")}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue
+                        placeholder={t("onboarding.model.placeholder")}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {models.map((model) => (
+                        <SelectItem
+                          key={`${model.providerId}:${model.name}`}
+                          value={model.name}>
+                          {model.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </>
+            )}
 
-        <DialogFooter>
-          {step === "privacy" && (
-            <>
-              <Button variant="outline" onClick={finish}>
-                {t("onboarding.permissions.dismiss")}
+            {stage === "test-chat" && (
+              <>
+                <DialogTitle>{t("onboarding.test_chat.title")}</DialogTitle>
+                <DialogDescription>
+                  {t("onboarding.test_chat.description")}
+                </DialogDescription>
+                <div className="select-all rounded-control bg-muted p-3 text-xs">
+                  {t("onboarding.test_chat.prompt")}
+                </div>
+                {selectedProvider && !isLocalProvider(selectedProvider) && (
+                  <div className="rounded-control bg-warning/10 p-2 text-xs">
+                    {t("onboarding.test_chat.cost")}
+                  </div>
+                )}
+              </>
+            )}
+          </DialogHeader>
+
+          <DialogFooter>
+            {stage !== "privacy" && (
+              <Button variant="ghost" onClick={() => void goBack()}>
+                <ArrowLeft className="icon-sm" />
+                {t("common.actions.back")}
               </Button>
-              <Button onClick={() => setStep("provider")}>
+            )}
+            <Button
+              variant="outline"
+              onClick={() => {
+                void skipOnboarding()
+                setOpen(false)
+              }}>
+              {t("onboarding.provider.skip")}
+            </Button>
+            {stage === "privacy" && (
+              <Button onClick={() => void persistStage("provider-choice")}>
                 {t("onboarding.continue")}
               </Button>
-            </>
-          )}
-          {step === "provider" && (
-            <>
-              <Button variant="ghost" onClick={openProviderSetup}>
-                {t("onboarding.provider.open_setup")}
-              </Button>
-              <Button variant="outline" onClick={() => setStep("permissions")}>
-                {t("onboarding.provider.skip")}
-              </Button>
-              {connection?.kind === "connected" ? (
-                <Button onClick={() => setStep("permissions")}>
-                  {t("onboarding.continue")}
+            )}
+            {stage === "provider-connection" && (
+              <>
+                <Button variant="ghost" onClick={openProviderSetup}>
+                  {t("onboarding.provider.open_setup")}
                 </Button>
-              ) : (
-                <Button
-                  disabled={checking || !baseUrl.trim()}
-                  onClick={testConnection}>
-                  {checking && <Loader2 className="icon-sm animate-spin" />}
+                <Button disabled={busy} onClick={() => void testConnection()}>
+                  {busy && <Loader2 className="icon-sm animate-spin" />}
                   {t("settings.providers.test")}
                 </Button>
-              )}
-            </>
-          )}
-          {step === "permissions" && (
-            <>
-              <Button variant="outline" onClick={finish}>
-                {t("onboarding.permissions.dismiss")}
+              </>
+            )}
+            {stage === "model-choice" && (
+              <Button disabled={!modelId} onClick={() => void chooseModel()}>
+                {t("onboarding.model.use")}
               </Button>
-              <Button onClick={openPermissions}>
-                {t("onboarding.permissions.open")}
+            )}
+            {stage === "test-chat" && (
+              <Button onClick={() => void openTestChat()}>
+                {t("onboarding.test_chat.open_chat")}
               </Button>
-            </>
-          )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <AddProviderDialog
+        open={addProviderOpen}
+        onOpenChange={setAddProviderOpen}
+        onAdd={addProvider}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- Replace the one-shot first-run dialog with resumable, provider-neutral onboarding.
- Add provider/model connection and discovery through background RPC, exclude embedding-only models, and start/send the first test chat in one click.
- Mark onboarding complete only after a successful final assistant response is durably stored.
- Add content-free local diagnostics, support codes, self-tests, safe bundle preview/copy/download, and explicit GitHub issue handoff.
- Bound diagnostic storage to 200 events / about 128 KiB / seven days, with a 50-event / about 32 KiB memory batch and 15-second writes.
- Upgrade vulnerable runtime/docs dependencies and keep print CSS outside the untrusted export payload.

## Why

First-run success needed to mean a working provider response, not merely a dismissed dialog. Support also needed actionable local diagnostics without telemetry or user-content collection.

The dependency audit blocked publication with 22 existing advisories. Patched direct and transitive versions reduce the production audit to zero while preserving sanitizer coverage.

## Impact

Users can resume onboarding, choose any configured provider and chat model, and send the test prompt in one click. Support bundles remain device-local and exclude chats, prompts, files, page content, provider/model identities, endpoints, credentials, and cookies.

## Validation

- `pnpm audit --prod --audit-level low`
- `pnpm check:i18n`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 269 files, 2,158 tests
- `pnpm build`
- `pnpm docs:build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds provider-neutral onboarding and local diagnostics. The main changes are:

- Resumable provider and model setup with a test-chat flow.
- Session-aware onboarding completion after a stored assistant response.
- Content-free local diagnostics, self-tests, bundle preview, and support handoff.
- Bounded diagnostic storage with pending-event persistence and serialized writes.
- Safer print export styling and updated runtime and documentation dependencies.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The queued onboarding prompt is retained until the send is accepted.
- Onboarding completion is limited to the recorded test session.
- Diagnostic clear and flush operations now share serialized storage access.
- The declared Node.js requirement matches the upgraded documentation dependencies.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/diagnostics/diagnostic-recorder.ts | Adds bounded pending-event storage and serializes diagnostic record, flush, read, and clear operations. |
| src/features/chat/components/chat.tsx | Keeps the onboarding prompt queued until the chat controller accepts it. |
| src/features/chat/hooks/use-chat-streaming.ts | Completes onboarding through the session associated with the successful stream. |
| src/lib/onboarding/state.ts | Stores resumable onboarding state and requires the response session to match the test session. |
| src/lib/diagnostics/diagnostics-service.ts | Adds local self-tests and privacy-filtered support bundle generation. |
| package.json | Updates runtime dependencies and raises the Node.js requirement to 22.12.0. |
| docs/package.json | Updates Astro dependencies and declares the matching Node.js requirement. |

<sub>Reviews (2): Last reviewed commit: ["fix: address onboarding diagnostics race..."](https://github.com/shishir435/ollama-client/commit/2bbc539fe50b06b11246dc694a54bb04876fcc76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46376254)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->