### PR TITLE
ci(release): never replace a published release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,15 +102,57 @@ jobs:
             fi
           done
 
-          # A tag can arrive here more than once. Moving a tag re-triggers this
+          # A tag can arrive here more than once: moving a tag re-triggers this
           # workflow, and `gh release create` fails on an existing release, so a
-          # corrected tag would report a red run for work that is already
-          # published. Refresh the assets instead, and leave the notes alone:
-          # a published body may have been edited by hand, and regenerating it
-          # would silently discard those edits.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists. Refreshing assets, keeping notes."
-            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          # corrected tag would report a red run for work already published.
+          #
+          # Only a genuine "not found" counts as absence. A network, rate-limit,
+          # or auth failure must not be read as "no release", because falling
+          # through to `create` would then fail on the existing release and bury
+          # the real diagnostic behind a misleading one.
+          set +e
+          view_error="$(gh release view "$TAG" 2>&1 >/dev/null)"
+          view_rc=$?
+          set -e
+          if [ "$view_rc" -eq 0 ]; then
+            release_exists=true
+          elif printf '%s' "$view_error" | grep -qiE "release not found|HTTP 404"; then
+            release_exists=false
+          else
+            echo "Could not determine whether release $TAG exists:"
+            printf '%s\n' "$view_error"
+            exit 1
+          fi
+
+          if [ "$release_exists" = true ]; then
+            # Add only what is absent; never replace a published asset.
+            #
+            # A published zip may already have been downloaded, and gh has no
+            # atomic multi-asset swap, so a --clobber that failed partway would
+            # leave the Chrome and Firefox packages out of step with each other
+            # — a worse outcome than the red run this branch exists to avoid.
+            # Additive-only keeps the step monotonic: a failed run leaves the
+            # release exactly as it was, and re-running finishes the job.
+            #
+            # Notes are left alone for the same reason: a published body may
+            # have been edited by hand, and --generate-notes would discard those
+            # edits without saying so.
+            published="$(gh release view "$TAG" --json assets -q '.assets[].name')"
+            missing=()
+            for asset in "${ASSETS[@]}"; do
+              if ! printf '%s\n' "$published" | grep -qxF "$(basename "$asset")"; then
+                missing+=("$asset")
+              fi
+            done
+
+            if [ ${#missing[@]} -eq 0 ]; then
+              echo "Release $TAG is already published with all its assets. Nothing to do."
+              exit 0
+            fi
+
+            echo "Release $TAG exists but is missing ${#missing[@]} asset(s):"
+            printf '  %s\n' "${missing[@]}"
+            gh release upload "$TAG" "${missing[@]}"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Addresses both Greptile findings from #209. That PR was merged before its review finished — my mistake — so the fixes land as a follow-up rather than as changes to it.

**P1 — refresh could leave partial assets.** The clobber approach was wrong, not just fragile. `gh` replaces assets one at a time and offers no atomic multi-asset swap, so a failure partway through would leave a *published* release carrying a Chrome package from one commit and a Firefox package from another. Users download those zips, which makes it a worse outcome than the red run that branch existed to prevent.

Replaced with additive-only publication:

- Every expected asset already present → the step mutates nothing and exits.
- Some absent → only the absent ones are uploaded, with no `--clobber`.
- A published asset is never replaced.

That makes the step monotonic. A partial failure leaves the release exactly as it was, so re-running finishes the job instead of deepening an inconsistency. Restoring assets after a failed swap is not needed, because no swap happens.

**P2 — lookup errors read as absence.** Every nonzero `gh release view` was treated as "no release", so a network, rate-limit, or auth error fell through to `gh release create`, failed on the existing release, and buried the real diagnostic. Now only an explicit not-found or `HTTP 404` counts as absence; any other failure fails the step with the original error printed.

Notes remain untouched on the existing-release path, for the same reason as before: a published body may have been hand-edited, and `--generate-notes` would discard those edits silently. The 0.12.4 body is currently hand-written.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Docs
- [x] Build / tooling / CI
- [ ] Breaking change (storage format, message protocol, manifest permissions, public API)

## Quality gates

No application code changed — the diff is `.github/workflows/release.yml` only.

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm format:check`
- [x] `pnpm test:run` (full suite, via pre-push)

The step's shell was extracted and run against a stubbed `gh` across six cases:

| Case | Result |
|---|---|
| Release absent (`release not found`) | creates, as before |
| Release absent (`HTTP 404`) | creates |
| Lookup fails 503 | step fails, 503 printed, no create attempted |
| Lookup fails 401 | step fails, 401 printed, no create attempted |
| Exists, all assets present | no mutation, exits 0 |
| Exists, two assets absent | uploads exactly those two, no clobber |

One caveat worth a reviewer's eye: the absence check matches `gh`'s error text. I widened it to cover both `release not found` and `HTTP 404` rather than depending on a single exact string, but I did not confirm the live wording against the CLI. If `gh` ever changes both forms, this fails closed — the step errors out instead of misclassifying — which is the safe direction.

## Surface area / risk

- [ ] Touches chat history persistence
- [ ] Touches the content script
- [ ] Touches the background worker message routing
- [ ] Touches a provider implementation
- [ ] Touches CSP / manifest / permissions
- [ ] Adds a new dependency

Release automation only. Strictly less destructive than what is on `main` today: the write path it removes could overwrite published artifacts, and nothing here can.

## Privacy / local-first

No change. No network call, telemetry hook, or endpoint added.

## Notes

`main` currently holds #209's clobber version, which is why this is worth landing before the next tag. Please let the review finish before merging — #209 went in early on my call, and that is what this PR is correcting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes release publication additive-only and improves release lookup error handling.
- Preserves existing published assets instead of replacing them.
- Uploads only assets missing from an existing release.
- Treats explicit not-found responses as absence while surfacing other lookup failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed release workflow.

The workflow fails closed on unrecognized lookup errors, preserves existing assets, and uploads only missing artifacts while retaining rerun-safe behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Safely distinguishes absent releases from lookup failures and avoids replacing existing release assets. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): never replace a published r..."](https://github.com/shishir435/ollama-client/commit/2e74544e1311f9910015925ff52d9a59e9d8fe53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47366703)</sub>

<!-- /greptile_comment -->