### PR TITLE
ci(release): make a re-pushed tag refresh instead of fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,13 @@ name: Release
 # 2. Manual: Actions → Release → Run workflow. Enter the version (e.g.
 #    0.12.0 or 0.13.0-rc.1) and pick the branch/commit to release from —
 #    the workflow creates the tag for you and publishes the release.
+#
+# Tag the merge commit on main, after the release PR merges — never a branch
+# commit beforehand. Squash-merging rewrites the SHA, which leaves the tag
+# pointing at a commit that is not in main's history. GitHub then cannot see
+# that tag when picking the previous release, so the next release's generated
+# notes silently reach further back and re-list the earlier release's PRs.
+# This happened to 0.12.3, whose tag had to be moved afterwards.
 
 on:
   push:
@@ -78,10 +85,35 @@ jobs:
       - name: Package Firefox (MV2)
         run: pnpm package:firefox
 
-      - name: Create GitHub release
+      - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          ASSETS=(build/chrome-mv3-prod/*.zip build/firefox-mv2-prod/*.zip)
+
+          # An unmatched glob stays literal in bash and would be handed to gh as
+          # a filename, which fails obscurely on create and, worse, uploads a
+          # partial asset set on refresh. Fail here with the missing path named.
+          for asset in "${ASSETS[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "Expected release asset is missing: $asset"
+              exit 1
+            fi
+          done
+
+          # A tag can arrive here more than once. Moving a tag re-triggers this
+          # workflow, and `gh release create` fails on an existing release, so a
+          # corrected tag would report a red run for work that is already
+          # published. Refresh the assets instead, and leave the notes alone:
+          # a published body may have been edited by hand, and regenerating it
+          # would silently discard those edits.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists. Refreshing assets, keeping notes."
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+            exit 0
+          fi
+
           PRERELEASE_FLAG=""
           if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
@@ -93,10 +125,9 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TARGET_FLAG="--target $GITHUB_SHA"
           fi
-          gh release create "${{ steps.meta.outputs.tag }}" \
-            --title "${{ steps.meta.outputs.tag }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes \
             $PRERELEASE_FLAG \
             $TARGET_FLAG \
-            build/chrome-mv3-prod/*.zip \
-            build/firefox-mv2-prod/*.zip
+            "${ASSETS[@]}"


### PR DESCRIPTION
## Summary

Brings the release-workflow fix onto `main`, where a tag push actually reads it. `main` still carries the version that fails on a re-pushed tag.

Moving the `0.12.3` tag onto `main`'s history (it had been cut on a branch commit before its PR squash-merged, leaving it unreachable from `main`) re-triggered `Release`. The job packaged both browsers, then failed on `gh release create` because the release already existed — a red run for work that was already published.

Changes:

- An existing release now means "refresh assets": `gh release upload --clobber` instead of `create`.
- Notes are left alone on that path. `--generate-notes` would have discarded the hand-written 0.12.4 release body without saying so.
- Asset globs are guarded. An unmatched glob stays literal in bash and would reach `gh` as a filename — obscure on create, and a silent *partial* asset set on refresh. It now fails naming the missing path.
- The header comment records the cause: tag the merge commit on `main` after the release PR merges, never a branch commit beforehand.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Docs
- [x] Build / tooling / CI
- [ ] Breaking change (storage format, message protocol, manifest permissions, public API)

## Quality gates

No application code changed — the diff is `.github/workflows/release.yml` only.

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm format:check`
- [x] `pnpm test:run` (full suite, via pre-push)
- [ ] `pnpm build` (Chrome MV3) — unaffected, verified on the 0.12.4 release PR
- [ ] `pnpm build:firefox` (Firefox MV2) — unaffected, verified on the 0.12.4 release PR

The step's shell was extracted and exercised against a stubbed `gh` across four cases: first tag push, moved tag with the release already present, `workflow_dispatch`, and a missing package artifact. Only the last exits non-zero.

## Surface area / risk

- [ ] Touches chat history persistence
- [ ] Touches the content script
- [ ] Touches the background worker message routing
- [ ] Touches a provider implementation
- [ ] Touches CSP / manifest / permissions
- [ ] Adds a new dependency

Release automation only. The failure mode it replaces was already non-destructive (it failed before mutating anything), so the downside risk is a re-pushed tag refreshing assets that are byte-identical.

## Privacy / local-first

No change. No network call, telemetry hook, or endpoint added.

## Notes

The failed `Release` run on `0.12.3` needs no re-run — its only remaining effect would be re-uploading identical zips. It stays in history as the record of the tag move.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes release publication idempotent for re-pushed tags.
- Validates both browser package globs before publication.
- Refreshes assets with `--clobber` when the release already exists while preserving its notes.
- Documents why release tags must point to the merged commit on `main`.

<h3>Confidence Score: 3/5</h3>

The release refresh path needs correction before merging because an interrupted clobber can leave the published browser packages inconsistent.

The workflow validates both local packages before publication, but replaces release assets non-atomically and does not restore the existing set after a partial upload failure; it also classifies operational lookup errors as release absence.

**Files Needing Attention:** .github/workflows/release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds guarded asset refresh behavior for existing releases, but lookup errors are treated as absence and a failed multi-asset clobber can leave an inconsistent release. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A111%0A**Distinguish%20lookup%20errors%20from%20absence**%0A%0AThe%20probe%20treats%20every%20nonzero%20result%20from%20%60gh%20release%20view%60%20as%20a%20missing%20release.%20A%20transient%20API%2C%20network%2C%20rate-limit%2C%20or%20authentication%20error%20therefore%20falls%20through%20to%20%60gh%20release%20create%60%2C%20producing%20another%20red%20run%20when%20the%20release%20already%20exists%20while%20also%20hiding%20the%20original%20diagnostic.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A113%0A**Refresh%20can%20leave%20partial%20assets**%0A%0AWhen%20%60gh%20release%20upload%20--clobber%60%20fails%20after%20replacing%20one%20of%20the%20two%20browser%20packages%2C%20the%20completed%20replacement%20remains%20while%20the%20other%20asset%20is%20old%20or%20missing%2C%20causing%20the%20published%20release%20to%20contain%20an%20inconsistent%20Chrome%2FFirefox%20package%20set.%20Refresh%20the%20coordinated%20asset%20set%20in%20a%20way%20that%20preserves%20or%20restores%20the%20existing%20assets%20when%20any%20upload%20fails.%0A%0A&repo=shishir435%2Follama-client&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22preview%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22preview%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A111%0A**Distinguish%20lookup%20errors%20from%20absence**%0A%0AThe%20probe%20treats%20every%20nonzero%20result%20from%20%60gh%20release%20view%60%20as%20a%20missing%20release.%20A%20transient%20API%2C%20network%2C%20rate-limit%2C%20or%20authentication%20error%20therefore%20falls%20through%20to%20%60gh%20release%20create%60%2C%20producing%20another%20red%20run%20when%20the%20release%20already%20exists%20while%20also%20hiding%20the%20original%20diagnostic.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A113%0A**Refresh%20can%20leave%20partial%20assets**%0A%0AWhen%20%60gh%20release%20upload%20--clobber%60%20fails%20after%20replacing%20one%20of%20the%20two%20browser%20packages%2C%20the%20completed%20replacement%20remains%20while%20the%20other%20asset%20is%20old%20or%20missing%2C%20causing%20the%20published%20release%20to%20contain%20an%20inconsistent%20Chrome%2FFirefox%20package%20set.%20Refresh%20the%20coordinated%20asset%20set%20in%20a%20way%20that%20preserves%20or%20restores%20the%20existing%20assets%20when%20any%20upload%20fails.%0A%0A&repo=shishir435%2Follama-client&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci(release): make a re-pushed tag refres..."](https://github.com/shishir435/ollama-client/commit/5b76a2ed9a3eb9e7185e938215628aa4249acb2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47365877)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->