### PR TITLE
feat: add post-uninstall feedback flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added a post-uninstall feedback page with optional GitHub and email prompts,
+  plus extension version and browser language context to help diagnose
+  release-specific issues without attaching chat content or settings.
+
 ## [0.12.4] - 2026-07-24
 
 ### Changed

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,9 @@
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.0",
     "astro": "7.1.3",
-    "postcss": "8.5.16",
-    "tailwindcss": "4.3.0"
+    "postcss": "8.5.18",
+    "tailwindcss": "4.3.0",
+    "typescript": "npm:@typescript/typescript6@6.0.2"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "7.2.1",

--- a/docs/src/pages/goodbye.astro
+++ b/docs/src/pages/goodbye.astro
@@ -1,0 +1,150 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro"
+import {
+  AUTHOR_URL,
+  CONTACT_EMAIL,
+  REPO_URL,
+  SITE_TITLE
+} from "@/seo/constants.mjs"
+
+const title = `Thank you for trying ${SITE_TITLE}`
+const description =
+  "Tell us what could have made Ollama Client work better for you. Your feedback helps guide future improvements."
+
+const REPO = REPO_URL
+const EMAIL = CONTACT_EMAIL
+
+const prompts = [
+  "What were you trying to do?",
+  "What did not work as expected?",
+  "What would have made you keep Ollama Client installed?"
+]
+---
+
+<BaseLayout title={title} description={description}>
+  <section class="mx-auto max-w-2xl pb-24 pt-24 sm:pt-32">
+    <p
+      class="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground"
+    >
+      Ollama Client · Feedback
+    </p>
+
+    <h1
+      class="mt-5 text-balance text-3xl font-semibold leading-[1.15] tracking-tight sm:text-4xl"
+    >
+      Thank you for trying Ollama Client
+    </h1>
+
+    <div class="mt-6 space-y-4 text-[15px] leading-relaxed text-foreground/70">
+      <p>
+        We are sorry to see you go. If something fell short, a brief note about
+        your experience would help us understand what to improve.
+      </p>
+      <p>
+        Ollama Client is independently developed by{" "}
+        <a
+          class="text-foreground underline decoration-border underline-offset-4 transition hover:decoration-foreground"
+          href={AUTHOR_URL}
+          target="_blank"
+          rel="noopener">Shishir</a
+        >. Every report is reviewed and helps prioritize fixes and future
+        improvements.
+      </p>
+    </div>
+
+    <div class="mt-8 flex flex-wrap items-center gap-3">
+      <a
+        id="issue-link"
+        class="inline-flex h-9 items-center rounded-md bg-foreground px-4 text-sm font-medium text-background transition hover:bg-foreground/90"
+        href={`${REPO}/issues/new`}
+        target="_blank"
+        rel="noopener"
+      >
+        Leave feedback on GitHub
+      </a>
+      <a
+        id="email-link"
+        class="inline-flex h-9 items-center rounded-md border border-border px-4 text-sm font-medium text-foreground transition hover:bg-foreground/5"
+        href={`mailto:${EMAIL}`}
+      >
+        Send feedback by email
+      </a>
+    </div>
+
+    <div class="mt-12 border-t border-border/60 pt-8">
+      <p class="text-sm font-medium text-foreground">
+        A few useful details to include
+      </p>
+      <ul class="mt-4 space-y-2.5 text-[15px] leading-relaxed text-foreground/70">
+        {
+          prompts.map((prompt) => (
+            <li class="flex gap-3">
+              <span class="select-none text-muted-foreground" aria-hidden="true">
+                &bull;
+              </span>
+              <span>{prompt}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+
+    <p class="mt-10 text-xs leading-relaxed text-muted-foreground">
+      The extension adds only its version and your browser language to the
+      feedback draft. It does not attach chat content, settings, or personal
+      identifiers.
+    </p>
+
+    <p class="mt-10 text-[15px] text-foreground/70">
+      Thank you for helping make Ollama Client better.
+    </p>
+  </section>
+
+  <script is:inline define:vars={{ REPO, EMAIL }}>
+    // Enrich the feedback links with the anonymous context the extension's
+    // setUninstallURL passes: ?v=<version>&l=<locale>. No identifiers.
+    ;(() => {
+      const params = new URLSearchParams(window.location.search)
+      const version = params.get("v")
+      const locale = params.get("l")
+
+      const footer = [
+        `Version: ${version || "unknown"}`,
+        `Language: ${locale || "unknown"}`
+      ].join("\n")
+
+      const questions = [
+        "## What were you trying to do?",
+        "",
+        "",
+        "## What happened?",
+        "",
+        "",
+        "## What could have made you keep Ollama Client installed?",
+        "",
+        "",
+        "---",
+        footer
+      ].join("\n")
+
+      const issueLink = document.getElementById("issue-link")
+      if (issueLink) {
+        const url = new URL(`${REPO}/issues/new`)
+        url.searchParams.set("title", "Feedback after uninstall")
+        url.searchParams.set("body", questions)
+        url.searchParams.set("labels", "feedback")
+        issueLink.href = url.toString()
+      }
+
+      const emailLink = document.getElementById("email-link")
+      if (emailLink) {
+        const subject = version
+          ? `Ollama Client feedback (v${version})`
+          : "Ollama Client feedback"
+        emailLink.href = `mailto:${EMAIL}?subject=${encodeURIComponent(
+          subject
+        )}&body=${encodeURIComponent(questions)}`
+      }
+    })()
+  </script>
+</BaseLayout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -2,6 +2,8 @@
 import BaseLayout from "@/layouts/BaseLayout.astro"
 import {
   APP_VERSION,
+  AUTHOR_NAME,
+  AUTHOR_URL,
   LANDING_TITLE,
   LANDING_DESCRIPTION,
   SITE_TITLE
@@ -45,8 +47,8 @@ const jsonLd = {
       },
       author: {
         "@type": "Person",
-        name: "Shishir Chaurasiya",
-        url: "https://www.shishirchaurasiya.in/"
+        name: AUTHOR_NAME,
+        url: AUTHOR_URL
       },
       url: "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
       downloadUrl:

--- a/docs/src/pages/og/[...route].ts
+++ b/docs/src/pages/og/[...route].ts
@@ -30,7 +30,7 @@ export const { getStaticPaths, GET } = await OGImageRoute({
   param: "route",
   pages,
   getImageOptions: (_path, page) => ({
-    title: page.title,
+    title: page.title || "",
     description: page.description,
     bgGradient: [[10, 10, 11], [23, 23, 27]],
     border: {

--- a/docs/src/seo/constants.d.mts
+++ b/docs/src/seo/constants.d.mts
@@ -7,3 +7,7 @@ export const SITE_DESCRIPTION: string
 export const LANDING_TITLE: string
 export const LANDING_DESCRIPTION: string
 export const KEYWORDS: string[]
+export const AUTHOR_NAME: string
+export const AUTHOR_URL: string
+export const CONTACT_EMAIL: string
+export const REPO_URL: string

--- a/docs/src/seo/constants.mjs
+++ b/docs/src/seo/constants.mjs
@@ -75,6 +75,14 @@ export const SITE_URL = normalizeSiteUrl(
 
 export const SITE_TITLE = "Ollama Client"
 
+export const REPO_URL = "https://github.com/Shishir435/ollama-client"
+
+export const CONTACT_EMAIL = "shishirchaurasiya435@gmail.com"
+
+export const AUTHOR_NAME = "Shishir Chaurasiya"
+
+export const AUTHOR_URL = "https://www.shishirchaurasiya.in/"
+
 export const SITE_DESCRIPTION =
   "Privacy-first browser extension for local LLM chat with Ollama, LM Studio, llama.cpp, and OpenAI-compatible servers."
 

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "knip": "^6.24.0",
     "lint-staged": "^16.4.0",
     "playwright": "^1.60.0",
-    "postcss": "8.5.16",
+    "postcss": "8.5.18",
     "rollup-plugin-visualizer": "^6.0.11",
     "selenium-webdriver": "^4.27.0",
     "shadcn": "^4.12.0",
@@ -182,7 +182,7 @@
   "pnpm": {
     "overrides": {
       "form-data@<4.0.6": ">=4.0.6",
-      "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
+      "brace-expansion@>=3.0.0 <5.0.8": "5.0.8",
       "immutable@>=5.0.0-beta.1 <5.1.8": "5.1.9",
       "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
       "linkify-it@<5.0.2": "5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   form-data@<4.0.6: '>=4.0.6'
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
   linkify-it@<5.0.2: 5.0.2
@@ -255,8 +255,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       postcss:
-        specifier: 8.5.16
-        version: 8.5.16
+        specifier: 8.5.18
+        version: 8.5.18
       rollup-plugin-visualizer:
         specifier: ^6.0.11
         version: 6.0.11(rolldown@1.1.4)(rollup@4.60.4)
@@ -334,11 +334,14 @@ importers:
         specifier: 7.1.3
         version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.7.0)(less@4.3.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       postcss:
-        specifier: 8.5.16
-        version: 8.5.16
+        specifier: 8.5.18
+        version: 8.5.18
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
+      typescript:
+        specifier: npm:@typescript/typescript6@6.0.2
+        version: '@typescript/typescript6@6.0.2'
 
 packages:
 
@@ -3291,9 +3294,9 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5790,8 +5793,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -8067,8 +8070,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.16
-      postcss-nested: 6.2.0(postcss@8.5.16)
+      postcss: 8.5.18
+      postcss-nested: 6.2.0(postcss@8.5.18)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -9115,7 +9118,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.16
+      postcss: 8.5.18
       tailwindcss: 4.3.0
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
@@ -9923,7 +9926,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12470,7 +12473,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -12888,9 +12891,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-nested@6.2.0(postcss@8.5.16):
+  postcss-nested@6.2.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.18
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.0.10:
@@ -12908,7 +12911,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.16:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -13540,7 +13543,7 @@ snapshots:
       kleur: 4.1.5
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.16
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.1
       prompts: 2.4.2
       recast: 0.23.11
@@ -14228,7 +14231,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.18
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14245,7 +14248,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.18
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/src/background/__tests__/index.test.ts
+++ b/src/background/__tests__/index.test.ts
@@ -28,7 +28,12 @@ const mockBrowser = {
     onStartup: {
       addListener: vi.fn((fn) => listeners.onStartup.push(fn))
     },
+    getManifest: vi.fn(() => ({ version: "0.12.4" })),
+    setUninstallURL: vi.fn().mockResolvedValue(undefined),
     getURL: vi.fn((path: string) => `chrome-extension://test/${path}`)
+  },
+  i18n: {
+    getUILanguage: vi.fn(() => "en-US")
   },
   windows: {
     create: vi.fn()
@@ -151,6 +156,9 @@ describe("Background Script Entry Point", () => {
   describe("Message Routing", () => {
     it("registers context menu handling on service worker startup", () => {
       expect(initializeContextMenu).toHaveBeenCalled()
+      expect(mockBrowser.runtime.setUninstallURL).toHaveBeenCalledWith(
+        "https://www.ollamaclient.in/goodbye?v=0.12.4&l=en-US"
+      )
     })
 
     it("should route GET_MODELS", () => {

--- a/src/background/startup.ts
+++ b/src/background/startup.ts
@@ -7,7 +7,11 @@ import { clearModelToolCapabilityCache } from "@/background/lib/resolve-model-to
 import { registerScheduledJobs } from "@/background/lib/scheduled-jobs"
 import { resumePendingAppLifecycle } from "@/lib/app-reset"
 import { browser, isChromiumBased } from "@/lib/browser-api"
-import { DEFAULT_EMBEDDING_MODEL, STORAGE_KEYS } from "@/lib/constants"
+import {
+  DEFAULT_EMBEDDING_MODEL,
+  EXTERNAL_URLS,
+  STORAGE_KEYS
+} from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { runEmbeddingDimensionMigration } from "@/lib/migration/embedding-dimension-migration"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
@@ -139,6 +143,36 @@ const registerInstallHandlers = () => {
   browser.runtime.onStartup.addListener(() => updateDNRRules())
 }
 
+// Point the browser's post-uninstall tab at the docs feedback page. Runs on
+// both Chromium and Firefox (both implement setUninstallURL), so it is NOT
+// gated behind isChromiumBased(). Set on every worker boot so the version
+// param tracks upgrades. Only anonymous context is attached — extension
+// version and UI locale — so a churn spike can be traced to a release without
+// identifying the user.
+const setUninstallFeedbackURL = () => {
+  if (!browser.runtime?.setUninstallURL) return
+
+  try {
+    const params = new URLSearchParams({
+      v: browser.runtime.getManifest().version,
+      l: browser.i18n?.getUILanguage?.() ?? "en"
+    })
+    void browser.runtime
+      .setUninstallURL(
+        `${EXTERNAL_URLS.UNINSTALL_FEEDBACK}?${params.toString()}`
+      )
+      .catch((error) => {
+        logger.warn("Failed to set uninstall feedback URL", "BackgroundSW", {
+          error
+        })
+      })
+  } catch (error) {
+    logger.warn("Failed to set uninstall feedback URL", "BackgroundSW", {
+      error
+    })
+  }
+}
+
 const registerToolRegistryInvalidation = () => {
   if (!browser.storage?.onChanged) return
 
@@ -214,6 +248,7 @@ export const initializeBackgroundStartup = () => {
   initializeContextMenu()
   registerActionHandler()
   registerInstallHandlers()
+  setUninstallFeedbackURL()
   registerToolRegistryInvalidation()
   registerOmniboxQuickAsk(openPanelForTab)
   registerScheduledJobs()

--- a/src/lib/constants/urls.ts
+++ b/src/lib/constants/urls.ts
@@ -7,6 +7,7 @@ const DOCS_HOME = DEFAULT_DOCS_HOME.replace(/\/+$/, "")
 
 export const EXTERNAL_URLS = {
   DOCS_HOME,
+  UNINSTALL_FEEDBACK: `${DOCS_HOME}/goodbye`,
   GITHUB_ISSUES: "https://github.com/Shishir435/ollama-client/issues",
   GITHUB_NEW_ISSUE: "https://github.com/Shishir435/ollama-client/issues/new",
   SETUP_GUIDE: `${DOCS_HOME}/guides/provider-setup/`,


### PR DESCRIPTION
## Summary

- register a versioned post-uninstall feedback URL on background startup
- add a responsive `/goodbye` page with professional GitHub and email feedback prompts
- attach only extension version and browser UI language to the draft feedback
- centralize shared author, repository, and contact metadata for the docs site
- document the flow in the Unreleased changelog and cover URL registration with a test
- patch newly disclosed PostCSS and brace-expansion vulnerabilities required by the pre-push audit gate

## Why

Browser stores report uninstall counts but not the reason a user left. This flow gives users an optional, low-friction way to report setup failures, missing features, or other problems while keeping extension data out of the feedback request.

The dependency patch is included because the repository's pre-push security gate detected two new high-severity advisories. PostCSS is upgraded to 8.5.18, brace-expansion to 5.0.8, and the docs workspace explicitly pins TypeScript 6 so TypeDoc keeps resolving against its supported compiler range.

## Impact

After uninstall, the browser opens the docs feedback page with extension version and browser language in the query string. The page prepares either a GitHub issue or email draft; nothing is submitted automatically. Chat content, settings, and personal identifiers are not attached by the extension.

## Validation

- visually checked `/goodbye` at desktop and 375 px mobile widths
- `pnpm audit --prod --audit-level high`
- `pnpm check:i18n`
- `pnpm test:run` — 270 files, 2,177 tests
- `pnpm build`
- `pnpm docs:build`
- `pnpm lint:check`
- `pnpm typecheck`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional post-uninstall feedback flow.
- Registers a versioned, locale-aware feedback URL during background startup with guarded error handling.
- Adds a responsive `/goodbye` page that prepares GitHub issue and email drafts without automatically submitting data.
- Centralizes repository, author, and contact metadata for the documentation site.
- Updates PostCSS, brace-expansion, and the docs TypeScript dependency resolution.
- Documents the feature and tests uninstall URL registration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The uninstall registration is compatibility-guarded and contains both synchronous and asynchronous failures, while the feedback page encodes its limited query context into drafts and the dependency resolutions remain pinned by the lockfile.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/background/startup.ts | Registers the uninstall feedback URL on worker startup while containing synchronous exceptions and asynchronous API rejections. |
| docs/src/pages/goodbye.astro | Adds the feedback landing page and safely URL-encodes extension version and browser-language context into user-editable drafts. |
| src/lib/constants/urls.ts | Adds the goodbye route derived from the normalized documentation origin. |
| src/background/__tests__/index.test.ts | Extends the browser mock and verifies the exact uninstall URL registered during startup. |
| docs/package.json | Updates PostCSS and explicitly supplies the TypeScript package expected by the documentation toolchain. |
| package.json | Updates the pinned PostCSS version and brace-expansion security override. |
| pnpm-lock.yaml | Locks the dependency updates to concrete versions and integrity hashes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant BG as Extension background
  participant BR as Browser runtime
  participant DOCS as Goodbye page
  participant U as User
  participant GH as GitHub or email client
  BG->>BR: "setUninstallURL(/goodbye?v=version&l=locale)"
  U->>BR: Uninstall extension
  BR->>DOCS: Open registered feedback URL
  DOCS->>DOCS: Prepare draft with version and locale
  U->>GH: Choose feedback channel
  GH-->>U: Display editable feedback draft
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): patch audit vulnerabilities"](https://github.com/shishir435/ollama-client/commit/bc4dfa2752d0495e9bf74b04bc6b7cb050f4ff56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47317247)</sub>

<!-- /greptile_comment -->