### PR TITLE
docs: prepare 0.12.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.12.4] - 2026-07-24
+
+### Changed
+
+- Reduced the packaged extension size by dropping a duplicate SQLite WASM binary
+  and a redundant bundled PDF worker (Chrome package about 6.3 MB down to about
+  4.3 MB), with no change to features or behavior.
+- Selected the persistence owner for each browser at build time so a build ships
+  only its own owner path — the Chromium offscreen document or the Firefox
+  background page — instead of carrying both.
+- Raised the minimum supported Chrome version to 116, the real floor for the
+  OPFS SQLite persistence backend, so the requirement is stated honestly.
+- Consolidated provider HTTP error handling into one shared path for consistent
+  status codes, retry hints, and user-facing messages across providers.
+- Bumped package version to `0.12.4`.
+
 ## [0.12.3] - 2026-07-23
 
 ### Added
@@ -477,7 +493,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.12.3...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.12.4...HEAD
+[0.12.4]: https://github.com/Shishir435/ollama-client/compare/0.12.3...0.12.4
 [0.12.3]: https://github.com/Shishir435/ollama-client/compare/0.11.27...0.12.3
 [0.11.27]: https://github.com/Shishir435/ollama-client/compare/v0.10.3...0.11.27
 [0.10.3]: https://github.com/Shishir435/ollama-client/compare/v0.10.2...v0.10.3


### PR DESCRIPTION
Adds the `[0.12.4]` CHANGELOG entry and compare links ahead of the `preview → main` release PR.

Covers the user-facing changes from #200:
- packaged size reduction (~6.3 MB → ~4.3 MB, duplicate wasm + redundant PDF worker removed)
- build-time persistence owner topology (each browser ships only its own path)
- minimum Chrome raised to 116 (OPFS persistence floor)
- consolidated provider HTTP error handling
- version bump to `0.12.4`

Gate 4d (#201) is dev-only test tooling and ships nothing, so it gets no changelog line.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the 0.12.4 release documentation.
- Adds release notes for package-size reduction, browser-specific persistence ownership, Chrome 116 support, shared provider error handling, and the version bump.
- Advances the Unreleased comparison base and adds the 0.12.4 comparison link.

<h3>Confidence Score: 5/5</h3>

The documentation-only release preparation appears safe to merge.

The stated version and release changes align with the repository configuration and underlying implementation, and the new comparison link follows the convention used by the immediately preceding release.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds an internally consistent 0.12.4 release entry and updates the release comparison links. |

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.12.4 release"](https://github.com/shishir435/ollama-client/commit/d0fb95b3e52f1d1a23043c80fe75279a527d2902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46818706)</sub>

<!-- /greptile_comment -->