### PR TITLE
Feature/docs seo 0 12 5

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,4 +1,1 @@
 PUBLIC_SITE_URL=https://www.ollamaclient.in
-# Google Search Console verification token (meta-tag method). No client-side
-# script is involved; leave unset and no tag is emitted.
-PUBLIC_GOOGLE_SITE_VERIFICATION=

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,1 +1,4 @@
 PUBLIC_SITE_URL=https://www.ollamaclient.in
+# Google Search Console verification token (meta-tag method). No client-side
+# script is involved; leave unset and no tag is emitted.
+PUBLIC_GOOGLE_SITE_VERIFICATION=

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -250,7 +250,14 @@ export default defineConfig({
        * They stay published and linked for people reading the codebase; Head.astro
        * pairs this with `noindex, follow` so existing links still pass through.
        */
-      filter: (page) => !/\/reference(\/|$)/.test(new URL(page).pathname),
+      filter: (page) => {
+        const { pathname } = new URL(page)
+        // /goodbye is the post-uninstall destination set by setUninstallURL. It
+        // is reachable and functional, but offering it as a search result means
+        // a brand query can answer with a farewell page.
+        if (/^\/goodbye\/?$/.test(pathname)) return false
+        return !/\/reference(\/|$)/.test(pathname)
+      },
       /*
        * lastmod from git history (see src/seo/last-modified.mjs). Omitted rather
        * than approximated when history is unavailable.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,6 +12,8 @@ import {
   SITE_DESCRIPTION,
   SITE_URL
 } from "./src/seo/constants.mjs"
+import { withReferenceGroup } from "./src/seo/doc-ia.mjs"
+import { lastModifiedForUrl } from "./src/seo/last-modified.mjs"
 
 /**
  * Astro config for the Ollama Client docs site.
@@ -154,78 +156,16 @@ export default defineConfig({
           }
         })
       ],
-      sidebar: [
-        {
-          label: "Guides",
-          items: [
-            { label: "Quick Start", slug: "guides/quick-start" },
-            { label: "Provider Setup", slug: "guides/provider-setup" },
-            {
-              label: "Context, Images, and Tools",
-              slug: "guides/context-and-tools"
-            },
-            {
-              label: "Fix Ollama CORS errors",
-              slug: "guides/troubleshooting/ollama-cors-error"
-            },
-            {
-              label: "Understand error reports",
-              slug: "guides/troubleshooting/error-reports"
-            }
-          ]
-        },
-        {
-          label: "Concepts",
-          items: [
-            { label: "Privacy", slug: "concepts/privacy" },
-            { label: "Architecture", slug: "concepts/architecture" },
-            {
-              label: "Provider capabilities",
-              slug: "concepts/provider-matrix"
-            }
-          ]
-        },
-        {
-          label: "Compare",
-          items: [
-            {
-              label: "vs Open WebUI",
-              slug: "compare/open-webui-vs-ollama-client"
-            },
-            {
-              label: "vs Page Assist",
-              slug: "compare/page-assist-vs-ollama-client"
-            },
-            {
-              label: "vs LM Studio",
-              slug: "compare/lm-studio-vs-ollama-client"
-            }
-          ]
-        },
-        {
-          label: "Internal",
-          items: [
-            {
-              label: "Frontend Design System",
-              slug: "internal/frontend-design-system"
-            }
-          ]
-        },
-        // Auto-populated by starlight-typedoc from the entryPoints above.
-        typeDocSidebarGroup,
-        {
-          label: "Legal",
-          items: [{ label: "Privacy Policy", slug: "legal/privacy-policy" }]
-        },
-        {
-          label: "About",
-          items: [
-            { label: "FAQ", slug: "about/faq" },
-            { label: "Changelog", slug: "about/changelog" },
-            { label: "Keyboard Shortcuts", slug: "about/keyboard-shortcuts" }
-          ]
-        }
-      ],
+      /*
+       * Content sections come from src/seo/doc-ia.mjs, which is also what the
+       * AI-entrypoint generator orders llms.txt/ai.txt by. Keeping one list
+       * means the sidebar and those files cannot drift apart again (they had:
+       * two guides pages were missing from the generator's copy and landed at
+       * the bottom of llms.txt). `typeDocSidebarGroup` is auto-populated by
+       * starlight-typedoc from the entryPoints above and is injected into its
+       * slot by the helper.
+       */
+      sidebar: withReferenceGroup(typeDocSidebarGroup),
       head: [
         {
           tag: "meta",
@@ -295,7 +235,31 @@ export default defineConfig({
       credits: false
     }),
     mdx(),
-    sitemap()
+    sitemap({
+      /*
+       * Keep the generated TypeDoc reference out of the sitemap.
+       *
+       * It was 62 of 80 URLs — pages like
+       * reference/lib/repositories/chat-history/variables/getMessage, none of
+       * which carry a description, so each offered no meta description, an OG
+       * image with an empty description line, and TechArticle JSON-LD with an
+       * undefined description. Near-duplicate thin pages outnumbered the
+       * hand-written ones 3.4:1, which is crawl budget spent on the pages least
+       * able to answer a query.
+       *
+       * They stay published and linked for people reading the codebase; Head.astro
+       * pairs this with `noindex, follow` so existing links still pass through.
+       */
+      filter: (page) => !/\/reference(\/|$)/.test(new URL(page).pathname),
+      /*
+       * lastmod from git history (see src/seo/last-modified.mjs). Omitted rather
+       * than approximated when history is unavailable.
+       */
+      serialize: (item) => {
+        const lastmod = lastModifiedForUrl(item.url)
+        return lastmod ? { ...item, lastmod } : item
+      }
+    })
   ],
   vite: {
     resolve: {

--- a/docs/src/components/starlight/Head.astro
+++ b/docs/src/components/starlight/Head.astro
@@ -1,9 +1,5 @@
 ---
-import {
-  GOOGLE_SITE_VERIFICATION,
-  IS_NON_PRODUCTION_DEPLOY,
-  SITE_URL,
-} from "@/seo/constants.mjs"
+import { IS_NON_PRODUCTION_DEPLOY, SITE_URL } from "@/seo/constants.mjs"
 import { SECTION_LABELS } from "@/seo/doc-ia.mjs"
 
 type StarlightHeadTag = {
@@ -105,11 +101,6 @@ const breadcrumbJsonLd = {
         IS_NON_PRODUCTION_DEPLOY ? "noindex, nofollow" : "noindex, follow"
       }
     />
-  )
-}
-{
-  GOOGLE_SITE_VERIFICATION && (
-    <meta name="google-site-verification" content={GOOGLE_SITE_VERIFICATION} />
   )
 }
 <meta property="og:image" content={ogUrl} />

--- a/docs/src/components/starlight/Head.astro
+++ b/docs/src/components/starlight/Head.astro
@@ -1,5 +1,10 @@
 ---
-import { SITE_URL } from "@/seo/constants.mjs"
+import {
+  GOOGLE_SITE_VERIFICATION,
+  IS_NON_PRODUCTION_DEPLOY,
+  SITE_URL,
+} from "@/seo/constants.mjs"
+import { SECTION_LABELS } from "@/seo/doc-ia.mjs"
 
 type StarlightHeadTag = {
   tag: "meta" | "link" | "script" | "style" | "title"
@@ -32,6 +37,8 @@ const ogUrl = `${site}/og/${slug}.png`
 const pageUrl = `${site}/${slug}/`
 const markdownUrl = `${site}/${slug}.md`
 
+const sectionLabel = SECTION_LABELS[slug.split("/")[0]]
+
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "TechArticle",
@@ -39,6 +46,7 @@ const jsonLd = {
   description: entry.data.description,
   url: pageUrl,
   ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
+  ...(sectionLabel && { articleSection: sectionLabel }),
   inLanguage: lang,
   isPartOf: {
     "@type": "WebSite",
@@ -46,9 +54,64 @@ const jsonLd = {
     url: site,
   },
 }
+
+/*
+ * The generated TypeDoc reference is published for people reading the codebase
+ * but kept out of search results: 62 of the site's 80 URLs lived under it, none
+ * with a description, which meant near-duplicate thin pages outnumbered the
+ * hand-written docs 3.4:1. `follow` keeps their internal links crawlable, and
+ * the sitemap filter in astro.config.mjs excludes the same subtree.
+ */
+const isReference = slug === "reference" || slug.startsWith("reference/")
+
+/*
+ * Breadcrumb trail. Deliberately two levels — site root, then this page.
+ *
+ * A three-level trail (Home > Guides > page) would need an `item` URL for the
+ * section, and the sidebar groups are not pages: /guides/ and
+ * /guides/troubleshooting/ do not exist. Google requires `item` on every
+ * element except the last, so the options were to invent URLs that 404 or to
+ * emit name-only intermediates it flags as invalid. The section name is carried
+ * as `articleSection` on the page instead, which is honest about the structure
+ * that actually exists. Adding real section index pages is a content decision;
+ * if they ever land, extend the trail here.
+ */
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: siteTitle,
+      item: `${site}/`,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: entry.data.title,
+      item: pageUrl,
+    },
+  ],
+}
 ---
 
 {head.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
+{
+  (IS_NON_PRODUCTION_DEPLOY || isReference) && (
+    <meta
+      name="robots"
+      content={
+        IS_NON_PRODUCTION_DEPLOY ? "noindex, nofollow" : "noindex, follow"
+      }
+    />
+  )
+}
+{
+  GOOGLE_SITE_VERIFICATION && (
+    <meta name="google-site-verification" content={GOOGLE_SITE_VERIFICATION} />
+  )
+}
 <meta property="og:image" content={ogUrl} />
 <meta property="og:image:alt" content={entry.data.title} />
 <meta property="og:image:width" content="1200" />
@@ -57,3 +120,4 @@ const jsonLd = {
 <meta name="twitter:image:alt" content={entry.data.title} />
 <link rel="alternate" type="text/markdown" href={markdownUrl} />
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+<script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />

--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -44,9 +44,11 @@ The WXT shells are intentionally minimal — `background.ts` is a 4-line import,
 **Background worker**
 
 - Provider resolution and streaming orchestration
+- Tool-loop execution, approval gating, and loop checkpointing
+- RPC server for provider configuration, connection tests, and diagnostics
 - Model management handlers
 - Embedding generation handlers for file chunks
-- Browser-level APIs (DNR / CORS rules, context menu)
+- Browser-level APIs (DNR / CORS rules, context menu, alarms)
 
 **Content scripts**
 
@@ -59,9 +61,10 @@ The WXT shells are intentionally minimal — `background.ts` is a 4-line import,
 2. UI opens a runtime port (`MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE`) to the background.
 3. Background receives `CHAT_WITH_MODEL` and resolves the provider using the model mapping.
 4. Provider starts streaming tokens back to the background.
-5. Background relays chunks to the UI through port messages.
-6. UI applies optimistic updates and persists completed messages in the local chat store.
-7. Optional embedding pipelines index chat / file content for retrieval.
+5. If the model requests a tool, the background runs the tool loop — gating on approval where the tool's risk requires it, checkpointing at each boundary — and continues the stream with the tool result appended.
+6. Background relays chunks to the UI through port messages.
+7. UI applies optimistic updates and persists completed messages in the local chat store.
+8. Optional embedding pipelines index chat / file content for retrieval.
 
 ```mermaid
 flowchart TD
@@ -71,19 +74,58 @@ flowchart TD
     D --> E["Ollama"]
     D --> F["LM Studio"]
     D --> G["llama.cpp"]
+    D --> N["OpenAI-compatible / Anthropic"]
     E --> H["Chunk Stream"]
     F --> H
     G --> H
-    H --> I["UI Stream State Update"]
+    N --> H
+    H --> T{"Tool call requested?"}
+    T -->|yes| U["Tool loop: approval gate, execute, checkpoint"]
+    U --> C
+    T -->|no| I["UI Stream State Update"]
     I --> J["SQLite Chat Store"]
     I --> K["Optional RAG Pipeline"]
     K --> L["Embedding Strategy Chain"]
     L --> M["Vector store"]
 ```
 
+Configuration traffic does not use this path — see [Provider RPC boundary](#provider-rpc-boundary).
+
+## Provider RPC boundary
+
+Token streaming uses runtime ports, but everything else that crosses the extension-page ↔ background boundary — reading provider configuration, testing a connection, listing models, running diagnostics — goes through a versioned request/response contract in `src/protocol/` rather than ad-hoc message keys.
+
+| File | Role |
+|---|---|
+| `src/protocol/rpc.ts` | Protocol version, `RpcMethod` / `RpcErrorCode` enums, request and response envelopes |
+| `src/protocol/provider-rpc.ts` | Per-method request/result schemas and the typed `RpcMap` |
+| `src/protocol/diagnostics-rpc.ts` | Diagnostics method schemas |
+| `src/protocol/rpc-registry.ts` | Per-method schema, sender policy, timeout, and operation metadata |
+| `src/protocol/extension-client.ts` | Validated client used by extension pages |
+| `src/background/rpc-server.ts` | Authorization, validation, dispatch, and safe error mapping |
+| `src/lib/providers/provider-rpc-service.ts` | Background-owned implementation of the provider operations |
+
+Why a separate boundary instead of more message keys:
+
+- **Both ends validate.** A method is registered once with its schemas; neither side trusts the other's payload shape.
+- **Errors are enumerated, not stringly typed.** `invalid_request`, `forbidden`, `not_found`, `provider_failed`, `timeout`, `internal`. Results carry i18n message keys plus safe fallback text, never raw provider errors that might embed a credential.
+- **Queries have no write side effects.** Methods registered as queries must not persist anything, so a client timeout cannot commit stale state. Derived state is persisted only after the caller receives and accepts the result.
+- **Cancellation is end-to-end.** A client timeout sends `app-rpc-cancel`; the server aborts the matching request and the provider's model-discovery `fetch` receives that `AbortSignal`.
+
+Legacy `MESSAGE_KEYS` handlers may delegate to the RPC service during migration, but new provider request/response work is added here.
+
 ## Model capabilities
 
-Feature availability is resolved per selected model. The capability layer covers text chat, image input, tool calling, reasoning output, embeddings, and context length. The resolver prefers explicit user overrides, then provider/model metadata, then provider defaults.
+Feature availability is resolved per selected model. The capability layer covers text chat, image input, tool calling, reasoning output, embeddings, and context length.
+
+Resolution runs in four layers, highest priority first:
+
+1. **User override** — what the user set by hand in the model menu. Always wins.
+2. **Empirical probe** — `capability-probe.ts` sends one trivial tool-call request and records whether the model actually emitted a native tool call. This is evidence from the real server, so it beats static metadata, but never the user's word. It is how models on providers with no capability metadata (effectively everything OpenAI-compatible) get `toolCalling` detected without hand-toggling.
+3. **Model metadata** — real tags where the provider reports them (Ollama `/api/show`), or partial inference (LM Studio model type).
+4. **Provider default** — the model itself was not inspected.
+
+Each resolved capability carries a confidence value (`high` / `medium` / `low`) alongside its source, so the UI can distinguish "this model reports vision" from "we assumed it."
 
 This keeps capability-sensitive UI from guessing. For example:
 
@@ -103,19 +145,54 @@ Tool calling is handled in the background worker, between provider streaming and
 4. If the model requests a tool, the stream loop executes it locally and appends a tool result to the working provider history.
 5. The loop continues until the model returns a normal answer or hits the iteration cap.
 
-Current internal tools:
-
-| Tool | Purpose |
-|---|---|
-| `current_tab` | Read the active tab's extracted text, including supported video transcripts. |
-| `list_tabs` | List readable open tabs with current ids, titles, and URLs. |
-| `read_tab` | Read a specific open tab by id or title/URL query. Stale ids are refreshed and can fall back to the active readable tab. |
-| `selected_text` | Use the most recent page selection captured by the extension. |
-| `file_search` | Search uploaded/indexed files. |
-| `rag_search` | Search local chat memory / indexed conversation context. |
-| `web_search` | Search the live web through the configured search provider. |
+Models that cannot emit native tool calls are handled by a text protocol in `src/lib/tools/non-native/`, which parses tool invocations out of the model's prose. The two loops (`stream-chat-with-tools.ts` and `stream-chat-with-non-native-tools.ts`) are separate implementations with the same lifecycle, approval, and checkpoint contract.
 
 Tool results are trimmed before they are fed back to the model. The UI persists the final assistant answer and trace metadata, not the intermediate tool messages.
+
+### Internal tools
+
+Tools are registered in `src/lib/tools/internal/internal-tool-source.ts` — appending to that list is the whole registration step; the registry, adapters, loop, and trace UI need no change. Browser-dependent tools check both API support and the live optional permission before they are offered.
+
+| Tool | Risk | Purpose |
+|---|---|---|
+| `rag_search` | low | Search local chat memory / indexed conversation context. |
+| `file_search` | low | Search uploaded and indexed files. |
+| `current_tab` | low | Read the active tab's extracted text, including supported video transcripts. |
+| `list_tabs` | low | List readable open tabs with current ids, titles, and URLs. |
+| `read_tab` | low | Read a specific open tab by id or title/URL query. Stale ids are refreshed and can fall back to the active readable tab. |
+| `list_tab_groups` | low | List the browser's tab groups. |
+| `read_tab_group` | low | Read the readable tabs inside one group. |
+| `selected_text` | low | Use the most recent page selection captured by the extension. |
+| `list_reminders` | low | List pending reminders. |
+| `web_search` | medium | Search the live web through the configured search provider. |
+| `get_recent_history` | medium | Query recent browsing history. |
+| `search_bookmarks` | medium | Search saved bookmarks. |
+| `list_recently_closed` | medium | List recently closed tabs and windows. |
+| `list_synced_sessions` | medium | List tabs open on the user's other synced devices. |
+| `restore_session` | medium | Reopen recently closed tabs or windows. Returns no page content, but it acts on the browser and leaves a visible trace. |
+| `capture_screenshot` | medium | Capture the visible area of the active tab. |
+| `save_artifact` | medium | Persist a generated artifact to the chat. |
+| `schedule_reminder` | medium | Schedule a reminder via browser alarms. |
+| `cancel_reminder` | high | Permanently remove a pending reminder. Destructive, so it is confirmed on every call. |
+
+### Approval and risk policy
+
+There is no single hardcoded confirmation flag. Each tool declares a risk level and the policy in `src/lib/tools/approval/` derives the prompt from it:
+
+| Risk | Policy |
+|---|---|
+| `low` | Runs automatically; never prompts. |
+| `medium` | Confirmed once per chat — an approval grants the rest of that chat. |
+| `high` | Confirmed on every call, with "always allow" offered. |
+| `critical` | Always confirmed; no grant of any scope is offered. |
+
+Grants are keyed per **tool × origin**, not per tool, so an approval for one site never silently covers another. Only `http(s)` origins are grantable; internal pages (`chrome://`, `about:`, `moz-extension://`) are already blocked by the tab-access filters, and a grant for them would be meaningless — a missing or unparseable origin means "no grant applies", never a fallback to the wildcard. Persisted "always" grants live in `approval-grants.ts`; "this chat" grants live in a background session map that dies with the worker.
+
+### Loop durability across worker restarts
+
+MV3 can terminate the service worker mid-turn, including while a tool loop is waiting on the user. Active loops therefore checkpoint into the SQLite `tool_loop_runs` table at every model, tool, and approval boundary, and force-flush before awaiting an approval — the one point where the loop can sit idle long enough to be killed.
+
+The sidepanel reconnects using the same request id after a restart and the loop resumes from its checkpoint. Completed runs delete their checkpoint; `startup.ts` prunes stale ones on boot. This checkpoint/reconnect pair is a contract — changing tool execution without preserving it turns a worker restart back into a lost turn.
 
 ### Web search adapter seam
 
@@ -164,6 +241,15 @@ Images reuse the existing file metadata path for local persistence and preview d
 - Per-model provider routing is stored via `ProviderStorageKey.MODEL_MAPPINGS`.
 - Background routing is performed by `ProviderFactory.getProviderForModel(modelId)`.
 
+### Credential separation
+
+API keys are never stored inside the provider config record. `provider-secret-store.ts` splits each config on write: the public fields go to the normal provider config key, and `apiKey` is stripped into a separate device-local secret map under `STORAGE_KEYS.PROVIDER.SECRETS`. Keys are re-attached only when a provider instance is actually constructed.
+
+Two consequences fall out of that split:
+
+- Secrets stay on the device. Provider configuration can ride `chrome.storage.sync` without syncing credentials, and diagnostics or RPC results that serialize a provider config carry no key.
+- The split write is journaled. Writing two storage keys is not atomic, so the store records a journal entry first and replays it on next boot if a crash lands between the two writes — otherwise an interrupted save could orphan a key or leave a config pointing at a secret that was never written.
+
 ## Streaming architecture
 
 Streaming occurs over extension runtime ports:
@@ -174,6 +260,14 @@ Streaming occurs over extension runtime ports:
 
 Runtime ports support continuous chunk delivery better than one-shot messages, and cancellation is clean via `AbortController` scoped to active stream keys. Tradeoff: message keys are provider-named (`PROVIDER.*`) with legacy `OLLAMA.*` compatibility.
 
+### Provider reasoning replay
+
+Some providers require that reasoning produced in an earlier turn be handed back verbatim to continue a tool loop — Anthropic's signed thinking and redacted-thinking blocks, OpenRouter's `reasoning_details`. These are opaque, provider-owned values: they cannot be regenerated, reordered, or paraphrased without invalidating the continuation.
+
+They are therefore kept apart from the reasoning text the UI displays. `ChatMessage.thinking` is display-only and safe to render or truncate. `ChatMessage.replayArtifact` is a versioned, size-capped, schema-validated record of the opaque blocks, stored in its own SQLite column and carried through tool-loop checkpoints in original block order.
+
+Before replay, the artifact's `providerId` and `model` are checked against the current turn — a block signed by one provider is not valid input to another. An artifact that fails validation surfaces as a "retry this turn" error rather than being sent anyway. Opaque block contents are never rendered and never logged.
+
 ## Storage architecture
 
 - **Chat / sessions / messages / files**: SQL WASM (`sql.js`) persisted to IndexedDB. The facade `src/lib/repositories/chat-history.ts` is the single entry point and now routes to SQLite only.
@@ -181,7 +275,9 @@ Runtime ports support continuous chunk delivery better than one-shot messages, a
 - **Settings / provider config**: `@plasmohq/storage` via the `plasmoGlobalStorage` wrapper. Sync-safe settings use `chrome.storage.sync`; device-local keys use `chrome.storage.local`.
 - **Settings IA**: six intent tabs — General, Models, Knowledge, Browser, Privacy, and Help. Legacy deep links resolve through the settings registry.
 - **RAG splitting**: files, chat memory, and live page sources share `src/lib/embeddings/chunker.ts`; the retired parallel text-splitter tree must not be restored.
-- **Session organization**: tags are JSON stored in the SQLite `sessions.tags` column and exposed through the chat-session store.
+- **Session organization**: tags are JSON stored in the SQLite `sessions.tags` column and exposed through the chat-session store. Pinned state and per-chat system prompts live on the same table.
+- **Tool-loop checkpoints**: the SQLite `tool_loop_runs` table, written at loop boundaries so an MV3 worker restart does not lose an in-flight turn.
+- **Schema changes**: forward-only migrations under `src/lib/sqlite/migrations/`, applied by `migration-runner.ts`. Add a column with a migration rather than editing the base schema.
 - **Export / restore**: ZIP bundles with versioned manifests; includes the chat SQLite blob plus Dexie dumps for vector embeddings and knowledge sets.
 
 ### Chat-history storage
@@ -203,8 +299,14 @@ See the [API reference](/reference/lib/repositories/chat-history/) for the full 
 - Embeddings use a fallback chain: provider-native → shared model → background warmup → Ollama fallback.
 - Background model preparation uses provider capabilities where available; Ollama remains the most complete management path.
 
+### Reranking
+
+Reranking is on by default and is a **cosine-similarity re-scorer**, not a cross-encoder. After hybrid search returns candidates, `src/lib/embeddings/reranker.ts` re-scores them by embedding cosine similarity against the query embedding, giving a semantic-only ordering independent of the keyword weight used in stage 1.
+
+A real cross-encoder was attempted via transformers.js / ONNX Runtime and abandoned: MV3's CSP blocked the path it needed, and neither library is a dependency of this project. `config.ts` still accepts the legacy `transformers-js` and `onnxruntime-web` backend strings, purely as a migration shim that collapses them to `cosine`.
+
 :::note[Constraint]
-There is no OCR pipeline. Cross-encoder reranking is browser/CSP-sensitive and depends on the bundled ONNX Runtime WASM path being available.
+There is no OCR pipeline, and no cross-encoder reranking. Retrieval precision comes from chunking, hybrid weighting, and cosine re-scoring only.
 :::
 
 ## Why a background worker
@@ -251,9 +353,10 @@ There is no OCR pipeline. Cross-encoder reranking is browser/CSP-sensitive and d
 
 ## Known risks and technical debt
 
-- Legacy `ollama-*` keys retained for compatibility while provider naming becomes default.
+- Legacy `ollama-*` keys retained for compatibility while provider naming becomes default, and some legacy `MESSAGE_KEYS` handlers still carry provider work that belongs on the RPC boundary.
 - Partial provider parity in model-management actions.
-- Dual persistence architecture during the migration period.
+- Two storage engines: chat history is SQLite-only, but vectors and knowledge sets are still Dexie. The Dexie *chat* fallback is retired — this is a split by domain, not a migration in progress.
+- `sql.js` ships in the production bundle. Replacing it is scoped work, not a permanent choice.
 - Retrieval quality depends on chunking / threshold tuning and model quality.
 
 ## Desktop design notes
@@ -267,7 +370,7 @@ These are non-implementation notes for a hypothetical desktop port.
 
 ## Near-term priorities
 
-1. Finish retiring legacy `ollama-*` naming where compatibility does not require it.
+1. Move the remaining legacy `MESSAGE_KEYS` provider handlers onto the RPC boundary, and retire `ollama-*` naming where compatibility does not require it.
 2. Migrate vector storage and knowledge sets off Dexie when the SQLite path is ready.
 3. Expand provider parity for management actions.
 4. Improve retrieval observability and failure diagnostics.

--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -1,2 +1,12 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+/*
+ * Fontsource packages are CSS-only: they ship no type declarations, and their
+ * "." export maps to index.css. `astro/client` declares relative `*.css`
+ * imports but not a bare specifier that resolves to a stylesheet, so a
+ * side-effect import of one is reported as having no module or type
+ * declarations. Declaring the namespace leaves the imports exactly as they are
+ * — the bundler loads the font CSS either way; only the type lookup failed.
+ */
+declare module "@fontsource-variable/*"

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -11,7 +11,6 @@ import "@fontsource-variable/geist"
 import "@fontsource-variable/geist-mono"
 import "@/styles/globals.css"
 import {
-  GOOGLE_SITE_VERIFICATION,
   IS_NON_PRODUCTION_DEPLOY,
   KEYWORDS,
   SITE_URL,
@@ -58,14 +57,6 @@ const ogUrl = new URL(ogPath, site)
     {
       IS_NON_PRODUCTION_DEPLOY && (
         <meta name="robots" content="noindex, nofollow" />
-      )
-    }
-    {
-      GOOGLE_SITE_VERIFICATION && (
-        <meta
-          name="google-site-verification"
-          content={GOOGLE_SITE_VERIFICATION}
-        />
       )
     }
     <link rel="alternate" type="text/markdown" href="/llms.txt" />

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -21,9 +21,14 @@ interface Props {
   title: string
   description: string
   jsonLd?: Record<string, unknown>
+  /**
+   * Keep this page out of search results while leaving it fully reachable.
+   * For pages that are destinations rather than answers — see goodbye.astro.
+   */
+  noindex?: boolean
 }
 
-const { title, description, jsonLd } = Astro.props
+const { title, description, jsonLd, noindex } = Astro.props
 const site = Astro.site?.toString() ?? SITE_URL
 
 /*
@@ -55,8 +60,13 @@ const ogUrl = new URL(ogPath, site)
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <link rel="canonical" href={canonical} />
     {
-      IS_NON_PRODUCTION_DEPLOY && (
-        <meta name="robots" content="noindex, nofollow" />
+      (IS_NON_PRODUCTION_DEPLOY || noindex) && (
+        <meta
+          name="robots"
+          content={
+            IS_NON_PRODUCTION_DEPLOY ? "noindex, nofollow" : "noindex, follow"
+          }
+        />
       )
     }
     <link rel="alternate" type="text/markdown" href="/llms.txt" />

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -10,7 +10,13 @@
 import "@fontsource-variable/geist"
 import "@fontsource-variable/geist-mono"
 import "@/styles/globals.css"
-import { KEYWORDS, SITE_URL, SITE_TITLE } from "@/seo/constants.mjs"
+import {
+  GOOGLE_SITE_VERIFICATION,
+  IS_NON_PRODUCTION_DEPLOY,
+  KEYWORDS,
+  SITE_URL,
+  SITE_TITLE
+} from "@/seo/constants.mjs"
 
 interface Props {
   title: string
@@ -20,7 +26,20 @@ interface Props {
 
 const { title, description, jsonLd } = Astro.props
 const site = Astro.site?.toString() ?? SITE_URL
-const canonical = new URL(Astro.url.pathname, site)
+
+/*
+ * Normalize to a trailing slash before building the canonical URL.
+ *
+ * `trailingSlash: "ignore"` means /goodbye and /goodbye/ both resolve, and
+ * echoing Astro.url.pathname straight back made each variant self-canonicalize
+ * to whichever form the visitor happened to arrive on — two canonical URLs for
+ * one page, which is the duplicate-content case canonical tags exist to close.
+ * The Starlight side already normalizes this way, so both surfaces now agree.
+ */
+const canonicalPath = Astro.url.pathname.endsWith("/")
+  ? Astro.url.pathname
+  : `${Astro.url.pathname}/`
+const canonical = new URL(canonicalPath, site)
 const ogPath =
   Astro.url.pathname === "/"
     ? "/og/index.png"
@@ -36,6 +55,19 @@ const ogUrl = new URL(ogPath, site)
     <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <link rel="canonical" href={canonical} />
+    {
+      IS_NON_PRODUCTION_DEPLOY && (
+        <meta name="robots" content="noindex, nofollow" />
+      )
+    }
+    {
+      GOOGLE_SITE_VERIFICATION && (
+        <meta
+          name="google-site-verification"
+          content={GOOGLE_SITE_VERIFICATION}
+        />
+      )
+    }
     <link rel="alternate" type="text/markdown" href="/llms.txt" />
     <title>{title}</title>
     <meta name="description" content={description} />

--- a/docs/src/pages/goodbye.astro
+++ b/docs/src/pages/goodbye.astro
@@ -21,7 +21,15 @@ const prompts = [
 ]
 ---
 
-<BaseLayout title={title} description={description}>
+{/*
+  Kept out of search results. This page is where `setUninstallURL` sends the
+  browser after the extension is removed, so the only person it is written for
+  arrived by leaving — while a searcher looking for the extension would be shown
+  "Thank you for trying Ollama Client" as a result for the product's own name.
+  It stays published and fully functional at the same URL, query parameters
+  included; only its search visibility is withdrawn.
+*/}
+<BaseLayout title={title} description={description} noindex>
   <section class="mx-auto max-w-2xl pb-24 pt-24 sm:pt-32">
     <p
       class="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground"

--- a/docs/src/pages/robots.txt.ts
+++ b/docs/src/pages/robots.txt.ts
@@ -1,4 +1,13 @@
-import { SITE_URL } from "@/seo/constants.mjs"
+import { IS_NON_PRODUCTION_DEPLOY, SITE_URL } from "@/seo/constants.mjs"
+
+/*
+ * A preview deployment serves a full copy of the site on a throwaway host that
+ * canonicalizes to itself. Refuse it outright rather than relying on the
+ * platform's default noindex header; the pages also carry a `noindex` meta tag.
+ */
+const previewContent = `User-agent: *
+Disallow: /
+`
 
 const content = `User-agent: *
 Allow: /
@@ -36,7 +45,7 @@ Sitemap: ${SITE_URL}/sitemap-index.xml
 `
 
 export function GET() {
-  return new Response(content, {
+  return new Response(IS_NON_PRODUCTION_DEPLOY ? previewContent : content, {
     headers: {
       "content-type": "text/plain; charset=utf-8"
     }

--- a/docs/src/seo/constants.d.mts
+++ b/docs/src/seo/constants.d.mts
@@ -6,7 +6,10 @@ export const SITE_TITLE: string
 export const SITE_DESCRIPTION: string
 export const LANDING_TITLE: string
 export const LANDING_DESCRIPTION: string
-export const KEYWORDS: string[]
+// A single comma-separated string, not a list: it is written straight into
+// <meta name="keywords" content={KEYWORDS} />. Declared as string[] until
+// 2026-07-26, which made every consumer of it a type error.
+export const KEYWORDS: string
 export const AUTHOR_NAME: string
 export const AUTHOR_URL: string
 export const CONTACT_EMAIL: string

--- a/docs/src/seo/constants.d.mts
+++ b/docs/src/seo/constants.d.mts
@@ -11,3 +11,5 @@ export const AUTHOR_NAME: string
 export const AUTHOR_URL: string
 export const CONTACT_EMAIL: string
 export const REPO_URL: string
+export const GOOGLE_SITE_VERIFICATION: string
+export const IS_NON_PRODUCTION_DEPLOY: boolean

--- a/docs/src/seo/constants.d.mts
+++ b/docs/src/seo/constants.d.mts
@@ -11,5 +11,4 @@ export const AUTHOR_NAME: string
 export const AUTHOR_URL: string
 export const CONTACT_EMAIL: string
 export const REPO_URL: string
-export const GOOGLE_SITE_VERIFICATION: string
 export const IS_NON_PRODUCTION_DEPLOY: boolean

--- a/docs/src/seo/constants.mjs
+++ b/docs/src/seo/constants.mjs
@@ -91,21 +91,6 @@ export const IS_NON_PRODUCTION_DEPLOY = Boolean(
   process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production"
 )
 
-/**
- * Google Search Console verification token, when configured.
- *
- * Search Console is the only measurement this site has: without it there is no
- * query, impression, or coverage data, so no SEO change here can be evaluated
- * afterwards. It verifies with a meta tag, a DNS record, or an HTML file and
- * ships **no client-side script**, which is what makes it compatible with the
- * project's no-telemetry, no-tracker position. Analytics stay out.
- *
- * Empty by default so nothing is emitted until a token is actually set.
- */
-export const GOOGLE_SITE_VERIFICATION = (
-  process.env.PUBLIC_GOOGLE_SITE_VERIFICATION || ""
-).trim()
-
 export const SITE_TITLE = "Ollama Client"
 
 export const REPO_URL = "https://github.com/Shishir435/ollama-client"

--- a/docs/src/seo/constants.mjs
+++ b/docs/src/seo/constants.mjs
@@ -73,6 +73,39 @@ export const SITE_URL = normalizeSiteUrl(
     process.env.VERCEL_URL
 )
 
+/**
+ * True on a deploy that is not production.
+ *
+ * Preview deployments resolve `SITE_URL` from `VERCEL_URL`, so every page
+ * canonicalizes to the preview host while `robots.txt` says `Allow: /` — a
+ * complete indexable copy of the site on a throwaway domain. Vercel does add
+ * `X-Robots-Tag: noindex` to preview deployments by default, which is why this
+ * has most likely never bitten; that is a platform default we neither control
+ * nor test, and stating the intent in the build costs one meta tag.
+ *
+ * Local builds are unaffected: the flag reads as production unless `VERCEL_ENV`
+ * is present and says otherwise, so `pnpm docs:build` on a laptop behaves
+ * exactly as it did.
+ */
+export const IS_NON_PRODUCTION_DEPLOY = Boolean(
+  process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production"
+)
+
+/**
+ * Google Search Console verification token, when configured.
+ *
+ * Search Console is the only measurement this site has: without it there is no
+ * query, impression, or coverage data, so no SEO change here can be evaluated
+ * afterwards. It verifies with a meta tag, a DNS record, or an HTML file and
+ * ships **no client-side script**, which is what makes it compatible with the
+ * project's no-telemetry, no-tracker position. Analytics stay out.
+ *
+ * Empty by default so nothing is emitted until a token is actually set.
+ */
+export const GOOGLE_SITE_VERIFICATION = (
+  process.env.PUBLIC_GOOGLE_SITE_VERIFICATION || ""
+).trim()
+
 export const SITE_TITLE = "Ollama Client"
 
 export const REPO_URL = "https://github.com/Shishir435/ollama-client"

--- a/docs/src/seo/doc-ia.d.mts
+++ b/docs/src/seo/doc-ia.d.mts
@@ -3,6 +3,8 @@
 export type DocIaItem = {
   label: string
   slug: string
+  /** Written by tools/generate-docs.ts and gitignored, not committed. */
+  generated?: boolean
 }
 
 export type DocIaSection = {
@@ -12,5 +14,6 @@ export type DocIaSection = {
 
 export const DOC_SECTIONS: DocIaSection[]
 export const DOC_ORDER: string[]
+export const GENERATED_DOC_SLUGS: string[]
 export const SECTION_LABELS: Record<string, string>
 export function withReferenceGroup<T>(referenceGroup: T): (DocIaSection | T)[]

--- a/docs/src/seo/doc-ia.d.mts
+++ b/docs/src/seo/doc-ia.d.mts
@@ -1,0 +1,16 @@
+// Type declarations for the plain-JS docs IA consumed by build tooling
+// (tools/generate-llms-docs.ts) under the strict root tsconfig.
+export type DocIaItem = {
+  label: string
+  slug: string
+}
+
+export type DocIaSection = {
+  label: string
+  items: DocIaItem[]
+}
+
+export const DOC_SECTIONS: DocIaSection[]
+export const DOC_ORDER: string[]
+export const SECTION_LABELS: Record<string, string>
+export function withReferenceGroup<T>(referenceGroup: T): (DocIaSection | T)[]

--- a/docs/src/seo/doc-ia.mjs
+++ b/docs/src/seo/doc-ia.mjs
@@ -1,0 +1,126 @@
+/**
+ * Ordered information architecture for the hand-written docs.
+ *
+ * Single source of truth for three consumers that used to declare the same
+ * ordering separately:
+ *
+ *   - the Starlight sidebar (docs/astro.config.mjs),
+ *   - `llms.txt` / `ai.txt` / `llms-full.txt` ordering
+ *     (tools/generate-llms-docs.ts),
+ *   - breadcrumb section labels (src/components/starlight/Head.astro).
+ *
+ * They had already diverged: the generator's list carried 14 slugs against the
+ * sidebar's 16, so `guides/context-and-tools` and
+ * `guides/troubleshooting/error-reports` were appended alphabetically to the end
+ * of the AI entrypoints instead of appearing in their real place in the IA. The
+ * generator now fails the build when this file and the content tree disagree,
+ * which is only meaningful because there is exactly one list to disagree with.
+ *
+ * The auto-generated TypeDoc `reference/**` tree is deliberately absent. It is
+ * not part of the indexable IA (see the sitemap filter and the `noindex` in
+ * Head.astro) and its pages carry no descriptions.
+ */
+
+export const DOC_SECTIONS = [
+  {
+    label: "Guides",
+    items: [
+      { label: "Quick Start", slug: "guides/quick-start" },
+      { label: "Provider Setup", slug: "guides/provider-setup" },
+      {
+        label: "Context, Images, and Tools",
+        slug: "guides/context-and-tools"
+      },
+      {
+        label: "Fix Ollama CORS errors",
+        slug: "guides/troubleshooting/ollama-cors-error"
+      },
+      {
+        label: "Understand error reports",
+        slug: "guides/troubleshooting/error-reports"
+      }
+    ]
+  },
+  {
+    label: "Concepts",
+    items: [
+      { label: "Privacy", slug: "concepts/privacy" },
+      { label: "Architecture", slug: "concepts/architecture" },
+      {
+        label: "Provider capabilities",
+        slug: "concepts/provider-matrix"
+      }
+    ]
+  },
+  {
+    label: "Compare",
+    items: [
+      {
+        label: "vs Open WebUI",
+        slug: "compare/open-webui-vs-ollama-client"
+      },
+      {
+        label: "vs Page Assist",
+        slug: "compare/page-assist-vs-ollama-client"
+      },
+      {
+        label: "vs LM Studio",
+        slug: "compare/lm-studio-vs-ollama-client"
+      }
+    ]
+  },
+  {
+    label: "Internal",
+    items: [
+      {
+        label: "Frontend Design System",
+        slug: "internal/frontend-design-system"
+      }
+    ]
+  },
+  {
+    label: "Legal",
+    items: [{ label: "Privacy Policy", slug: "legal/privacy-policy" }]
+  },
+  {
+    label: "About",
+    items: [
+      { label: "FAQ", slug: "about/faq" },
+      { label: "Changelog", slug: "about/changelog" },
+      { label: "Keyboard Shortcuts", slug: "about/keyboard-shortcuts" }
+    ]
+  }
+]
+
+/**
+ * The generated API reference sits between Internal and Legal in the sidebar.
+ * Named here rather than spliced by index at the call site so the position is
+ * stated once, next to the sections it sits between.
+ */
+const REFERENCE_AFTER_SECTION = "Internal"
+
+/** Sidebar order: content sections with the TypeDoc group in its slot. */
+export const withReferenceGroup = (referenceGroup) =>
+  DOC_SECTIONS.flatMap((section) =>
+    section.label === REFERENCE_AFTER_SECTION
+      ? [section, referenceGroup]
+      : [section]
+  )
+
+/** Flat slug order used by the AI-entrypoint generator. */
+export const DOC_ORDER = DOC_SECTIONS.flatMap((section) =>
+  section.items.map((item) => item.slug)
+)
+
+/**
+ * First path segment to its human section label, derived from the sections
+ * above rather than restated. Used for breadcrumb naming.
+ *
+ * A segment shared by two sections would be ambiguous; none is today, and the
+ * generator's drift check would surface a new page that introduced one.
+ */
+export const SECTION_LABELS = Object.fromEntries(
+  DOC_SECTIONS.flatMap((section) =>
+    section.items.map((item) => [item.slug.split("/")[0], section.label])
+  )
+)

--- a/docs/src/seo/doc-ia.mjs
+++ b/docs/src/seo/doc-ia.mjs
@@ -48,7 +48,8 @@ export const DOC_SECTIONS = [
       { label: "Architecture", slug: "concepts/architecture" },
       {
         label: "Provider capabilities",
-        slug: "concepts/provider-matrix"
+        slug: "concepts/provider-matrix",
+        generated: true
       }
     ]
   },
@@ -86,7 +87,7 @@ export const DOC_SECTIONS = [
     label: "About",
     items: [
       { label: "FAQ", slug: "about/faq" },
-      { label: "Changelog", slug: "about/changelog" },
+      { label: "Changelog", slug: "about/changelog", generated: true },
       { label: "Keyboard Shortcuts", slug: "about/keyboard-shortcuts" }
     ]
   }
@@ -110,6 +111,22 @@ export const withReferenceGroup = (referenceGroup) =>
 /** Flat slug order used by the AI-entrypoint generator. */
 export const DOC_ORDER = DOC_SECTIONS.flatMap((section) =>
   section.items.map((item) => item.slug)
+)
+
+/**
+ * Slugs whose content file is written by tools/generate-docs.ts rather than
+ * committed. Both are gitignored, so they exist only after `pnpm docs:generate`
+ * — which `docs:build` and `docs:dev` always run first and `pnpm test:run`
+ * never does.
+ *
+ * Marking them here rather than in the drift check keeps the strictness where
+ * it belongs: the docs build still requires every slug in this file to have a
+ * real page, because generation has already happened by then. Only a test
+ * running against a clean tree may skip them, and it verifies separately that
+ * this list still matches what the generator writes.
+ */
+export const GENERATED_DOC_SLUGS = DOC_SECTIONS.flatMap((section) =>
+  section.items.filter((item) => item.generated).map((item) => item.slug)
 )
 
 /**

--- a/docs/src/seo/last-modified.mjs
+++ b/docs/src/seo/last-modified.mjs
@@ -1,0 +1,112 @@
+/**
+ * Per-page last-modified dates for the sitemap, read from git history.
+ *
+ * The sitemap previously carried no `lastmod` at all, which tells crawlers
+ * nothing about which of ~18 indexable pages actually changed. Starlight
+ * already derives a "Last updated" date from git for its footer; this reads the
+ * same underlying source so the two cannot disagree.
+ *
+ * Deliberately fails silent-but-empty rather than approximate. Filesystem
+ * mtimes are the tempting fallback and would be wrong: a CI checkout stamps
+ * every file with the checkout time, which would advertise the whole site as
+ * modified on every deploy. An absent `lastmod` is a missing hint; a wrong one
+ * is a lie that trains crawlers to ignore the field.
+ *
+ * Shallow clones (Vercel's default) simply yield fewer entries: `--name-only`
+ * lists the files each available commit touched, so pages outside that window
+ * are omitted instead of misdated.
+ */
+import { execFileSync } from "node:child_process"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..")
+const CONTENT_PREFIX = "docs/src/content/docs/"
+
+const slugFromRepoPath = (path) => {
+  if (!path.startsWith(CONTENT_PREFIX)) return undefined
+  const withoutExt = path
+    .slice(CONTENT_PREFIX.length)
+    .replace(/\.(md|mdx)$/, "")
+  if (withoutExt === path.slice(CONTENT_PREFIX.length)) return undefined
+  return withoutExt.endsWith("/index")
+    ? withoutExt.slice(0, -"/index".length)
+    : withoutExt
+}
+
+const git = (args) => {
+  try {
+    return execFileSync("git", ["-C", REPO_ROOT, ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"]
+    })
+  } catch {
+    // No git, no history, or a non-repo export. Emit no lastmod at all.
+    return ""
+  }
+}
+
+const readGitLog = () =>
+  git(["log", "--pretty=format:@%cI", "--name-only", "--", CONTENT_PREFIX])
+
+/**
+ * Pages whose content is not a tracked file under the docs content tree, mapped
+ * to the paths that actually determine them.
+ *
+ * Without this the four most-linked URLs on the site — the landing page above
+ * all — would be the ones missing a date, because `/` and `/goodbye/` are Astro
+ * pages rather than content entries, and `about/changelog` and
+ * `concepts/provider-matrix` are build outputs (gitignored, so the generated
+ * file itself has no history). Dating them by their real sources is accurate;
+ * omitting them would have quietly excluded exactly the pages that matter most.
+ */
+const SLUG_SOURCES = {
+  "": ["docs/src/pages/index.astro"],
+  goodbye: ["docs/src/pages/goodbye.astro"],
+  "about/changelog": ["CHANGELOG.md"],
+  // Regenerated from the provider implementations by tools/generate-docs.ts, so
+  // the matrix is as current as the newest change in that directory.
+  "concepts/provider-matrix": ["src/lib/providers"]
+}
+
+const newestCommitDate = (paths) => {
+  const date = git(["log", "-1", "--pretty=format:%cI", "--", ...paths]).trim()
+  return date || undefined
+}
+
+const buildMap = () => {
+  const dates = new Map()
+  let current
+
+  for (const line of readGitLog().split("\n")) {
+    if (line.startsWith("@")) {
+      current = line.slice(1).trim()
+      continue
+    }
+    const path = line.trim()
+    if (!path || !current) continue
+    const slug = slugFromRepoPath(path)
+    // git log walks newest-first, so the first date seen for a file is its
+    // most recent change. Later (older) commits must not overwrite it.
+    if (slug && !dates.has(slug)) dates.set(slug, current)
+  }
+
+  // Explicit sources win: a generated content file may exist on disk with no
+  // history, and for the two Astro pages there is no content file at all.
+  for (const [slug, paths] of Object.entries(SLUG_SOURCES)) {
+    const date = newestCommitDate(paths)
+    if (date) dates.set(slug, date)
+  }
+
+  return dates
+}
+
+const lastModifiedBySlug = buildMap()
+
+/**
+ * Resolve a built page URL to its slug and return that page's date. The landing
+ * page resolves to the empty slug. Returns undefined for generated reference
+ * pages and anything else with no tracked source.
+ */
+export const lastModifiedForUrl = (url) =>
+  lastModifiedBySlug.get(new URL(url).pathname.replace(/^\/|\/$/g, ""))

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "astro.config.mjs"]

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "spike:owner-gates": "tsx tools/spike-owner-gates.ts",
     "spike:sw-termination": "tsx tools/spike-sw-termination.ts",
     "spike:firefox-owner-gates": "tsx tools/spike-firefox-owner-gates.ts",
+    "verify:ci-parity": "tsx tools/verify-ci-parity.ts",
     "verify:opfs-migration": "tsx tools/verify-opfs-migration.ts",
     "verify": "pnpm typecheck && pnpm lint:check && pnpm test:run && pnpm check:generated",
     "test": "vitest",

--- a/src/lib/__tests__/generate-llms-docs.test.ts
+++ b/src/lib/__tests__/generate-llms-docs.test.ts
@@ -1,5 +1,13 @@
+import { readdirSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
+
 import { describe, expect, it } from "vitest"
-import { cleanMarkdown } from "../../../tools/generate-llms-docs"
+
+import { DOC_ORDER } from "../../../docs/src/seo/doc-ia.mjs"
+import {
+  assertIaMatches,
+  cleanMarkdown
+} from "../../../tools/generate-llms-docs"
 
 describe("cleanMarkdown", () => {
   it("removes multiline MDX export declarations but keeps prose", () => {
@@ -64,5 +72,47 @@ Body text.`
     expect(cleaned).not.toContain("FAQPageJsonLd")
     expect(cleaned).not.toContain("Rendered component")
     expect(cleaned).toContain("# Public")
+  })
+})
+
+const DOCS_CONTENT_DIR = join(__dirname, "../../../docs/src/content/docs")
+
+const contentSlugs = () => {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+      const path = join(dir, entry)
+      return statSync(path).isDirectory() ? walk(path) : [path]
+    })
+
+  return walk(DOCS_CONTENT_DIR)
+    .filter((path) => /\.(md|mdx)$/.test(path))
+    .map((path) => relative(DOCS_CONTENT_DIR, path).replace(/\\/g, "/"))
+    .filter((path) => !path.startsWith("reference/"))
+    .map((path) => path.replace(/\.(md|mdx)$/, "").replace(/\/index$/, ""))
+}
+
+describe("docs IA", () => {
+  /*
+   * The generator enforces this at build time, but a build runs later than a
+   * push. Failing here means a new docs page shows up in `pnpm test:run` rather
+   * than silently landing at the bottom of llms.txt — the exact regression this
+   * check exists for, which went unnoticed for two pages.
+   */
+  it("matches the content tree", () => {
+    expect(() => assertIaMatches(contentSlugs())).not.toThrow()
+  })
+
+  it("names the page when the content tree has one the IA does not", () => {
+    expect(() =>
+      assertIaMatches([...contentSlugs(), "guides/unlisted-page"])
+    ).toThrow(/guides\/unlisted-page.*not in DOC_SECTIONS/s)
+  })
+
+  it("names the page when the IA has one the content tree does not", () => {
+    const withoutFirst = contentSlugs().filter((slug) => slug !== DOC_ORDER[0])
+
+    expect(() => assertIaMatches(withoutFirst)).toThrow(
+      new RegExp(`${DOC_ORDER[0]}.*has no content file`, "s")
+    )
   })
 })

--- a/src/lib/__tests__/generate-llms-docs.test.ts
+++ b/src/lib/__tests__/generate-llms-docs.test.ts
@@ -3,7 +3,11 @@ import { join, relative } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
-import { DOC_ORDER } from "../../../docs/src/seo/doc-ia.mjs"
+import {
+  DOC_ORDER,
+  GENERATED_DOC_SLUGS
+} from "../../../docs/src/seo/doc-ia.mjs"
+import { GENERATED_PAGE_SLUGS } from "../../../tools/generate-docs"
 import {
   assertIaMatches,
   cleanMarkdown
@@ -91,6 +95,15 @@ const contentSlugs = () => {
     .map((path) => path.replace(/\.(md|mdx)$/, "").replace(/\/index$/, ""))
 }
 
+/*
+ * `about/changelog` and `concepts/provider-matrix` are written by
+ * generate-docs.ts and gitignored, so they are present in a working tree that
+ * has run `pnpm docs:build` and absent in a fresh CI checkout. Skipping them
+ * here is what makes this suite hermetic; the build path still requires them,
+ * and the test below keeps this list honest.
+ */
+const skipGenerated = { skipMissing: GENERATED_DOC_SLUGS }
+
 describe("docs IA", () => {
   /*
    * The generator enforces this at build time, but a build runs later than a
@@ -99,20 +112,49 @@ describe("docs IA", () => {
    * check exists for, which went unnoticed for two pages.
    */
   it("matches the content tree", () => {
-    expect(() => assertIaMatches(contentSlugs())).not.toThrow()
+    expect(() => assertIaMatches(contentSlugs(), skipGenerated)).not.toThrow()
   })
 
   it("names the page when the content tree has one the IA does not", () => {
     expect(() =>
-      assertIaMatches([...contentSlugs(), "guides/unlisted-page"])
+      assertIaMatches(
+        [...contentSlugs(), "guides/unlisted-page"],
+        skipGenerated
+      )
     ).toThrow(/guides\/unlisted-page.*not in DOC_SECTIONS/s)
   })
 
   it("names the page when the IA has one the content tree does not", () => {
-    const withoutFirst = contentSlugs().filter((slug) => slug !== DOC_ORDER[0])
+    const handWritten = DOC_ORDER.filter(
+      (slug) => !GENERATED_DOC_SLUGS.includes(slug)
+    )
+    const dropped = handWritten[0]
+    const withoutFirst = contentSlugs().filter((slug) => slug !== dropped)
 
-    expect(() => assertIaMatches(withoutFirst)).toThrow(
-      new RegExp(`${DOC_ORDER[0]}.*has no content file`, "s")
+    expect(() => assertIaMatches(withoutFirst, skipGenerated)).toThrow(
+      new RegExp(`${dropped}.*has no content file`, "s")
+    )
+  })
+
+  /*
+   * The skip above is only safe while the IA's `generated: true` flags name the
+   * same pages generate-docs.ts actually writes. If a future generated page is
+   * added to one list and not the other, either the build breaks on a page the
+   * test excused, or a real committed page gets silently excused here.
+   */
+  it("skips exactly the pages the generator owns", () => {
+    expect([...GENERATED_DOC_SLUGS].sort()).toEqual(
+      [...GENERATED_PAGE_SLUGS].sort()
+    )
+  })
+
+  it("still fails on a generated page missing at build time", () => {
+    const withoutGenerated = contentSlugs().filter(
+      (slug) => !GENERATED_DOC_SLUGS.includes(slug)
+    )
+
+    expect(() => assertIaMatches(withoutGenerated)).toThrow(
+      new RegExp(`${GENERATED_DOC_SLUGS[0]}.*has no content file`, "s")
     )
   })
 })

--- a/tools/generate-docs.ts
+++ b/tools/generate-docs.ts
@@ -10,8 +10,8 @@ import {
   readFileSync,
   writeFileSync
 } from "node:fs"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { AnthropicProvider } from "../src/lib/providers/anthropic"
 import { LlamaCppProvider } from "../src/lib/providers/llama-cpp"
@@ -35,6 +35,20 @@ const CHANGELOG_OUTPUT_PATH = join(
 const PROVIDER_MATRIX_OUTPUT_PATH = join(
   REPO_ROOT,
   "docs/src/content/docs/concepts/provider-matrix.md"
+)
+
+/**
+ * The pages this generator owns, as docs slugs. Exported so the IA drift test
+ * can check them against `GENERATED_DOC_SLUGS` in docs/src/seo/doc-ia.mjs
+ * instead of restating the pair a third time.
+ */
+export const GENERATED_PAGE_SLUGS = [
+  CHANGELOG_OUTPUT_PATH,
+  PROVIDER_MATRIX_OUTPUT_PATH
+].map((path) =>
+  relative(join(REPO_ROOT, "docs/src/content/docs"), path)
+    .replace(/\\/g, "/")
+    .replace(/\.mdx?$/, "")
 )
 
 function generateChangelogPage() {
@@ -219,5 +233,15 @@ The first three are mandatory for the runtime; the fourth keeps the docs honest.
   console.log(`  ${providers.length} providers × ${COLUMNS.length} capabilities`)
 }
 
-generateProviderMatrix()
-generateChangelogPage()
+/*
+ * Guarded the way generate-llms-docs.ts is. Without this, importing the module
+ * to read GENERATED_PAGE_SLUGS would write both pages as a side effect — a test
+ * that asserts a clean tree would create the very files it is checking for.
+ */
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  generateProviderMatrix()
+  generateChangelogPage()
+}

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -171,12 +171,23 @@ function sortPages(a: DocPage, b: DocPage) {
  * ai.txt, below the changelog, for however long it had been. Appending silently
  * makes a new page look published while presenting it to AI crawlers in the
  * wrong place; a missing page is worth stopping for.
+ *
+ * `skipMissing` exists for callers that run against a clean tree, where the
+ * generated pages (GENERATED_DOC_SLUGS) have not been written yet. The build
+ * never passes it: by the time this runs in `docs:generate`, generate-docs.ts
+ * has already emitted them, so an absent one is a real failure there.
  */
-export function assertIaMatches(slugs: string[]) {
+export function assertIaMatches(
+  slugs: string[],
+  { skipMissing = [] }: { skipMissing?: readonly string[] } = {}
+) {
   const inIa = new Set(DOC_ORDER)
   const onDisk = new Set(slugs)
+  const skipped = new Set(skipMissing)
   const missing = slugs.filter((slug) => !inIa.has(slug))
-  const stale = DOC_ORDER.filter((slug) => !onDisk.has(slug))
+  const stale = DOC_ORDER.filter(
+    (slug) => !onDisk.has(slug) && !skipped.has(slug)
+  )
 
   if (missing.length === 0 && stale.length === 0) return
 

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -24,6 +24,7 @@ import {
   SITE_TITLE,
   SITE_URL
 } from "../docs/src/seo/constants.mjs"
+import { DOC_ORDER } from "../docs/src/seo/doc-ia.mjs"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = join(__dirname, "..")
@@ -40,23 +41,6 @@ type DocPage = {
   markdownUrl: string
   body: string
 }
-
-const DOC_ORDER = [
-  "about/faq",
-  "guides/quick-start",
-  "guides/provider-setup",
-  "guides/troubleshooting/ollama-cors-error",
-  "concepts/privacy",
-  "concepts/architecture",
-  "concepts/provider-matrix",
-  "compare/open-webui-vs-ollama-client",
-  "compare/page-assist-vs-ollama-client",
-  "compare/lm-studio-vs-ollama-client",
-  "internal/frontend-design-system",
-  "legal/privacy-policy",
-  "about/changelog",
-  "about/keyboard-shortcuts"
-]
 
 function walk(dir: string): string[] {
   return readdirSync(dir)
@@ -173,25 +157,73 @@ export function cleanMarkdown(body: string) {
 }
 
 function sortPages(a: DocPage, b: DocPage) {
-  const aIndex = DOC_ORDER.indexOf(a.slug)
-  const bIndex = DOC_ORDER.indexOf(b.slug)
-  if (aIndex !== -1 || bIndex !== -1) {
-    if (aIndex === -1) return 1
-    if (bIndex === -1) return -1
-    return aIndex - bIndex
-  }
-  return a.slug.localeCompare(b.slug)
+  // Every slug is present in DOC_ORDER by the time this runs — assertIaMatches
+  // has already failed the build otherwise — so index order is total.
+  return DOC_ORDER.indexOf(a.slug) - DOC_ORDER.indexOf(b.slug)
+}
+
+/**
+ * Fail the build when the content tree and the shared IA disagree.
+ *
+ * The previous behavior was to sort unknown slugs to the end alphabetically,
+ * which is how `guides/context-and-tools` and
+ * `guides/troubleshooting/error-reports` ended up at the bottom of llms.txt and
+ * ai.txt, below the changelog, for however long it had been. Appending silently
+ * makes a new page look published while presenting it to AI crawlers in the
+ * wrong place; a missing page is worth stopping for.
+ */
+export function assertIaMatches(slugs: string[]) {
+  const inIa = new Set(DOC_ORDER)
+  const onDisk = new Set(slugs)
+  const missing = slugs.filter((slug) => !inIa.has(slug))
+  const stale = DOC_ORDER.filter((slug) => !onDisk.has(slug))
+
+  if (missing.length === 0 && stale.length === 0) return
+
+  const problems = [
+    ...missing.map(
+      (slug) =>
+        `  + ${slug} exists in docs/src/content/docs but is not in DOC_SECTIONS`
+    ),
+    ...stale.map(
+      (slug) => `  - ${slug} is in DOC_SECTIONS but has no content file`
+    )
+  ]
+
+  throw new Error(
+    `docs IA is out of sync with the content tree.\n${problems.join("\n")}\n` +
+      "Add or remove the page in docs/src/seo/doc-ia.mjs, which also drives the " +
+      "Starlight sidebar."
+  )
 }
 
 function loadPages() {
-  return walk(DOCS_CONTENT_DIR)
+  const pages = walk(DOCS_CONTENT_DIR)
     .filter((path) => !relative(DOCS_CONTENT_DIR, path).startsWith("reference/"))
     .map((sourcePath) => {
       const raw = readFileSync(sourcePath, "utf-8")
       const { data, body } = parseFrontmatter(raw)
       const slug = routeFromSource(sourcePath)
-      const title = data.get("title") || slug
-      const description = data.get("description") || SITE_DESCRIPTION
+      const title = data.get("title")
+      const description = data.get("description")
+
+      /*
+       * Both were previously optional: title fell back to the slug and
+       * description to SITE_DESCRIPTION, so an undescribed page shipped the same
+       * generic sentence as every other one into llms.txt, ai.txt, its .md
+       * header, and its OG image — indistinguishable from a real description
+       * while being useless as one. A page in the indexable IA has to say what
+       * it is.
+       */
+      if (!title || !description) {
+        const missing = [!title && "title", !description && "description"]
+          .filter(Boolean)
+          .join(" and ")
+        throw new Error(
+          `${relative(REPO_ROOT, sourcePath)} is missing frontmatter ${missing}.`
+        )
+      }
+
       const url = `${SITE_URL}/${slug}/`
       const markdownUrl = `${SITE_URL}/${slug}.md`
       const markdownPath = join(PUBLIC_DIR, `${slug}.md`)
@@ -207,7 +239,9 @@ function loadPages() {
         body: cleanMarkdown(body)
       }
     })
-    .sort(sortPages)
+
+  assertIaMatches(pages.map((page) => page.slug))
+  return pages.sort(sortPages)
 }
 
 function pageMarkdown(page: DocPage) {

--- a/tools/verify-ci-parity.ts
+++ b/tools/verify-ci-parity.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+
+/**
+ * Run the CI check job against a pristine checkout of HEAD.
+ *
+ * Why this exists: `pnpm test:run` in your working tree sees files CI never
+ * has. Several build artifacts are gitignored on purpose —
+ * `docs/src/content/docs/about/changelog.md`,
+ * `docs/src/content/docs/concepts/provider-matrix.md`,
+ * `docs/src/content/docs/reference/`, `docs/public/llms*.txt` — and once a
+ * `pnpm docs:build` has written them they stay written. A test that reads the
+ * docs content tree therefore passes locally forever and fails on the first
+ * fresh checkout. That is exactly how the IA drift test got through pre-push
+ * and broke CI: locally the two generated pages were on disk, in CI they were
+ * not.
+ *
+ * The fix is to check out HEAD into a throwaway worktree, which carries only
+ * committed files, and run the same steps in the same order as
+ * .github/workflows/ci.yml's `checks` job. node_modules is symlinked rather
+ * than reinstalled — pnpm's layout is self-contained, and an install here would
+ * cost minutes to verify a lockfile CI verifies anyway.
+ *
+ * Scope: this tests HEAD, not your uncommitted work. That matches what a push
+ * actually sends, so commit first, then run it.
+ *
+ * Usage: pnpm verify:ci-parity
+ */
+
+import { execFileSync, spawnSync } from "node:child_process"
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dirname, "..")
+
+/*
+ * Mirrors the `checks` job. `pnpm install --frozen-lockfile` is represented by
+ * generate:resources alone: its only effect this suite depends on is the
+ * `prepare` hook writing the gitignored src/i18n/resources.ts.
+ */
+const STEPS: ReadonlyArray<{ name: string; args: string[] }> = [
+  { name: "Generate resources (install prepare hook)", args: ["generate:resources"] },
+  { name: "Typecheck", args: ["typecheck"] },
+  { name: "Lint", args: ["lint:check"] },
+  { name: "Format check", args: ["format:check"] },
+  { name: "Tests", args: ["test:run"] }
+]
+
+const git = (...args: string[]): string =>
+  execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf-8" }).trim()
+
+const head = git("rev-parse", "--short", "HEAD")
+const dirty = git("status", "--porcelain")
+
+if (dirty) {
+  console.warn(
+    `Working tree has uncommitted changes. They are NOT included — this runs ${head} as pushed.\n`
+  )
+}
+
+// `git worktree add` refuses a path that already exists, so mkdtemp only
+// provides the parent and git creates the leaf itself.
+const scratch = mkdtempSync(join(tmpdir(), "ollama-client-ci-parity-"))
+const worktree = join(scratch, "repo")
+let failed: string | undefined
+
+try {
+  console.log(`Checking out ${head} into ${worktree}`)
+  git("worktree", "add", "--detach", "--quiet", worktree, "HEAD")
+
+  const modules = join(REPO_ROOT, "node_modules")
+  if (!existsSync(modules)) {
+    throw new Error("node_modules missing — run pnpm install first")
+  }
+  symlinkSync(modules, join(worktree, "node_modules"), "dir")
+
+  for (const step of STEPS) {
+    console.log(`\n▸ ${step.name}`)
+    const result = spawnSync("pnpm", step.args, {
+      cwd: worktree,
+      stdio: "inherit"
+    })
+    if (result.status !== 0) {
+      failed = step.name
+      break
+    }
+  }
+} finally {
+  rmSync(scratch, { recursive: true, force: true })
+  // The worktree directory is already gone; this clears the stale admin entry.
+  git("worktree", "prune")
+}
+
+if (failed) {
+  console.error(`\nCI parity FAILED at: ${failed}`)
+  console.error("This is what the pull request will see. Fix before pushing.")
+  process.exit(1)
+}
+
+console.log(`\nCI parity passed for ${head}.`)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands documentation SEO and fixes the generated-page IA validation failure.
- Centralizes documentation ordering for the Starlight sidebar and AI-readable documentation.
- Marks generated changelog and provider-matrix pages in the shared IA and validates their ownership in tests.
- Adds canonical, robots, sitemap, breadcrumb, and last-modified metadata.
- Expands architecture documentation and adds a clean-checkout CI parity utility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported generated-page IA failure is resolved: both generated slugs are declared in the shared IA, generation runs before strict validation, and clean-checkout tests exempt only those generator-owned pages.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/src/seo/doc-ia.mjs | Defines the shared documentation IA, including both generated pages from the previous finding. |
| tools/generate-docs.ts | Exports generated-page slugs and guards generation so test imports have no filesystem side effects. |
| tools/generate-llms-docs.ts | Validates the content tree against the shared IA after generated pages have been created. |
| src/lib/__tests__/generate-llms-docs.test.ts | Covers clean-checkout generated-page exemptions, generator ownership drift, and strict build-time validation. |
| docs/astro.config.mjs | Uses the shared IA for navigation and adds sitemap filtering and last-modified metadata. |
| tools/verify-ci-parity.ts | Adds a pristine-worktree check that mirrors the repository’s CI validation sequence. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): add a local run against a pris..."](https://github.com/shishir435/ollama-client/commit/4bfa067f20bfe8d2c566fc76c8a89c4aa2d7a060) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47492663)</sub>

<!-- /greptile_comment -->