### PR TITLE
fix: report provider error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   plus extension version and browser language context to help diagnose
   release-specific issues without attaching chat content or settings.
 
+### Fixed
+
+- Provider response errors now identify the configured provider, selected
+  model, sanitized base URL, and HTTP status in chat and prefilled issue
+  reports, while keeping credentials and raw upstream responses private.
+
 ## [0.12.4] - 2026-07-24
 
 ### Changed

--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { STORAGE_KEYS } from "@/lib/constants"
+import { createAppError } from "@/lib/error-utils"
 import type { ChatMessage, ChatWithModelMessage } from "@/types"
 import { handleChatWithModel } from "../handle-chat-with-model"
 import {
@@ -524,6 +525,45 @@ describe("handleChatWithModel", () => {
   })
 
   describe("error handling", () => {
+    it("reports the resolved provider, model, base URL, and status", async () => {
+      mockStreamChat.mockRejectedValueOnce(
+        createAppError("raw Ollama response", {
+          kind: "provider",
+          status: 500,
+          debug: "private upstream body"
+        })
+      )
+
+      const message: ChatWithModelMessage = {
+        type: "CHAT_WITH_MODEL",
+        payload: {
+          model: "llama3:latest",
+          providerId: "ollama",
+          messages: [{ role: "user", content: "Test" }]
+        }
+      }
+
+      await handleChatWithModel(message, mockPort, mockIsPortClosed)
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({
+        error: expect.objectContaining({
+          status: 500,
+          kind: "provider",
+          providerId: "ollama",
+          providerName: "Ollama",
+          model: "llama3:latest",
+          baseUrl: "http://localhost:11434",
+          userMessage: expect.stringContaining(
+            'Ollama at http://localhost:11434 returned HTTP 500 while generating a response with model "llama3:latest"'
+          )
+        })
+      })
+      const postMessage = mockPort.postMessage as ReturnType<typeof vi.fn>
+      expect(JSON.stringify(postMessage.mock.calls)).not.toContain(
+        "private upstream body"
+      )
+    })
+
     it("should handle stream errors", async () => {
       mockStreamChat.mockRejectedValueOnce(new Error("Stream failure"))
 

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -17,6 +17,7 @@ import {
 import { logger } from "@/lib/logger"
 import { resolveModelConfig } from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { getSession } from "@/lib/repositories/chat-history"
 import {
@@ -375,6 +376,19 @@ export const handleChatWithModel = withErrorContext(
   },
   {
     handler: "handleChatWithModel",
-    operation: "streaming chat"
+    operation: "streaming chat",
+    resolveProviderErrorContext: async (msg) => {
+      const { model, providerId } = msg.payload
+      const provider = await ProviderFactory.getProviderForModel(
+        model,
+        providerId
+      )
+      return {
+        providerId: provider.id,
+        providerName: provider.config.name,
+        model,
+        baseUrl: resolveProviderBaseUrl(provider.config)
+      }
+    }
   }
 )

--- a/src/background/lib/__tests__/error-handler.test.ts
+++ b/src/background/lib/__tests__/error-handler.test.ts
@@ -142,4 +142,49 @@ describe("error-handler", () => {
       }
     })
   })
+
+  it("adds resolved provider context without exposing debug data", async () => {
+    const port = {
+      name: "test-port",
+      postMessage: vi.fn()
+    } as any
+    const handler = withErrorContext(
+      async () => {
+        throw createAppError("raw upstream failure", {
+          kind: "provider",
+          status: 500,
+          debug: "private response body"
+        })
+      },
+      {
+        handler: "testHandler",
+        operation: "streaming chat",
+        resolveProviderErrorContext: async () => ({
+          providerId: "ollama",
+          providerName: "Ollama",
+          model: "llama3.2",
+          baseUrl: "http://user:secret@localhost:11434?token=private"
+        })
+      }
+    )
+
+    await handler({} as never, port, () => false)
+
+    expect(port.postMessage).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        status: 500,
+        kind: "provider",
+        providerId: "ollama",
+        providerName: "Ollama",
+        model: "llama3.2",
+        baseUrl: "http://localhost:11434",
+        userMessage: expect.stringContaining(
+          'Ollama at http://localhost:11434 returned HTTP 500 while generating a response with model "llama3.2"'
+        )
+      })
+    })
+    expect(JSON.stringify(port.postMessage.mock.calls)).not.toContain(
+      "private response body"
+    )
+  })
 })

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -1,5 +1,9 @@
 import { getErrorMessage, isAbortError, isAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
+import {
+  applyProviderErrorContext,
+  type ProviderErrorContext
+} from "@/lib/providers/provider-errors"
 import type {
   ChromePort,
   ChromeResponse,
@@ -14,11 +18,14 @@ type HandlerFunction<T> = (
   isPortClosed: PortStatusFunction
 ) => Promise<void>
 
-interface ErrorContext {
+interface ErrorContext<T> {
   handler: string
   operation?: string
   modelId?: string
   providerId?: string
+  resolveProviderErrorContext?: (
+    msg: T
+  ) => Promise<ProviderErrorContext | undefined>
 }
 
 type ErrorEnvelope = NonNullable<ChromeResponse["error"]>
@@ -61,7 +68,11 @@ export const normalizeError = (
       isAppError(error) &&
       error.providerId && {
         providerId: error.providerId
-      })
+      }),
+    ...(isAppError(error) &&
+      error.providerName && { providerName: error.providerName }),
+    ...(isAppError(error) && error.model && { model: error.model }),
+    ...(isAppError(error) && error.baseUrl && { baseUrl: error.baseUrl })
   }
 }
 
