### PR TITLE
feat(providers): mark custom flow beta

### DIFF
--- a/src/features/model/components/__tests__/add-provider-dialog.test.tsx
+++ b/src/features/model/components/__tests__/add-provider-dialog.test.tsx
@@ -10,6 +10,18 @@ vi.mock("react-i18next", () => ({
 }))
 
 describe("AddProviderDialog", () => {
+  it("labels custom provider setup as beta", () => {
+    render(
+      <TooltipProvider>
+        <AddProviderDialog open onOpenChange={vi.fn()} onAdd={vi.fn()} />
+      </TooltipProvider>
+    )
+
+    expect(
+      screen.getByText("settings.providers.beta_badge")
+    ).toBeInTheDocument()
+  })
+
   it("adds a native Anthropic provider with manual models", async () => {
     const onAdd = vi.fn().mockResolvedValue(true)
     const onOpenChange = vi.fn()

--- a/src/features/model/components/__tests__/provider-grid.test.tsx
+++ b/src/features/model/components/__tests__/provider-grid.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { type ProviderConfig, ProviderType } from "@/lib/providers/types"
 import { ProviderGrid } from "../provider-grid"
@@ -57,9 +57,13 @@ describe("ProviderGrid", () => {
       />
     )
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /settings.providers.add.button/ })
-    )
+    const addProvider = screen.getByRole("button", {
+      name: /settings.providers.add.button/
+    })
+    expect(
+      within(addProvider).getByText("settings.providers.beta_badge")
+    ).toBeInTheDocument()
+    fireEvent.click(addProvider)
     expect(onAdd).toHaveBeenCalled()
   })
 
@@ -86,6 +90,10 @@ describe("ProviderGrid", () => {
     expect(screen.getByText("Home box")).toBeInTheDocument()
     expect(
       screen.getByText("settings.providers.add.custom_badge")
+    ).toBeInTheDocument()
+    const customProvider = screen.getByRole("button", { name: /Home box/ })
+    expect(
+      within(customProvider).getByText("settings.providers.beta_badge")
     ).toBeInTheDocument()
   })
 

