### PR TITLE
docs: prepare 0.12.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   storage, permissions, and browser compatibility.
 - Added a single-owner OPFS SQLite persistence backend with verified migration
   and packaged-browser persistence benchmarks for Chrome and Firefox.
+- Added durable SQLite checkpoints for native and prompt-based tool loops, with
+  same-request recovery after MV3 service-worker restarts.
+- Added native Anthropic Messages API support for user-added providers,
+  including streaming, images, tool calls, and manual model IDs.
+- Added session tags, explicit message forks, and a local-data inventory with
+  backup and wipe controls.
 
 ### Changed
 - Rebuilt the settings and maintenance experience with intent-based navigation,
@@ -28,6 +34,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   and runtime evidence remain the source of truth.
 - Marked custom provider setup as Beta to reflect its first public release and
   distinguish it from verified built-in providers.
+- Limited verified built-in provider profiles to Ollama, LM Studio, and
+  llama.cpp; other compatible endpoints now use the custom-provider flow.
+- Unified composer context controls and RAG chunking, simplified message edits,
+  and disabled chat-memory indexing by default for new profiles.
+- Added Ollama model capability overrides and made model refresh invalidate
+  cached capability details.
 - Adopted the TypeScript 7 compiler and reduced build and test times.
 - Bumped package version to `0.12.3`.
 
@@ -40,6 +52,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   handles, and loading-state recovery.
 - Fixed interrupted chat persistence, atomic message saves, provider error
   attribution, alternating tool-result roles, and native llama.cpp tool loops.
+- Fixed provider lifecycle requests using inconsistent base URLs, failed model
+  details being cached as successful empty data, and invalid runtime payloads
+  leaving message channels open.
 
 ### Security
 - Upgraded PostCSS to `8.5.16`, removing the vulnerable docs-build dependency
@@ -51,76 +66,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Sanitized print and PDF export content and bound sensitive browser-tool grants
   to their approved origin.
 
-## [0.12.2] - 2026-07-04
-
-### Changed
-- Model capability overrides are now available for Ollama models as well as
-  custom providers, so users can correct incomplete or inaccurate capability
-  metadata reported by the installed model.
-- Refreshing the model menu now reloads the Ollama tag list and invalidates
-  cached per-model capability details together.
-- Bumped package version to `0.12.2`.
-
-### Fixed
-- Provider lifecycle requests now resolve one canonical configured base URL;
-  stale legacy/global Ollama URLs migrate once and can no longer split model
-  listing, details, version, pull, unload, warmup, embeddings, and chat across
-  different servers.
-- Model details and capability badges now share one failure-aware query
-  contract, preventing a failed capability request from being cached as
-  successful empty model information. Empty Ollama details surface an error and
-  in-place Retry action instead of silently hiding the card.
-- Runtime routes now return explicit invalid-payload responses instead of
-  leaving message channels open without a response.
-
-## [0.12.1] - 2026-07-04
+## [0.11.27] - 2026-07-01
 
 ### Added
-- Durable SQLite checkpoints for native and prompt-based tool loops, with
-  approval-prompt keepalive and same-request recovery after an MV3
-  service-worker restart.
-- A localized three-step first-run flow covering the local privacy contract,
-  an in-app Ollama connection check with CORS/port guidance, and optional
-  browser permissions.
-- Native Anthropic Messages API support for user-added providers, including
-  model discovery, streaming, images, tool calls, and manual model IDs.
-- Session tags, explicit message forks, and a local-data inventory with
-  backup and wipe controls promoted into Privacy settings.
-
-### Changed
-- Provider settings now show only verified Ollama, LM Studio, and llama.cpp
-  built-ins. vLLM, LocalAI, KoboldCPP, and other compatible endpoints use the
-  redesigned custom-provider flow.
-- Composer context controls now use one full-height tray for page context,
-  knowledge, web search, files, screenshots, and attachment inspection.
-- Settings now use six intent-based tabs; legacy deep links redirect to their
-  new destination.
-- RAG ingestion and live-page retrieval now share one chunker implementation.
-- Reasoning trace events use isolated activity, tool, and thinking renderers.
-- Message edits update in place by default; Fork remains an explicit action.
-- Chat-memory indexing is off by default for new profiles.
-- Bumped package version to `0.12.1`.
-
-## [0.11.25] - 2026-06-30
-
-### Added
-- Session-title filtering in the chat-session sidebar, with localized empty and
-  clear-search states.
+- Unified chat search across session titles and message content, with localized
+  empty and clear-search states.
 - S4 vector durability smoke coverage: persist a chunk, reload the module graph,
   and verify similarity search still finds it.