@@ -86,7 +97,7 @@ export const createErrorResponse = (
  */
 export const withErrorContext = <T>(
   handler: HandlerFunction<T>,
-  context: ErrorContext
+  context: ErrorContext<T>
 ) => {
   return async (msg: T, port: ChromePort, isPortClosed: PortStatusFunction) => {
     try {
@@ -100,12 +111,32 @@ export const withErrorContext = <T>(
         return
       }
 
+      let reportedError = err
+      if (
+        isAppError(err) &&
+        err.kind === "provider" &&
+        context.resolveProviderErrorContext
+      ) {
+        try {
+          const providerContext = await context.resolveProviderErrorContext(msg)
+          if (providerContext) {
+            reportedError = applyProviderErrorContext(err, providerContext)
+          }
+        } catch (contextError) {
+          logger.debug(
+            "Failed to resolve provider error context",
+            context.handler,
+            { error: contextError }
+          )
+        }
+      }
+
       // 4. Handle generic errors with enhanced logging
       logger.error(
         `Error during ${context.operation || "operation"}`,
         context.handler,
         {
-          message: getErrorMessage(err),
+          message: getErrorMessage(reportedError),
           model: context.modelId,
           provider: context.providerId,
           stack: err instanceof Error ? err.stack : undefined
@@ -113,10 +144,12 @@ export const withErrorContext = <T>(
       )
 
       if (!isPortClosed()) {
-        const response = createErrorResponse(err, {
+        const response = createErrorResponse(reportedError, {
           status:
-            err && typeof err === "object" && "status" in err
-              ? ((err as Partial<NetworkError>).status ?? 500)
+            reportedError &&
+            typeof reportedError === "object" &&
+            "status" in reportedError
+              ? ((reportedError as Partial<NetworkError>).status ?? 500)
               : 500,
           context: `${context.handler}${context.operation ? ` - ${context.operation}` : ""}`,
           providerId: context.providerId

--- a/src/features/chat/components/chat-message-footer.tsx
+++ b/src/features/chat/components/chat-message-footer.tsx
@@ -78,7 +78,11 @@ export const ChatMessageFooter = ({
     ? buildErrorReportUrl({
         status: msg.error?.status,
         kind: msg.error?.kind,
-        message: msg.content
+        message: msg.error?.userMessage || msg.content,
+        providerId: msg.error?.providerId,
+        providerName: msg.error?.providerName,
+        model: msg.error?.model || msg.model,
+        baseUrl: msg.error?.baseUrl
       })
     : null
   const footerButtonClass = cn(chatIconBtnCls, "[&_svg]:icon-xs")

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -561,9 +561,12 @@ describe("useChatStream", () => {
           status: 500,
           kind: "provider",
           providerId: "llamacpp",
+          providerName: "llama.cpp",
+          model: "gemma.gguf",
+          baseUrl: "http://localhost:8000/v1",
           message: "raw failure",
           userMessage:
-            'llama.cpp returned a server error. Check that llama.cpp is running and model "gemma.gguf" is loaded.',
+            'llama.cpp at http://localhost:8000/v1 returned HTTP 500 while generating a response with model "gemma.gguf".',
           retryable: true
         }
       })
@@ -576,8 +579,14 @@ describe("useChatStream", () => {
       })
     )
     const lastMessages = vi.mocked(setMessages).mock.calls.at(-1)?.[0]
-    expect(lastMessages?.at(-1)?.content).toContain("[Open a new issue](")
+    expect(lastMessages?.at(-1)?.content).not.toContain("[Open a new issue](")
     expect(lastMessages?.at(-1)?.content).toContain("llama.cpp")
+    expect(lastMessages?.at(-1)?.error).toMatchObject({
+      providerId: "llamacpp",
+      providerName: "llama.cpp",
+      model: "gemma.gguf",
+      baseUrl: "http://localhost:8000/v1"
+    })
   })
 
   it("does not mislabel a generic background 500 as a provider failure", () => {

--- a/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -266,7 +266,15 @@ describe("useChatStreaming", () => {
           blocks: [{ type: "reasoning.encrypted", data: "opaque" }]
         },
         done: true,
-        metrics: { eval_count: 5 }
+        metrics: { eval_count: 5 },
+        error: {
+          status: 500,
+          kind: "provider" as const,
+          providerId: "openrouter",
+          providerName: "OpenRouter",
+          model: "m",
+          baseUrl: "https://openrouter.ai/api/v1"
+        }
       }
     ]
     await capturedSetMessages?.(finalMessages)
@@ -276,7 +284,11 @@ describe("useChatStreaming", () => {
     expect(spies.updateMessage).toHaveBeenNthCalledWith(
       2,
       11,
-      expect.objectContaining({ content: "complete", done: true }),
+      expect.objectContaining({
+        content: "complete",
+        done: true,
+        error: finalMessages[0].error
+      }),
       true
     )
     expect(spies.updateMessage).toHaveBeenNthCalledWith(
@@ -285,7 +297,8 @@ describe("useChatStreaming", () => {
       expect.objectContaining({
         content: "complete",
         done: true,
-        replayArtifact: finalMessages[0].replayArtifact
+        replayArtifact: finalMessages[0].replayArtifact,
+        error: finalMessages[0].error
       }),
       false
     )

--- a/src/features/chat/hooks/chat-stream-reducer.ts
+++ b/src/features/chat/hooks/chat-stream-reducer.ts
@@ -47,6 +47,9 @@ export interface StreamMessage {
     retryAfterMs?: number
     context?: string
     providerId?: string
+    providerName?: string
+    model?: string
+    baseUrl?: string
     debug?: unknown
   }
   aborted?: boolean

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -8,11 +8,9 @@ import {
   formatErrorForDisplay,
   getDisplayErrorMessage
 } from "@/lib/error-display"
+import { buildErrorReportUrl } from "@/lib/error-report"
 import { logger } from "@/lib/logger"
-import {
-  buildProviderServerIssueUrl,
-  providerErrorUserMessage
-} from "@/lib/providers/provider-errors"
+import { providerErrorUserMessage } from "@/lib/providers/provider-errors"
 import { getProviderDisplayName } from "@/lib/providers/registry"
 import type { ChatMessage } from "@/types"
 import {
@@ -176,16 +174,12 @@ export const useChatStream = ({
           const errorProviderId = isProviderError
             ? error.providerId || providerId
             : undefined
-          const providerName = errorProviderId
-            ? getProviderDisplayName(errorProviderId, errorProviderId)
-            : undefined
-          const issueUrl =
-            isProviderError && error.status >= 500
-              ? buildProviderServerIssueUrl(error.status, {
-                  providerName,
-                  model
-                })
-              : undefined
+          const providerName =
+            error.providerName ||
+            (errorProviderId
+              ? getProviderDisplayName(errorProviderId)
+              : undefined)
+          const errorModel = error.model || model
           const localizedUserMessage = error.messageKey
             ? t(error.messageKey)
             : error.userMessage
@@ -201,30 +195,45 @@ export const useChatStream = ({
             (isProviderError && error.status > 0
               ? providerErrorUserMessage(error.status, {
                   providerName,
-                  model
+                  model: errorModel,
+                  baseUrl: error.baseUrl
                 })
               : t("chat.errors.unknown_error", {
                   message:
                     getDisplayErrorMessage(error) || t("chat.errors.no_message")
                 }))
-          const chatErrorMessage = issueUrl
-            ? `${errMsg}\n\n[Open a new issue](${issueUrl})`
-            : errMsg
+          const issueUrl =
+            isProviderError && error.status >= 500
+              ? buildErrorReportUrl({
+                  status: error.status,
+                  kind: error.kind,
+                  message: errMsg,
+                  providerId: errorProviderId,
+                  providerName,
+                  model: errorModel,
+                  baseUrl: error.baseUrl
+                })
+              : undefined
           const toastDescription =
             error.kind === "provider" && providerName
-              ? `${displayError.rawMessage}${
+              ? `${displayError.message}${
                   error.retryable ? " This may be temporary; try again." : ""
                 }`
               : displayError.message
           void renderAssistant({
             ...partial,
-            content: chatErrorMessage,
+            content: errMsg,
             done: true,
             error: {
               status: error.status,
               kind: error.kind,
               retryable: error.retryable,
-              retryAfterMs: error.retryAfterMs
+              retryAfterMs: error.retryAfterMs,
+              userMessage: errMsg,
+              providerId: errorProviderId,
+              providerName,
+              model: errorModel,
+              baseUrl: error.baseUrl
             }
           })
           toast({

--- a/src/features/chat/hooks/use-chat-streaming.ts
+++ b/src/features/chat/hooks/use-chat-streaming.ts
@@ -111,7 +111,8 @@ export const useChatStreaming = ({
           thinking: streamedMsg.thinking,
           replayArtifact: streamedMsg.replayArtifact,
           metrics: streamedMsg.metrics,
-          done: streamedMsg.done
+          done: streamedMsg.done,
+          error: streamedMsg.error
         },
         true
       )
@@ -139,7 +140,8 @@ export const useChatStreaming = ({
           thinking: streamedMsg.thinking,
           replayArtifact: streamedMsg.replayArtifact,
           metrics: streamedMsg.metrics,
-          done: true
+          done: true,
+          error: streamedMsg.error
         },
         false
       )

--- a/src/lib/error-report.ts
+++ b/src/lib/error-report.ts
@@ -1,5 +1,6 @@
 import { runtime } from "@/lib/browser-api"
 import { EXTERNAL_URLS } from "@/lib/constants"
+import { sanitizeProviderBaseUrl } from "@/lib/error-utils"
 
 /**
  * Prefilled GitHub new-issue URL for a chat error. Every user-facing error
@@ -10,6 +11,10 @@ export const buildErrorReportUrl = (error: {
   status?: number
   kind?: string
   message?: string
+  providerId?: string
+  providerName?: string
+  model?: string
+  baseUrl?: string
 }): string => {
   let version = "unknown"
   try {
@@ -18,16 +23,40 @@ export const buildErrorReportUrl = (error: {
     // Not running inside the extension (tests); leave "unknown".
   }
   const message = (error.message ?? "").replace(/\s+/g, " ").trim()
-  const title = `[bug] ${message.slice(0, 80) || "Error while chatting"}`
+  const providerName = error.providerName?.trim()
+  const model = error.model?.trim()
+  const baseUrl = sanitizeProviderBaseUrl(error.baseUrl)
+  const browser =
+    typeof navigator === "undefined"
+      ? "unknown"
+      : /Firefox\//.test(navigator.userAgent)
+        ? "Firefox"
+        : /Edg\//.test(navigator.userAgent)
+          ? "Edge"
+          : /Chrome\//.test(navigator.userAgent)
+            ? "Chrome"
+            : "unknown"
+  const subject = providerName
+    ? `${providerName} server error`
+    : message.slice(0, 80) || "Error while chatting"
+  const title = `[bug] ${subject}${error.status ? ` (${error.status})` : ""}`
   const body = [
     "**What happened**",
     message || "_describe the error here_",
     "",
+    "**Checks tried**",
+    "- Provider app is running: ",
+    "- Selected model is loaded: ",
+    "- Base URL/port is correct: ",
+    "",
     "**Details**",
     `- Extension version: ${version}`,
+    `- Browser: ${browser}`,
     `- Error status: ${error.status ?? "n/a"}`,
     `- Error kind: ${error.kind ?? "n/a"}`,
-    `- Provider/model: `,
+    `- Provider: ${providerName || error.providerId || "n/a"}`,
+    `- Model: ${model || "n/a"}`,
+    `- Base URL: ${baseUrl || "n/a"}`,
     "",
     "**Steps to reproduce**",
     "1. "

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -18,6 +18,9 @@ export type AppErrorOptions = {
   retryAfterMs?: number
   context?: string
   providerId?: string
+  providerName?: string
+  model?: string
+  baseUrl?: string
   debug?: unknown
   cause?: unknown
 }
@@ -32,6 +35,9 @@ export class AppError extends Error {
   retryAfterMs?: number
   context?: string
   providerId?: string
+  providerName?: string
+  model?: string
+  baseUrl?: string
   debug?: unknown
 
   constructor(message: string, options: AppErrorOptions = {}) {
@@ -46,6 +52,9 @@ export class AppError extends Error {
     this.retryAfterMs = options.retryAfterMs
     this.context = options.context
     this.providerId = options.providerId
+    this.providerName = options.providerName
+    this.model = options.model
+    this.baseUrl = options.baseUrl
     this.debug = options.debug
   }
 }
@@ -84,3 +93,24 @@ export const isNamedError = (error: unknown, name: string) =>
 
 export const isAbortError = (error: unknown) =>
   isNamedError(error, "AbortError")
+
+/**
+ * Keep provider endpoints useful for support without ever exposing embedded
+ * credentials, query parameters, or fragments.
+ */
+export const sanitizeProviderBaseUrl = (
+  baseUrl?: string
+): string | undefined => {
+  if (!baseUrl?.trim()) return undefined
+  try {
+    const url = new URL(baseUrl.trim())
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined
+    url.username = ""
+    url.password = ""
+    url.search = ""
+    url.hash = ""
+    return url.toString().replace(/\/$/, "")
+  } catch {
+    return undefined
+  }
+}

--- a/src/lib/providers/__tests__/provider-errors.test.ts
+++ b/src/lib/providers/__tests__/provider-errors.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { buildErrorReportUrl } from "@/lib/error-report"
 import { isAppError } from "@/lib/error-utils"
 import { OllamaProvider } from "../ollama"
 import { OpenAICompatibleProvider } from "../openai-compatible"
 import {
-  buildProviderServerIssueUrl,
   isLocalProviderBaseUrl,
   parseRetryAfter,
   providerErrorUserMessage
@@ -31,16 +31,22 @@ describe("providerErrorUserMessage", () => {
       model: "gemma.gguf"
     })
 
-    expect(msg).toContain("llama.cpp returned a server error")
+    expect(msg).toContain(
+      'llama.cpp returned HTTP 500 while generating a response with model "gemma.gguf"'
+    )
     expect(msg).toContain("llama.cpp is running")
     expect(msg).toContain('model "gemma.gguf" is loaded')
     expect(msg).toContain("base URL/port")
     expect(msg).not.toContain("http")
     expect(msg).not.toContain("[open an issue]")
 
-    const issueUrlValue = buildProviderServerIssueUrl(500, {
+    const issueUrlValue = buildErrorReportUrl({
+      status: 500,
+      kind: "provider",
+      message: msg,
       providerName: "llama.cpp",
-      model: "gemma.gguf"
+      model: "gemma.gguf",
+      baseUrl: "http://user:secret@localhost:8000/v1?token=private"
     })
     expect(issueUrlValue).toContain(
       "https://github.com/Shishir435/ollama-client/issues/new?"
@@ -50,9 +56,13 @@ describe("providerErrorUserMessage", () => {
       "[bug] llama.cpp server error (500)"
     )
     expect(issueUrl.searchParams.get("body")).toContain("- Error status: 500")
+    expect(issueUrl.searchParams.get("body")).toContain("- Provider: llama.cpp")
+    expect(issueUrl.searchParams.get("body")).toContain("- Model: gemma.gguf")
     expect(issueUrl.searchParams.get("body")).toContain(
-      "- Provider/model: llama.cpp / gemma.gguf"
+      "- Base URL: http://localhost:8000/v1"
     )
+    expect(issueUrl.searchParams.get("body")).not.toContain("secret")
+    expect(issueUrl.searchParams.get("body")).not.toContain("private")
   })
 
   it("points local 401/403 responses at CORS setup instead of credentials", () => {
@@ -185,6 +195,45 @@ describe("hosted provider retry metadata", () => {
   })
 })
 
+describe("custom provider connection errors", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("identifies the saved provider, base URL, and selected model", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("Failed to fetch")
+    )
+    const provider = new OpenAICompatibleProvider({
+      id: "custom:openai:localai",
+      type: ProviderType.OPENAI,
+      enabled: true,
+      baseUrl: "http://localhost:8080/v1",
+      name: "My LocalAI"
+    })
+
+    try {
+      await provider.streamChat({ model: "qwen3", messages: [] }, () => {})
+      throw new Error("Expected streamChat to fail")
+    } catch (error) {
+      expect(isAppError(error)).toBe(true)
+      if (isAppError(error)) {
+        expect(error).toMatchObject({
+          kind: "provider",
+          status: 0,
+          providerId: "custom:openai:localai",
+          providerName: "My LocalAI",
+          model: "qwen3",
+          baseUrl: "http://localhost:8080/v1",
+          retryable: true
+        })
+        expect(error.userMessage).toContain(
+          'My LocalAI at http://localhost:8080/v1 could not be reached while requesting a response with model "qwen3"'
+        )
+        expect(error.userMessage).not.toContain("Failed to fetch")
+      }
+    }
+  })
+})
+
 describe("provider-specific server errors", () => {
   afterEach(() => vi.restoreAllMocks())
 
@@ -209,9 +258,11 @@ describe("provider-specific server errors", () => {
     } catch (error) {
       expect(isAppError(error)).toBe(true)
       if (isAppError(error)) {
-        expect(error.userMessage).toContain("llama.cpp returned a server error")
+        expect(error.userMessage).toContain(
+          'llama.cpp at http://localhost:8000/v1 returned HTTP 500 while generating a response with model "gemma.gguf"'
+        )
         expect(error.userMessage).toContain('model "gemma.gguf" is loaded')
-        expect(error.userMessage).not.toContain("https://")
+        expect(error.userMessage).not.toContain("template failure")
       }
     }
   })

--- a/src/lib/providers/__tests__/provider-errors.test.ts
+++ b/src/lib/providers/__tests__/provider-errors.test.ts
@@ -232,6 +232,45 @@ describe("custom provider connection errors", () => {
       }
     }
   })
+
+  it("keeps provider context when an HTTP-200 stream disconnects", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new TypeError("socket closed"))
+      }
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, { status: 200 })
+    )
+    const provider = new OpenAICompatibleProvider({
+      id: "custom:openai:localai",
+      type: ProviderType.OPENAI,
+      enabled: true,
+      baseUrl: "http://localhost:8080/v1",
+      name: "My LocalAI"
+    })
+
+    try {
+      await provider.streamChat({ model: "qwen3", messages: [] }, () => {})
+      throw new Error("Expected streamChat to fail")
+    } catch (error) {
+      expect(isAppError(error)).toBe(true)
+      if (isAppError(error)) {
+        expect(error).toMatchObject({
+          kind: "provider",
+          status: 0,
+          providerId: "custom:openai:localai",
+          providerName: "My LocalAI",
+          model: "qwen3",
+          baseUrl: "http://localhost:8080/v1"
+        })
+        expect(error.userMessage).toContain(
+          "My LocalAI at http://localhost:8080/v1 could not be reached"
+        )
+        expect(error.userMessage).not.toContain("socket closed")
+      }
+    }
+  })
 })
 
 describe("provider-specific server errors", () => {

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,6 +1,7 @@
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import {
+  readProviderStreamChunk,
   throwProviderConnectionError,
   throwProviderResponseError
 } from "@/lib/providers/provider-errors"
@@ -551,7 +552,12 @@ export class AnthropicProvider implements LLMProvider {
 
     try {
       while (true) {
-        const { done, value } = await reader.read()
+        const { done, value } = await readProviderStreamChunk(reader, {
+          providerId: this.id,
+          providerName: this.config.name,
+          model,
+          baseUrl: this.baseUrl
+        })
         if (done) {
           if (buffer.trim()) processLine(buffer)
           emitDone()

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,6 +1,9 @@
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { throwProviderResponseError } from "@/lib/providers/provider-errors"
+import {
+  throwProviderConnectionError,
+  throwProviderResponseError
+} from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
 import type { ChatMessage, ChatStreamMessage, ProviderModel } from "@/types"
 import { ANTHROPIC_PROVIDER_CAPABILITIES } from "./capabilities"
@@ -306,7 +309,14 @@ export class AnthropicProvider implements LLMProvider {
       headers: this.headers(),
       body: JSON.stringify(body),
       signal
-    })
+    }).catch((error) =>
+      throwProviderConnectionError(error, {
+        providerId: this.id,
+        providerName: this.config.name,
+        model: request.model,
+        baseUrl: this.baseUrl
+      })
+    )
     if (!response.ok) {
       await this.responseError(response, request.model)
     }

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -2,7 +2,8 @@ import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import {
   localCorsForbiddenMessage,
-  providerErrorUserMessage
+  providerErrorUserMessage,
+  throwProviderConnectionError
 } from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
 import type {
@@ -187,7 +188,14 @@ export class OllamaProvider implements LLMProvider {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
       signal
-    })
+    }).catch((error) =>
+      throwProviderConnectionError(error, {
+        providerId: this.id,
+        providerName: this.config.name,
+        model,
+        baseUrl
+      })
+    )
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger"
 import {
   localCorsForbiddenMessage,
   providerErrorUserMessage,
+  readProviderStreamChunk,
   throwProviderConnectionError
 } from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
@@ -314,7 +315,12 @@ export class OllamaProvider implements LLMProvider {
 
     try {
       while (true) {
-        const { done, value } = await reader.read()
+        const { done, value } = await readProviderStreamChunk(reader, {
+          providerId: this.id,
+          providerName: this.config.name,
+          model,
+          baseUrl
+        })
         if (done) {
           // Flush a final line left without a trailing newline at EOF.
           if (buffer.trim()) processLine(buffer)

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -5,6 +5,7 @@ import {
   isRetryableProviderStatus,
   parseRetryAfter,
   providerErrorUserMessage,
+  readProviderStreamChunk,
   throwProviderConnectionError,
   throwProviderResponseError
 } from "@/lib/providers/provider-errors"
@@ -541,7 +542,12 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
     try {
       while (true) {
-        const { done, value } = await reader.read()
+        const { done, value } = await readProviderStreamChunk(reader, {
+          providerId: this.id,
+          providerName: this.config.name,
+          model,
+          baseUrl: resolveProviderBaseUrl(this.config)
+        })
         if (done) {
           // Flush a final data line left without a trailing newline at EOF.
           if (buffer.trim()) processLine(buffer)

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -5,6 +5,7 @@ import {
   isRetryableProviderStatus,
   parseRetryAfter,
   providerErrorUserMessage,
+  throwProviderConnectionError,
   throwProviderResponseError
 } from "@/lib/providers/provider-errors"
 import type { ToolCall, ToolDefinition } from "@/lib/tools/types"
@@ -339,7 +340,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
       headers: this.headers(),
       body: JSON.stringify(body),
       signal
-    })
+    }).catch((error) =>
+      throwProviderConnectionError(error, {
+        providerId: this.id,
+        providerName: this.config.name,
+        model,
+        baseUrl
+      })
+    )
 
     if (!response.ok) {
       await this.responseError(response, "OpenAI Error", baseUrl, model)

--- a/src/lib/providers/provider-errors.ts
+++ b/src/lib/providers/provider-errors.ts
@@ -1,5 +1,11 @@
 import { EXTERNAL_URLS } from "@/lib/constants/urls"
-import { createAppError } from "@/lib/error-utils"
+import {
+  type AppError,
+  createAppError,
+  getErrorMessage,
+  isAbortError,
+  sanitizeProviderBaseUrl
+} from "@/lib/error-utils"
 
 /**
  * A 401/403 from a LOCAL provider (Ollama et al.) is almost always a CORS/origin
@@ -46,40 +52,6 @@ export const parseRetryAfter = (
 export const isRetryableProviderStatus = (status: number): boolean =>
   status === 408 || status === 429 || status === 529 || status >= 500
 
-export const buildProviderServerIssueUrl = (
-  status: number,
-  options: { providerName?: string; model?: string } = {}
-): string => {
-  const providerName = options.providerName?.trim()
-  const model = options.model?.trim()
-  const subject = providerName
-    ? `${providerName} server error`
-    : "Provider server error"
-  const params = new URLSearchParams({
-    title: `[bug] ${subject} (${status})`,
-    body: [
-      "**What happened**",
-      "The provider server returned an error while generating a response.",
-      "",
-      "**Checks tried**",
-      "- Provider app is running: ",
-      "- Selected model is loaded: ",
-      "- Base URL/port is correct: ",
-      "",
-      "**Details**",
-      `- Error status: ${status}`,
-      `- Provider/model: ${[providerName, model].filter(Boolean).join(" / ")}`,
-      "- Browser: ",
-      "- Extension version: ",
-      "",
-      "**Steps to reproduce**",
-      "1. "
-    ].join("\n")
-  })
-
-  return `${EXTERNAL_URLS.GITHUB_NEW_ISSUE}?${params.toString()}`
-}
-
 /**
  * Map a provider HTTP status to a clean, user-facing message. Keeps raw
  * provider response bodies (which can be JSON or stack traces) out of the chat
@@ -99,46 +71,121 @@ export const providerErrorUserMessage = (
   const providerLower = providerName || "the provider"
   const model = options.model?.trim()
   const selectedModel = model ? `model "${model}"` : "selected model"
+  const baseUrl = sanitizeProviderBaseUrl(options.baseUrl)
+  const endpoint = baseUrl ? ` at ${baseUrl}` : ""
+  const operation = model
+    ? ` while generating a response with model "${model}"`
+    : " while generating a response"
+  const lead = `${provider}${endpoint} returned HTTP ${status}${operation}.`
   if (status === 400) {
-    return `${provider} rejected the request. The ${selectedModel} may not support this input — for example, images on a model without vision support.`
+    return `${lead} The ${selectedModel} may not support this input — for example, images on a model without vision support.`
   }
   if (status === 401 || status === 403) {
     if (isLocalProviderBaseUrl(options.baseUrl)) {
-      return localCorsForbiddenMessage(status)
+      return `${lead} This is likely a CORS/origin block. Allow chrome-extension://* and moz-extension://* in the provider's CORS or origin settings, then retry. Provider-specific setup: ${EXTERNAL_URLS.SETUP_GUIDE}`
     }
-    return `${provider} rejected your credentials. Check its API key or account access.`
+    return `${lead} Check its credentials, API key, or account access.`
   }
   if (status === 404) {
-    return `${provider} could not find the ${selectedModel} or endpoint. Check the model name and ${providerLower}'s base URL.`
+    return `${lead} ${provider} could not find the ${selectedModel} or endpoint. Check the model name and ${providerLower}'s base URL.`
   }
   if (status === 408 || status === 504) {
-    return `${provider} timed out. Check that its server is responsive and try again.`
+    return `${lead} Check that its server is responsive and try again.`
   }
   if (status === 413) {
-    return "The request was too large. Try a smaller image or shorter message."
+    return `${lead} The request was too large. Try a smaller image or shorter message.`
   }
   if (status === 402) {
-    return "The provider account has insufficient credits or requires payment. Add credits or choose another provider."
+    return `${lead} The provider account has insufficient credits or requires payment. Add credits or choose another provider.`
   }
   if (status === 429) {
     const retryIn = options.retryAfterMs
       ? ` Retry in about ${Math.max(1, Math.ceil(options.retryAfterMs / 1000))} seconds.`
       : " Wait a moment and try again."
-    return `${provider} is rate-limiting requests.${retryIn}`
+    return `${lead} The provider is rate-limiting requests.${retryIn}`
   }
   if (status === 529) {
-    return "The hosted provider is temporarily overloaded. Wait a moment and try again."
+    return `${lead} The hosted provider is temporarily overloaded. Wait a moment and try again.`
   }
   if (status >= 500) {
     if (!isLocalProviderBaseUrl(options.baseUrl)) {
       const retryIn = options.retryAfterMs
         ? ` Retry in about ${Math.max(1, Math.ceil(options.retryAfterMs / 1000))} seconds.`
         : " Try again shortly."
-      return `${providerName || "The hosted provider"} is temporarily unavailable.${retryIn}`
+      return `${lead} The hosted provider is temporarily unavailable.${retryIn}`
     }
-    return `${provider} returned a server error. Check that ${providerLower} is running, the ${selectedModel} is loaded, and its base URL/port are correct.`
+    return `${lead} Check that ${providerLower} is running, the ${selectedModel} is loaded, and its base URL/port are correct.`
   }
-  return `${provider} returned an error. Check ${providerLower}, the ${selectedModel}, and its server logs.`
+  return `${lead} Check ${providerLower}, the ${selectedModel}, and its server logs.`
+}
+
+export interface ProviderErrorContext {
+  providerId?: string
+  providerName?: string
+  model?: string
+  baseUrl?: string
+}
+
+export const throwProviderConnectionError = (
+  error: unknown,
+  context: ProviderErrorContext
+): never => {
+  if (isAbortError(error)) throw error
+
+  const providerName = context.providerName?.trim() || "The provider"
+  const baseUrl = sanitizeProviderBaseUrl(context.baseUrl)
+  const endpoint = baseUrl ? ` at ${baseUrl}` : ""
+  const model = context.model?.trim()
+  const modelContext = model ? ` with model "${model}"` : ""
+
+  throw createAppError(
+    `${providerName}${endpoint} connection failed: ${getErrorMessage(error)}`,
+    {
+      kind: "provider",
+      status: 0,
+      providerId: context.providerId,
+      providerName,
+      model,
+      baseUrl,
+      retryable: true,
+      userMessage: `${providerName}${endpoint} could not be reached while requesting a response${modelContext}. Check that the provider is running and the configured base URL is correct.`,
+      debug: getErrorMessage(error),
+      cause: error
+    }
+  )
+}
+
+/**
+ * Add request context at the background boundary, where the resolved provider
+ * config is authoritative. Provider adapters never need to duplicate this
+ * metadata, and custom provider names survive transport to the UI.
+ */
+export const applyProviderErrorContext = (
+  error: AppError,
+  context: ProviderErrorContext
+): AppError => {
+  error.providerId = context.providerId || error.providerId
+  error.providerName = context.providerName || error.providerName
+  error.model = context.model || error.model
+  error.baseUrl =
+    sanitizeProviderBaseUrl(context.baseUrl) ||
+    sanitizeProviderBaseUrl(error.baseUrl)
+
+  if (error.status) {
+    error.userMessage = providerErrorUserMessage(error.status, {
+      retryAfterMs: error.retryAfterMs,
+      providerName: error.providerName,
+      model: error.model,
+      baseUrl: error.baseUrl
+    })
+  } else if (!error.userMessage) {
+    const provider = error.providerName || "The provider"
+    const endpoint = error.baseUrl ? ` at ${error.baseUrl}` : ""
+    const model = error.model ? ` with model "${error.model}"` : ""
+    error.userMessage = `${provider}${endpoint} returned an error while generating a response${model}. Check its server logs and configuration.`
+  }
+
+  return error
 }
 
 /**
@@ -167,6 +214,9 @@ export const throwProviderResponseError = async (
     kind: "provider",
     status: response.status,
     providerId: options.providerId,
+    providerName: options.providerName,
+    model: options.model,
+    baseUrl: sanitizeProviderBaseUrl(options.baseUrl),
     retryable: isRetryableProviderStatus(response.status),
     retryAfterMs,
     userMessage: providerErrorUserMessage(response.status, {

--- a/src/lib/providers/provider-errors.ts
+++ b/src/lib/providers/provider-errors.ts
@@ -155,6 +155,17 @@ export const throwProviderConnectionError = (
   )
 }
 
+export const readProviderStreamChunk = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  context: ProviderErrorContext
+): Promise<ReadableStreamReadResult<Uint8Array>> => {
+  try {
+    return await reader.read()
+  } catch (error) {
+    return throwProviderConnectionError(error, context)
+  }
+}
+
 /**
  * Add request context at the background boundary, where the resolved provider
  * config is authoritative. Provider adapters never need to duplicate this

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -325,6 +325,8 @@ describe("messages", () => {
         done: 0,
         metrics: '{"prompt_eval_count":3}',
         thinking: "reasoning...",
+        error:
+          '{"status":500,"kind":"provider","providerName":"Ollama","model":"m","baseUrl":"http://localhost:11434"}',
         replayArtifact:
           '{"version":1,"wire":"openai","providerId":"openrouter","model":"m","blocks":[{"type":"reasoning.encrypted","data":"opaque"}]}'
       }
@@ -334,6 +336,12 @@ describe("messages", () => {
     expect(msg.parentId).toBeUndefined()
     expect(msg.metrics).toEqual({ prompt_eval_count: 3 })
     expect(msg.thinking).toBe("reasoning...")
+    expect(msg.error).toMatchObject({
+      status: 500,
+      providerName: "Ollama",
+      model: "m",
+      baseUrl: "http://localhost:11434"
+    })
     expect(msg.replayArtifact?.blocks).toEqual([
       { type: "reasoning.encrypted", data: "opaque" }
     ])
@@ -468,6 +476,7 @@ describe("messages", () => {
       null,
       null,
       null,
+      null,
       // updatedAt seeded to the creation timestamp
       100
     ])
@@ -567,6 +576,28 @@ describe("messages", () => {
     expect(JSON.parse(String(params?.[0]))).toMatchObject({
       providerId: "openrouter",
       blocks: [{ type: "reasoning.encrypted", data: "opaque" }]
+    })
+  })
+
+  it("updateMessage persists safe provider error context", async () => {
+    mockedRun.mockResolvedValueOnce(undefined)
+    await repo.updateMessage(5, {
+      error: {
+        status: 500,
+        kind: "provider",
+        providerName: "Ollama",
+        model: "llama3.2",
+        baseUrl: "http://localhost:11434"
+      }
+    })
+    const [sql, params] = mockedRun.mock.calls[0]
+    expect(sql).toBe(
+      "UPDATE messages SET error = ?, updatedAt = ? WHERE id = ?"
+    )
+    expect(JSON.parse(String(params?.[0]))).toMatchObject({
+      providerName: "Ollama",
+      model: "llama3.2",
+      baseUrl: "http://localhost:11434"
     })
   })
 

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -12,7 +12,10 @@ import {
   withTransaction
 } from "@/lib/sqlite/db"
 import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
-import { ChatMessageMetricsSchema } from "@/types/chat.schemas"
+import {
+  ChatMessageErrorSchema,
+  ChatMessageMetricsSchema
+} from "@/types/chat.schemas"
 
 /**
  * SQLite-backed implementation of the chat-history persistence surface.
@@ -69,6 +72,16 @@ const parseMetrics = (raw: RowValue): ChatMessage["metrics"] => {
   }
 }
 
+const parseMessageError = (raw: RowValue): ChatMessage["error"] => {
+  if (typeof raw !== "string" || raw.length === 0) return undefined
+  try {
+    const result = ChatMessageErrorSchema.safeParse(JSON.parse(raw))
+    return result.success ? result.data : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const messageFromRow = (row: Row): StoredMessage => ({
   id: row.id as number,
   sessionId: row.sessionId as string,
@@ -80,7 +93,8 @@ const messageFromRow = (row: Row): StoredMessage => ({
   done: ((row.done as number | null) ?? 1) !== 0,
   metrics: parseMetrics(row.metrics),
   thinking: (row.thinking as string | null) ?? undefined,
-  replayArtifact: parseStoredReplayArtifact(row.replayArtifact)
+  replayArtifact: parseStoredReplayArtifact(row.replayArtifact),
+  error: parseMessageError(row.error)
 })
 
 const fileFromRow = (row: Row): StoredFile => ({
@@ -122,8 +136,8 @@ const insertImportedMessage = async (
   // which is the only race-free read on the shared OPFS connection.
   const { lastInsertRowid } = await runWithMeta(
     `INSERT INTO messages
-     (sessionId, role, content, model, timestamp, parentId, done, metrics, thinking, replayArtifact)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     (sessionId, role, content, model, timestamp, parentId, done, metrics, thinking, replayArtifact, error)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       sessionId,
       message.role,
@@ -134,7 +148,8 @@ const insertImportedMessage = async (
       message.done === false ? 0 : 1,
       message.metrics ? JSON.stringify(message.metrics) : null,
       message.thinking ?? null,
-      serializeReplayArtifact(message.replayArtifact)
+      serializeReplayArtifact(message.replayArtifact),
+      message.error ? JSON.stringify(message.error) : null
     ]
   )
   return lastInsertRowid
@@ -418,8 +433,8 @@ export const addMessage = async (
   const timestamp = message.timestamp ?? Date.now()
   const { lastInsertRowid } = await runWithMeta(
     `INSERT INTO messages
-     (sessionId, role, content, model, timestamp, parentId, done, metrics, thinking, replayArtifact, updatedAt)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     (sessionId, role, content, model, timestamp, parentId, done, metrics, thinking, replayArtifact, error, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       message.sessionId,
       message.role,
@@ -431,6 +446,7 @@ export const addMessage = async (
       message.metrics ? JSON.stringify(message.metrics) : null,
       message.thinking ?? null,
       serializeReplayArtifact(message.replayArtifact),
+      message.error ? JSON.stringify(message.error) : null,
       // Seed last-touched at creation so a shell that dies before its first
       // streaming write still ages into "stale" for the interrupted sweep.
       timestamp
@@ -498,6 +514,10 @@ export const updateMessage = async (
   if (Object.hasOwn(updates, "replayArtifact")) {
     fields.push("replayArtifact = ?")
     values.push(serializeReplayArtifact(updates.replayArtifact))
+  }
+  if (Object.hasOwn(updates, "error")) {
+    fields.push("error = ?")
+    values.push(updates.error ? JSON.stringify(updates.error) : null)
   }
   if (Object.hasOwn(updates, "done")) {
     fields.push("done = ?")

--- a/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
@@ -43,6 +43,11 @@ vi.mock("../add-message-updated-at-column", () => ({
     ensureMessagesUpdatedAtColumn(db)
 }))
 
+const ensureMessagesErrorColumn = vi.fn()
+vi.mock("../add-message-error-column", () => ({
+  ensureMessagesErrorColumn: (db: unknown) => ensureMessagesErrorColumn(db)
+}))
+
 import {
   getSchemaVersion,
   LATEST_SCHEMA_VERSION,
@@ -63,7 +68,12 @@ const makeDb = (
 ) => {
   let userVersion = initialVersion
   const columns = {
-    messages: schema.messages ?? ["thinking", "replayArtifact", "updatedAt"],
+    messages: schema.messages ?? [
+      "thinking",
+      "replayArtifact",
+      "updatedAt",
+      "error"
+    ],
     sessions: schema.sessions ?? ["pinned", "systemPrompt", "tags"]
   }
   const tables = new Set(schema.tables ?? ["tool_loop_runs"])
@@ -116,6 +126,7 @@ beforeEach(() => {
   ensureSessionsTagsColumn.mockClear()
   ensureMessagesReplayArtifactColumn.mockClear()
   ensureMessagesUpdatedAtColumn.mockClear()
+  ensureMessagesErrorColumn.mockClear()
 })
 
 describe("migration-runner", () => {
@@ -154,6 +165,7 @@ describe("migration-runner", () => {
     expect(ensureToolLoopRunsTable).toHaveBeenCalledTimes(1)
     expect(ensureSessionsTagsColumn).toHaveBeenCalledTimes(1)
     expect(ensureMessagesReplayArtifactColumn).toHaveBeenCalledTimes(1)
+    expect(ensureMessagesErrorColumn).toHaveBeenCalledTimes(1)
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
 
@@ -168,6 +180,7 @@ describe("migration-runner", () => {
     expect(ensureToolLoopRunsTable).toHaveBeenCalledTimes(1)
     expect(ensureSessionsTagsColumn).toHaveBeenCalledTimes(1)
     expect(ensureMessagesReplayArtifactColumn).toHaveBeenCalledTimes(1)
+    expect(ensureMessagesErrorColumn).toHaveBeenCalledTimes(1)
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
 
@@ -196,8 +209,9 @@ describe("migration-runner", () => {
 
     const repaired = repairSchemaDrift(db as never)
 
-    expect(repaired).toBe(3)
+    expect(repaired).toBe(4)
     expect(ensureMessagesReplayArtifactColumn).toHaveBeenCalledWith(db)
+    expect(ensureMessagesErrorColumn).toHaveBeenCalledWith(db)
     expect(ensureSessionsTagsColumn).toHaveBeenCalledWith(db)
     expect(ensureToolLoopRunsTable).toHaveBeenCalledWith(db)
     expect(ensureMessagesThinkingColumn).not.toHaveBeenCalled()
@@ -210,6 +224,7 @@ describe("migration-runner", () => {
     expect(repairSchemaDrift(db as never)).toBe(0)
     expect(ensureMessagesThinkingColumn).not.toHaveBeenCalled()
     expect(ensureMessagesReplayArtifactColumn).not.toHaveBeenCalled()
+    expect(ensureMessagesErrorColumn).not.toHaveBeenCalled()
     expect(ensureSessionsPinnedColumn).not.toHaveBeenCalled()
     expect(ensureSessionsSystemPromptColumn).not.toHaveBeenCalled()
     expect(ensureSessionsTagsColumn).not.toHaveBeenCalled()

--- a/src/lib/sqlite/migrations/__tests__/migrations.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migrations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { ensureMessagesErrorColumn } from "../add-message-error-column"
 import { ensureMessagesReplayArtifactColumn } from "../add-message-replay-artifact-column"
 import { ensureMessagesThinkingColumn } from "../add-thinking-column"
 
@@ -55,6 +56,22 @@ describe("ensureMessagesReplayArtifactColumn", () => {
     ensureMessagesReplayArtifactColumn(db as any)
     expect(db.run).toHaveBeenCalledWith(
       "ALTER TABLE messages ADD COLUMN replayArtifact TEXT"
+    )
+  })
+})
+
+describe("ensureMessagesErrorColumn", () => {
+  it("does nothing when error already exists", () => {
+    const db = makeDb(["id", "error"])
+    ensureMessagesErrorColumn(db as any)
+    expect(db.run).not.toHaveBeenCalled()
+  })
+
+  it("adds error to legacy message tables", () => {
+    const db = makeDb(["id", "content"])
+    ensureMessagesErrorColumn(db as any)
+    expect(db.run).toHaveBeenCalledWith(
+      "ALTER TABLE messages ADD COLUMN error TEXT"
     )
   })
 })

--- a/src/lib/sqlite/migrations/add-message-error-column.ts
+++ b/src/lib/sqlite/migrations/add-message-error-column.ts
@@ -1,0 +1,19 @@
+import type { Database } from "sql.js"
+
+import { logger } from "@/lib/logger"
+
+/** Persist safe, user-facing terminal error context with assistant messages. */
+export const ensureMessagesErrorColumn = (db: Database): void => {
+  const stmt = db.prepare("PRAGMA table_info(messages)")
+  const columns: string[] = []
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { name?: string }
+    if (row.name) columns.push(row.name)
+  }
+  stmt.free()
+
+  if (columns.includes("error")) return
+
+  logger.info("Adding `error` column to messages table", "SQLite/migrations")
+  db.run("ALTER TABLE messages ADD COLUMN error TEXT")
+}

--- a/src/lib/sqlite/migrations/migration-runner.ts
+++ b/src/lib/sqlite/migrations/migration-runner.ts
@@ -1,6 +1,7 @@
 import type { Database } from "sql.js"
 
 import { logger } from "@/lib/logger"
+import { ensureMessagesErrorColumn } from "./add-message-error-column"
 import { ensureMessagesReplayArtifactColumn } from "./add-message-replay-artifact-column"
 import { ensureMessagesUpdatedAtColumn } from "./add-message-updated-at-column"
 import { ensureSessionsPinnedColumn } from "./add-session-pinned-column"
@@ -67,6 +68,11 @@ export const MIGRATIONS: Migration[] = [
     version: 7,
     name: "add-message-updated-at-column",
     up: ensureMessagesUpdatedAtColumn
+  },
+  {
+    version: 8,
+    name: "add-message-error-column",
+    up: ensureMessagesErrorColumn
   }
 ]
 
@@ -135,6 +141,10 @@ export const repairSchemaDrift = (db: Database): number => {
     {
       missing: !messageColumns.has("updatedAt"),
       apply: () => ensureMessagesUpdatedAtColumn(db)
+    },
+    {
+      missing: !messageColumns.has("error"),
+      apply: () => ensureMessagesErrorColumn(db)
     },
     {
       missing: !sessionColumns.has("pinned"),

--- a/src/lib/sqlite/schema.ts
+++ b/src/lib/sqlite/schema.ts
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS messages (
   metrics TEXT,
   thinking TEXT,
   replayArtifact TEXT,
+  error TEXT,
   updatedAt INTEGER,
   FOREIGN KEY(sessionId) REFERENCES sessions(id) ON DELETE CASCADE
 );

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -30,6 +30,17 @@ describe("ChatMessageSchema", () => {
       },
       done: true,
       model: "llama3",
+      error: {
+        status: 500,
+        kind: "provider",
+        retryable: true,
+        userMessage:
+          "Ollama at http://localhost:11434 returned HTTP 500 while generating a response with model llama3.",
+        providerId: "ollama",
+        providerName: "Ollama",
+        model: "llama3",
+        baseUrl: "http://localhost:11434"
+      },
       toolName: "read_tab",
       toolCallId: "call-1",
       toolCalls: [

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -249,6 +249,20 @@ const ImageAttachmentSchema = z.object({
 
 // ---- ChatMessage ----
 
+export const ChatMessageErrorSchema = z.object({
+  status: z.number().optional(),
+  kind: z
+    .enum(["network", "provider", "storage", "validation", "abort", "unknown"])
+    .optional(),
+  retryable: z.boolean().optional(),
+  retryAfterMs: z.number().optional(),
+  userMessage: z.string().optional(),
+  providerId: z.string().optional(),
+  providerName: z.string().optional(),
+  model: z.string().optional(),
+  baseUrl: z.string().optional()
+})
+
 export const ChatMessageSchema = z.object({
   id: z.union([z.number(), z.string()]).optional(),
   role: z.enum(["user", "assistant", "system", "tool"]),
@@ -263,6 +277,7 @@ export const ChatMessageSchema = z.object({
   toolName: z.string().optional(),
   toolCallId: z.string().optional(),
   toolIsError: z.boolean().optional(),
+  error: ChatMessageErrorSchema.optional(),
   timestamp: z.number().optional(),
   metrics: ChatMessageMetricsSchema.optional(),
   parentId: z.union([z.number(), z.string()]).optional(),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -133,6 +133,11 @@ export interface ChatMessage {
     kind?: import("./errors").AppErrorKind
     retryable?: boolean
     retryAfterMs?: number
+    userMessage?: string
+    providerId?: string
+    providerName?: string
+    model?: string
+    baseUrl?: string
   }
   timestamp?: number
   metrics?: {
@@ -270,6 +275,9 @@ export interface ChatStreamMessage {
     retryAfterMs?: number
     context?: string
     providerId?: string
+    providerName?: string
+    model?: string
+    baseUrl?: string
   }
   metrics?: {
     total_duration?: number

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -36,6 +36,9 @@ export interface ChromeMessage {
     retryAfterMs?: number
     context?: string
     providerId?: string
+    providerName?: string
+    model?: string
+    baseUrl?: string
   }
 }
 
@@ -78,6 +81,9 @@ export interface ChromeResponse {
     retryAfterMs?: number
     context?: string
     providerId?: string
+    providerName?: string
+    model?: string
+    baseUrl?: string
   }
   tabs?: browser.Tabs.Tab[]
   html?: string


### PR DESCRIPTION
## What changed

- show configured provider name, selected model, sanitized base URL, and HTTP status for provider response failures
- identify generic/custom OpenAI-compatible provider connection failures even when no HTTP response exists
- use the same safe context in chat, toast actions, and prefilled GitHub issue reports
- persist terminal error context through SQLite so reporting still works after reload
- add a forward-only nullable `messages.error` migration and changelog entry

## Why

Provider failures were reduced to generic messages, while custom providers could appear as “Local Provider.” The live stream knew the selected model and provider ID, but the stored provider name and base URL were not carried through the error envelope. Persisted assistant messages then dropped the remaining error context, and the footer report action used a separate issue builder with a blank provider/model field.

## Impact

Users now see factual errors such as:

> Ollama at `http://localhost:11434` returned HTTP 500 while generating a response with model `llama3.2`.

Credentials, URL query parameters/fragments, and raw upstream response bodies remain excluded from UI and issue reports.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 270 files, 2,183 tests
- `pnpm build`
- `pnpm docs:build`
- strict i18n drift check
- production dependency audit

Closes #203

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Provider failures now retain sanitized provider context from the adapter through the UI and persistent chat history.
- Wraps connection and stream-read failures with provider, model, endpoint, and status context while preserving abort behavior.
- Persists validated terminal error metadata through the SQLite schema, migration, repository, and reload paths.
- Uses the same safe context for chat messages, toast actions, and prefilled GitHub issue reports.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported persistence gap now carries terminal error metadata through the final SQLite write and reload path, while stream-read failures are wrapped across all provider adapters without changing abort handling; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/providers/provider-errors.ts | Centralizes safe provider-error formatting, connection wrapping, stream-read wrapping, and context enrichment. |
| src/background/lib/error-handler.ts | Resolves request-specific provider metadata for provider errors and includes it in normalized envelopes. |
| src/features/chat/hooks/use-chat-stream.ts | Attaches normalized provider context to terminal assistant messages and report actions. |
| src/features/chat/hooks/use-chat-streaming.ts | Includes terminal error metadata in the synchronous final persistence update. |
| src/lib/repositories/sqlite-chat-history.ts | Serializes, validates, restores, and updates persisted message error metadata. |
| src/lib/sqlite/migrations/migration-runner.ts | Registers the forward error-column migration and repairs schema drift. |
| src/lib/error-report.ts | Builds issue reports containing sanitized provider, model, endpoint, browser, and status details. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant P as Provider adapter
  participant B as Background handler
  participant U as Chat UI
  participant DB as SQLite
  P-->>B: Provider error with safe context
  B-->>U: Normalized error envelope
  U->>U: Render message and report action
  U->>DB: Persist terminal error context
  DB-->>U: Restore context after reload
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(chat): persist streamed error contex..."](https://github.com/shishir435/ollama-client/commit/301aa92951dc4dfe09ec929503ea0204d46b0c9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47319359)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)
- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)
- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)
</details>

<!-- /greptile_comment -->