### PR TITLE
Chore/0 12 4 hygiene spike

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Chat with Local LLM Models",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Local-first Chrome extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local/remote providers, including local RAG workflows.",
   "author": "Shishir Chaurasiya",
   "keywords": [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,24 +3,29 @@ import "webextension-polyfill"
 import { registerMessageRouter } from "@/background/message-router"
 import { registerPortRouter } from "@/background/port-router"
 import { initializeBackgroundStartup } from "@/background/startup"
-import { isChromiumBased } from "@/lib/browser-api"
 
 // Production persistence topology. Chromium: the service worker guarantees
 // the offscreen owner document exists (for itself and for extension pages).
 // Firefox: the persistent background page IS the owner and hosts the SQLite
 // worker directly.
+//
+// The branch is resolved at build time via __FIREFOX_BG_OWNER__ (not a runtime
+// browser check) so the bundler dead-code eliminates the unused arm. On
+// Chromium that drops owner-host and its ~1.4 MB SQLite worker chunk from the
+// background entry entirely — the offscreen document (persistence-host) is the
+// only Chromium worker host.
 function registerPersistenceTopology() {
   // Test environments mock a minimal chrome; the topology only registers
   // where runtime messaging actually exists.
   if (!chrome?.runtime?.onMessage?.addListener) return
-  if (isChromiumBased() && chrome.offscreen) {
-    void import("@/lib/persistence/chromium-owner").then((module) =>
-      module.registerChromiumPersistenceControl()
+  if (__FIREFOX_BG_OWNER__) {
+    void import("@/lib/persistence/owner-host").then((module) =>
+      module.registerPersistenceHost()
     )
     return
   }
-  void import("@/lib/persistence/owner-host").then((module) =>
-    module.registerPersistenceHost()
+  void import("@/lib/persistence/chromium-owner").then((module) =>
+    module.registerChromiumPersistenceControl()
   )
 }
 

--- a/src/features/file-upload/processors/pdf-processor.ts
+++ b/src/features/file-upload/processors/pdf-processor.ts
@@ -19,9 +19,10 @@ export class PdfProcessor implements FileProcessor {
       // Lazy load pdfjs-dist
       const pdfjsLib = await import("pdfjs-dist")
 
-      // Import worker
-      await import("pdfjs-dist/build/pdf.worker.min.mjs")
-
+      // pdf.js spawns the worker itself from workerSrc below; the URL
+      // reference is what makes the bundler emit the worker asset. Do NOT also
+      // `import()` the worker module — that only forces a redundant ~1.3 MB
+      // duplicate chunk of the same file into the bundle.
       pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
         "pdfjs-dist/build/pdf.worker.min.mjs",
         import.meta.url

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,10 +1,6 @@
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import {
-  isRetryableProviderStatus,
-  parseRetryAfter,
-  providerErrorUserMessage
-} from "@/lib/providers/provider-errors"
+import { throwProviderResponseError } from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
 import type { ChatMessage, ChatStreamMessage, ProviderModel } from "@/types"
 import { ANTHROPIC_PROVIDER_CAPABILITIES } from "./capabilities"
@@ -191,25 +187,13 @@ export class AnthropicProvider implements LLMProvider {
     }
   }
 
-  private async responseError(
-    response: Response,
-    model?: string
-  ): Promise<never> {
-    const detail = await response.text()
-    const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"))
-    throw createAppError(`Anthropic Error (${response.status}): ${detail}`, {
-      kind: "provider",
-      status: response.status,
+  private responseError(response: Response, model?: string): Promise<never> {
+    return throwProviderResponseError(response, {
+      label: "Anthropic Error",
       providerId: this.id,
-      retryable: isRetryableProviderStatus(response.status),
-      retryAfterMs,
-      userMessage: providerErrorUserMessage(response.status, {
-        baseUrl: this.baseUrl,
-        retryAfterMs,
-        providerName: this.config.name,
-        model
-      }),
-      debug: detail
+      baseUrl: this.baseUrl,
+      providerName: this.config.name,
+      model
     })
   }
 

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -4,7 +4,8 @@ import { logger } from "@/lib/logger"
 import {
   isRetryableProviderStatus,
   parseRetryAfter,
-  providerErrorUserMessage
+  providerErrorUserMessage,
+  throwProviderResponseError
 } from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
 import type { ChatMessage, ChatStreamMessage, ProviderModel } from "@/types"
@@ -207,27 +208,18 @@ export class OpenAICompatibleProvider implements LLMProvider {
     }
   }
 
-  private async responseError(
+  private responseError(
     response: Response,
     label: string,
     baseUrl: string,
     model?: string
   ): Promise<never> {
-    const detail = await response.text()
-    const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"))
-    throw createAppError(`${label} (${response.status}): ${detail}`, {
-      kind: "provider",
-      status: response.status,
+    return throwProviderResponseError(response, {
+      label,
       providerId: this.id,
-      retryable: isRetryableProviderStatus(response.status),
-      retryAfterMs,
-      userMessage: providerErrorUserMessage(response.status, {
-        baseUrl,
-        retryAfterMs,
-        providerName: this.config.name,
-        model
-      }),
-      debug: detail
+      baseUrl,
+      providerName: this.config.name,
+      model
     })
   }
 

--- a/src/lib/providers/provider-errors.ts
+++ b/src/lib/providers/provider-errors.ts
@@ -1,4 +1,5 @@
 import { EXTERNAL_URLS } from "@/lib/constants/urls"
+import { createAppError } from "@/lib/error-utils"
 
 /**
  * A 401/403 from a LOCAL provider (Ollama et al.) is almost always a CORS/origin
@@ -138,4 +139,42 @@ export const providerErrorUserMessage = (
     return `${provider} returned a server error. Check that ${providerLower} is running, the ${selectedModel} is loaded, and its base URL/port are correct.`
   }
   return `${provider} returned an error. Check ${providerLower}, the ${selectedModel}, and its server logs.`
+}
+
+/**
+ * Shape a failed provider HTTP response into an `AppError` and throw it.
+ * Shared by the OpenAI-compatible and Anthropic adapters, whose per-response
+ * error handling was byte-identical: read the body for `debug`, parse
+ * `Retry-After`, and map the status to a safe user message. Raw response
+ * bodies stay in `debug`, never in `userMessage`.
+ *
+ * Ollama does NOT use this: its local-provider 401/403 CORS special-case and
+ * `>= 500`-only retryability differ intentionally.
+ */
+export const throwProviderResponseError = async (
+  response: Response,
+  options: {
+    label: string
+    providerId: string
+    baseUrl?: string
+    providerName?: string
+    model?: string
+  }
+): Promise<never> => {
+  const detail = await response.text()
+  const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"))
+  throw createAppError(`${options.label} (${response.status}): ${detail}`, {
+    kind: "provider",
+    status: response.status,
+    providerId: options.providerId,
+    retryable: isRetryableProviderStatus(response.status),
+    retryAfterMs,
+    userMessage: providerErrorUserMessage(response.status, {
+      baseUrl: options.baseUrl,
+      retryAfterMs,
+      providerName: options.providerName,
+      model: options.model
+    }),
+    debug: detail
+  })
 }

--- a/src/lib/sqlite/schema.ts
+++ b/src/lib/sqlite/schema.ts
@@ -40,11 +40,10 @@ CREATE TABLE IF NOT EXISTS files (
   FOREIGN KEY(sessionId) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS vectors (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  embedding BLOB NOT NULL,
-  metadata TEXT NOT NULL
-);
+-- No embeddings table here by design: the vector store lives in IndexedDB
+-- (Dexie) via lib/embeddings/. Persistence convergence (plan 9.3/9.4)
+-- deliberately did not migrate embeddings to SQLite. Do not add a vectors
+-- table here unless that decision is revisited.
 
 CREATE TABLE IF NOT EXISTS kv_store (
   key TEXT PRIMARY KEY,

--- a/src/types/vendor.d.ts
+++ b/src/types/vendor.d.ts
@@ -62,3 +62,10 @@ declare const __SPIKE_OPFS_OWNER__: boolean
 // True only for WXT_BENCHMARK=1 Firefox builds: the MV2 background page
 // hosts the section 9.4 spike owner worker directly (no offscreen API).
 declare const __SPIKE_OPFS_OWNER_MV2__: boolean
+
+// Compile-time flag defined in wxt.config.ts vite `define`; true only for
+// Firefox (MV2) builds, whose persistent background page hosts the SQLite
+// persistence worker directly. On Chromium (false) the offscreen document is
+// the owner, so this lets the bundler dead-code-eliminate the owner-host +
+// worker chunk out of the Chromium background entry.
+declare const __FIREFOX_BG_OWNER__: boolean

--- a/tools/ollama-env.sh
+++ b/tools/ollama-env.sh
@@ -25,10 +25,13 @@
 #
 # What this script does:
 #   ✅ Detects your OS (macOS, Linux, Windows)
-#   ✅ Stops any running Ollama instances (including the macOS menu-bar app,
-#      which would otherwise restart the server without these settings)
-#   ✅ Sets OLLAMA_ORIGINS for Chrome and Firefox extensions
-#   ✅ Starts Ollama in the background and verifies it is actually up
+#   ✅ macOS + Ollama.app: sets OLLAMA_ORIGINS in the launchd session env and
+#      restarts the app, so its own server inherits CORS and keeps it across the
+#      app's auto-relaunch (persists until logout)
+#   ✅ Otherwise (CLI Ollama): stops the running server and starts its own with
+#      OLLAMA_ORIGINS set for Chrome and Firefox extensions
+#   ✅ Verifies the server is up AND actually allows the extension origin (an
+#      Origin-header probe), so it never reports success on a non-CORS server
 #   ✅ With --lan: sets OLLAMA_HOST=0.0.0.0 and shows your local IP
 #
 # Requirements:
@@ -84,29 +87,32 @@ if [ "$OS_TYPE" = "linux" ] && command -v systemctl >/dev/null 2>&1; then
   fi
 fi
 
-# Stop existing Ollama instances.
-if [ "$OS_TYPE" = "windows" ]; then
-  taskkill //F //IM ollama.exe 2>/dev/null || true
-else
-  if [ "$OS_TYPE" = "macos" ] && pgrep -x Ollama >/dev/null 2>&1; then
-    # The menu-bar app supervises `ollama serve` and would relaunch it
-    # WITHOUT our env vars right after pkill — quit the app first.
-    echo "ℹ️  Quitting the Ollama menu-bar app (it would restart the server without CORS settings)..."
-    osascript -e 'quit app "Ollama"' 2>/dev/null || true
-    sleep 2
-  fi
-  pkill -f "ollama serve" 2>/dev/null || true
-fi
+PORT="11434"
+ORIGINS="chrome-extension://*,moz-extension://*"
 
-sleep 1
+# PIDs of processes LISTENing on the Ollama port (not browser client
+# connections). Name-agnostic: the macOS app launches the server under a path
+# that `pkill -f "ollama serve"` does not match, so we target the port instead.
+port_listener_pids() {
+  lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true
+}
 
-# Allow browser extensions (Chrome + Firefox) to call the API.
-export OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*"
+# Is a server answering at all (no Origin header — checks liveness only)?
+server_up() {
+  curl -sf "http://localhost:$PORT/api/version" >/dev/null 2>&1
+}
 
-if [ "$MODE" = "lan" ]; then
-  # Bind to all interfaces so LAN devices can access it.
-  export OLLAMA_HOST="0.0.0.0"
-fi
+# Does the running server actually allow the extension origin? A server without
+# OLLAMA_ORIGINS returns 403 to a browser-extension Origin; a configured one
+# returns 200. This is what distinguishes "up" from "up AND usable by the
+# extension", so we never print a green check on a non-CORS server.
+cors_ok() {
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Origin: moz-extension://cors-probe" \
+    "http://localhost:$PORT/api/version" 2>/dev/null || echo "000")
+  [ "$code" = "200" ]
+}
 
 # Get local IP address (cross-platform)
 get_local_ip() {
@@ -126,24 +132,112 @@ get_local_ip() {
   fi
 }
 
-LOG_FILE="$HOME/.ollama-serve.log"
-nohup ollama serve > "$LOG_FILE" 2>&1 &
+# macOS + the Ollama.app: the app supervises its OWN `ollama serve` and
+# relaunches itself (login item), so killing the server and starting our own is
+# futile — the app comes back with a non-CORS server. Instead set the origin in
+# the launchd session environment (which the app-spawned server inherits) and
+# restart the app.
+MACOS_APP=""
+if [ "$OS_TYPE" = "macos" ] && [ -d "/Applications/Ollama.app" ]; then
+  MACOS_APP="yes"
+fi
 
-# Verify the server actually came up (catches port-in-use, respawned app
-# instances, missing binary, etc. — don't print ✅ on faith).
+if [ -n "$MACOS_APP" ]; then
+  echo "ℹ️  Configuring the Ollama menu-bar app for extension CORS..."
+  # Session-wide env the app's server inherits on launch. Persists until logout;
+  # revert with: launchctl unsetenv OLLAMA_ORIGINS
+  launchctl setenv OLLAMA_ORIGINS "$ORIGINS"
+  if [ "$MODE" = "lan" ]; then
+    launchctl setenv OLLAMA_HOST "0.0.0.0"
+  else
+    # Drop any stale LAN binding from a previous --lan run.
+    launchctl unsetenv OLLAMA_HOST 2>/dev/null || true
+  fi
+
+  # Restart the app so its server picks up the new environment. It MUST be
+  # fully dead (app process + server, port free) before we relaunch — otherwise
+  # `open -a Ollama` no-ops on the still-running instance, which keeps its stale
+  # env and CORS never applies. The app auto-relaunches, so force it if a plain
+  # quit does not take.
+  osascript -e 'quit app "Ollama"' 2>/dev/null || true
+  for _ in 1 2 3 4 5; do
+    pgrep -x Ollama >/dev/null 2>&1 || break
+    sleep 1
+  done
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! pgrep -x Ollama >/dev/null 2>&1 && [ -z "$(port_listener_pids)" ]; then
+      break
+    fi
+    pkill -x Ollama 2>/dev/null || true
+    pids="$(port_listener_pids)"
+    [ -n "$pids" ] && kill $pids 2>/dev/null || true
+    sleep 1
+  done
+  open -a Ollama 2>/dev/null || true
+else
+  # No app (CLI-managed Ollama): stop the running server and start our own with
+  # the env vars exported into this process.
+  if [ "$OS_TYPE" = "windows" ]; then
+    taskkill //F //IM ollama.exe 2>/dev/null || true
+    sleep 1
+  else
+    pids="$(port_listener_pids)"
+    [ -n "$pids" ] && kill $pids 2>/dev/null || true
+    pkill -f "ollama serve" 2>/dev/null || true
+  fi
+
+  # Wait for the port to free so our server can bind (and we don't mistake a
+  # leftover non-CORS server for success).
+  freed=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if [ -z "$(port_listener_pids)" ]; then
+      freed="yes"
+      break
+    fi
+    sleep 1
+  done
+  if [ -z "$freed" ]; then
+    echo "❌ Port $PORT is still in use after stopping Ollama — a supervisor is"
+    echo "   respawning the server, so a new one with CORS settings cannot bind."
+    echo "   Stop the service/supervisor managing Ollama, then re-run this script."
+    echo "   Current listener(s): $(port_listener_pids | tr '\n' ' ')"
+    exit 1
+  fi
+
+  export OLLAMA_ORIGINS="$ORIGINS"
+  [ "$MODE" = "lan" ] && export OLLAMA_HOST="0.0.0.0"
+
+  LOG_FILE="$HOME/.ollama-serve.log"
+  nohup ollama serve > "$LOG_FILE" 2>&1 &
+fi
+
+# Verify: the server must be UP and actually allow the extension origin. A plain
+# liveness check is not enough — a non-CORS server answers /api/version too.
 started=""
-for _ in 1 2 3 4 5 6 7 8 9 10; do
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
   sleep 1
-  if curl -sf http://localhost:11434/api/version >/dev/null 2>&1; then
+  if server_up && cors_ok; then
     started="yes"
     break
   fi
 done
 
 if [ -z "$started" ]; then
-  echo "❌ Ollama did not start (no response on http://localhost:11434 after 10s)."
-  echo "   Last log lines from $LOG_FILE:"
-  tail -5 "$LOG_FILE" 2>/dev/null | sed 's/^/   | /'
+  if server_up; then
+    echo "❌ A server is running on $PORT but it is rejecting the extension origin (403)."
+    if [ -n "$MACOS_APP" ]; then
+      echo "   The Ollama app did not pick up OLLAMA_ORIGINS. Fully quit it from the"
+      echo "   menu bar, then re-run this script (launchctl env applies on next launch)."
+    else
+      echo "   Another Ollama (without OLLAMA_ORIGINS) owns the port. Stop it, then re-run."
+    fi
+  else
+    echo "❌ Ollama did not start (no response on http://localhost:$PORT after 15s)."
+    if [ -z "$MACOS_APP" ]; then
+      echo "   Last log lines from ${LOG_FILE:-$HOME/.ollama-serve.log}:"
+      tail -5 "${LOG_FILE:-$HOME/.ollama-serve.log}" 2>/dev/null | sed 's/^/   | /'
+    fi
+  fi
   exit 1
 fi
 
@@ -155,18 +249,22 @@ fi
 
 echo ""
 echo "🌍 Access URLs:"
-echo "   • http://localhost:11434"
+echo "   • http://localhost:$PORT"
 if [ "$MODE" = "lan" ]; then
   LOCAL_IP=$(get_local_ip)
   if [ -n "$LOCAL_IP" ]; then
-    echo "   • http://$LOCAL_IP:11434"
+    echo "   • http://$LOCAL_IP:$PORT"
   fi
   echo ""
   echo "⚠️  LAN mode: anyone on your network can reach this server (Ollama has no auth)."
 fi
 echo ""
 
-if [ "$OS_TYPE" = "windows" ]; then
+if [ -n "$MACOS_APP" ]; then
+  echo "💡 The Ollama app now runs the server with CORS (persists until logout)."
+  echo "   To stop: quit Ollama from the menu bar."
+  echo "   To revert CORS: launchctl unsetenv OLLAMA_ORIGINS"
+elif [ "$OS_TYPE" = "windows" ]; then
   echo "💡 Tip: Ollama is running. To stop it, run:"
   echo "   taskkill //F //IM ollama.exe"
 else

--- a/tools/ollama-env.sh
+++ b/tools/ollama-env.sh
@@ -129,6 +129,18 @@ kill_ollama_listeners() {
   [ -n "$ollama_pids" ] && kill $ollama_pids 2>/dev/null || true
 }
 
+# Kill lingering `ollama serve` processes that are not (yet) holding the port —
+# but verify each candidate's executable is actually Ollama first. `pkill -f`
+# alone would match ANY process whose command line merely contains
+# "ollama serve", killing an unrelated program.
+kill_ollama_serve() {
+  local pid exe
+  for pid in $(pgrep -f "ollama serve" 2>/dev/null || true); do
+    exe=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+    [ "${exe##*/}" = "ollama" ] && kill "$pid" 2>/dev/null || true
+  done
+}
+
 # Is a server answering at all (no Origin header — checks liveness only)?
 server_up() {
   curl -sf "http://localhost:$PORT/api/version" >/dev/null 2>&1
@@ -213,7 +225,7 @@ else
     sleep 1
   else
     kill_ollama_listeners
-    pkill -f "ollama serve" 2>/dev/null || true
+    kill_ollama_serve
   fi
 
   # Wait for the port to free so our server can bind (and we don't mistake a

--- a/tools/ollama-env.sh
+++ b/tools/ollama-env.sh
@@ -97,6 +97,33 @@ port_listener_pids() {
   lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true
 }
 
+# Kill ONLY Ollama processes that hold the port. If some other program owns the
+# port, refuse to touch it — blindly killing the port owner could terminate an
+# unrelated local service and lose its unsaved state. Exits the script on a
+# foreign holder so the caller does not proceed to start a server that cannot
+# bind anyway.
+kill_ollama_listeners() {
+  local pid cmd ollama_pids="" foreign=""
+  for pid in $(port_listener_pids); do
+    cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
+    # Process vanished between the lookup and now — nothing to do.
+    [ -z "$cmd" ] && continue
+    if printf '%s' "$cmd" | grep -qi "ollama"; then
+      ollama_pids="$ollama_pids $pid"
+    else
+      foreign="$foreign
+   • PID $pid: $cmd"
+    fi
+  done
+  if [ -n "$foreign" ]; then
+    echo "❌ Port $PORT is held by a non-Ollama process; refusing to kill it:$foreign"
+    echo "   Free the port yourself, then re-run this script."
+    exit 1
+  fi
+  # shellcheck disable=SC2086
+  [ -n "$ollama_pids" ] && kill $ollama_pids 2>/dev/null || true
+}
+
 # Is a server answering at all (no Origin header — checks liveness only)?
 server_up() {
   curl -sf "http://localhost:$PORT/api/version" >/dev/null 2>&1
@@ -169,8 +196,7 @@ if [ -n "$MACOS_APP" ]; then
       break
     fi
     pkill -x Ollama 2>/dev/null || true
-    pids="$(port_listener_pids)"
-    [ -n "$pids" ] && kill $pids 2>/dev/null || true
+    kill_ollama_listeners
     sleep 1
   done
   open -a Ollama 2>/dev/null || true
@@ -181,8 +207,7 @@ else
     taskkill //F //IM ollama.exe 2>/dev/null || true
     sleep 1
   else
-    pids="$(port_listener_pids)"
-    [ -n "$pids" ] && kill $pids 2>/dev/null || true
+    kill_ollama_listeners
     pkill -f "ollama serve" 2>/dev/null || true
   fi
 

--- a/tools/ollama-env.sh
+++ b/tools/ollama-env.sh
@@ -103,16 +103,21 @@ port_listener_pids() {
 # foreign holder so the caller does not proceed to start a server that cannot
 # bind anyway.
 kill_ollama_listeners() {
-  local pid cmd ollama_pids="" foreign=""
+  local pid exe base ollama_pids="" foreign=""
   for pid in $(port_listener_pids); do
-    cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
+    # Classify by the EXECUTABLE basename only (`comm` excludes arguments), not
+    # a substring of the full command line: otherwise any listener whose path
+    # or args merely contain "ollama" (e.g. a process started from an
+    # ollama-* directory) would be misidentified as Ollama and killed.
+    exe=$(ps -o comm= -p "$pid" 2>/dev/null || true)
     # Process vanished between the lookup and now — nothing to do.
-    [ -z "$cmd" ] && continue
-    if printf '%s' "$cmd" | grep -qi "ollama"; then
+    [ -z "$exe" ] && continue
+    base=${exe##*/}
+    if [ "$base" = "ollama" ]; then
       ollama_pids="$ollama_pids $pid"
     else
       foreign="$foreign
-   • PID $pid: $cmd"
+   • PID $pid: $(ps -o command= -p "$pid" 2>/dev/null || printf '%s' "$exe")"
     fi
   done
   if [ -n "$foreign" ]; then

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -77,7 +77,10 @@ export default defineConfig({
     description: "__MSG_extDescription__",
     default_locale: "en",
     version: packageJson.version,
-    ...(browser === "firefox" ? {} : { minimum_chrome_version: "88" }),
+    // The Chromium persistence owner uses chrome.offscreen (Chrome 109+) and
+    // chrome.runtime.getContexts (Chrome 116+); 116 is the real floor for
+    // durable chat history on Chromium, so the manifest states it honestly.
+    ...(browser === "firefox" ? {} : { minimum_chrome_version: "116" }),
     homepage_url: packageJson.homepage,
     icons: {
       16: "assets/icon.png",
@@ -175,9 +178,33 @@ export default defineConfig({
         ),
         __SPIKE_OPFS_OWNER_MV2__: JSON.stringify(
           process.env.WXT_BENCHMARK === "1" && env.browser === "firefox"
-        )
+        ),
+        // Persistence owner topology, resolved at build time so the unused
+        // branch (and its ~1.4 MB SQLite worker chunk) is dead-code eliminated
+        // from the background entry. Firefox MV2 hosts the worker in its
+        // persistent background page; Chromium delegates to the offscreen
+        // document, so its background never bundles the worker.
+        __FIREFOX_BG_OWNER__: JSON.stringify(env.browser === "firefox")
       },
       plugins: [
+        // Drop the content-hashed sqlite3-<hash>.wasm that the sqlite-wasm
+        // emscripten glue's `new URL("sqlite3.wasm", import.meta.url)` makes
+        // the bundler emit. It is byte-identical to the stable
+        // assets/sqlite3.wasm we copy in `build:publicAssets`, and the worker
+        // inits with wasmBinary from that stable copy, so the glue never
+        // fetches the hashed URL. Removing it at generateBundle means it is
+        // never written, never recorded in the manifest, and never packaged —
+        // no ENOENT warning, single copy in both the unpacked build and zip.
+        {
+          name: "wxt:drop-redundant-sqlite-wasm",
+          generateBundle(_options, bundle) {
+            for (const fileName of Object.keys(bundle)) {
+              if (/(^|\/)sqlite3-[^/]*\.wasm$/.test(fileName)) {
+                delete bundle[fileName]
+              }
+            }
+          }
+        },
         react({
           exclude: [/node_modules/, /src\/i18n\/resources\.ts$/],
           babel: {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hygiene release reduces duplicate bundle assets and centralizes provider error handling while refining persistence ownership and Ollama startup behavior.
- Selects the Chromium or Firefox persistence owner at build time and raises Chromium’s minimum version to 116.
- Removes redundant PDF worker, SQLite WASM, and obsolete SQLite vector-table output.
- Consolidates Anthropic and OpenAI-compatible HTTP response error handling.
- Makes the Ollama environment script verify process identity, configure macOS app launches, and validate extension CORS.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with respect to the previously reported process-termination issues.

No blocking failure remains within the scope of the previous review threads.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/ollama-env.sh | Reworks Ollama process shutdown, macOS app configuration, startup, and CORS verification without leaving a blocking failure related to the prior termination-safety threads. |
| src/background/index.ts | Replaces runtime browser detection with a build-time persistence-owner flag. |
| wxt.config.ts | Defines the browser-specific persistence flag, raises the Chromium floor, and removes a redundant emitted SQLite WASM asset. |
| src/lib/providers/provider-errors.ts | Adds shared provider HTTP-response error construction used by Anthropic and OpenAI-compatible adapters. |
| src/features/file-upload/processors/pdf-processor.ts | Removes a redundant PDF worker module import while retaining the worker URL asset reference. |
| src/lib/sqlite/schema.ts | Removes the unused SQLite vectors table because embeddings remain in Dexie. |

<sub>Reviews (4): Last reviewed commit: ["fix(tools): identity-check the ollama-se..."](https://github.com/shishir435/ollama-client/commit/325819aac37b8c5c7361bc60d8a48ff755708d09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46787894)</sub>

<!-- /greptile_comment -->