+- Competitor comparison pages for the documentation site.
 
 ### Changed
 - Updated shadcn tooling and added restrained scroll fades plus live-status
   shimmer to existing chat and settings surfaces.
 - AI-readable docs now remove MDX `export const` data and SEO-only FAQ markup
   while preserving the rendered documentation prose.
-- Bumped package version to `0.11.25`.
+- Polished the prompt sheet, options tab naming, sources icon, and compact
+  scroll-to-bottom control.
+- Bumped package version to `0.11.27`.
 
 ### Fixed
 - Selection Actions now preserve configured model system instructions and
   requested output language instead of biasing extraction results toward English.
 - Message footers use explicit export and delete actions instead of ambiguous
   ellipsis menus, and chat-memory sources use a primary-colored user icon.
+- Session titles now truncate through CSS without clipping focus rings, chat
+  search resets cleanly, and the scroll-to-bottom button hides near the end.
 
 ## [0.11.24] - 2026-06-29
 
@@ -513,8 +483,8 @@ Consolidated 0.11.x line: the "agent's hands" features plus a data-integrity har
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
 [Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.12.3...HEAD
-[0.12.3]: https://github.com/Shishir435/ollama-client/compare/0.12.2-rc...0.12.3
-[0.11.25]: https://github.com/Shishir435/ollama-client/compare/v0.11.24...v0.11.25
+[0.12.3]: https://github.com/Shishir435/ollama-client/compare/0.11.27...0.12.3
+[0.11.27]: https://github.com/Shishir435/ollama-client/compare/0.11.24...0.11.27
 [0.11.24]: https://github.com/Shishir435/ollama-client/compare/v0.11.23...v0.11.24
 [0.11.23]: https://github.com/Shishir435/ollama-client/compare/v0.11.22...v0.11.23
 [0.11.22]: https://github.com/Shishir435/ollama-client/compare/v0.11.20...v0.11.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   attribution, alternating tool-result roles, and native llama.cpp tool loops.
 
 ### Security
+- Upgraded PostCSS to `8.5.16`, removing the vulnerable docs-build dependency
+  path reported in `GHSA-6g55-p6wh-862q`.
 - Kept provider API keys and other private provider state in device-local
   storage and excluded them from backups.
 - Redacted private values from diagnostics and restricted runtime messages to
@@ -510,7 +512,8 @@ Consolidated 0.11.x line: the "agent's hands" features plus a data-integrity har
 ### Documentation
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/v0.11.25...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.12.3...HEAD
+[0.12.3]: https://github.com/Shishir435/ollama-client/compare/0.12.2-rc...0.12.3
 [0.11.25]: https://github.com/Shishir435/ollama-client/compare/v0.11.24...v0.11.25
 [0.11.24]: https://github.com/Shishir435/ollama-client/compare/v0.11.23...v0.11.24
 [0.11.23]: https://github.com/Shishir435/ollama-client/compare/v0.11.22...v0.11.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-07-23
+
+### Added
+- Added OpenRouter support and normalized remote-provider handling, including
+  durable replay of provider reasoning metadata across tool calls and restarts.
+- Added a versioned, validated provider RPC boundary for configuration,
+  connection tests, and model discovery, with authorization, safe errors,
+  timeouts, and end-to-end cancellation.
+- Added a provider-neutral onboarding flow and local diagnostics for connection,
+  storage, permissions, and browser compatibility.
+- Added a single-owner OPFS SQLite persistence backend with verified migration
+  and packaged-browser persistence benchmarks for Chrome and Firefox.
+
+### Changed
+- Rebuilt the settings and maintenance experience with intent-based navigation,
+  searchable settings, consistent controls, improved responsive layouts, and
+  clearer status and recovery feedback.
+- Centralized provider capability detection and model routing so saved mappings
+  and runtime evidence remain the source of truth.
+- Marked custom provider setup as Beta to reflect its first public release and
+  distinguish it from verified built-in providers.
+- Adopted the TypeScript 7 compiler and reduced build and test times.
+- Bumped package version to `0.12.3`.
+
+### Fixed
+- Fixed provider state races involving saves, model refreshes, tool probes,
+  provider switching, and stale RPC responses.
+- Fixed provider removal confirmation remaining open and retargeting another
+  provider after a successful removal.
+- Fixed backup import and reset flows for encoded settings, open database
+  handles, and loading-state recovery.
+- Fixed interrupted chat persistence, atomic message saves, provider error
+  attribution, alternating tool-result roles, and native llama.cpp tool loops.
+
+### Security
+- Kept provider API keys and other private provider state in device-local
+  storage and excluded them from backups.
+- Redacted private values from diagnostics and restricted runtime messages to
+  authorized extension surfaces.
+- Sanitized print and PDF export content and bound sensitive browser-tool grants
+  to their approved origin.
+
 ## [0.12.2] - 2026-07-04
 
 ### Changed

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.0",
     "astro": "7.1.3",
-    "postcss": "8.5.10",
+    "postcss": "8.5.16",
     "tailwindcss": "4.3.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "knip": "^6.24.0",
     "lint-staged": "^16.4.0",
     "playwright": "^1.60.0",
-    "postcss": "8.5.10",
+    "postcss": "8.5.16",
     "rollup-plugin-visualizer": "^6.0.11",
     "selenium-webdriver": "^4.27.0",
     "shadcn": "^4.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,8 +255,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       postcss:
-        specifier: 8.5.10
-        version: 8.5.10
+        specifier: 8.5.16
+        version: 8.5.16
       rollup-plugin-visualizer:
         specifier: ^6.0.11
         version: 6.0.11(rolldown@1.1.4)(rollup@4.60.4)
@@ -334,8 +334,8 @@ importers:
         specifier: 7.1.3
         version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       postcss:
-        specifier: 8.5.10
-        version: 8.5.10
+        specifier: 8.5.16
+        version: 8.5.16
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
@@ -5790,10 +5790,6 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8071,8 +8067,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.10
-      postcss-nested: 6.2.0(postcss@8.5.10)
+      postcss: 8.5.16
+      postcss-nested: 6.2.0(postcss@8.5.16)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -9119,7 +9115,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.10
+      postcss: 8.5.16
       tailwindcss: 4.3.0
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
@@ -12892,9 +12888,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-nested@6.2.0(postcss@8.5.10):
+  postcss-nested@6.2.0(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.16
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.0.10:
@@ -12911,12 +12907,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
@@ -13550,7 +13540,7 @@ snapshots:
       kleur: 4.1.5
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.10
+      postcss: 8.5.16
       postcss-selector-parser: 7.1.1
       prompts: 2.4.2
       recast: 0.23.11


### PR DESCRIPTION
## Summary

- add complete 0.12.3 changelog covering provider, persistence, UI, reliability, and security work
- upgrade PostCSS from 8.5.10 to 8.5.16 in root and docs workspaces
- remove GHSA-6g55-p6wh-862q from the docs build dependency path

## Why

The final 0.12.3 release needed published release notes. The first push attempt also exposed a high-severity PostCSS advisory in the mandatory pre-push audit, so this PR includes the patched dependency rather than bypassing the gate.

## Impact

0.12.3 release documentation becomes complete, generated docs include the new notes, and the dependency audit returns no known vulnerabilities.

## Validation

- `pnpm verify:release`
- `pnpm docs:build`
- pre-push audit: no known vulnerabilities
- pre-push i18n: all locales 100%
- 270 test files / 2,177 tests
- Chrome MV3 production build
- Firefox MV2 production build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the 0.12.3 release.
- Consolidates the changelog and restores release comparison references.
- Documents the PostCSS advisory remediation.
- Upgrades PostCSS from 8.5.10 to 8.5.16 in both workspaces and updates the lockfile.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the fixes related to the previous review threads.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds consolidated 0.12.3 release notes, security remediation details, and corrected comparison references. |
| docs/package.json | Pins the docs workspace to PostCSS 8.5.16. |
| package.json | Pins the root workspace to PostCSS 8.5.16. |
| pnpm-lock.yaml | Updates both importers and dependent snapshots to resolve PostCSS 8.5.16 consistently. |

<sub>Reviews (3): Last reviewed commit: ["docs: consolidate store release history"](https://github.com/shishir435/ollama-client/commit/1ce882c28082f17ffdd7e66a5acd89d91c096057) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46717717)</sub>

<!-- /greptile_comment -->