--- a/src/features/model/components/__tests__/provider-settings.test.tsx
+++ b/src/features/model/components/__tests__/provider-settings.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, within } from "@testing-library/react"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { ProviderId, ProviderType } from "@/lib/providers/types"
@@ -53,6 +59,8 @@ const mockProviderState = (
   const updateConfig = vi.fn()
   const setProviderEnabled = vi.fn()
   const setSelectedId = vi.fn()
+  const addProvider = vi.fn()
+  const removeProvider = vi.fn().mockResolvedValue(true)
 
   state.useProviderSettingsState.mockReturnValue({
     providers: [baseProvider, remoteProvider],
@@ -72,6 +80,8 @@ const mockProviderState = (
     handleSave,
     updateConfig,
     setProviderEnabled,
+    addProvider,
+    removeProvider,
     ...overrides
   })
 
@@ -80,7 +90,9 @@ const mockProviderState = (
     handleSave,
     updateConfig,
     setProviderEnabled,
-    setSelectedId
+    setSelectedId,
+    addProvider,
+    removeProvider
   }
 }
 
@@ -161,6 +173,45 @@ describe("ProviderSettings", () => {
     expect(
       screen.getByRole("button", { name: "settings.providers.add.remove" })
     ).toBeInTheDocument()
+  })
+
+  it("closes the confirmation after removing its captured provider", async () => {
+    const customProvider = {
+      ...remoteProvider,
+      id: "custom:openai:test",
+      name: "Custom server"
+    }
+    const actions = mockProviderState({
+      providers: [baseProvider, customProvider],
+      selectedId: customProvider.id,
+      activeConfig: customProvider,
+      isCustomProvider: true,
+      isLocalProvider: false,
+      isRemoteEndpoint: true
+    })
+
+    renderProviderSettings()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.providers.add.remove" })
+    )
+    const dialog = screen.getByRole("alertdialog")
+    expect(
+      within(dialog).getByText(
+        "settings.providers.add.remove_confirm_title Custom server"
+      )
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "settings.providers.add.remove"
+      })
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    )
+    expect(actions.removeProvider).toHaveBeenCalledWith(customProvider.id)
   })
 
   it("renders remote provider fields and custom model actions", () => {

--- a/src/features/model/components/add-provider-dialog.tsx
+++ b/src/features/model/components/add-provider-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { MiniBadge } from "@/components/ui/mini-badge"
 import { ModelIdListEditor } from "@/features/model/components/model-id-list-editor"
 import { Bot, Globe, Loader2, Server } from "@/lib/lucide-icon"
 import { providerProfileRequiresApiKey } from "@/lib/providers/service-profile"
@@ -207,7 +208,10 @@ export const AddProviderDialog = ({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>{t("settings.providers.add.title")}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            {t("settings.providers.add.title")}
+            <MiniBadge text={t("settings.providers.beta_badge")} />
+          </DialogTitle>
           <DialogDescription>
             {t("settings.providers.add.description")}
           </DialogDescription>

--- a/src/features/model/components/provider-grid.tsx
+++ b/src/features/model/components/provider-grid.tsx
@@ -136,6 +136,7 @@ export const ProviderGrid = ({
           <span className="font-medium">
             {t("settings.providers.add.button")}
           </span>
+          <MiniBadge text={t("settings.providers.beta_badge")} />
         </span>
       </Button>
     </div>

--- a/src/features/model/components/provider-settings.tsx
+++ b/src/features/model/components/provider-settings.tsx
@@ -59,7 +59,10 @@ export const ProviderSettings = () => {
     removeProvider
   } = useProviderSettingsState()
   const [addOpen, setAddOpen] = useState(false)
-  const [removeOpen, setRemoveOpen] = useState(false)
+  const [pendingRemoval, setPendingRemoval] = useState<{
+    id: string
+    name: string
+  } | null>(null)
 
   if (loading) {
     return (
@@ -160,7 +163,12 @@ export const ProviderSettings = () => {
                   variant="outline"
                   size="sm"
                   className="text-status-danger hover:text-status-danger"
-                  onClick={() => setRemoveOpen(true)}>
+                  onClick={() =>
+                    setPendingRemoval({
+                      id: String(activeConfig.id),
+                      name: activeConfig.name
+                    })
+                  }>
                   <Trash2 className="icon-md mr-2" />
                   {t("settings.providers.add.remove")}
                 </Button>
@@ -206,13 +214,17 @@ export const ProviderSettings = () => {
         </Card>
       )}
 
-      {activeConfig && (
-        <AlertDialog open={removeOpen} onOpenChange={setRemoveOpen}>
+      {pendingRemoval && (
+        <AlertDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setPendingRemoval(null)
+          }}>
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>
                 {t("settings.providers.add.remove_confirm_title", {
-                  name: activeConfig.name
+                  name: pendingRemoval.name
                 })}
               </AlertDialogTitle>
               <AlertDialogDescription>
@@ -222,7 +234,11 @@ export const ProviderSettings = () => {
             <AlertDialogFooter>
               <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
               <AlertDialogAction
-                onClick={() => removeProvider(String(activeConfig.id))}>
+                onClick={async () => {
+                  if (await removeProvider(pendingRemoval.id)) {
+                    setPendingRemoval(null)
+                  }
+                }}>
                 {t("settings.providers.add.remove")}
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/src/features/model/hooks/__tests__/use-provider-settings-state.test.ts
+++ b/src/features/model/hooks/__tests__/use-provider-settings-state.test.ts
@@ -72,10 +72,12 @@ describe("useProviderSettingsState", () => {
       result.current.updateConfig({ baseUrl: "http://localhost:11435" })
     })
 
+    let removed = false
     await act(async () => {
-      await result.current.removeProvider(custom.id)
+      removed = await result.current.removeProvider(custom.id)
     })
 
+    expect(removed).toBe(true)
     expect(result.current.providers).toEqual([
       { ...ollama, baseUrl: "http://localhost:11435" }
     ])

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -392,7 +392,7 @@ export const useProviderSettingsState = () => {
     }
   }
 
-  const removeProvider = async (id: string) => {
+  const removeProvider = async (id: string): Promise<boolean> => {
     const providerName = providers.find(
       (provider) => String(provider.id) === id
     )?.name
@@ -413,6 +413,7 @@ export const useProviderSettingsState = () => {
           name: providerName ?? id
         })
       })
+      return true
     } catch (error) {
       logger.error("Failed to remove provider", "ProviderSettings", { error })
       toast({
@@ -423,6 +424,7 @@ export const useProviderSettingsState = () => {
           t("settings.providers.add.remove_failed_title")
         )
       })
+      return false
     }
   }
 

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -64,7 +64,8 @@ export const getProviderMeta = (
     return {
       id,
       displayName: fallbackName || FALLBACK_PROVIDER_META.displayName,
-      icon: { kind: "lucide", icon: Server }
+      icon: { kind: "lucide", icon: Server },
+      isBeta: true
     }
   }
   return FALLBACK_PROVIDER_META


### PR DESCRIPTION
## Summary

- mark custom provider metadata as beta
- show a Beta badge on the Add provider entry point and dialog
- keep saved custom providers visibly marked Beta alongside Custom
- close provider-removal confirmation after successful deletion without retargeting it to the newly selected provider

## Why

Custom OpenAI-compatible, Anthropic-compatible, hosted, and alternate Ollama configurations are shipping broadly for the first time and are not yet battle-tested like the built-in providers.

The removal dialog previously read directly from the active provider while its open state survived deletion. Removing the selected custom provider switched selection to Ollama, so the still-open dialog changed to “Remove Ollama?”. It now captures the intended provider and closes only after a successful removal.

## Validation

- `pnpm verify` (typecheck, lint, 270 test files / 2177 tests)
- `pnpm check:generated`
- provider-removal regression test
- pre-push audit, i18n drift check, Chrome build, and docs build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR marks the custom provider flow as Beta and fixes provider-removal confirmation state. The main changes are:

- Adds Beta badges to the custom provider entry point and dialog.
- Marks saved custom providers as Beta through provider metadata.
- Captures the removal target so the dialog cannot switch to another provider.
- Closes the removal dialog only after successful deletion.
- Adds coverage for the new labels and removal behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The removal dialog keeps the provider captured when confirmation opens.
- Failed removals leave the confirmation open, while successful removals close it.
- Beta metadata applies to custom provider IDs without affecting registered built-ins.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/features/model/components/provider-settings.tsx | Captures the provider targeted for removal and clears the confirmation only after successful deletion. |
| src/features/model/hooks/use-provider-settings-state.ts | Returns an explicit removal result while preserving existing state updates and error handling. |
| src/lib/providers/registry.ts | Marks custom provider metadata as Beta without changing built-in provider metadata. |
| src/features/model/components/provider-grid.tsx | Adds Beta labels to the custom provider entry point and saved custom provider tiles. |
| src/features/model/components/add-provider-dialog.tsx | Adds a Beta label to the custom provider setup dialog. |

<sub>Reviews (1): Last reviewed commit: ["fix(providers): close removal confirmati..."](https://github.com/shishir435/ollama-client/commit/aebe2008e0b129a52e14df4d6d980e65a3aaa383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46434984)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/shishir435/github/Shishir435/ollama-client/-/custom-context?memory=e25238d4-69e0-44c6-b9b5-43440fe11231))

<!-- /greptile_comment -->