### PR TITLE
Finalize 0.12.6 compatibility and release provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,16 @@ jobs:
       - name: Check bundle budgets
         run: pnpm ${{ matrix.target == 'firefox' && 'bundle:check:firefox' || 'bundle:check' }}
 
+      # Release workflow downloads these exact ZIPs from a successful run for
+      # its commit. It never rebuilds a second, unverified artifact.
+      - name: Upload release package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-package-${{ matrix.target }}
+          path: build/${{ matrix.target == 'firefox' && 'firefox-mv2-prod' || 'chrome-mv3-prod' }}/*.zip
+          retention-days: 14
+          if-no-files-found: error
+
       # The persistence gates drive a benchmark build, which exposes the
       # lifecycle harness the production build strips. Built here so the whole
       # CI run pays for each build exactly once.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ name: Release
 #    0.12.0 or 0.13.0-rc.1) and pick the branch/commit to release from —
 #    the workflow creates the tag for you and publishes the release.
 #
+# Both paths require a successful CI run for the exact release commit, including
+# Critical browser gates. Release downloads CI's retained Chrome and Firefox
+# ZIPs; it never rebuilds packages after verification.
+#
 # Tag the merge commit on main, after the release PR merges — never a branch
 # commit beforehand. Squash-merging rewrites the SHA, which leaves the tag
 # pointing at a commit that is not in main's history. GitHub then cannot see
@@ -32,23 +36,14 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Resolve release tag
         id: meta
@@ -79,22 +74,65 @@ jobs:
             exit 1
           fi
 
-      - name: Package Chrome (MV3)
-        run: pnpm package
+      - name: Resolve verified CI run
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t CANDIDATE_RUNS < <(gh run list \
+            --workflow ci.yml \
+            --commit "$GITHUB_SHA" \
+            --status success \
+            --limit 20 \
+            --json databaseId,event \
+            --jq '.[] | select(.event == "push" or .event == "workflow_dispatch") | .databaseId')
 
-      - name: Package Firefox (MV2)
-        run: pnpm package:firefox
+          RUN_ID=""
+          for candidate in "${CANDIDATE_RUNS[@]}"; do
+            E2E_CONCLUSION="$(gh run view "$candidate" \
+              --json jobs \
+              --jq '[.jobs[] | select(.name == "Critical browser gates")][0].conclusion')"
+            if [ "$E2E_CONCLUSION" = "success" ]; then
+              RUN_ID="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No trusted CI run passed Critical browser gates for $GITHUB_SHA."
+            echo "Run CI manually for this exact commit before releasing it."
+            exit 1
+          fi
+
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download verified release packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          run-id: ${{ steps.ci.outputs.run-id }}
+          github-token: ${{ github.token }}
+          pattern: release-package-*
+          merge-multiple: true
+          path: verified-release-artifacts
 
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.meta.outputs.tag }}"
-          ASSETS=(build/chrome-mv3-prod/*.zip build/firefox-mv2-prod/*.zip)
+          ASSETS=(
+            verified-release-artifacts/*-chrome.zip
+            verified-release-artifacts/*-firefox.zip
+            verified-release-artifacts/*-sources.zip
+          )
 
-          # An unmatched glob stays literal in bash and would be handed to gh as
-          # a filename, which fails obscurely on create and, worse, uploads a
-          # partial asset set on refresh. Fail here with the missing path named.
+          # CI publishes one Chrome ZIP, one Firefox ZIP, and Firefox's required
+          # source ZIP. Refuse an incomplete or ambiguous set before touching a
+          # release.
+          if [ ${#ASSETS[@]} -ne 3 ]; then
+            echo "Expected exactly three verified release assets; found ${#ASSETS[@]}."
+            exit 1
+          fi
           for asset in "${ASSETS[@]}"; do
             if [ ! -f "$asset" ]; then
               echo "Expected release asset is missing: $asset"

--- a/compatibility-ledger.json
+++ b/compatibility-ledger.json
@@ -1,15 +1,18 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-28",
+  "lastReviewed": "2026-07-29",
   "entries": [
     {
       "id": "legacy-sqljs-live-fallback",
       "owner": "src/lib/sqlite/legacy-db.ts",
       "introducedIn": "pre-0.12.3",
-      "sourceVersions": ["<=0.12.2", "unmarked profiles"],
-      "removalGate": "Historical Dexie/sql.js/OPFS migration fixtures pass in packaged Chrome and Firefox, rollback evidence is retained, and the fallback has completed its evidence window.",
+      "sourceVersions": [
+        "0.6.0-0.12.2 sql.js profiles",
+        "unmarked sql.js profiles"
+      ],
+      "removalGate": "Supported sql.js/OPFS migration fixtures pass in packaged Chrome and Firefox, including offscreen eviction and integrity verification; a migration receipt and operator rollback switch exist; rollback evidence is retained; and the fallback has completed its evidence window.",
       "targetRelease": "0.13.x",
-      "recoveryPath": "Keep a lazy migration-only reader and the untouched source blob so skipped upgrades and offline returning profiles remain recoverable."
+      "recoveryPath": "Keep a lazy sql.js migration-only reader and the untouched source blob so supported skipped upgrades from 0.6.0 onward remain recoverable. Pre-0.6.0 Dexie-only chat history is outside the direct-upgrade contract."
     },
     {
       "id": "legacy-sqljs-import-generation-guard",
@@ -24,7 +27,7 @@
       "id": "legacy-chat-blob-reader",
       "owner": "src/lib/persistence/legacy-blob-reader.ts",
       "introducedIn": "0.12.3",
-      "sourceVersions": ["sql.js chat-history releases"],
+      "sourceVersions": ["0.6.0+ sql.js chat-history releases"],
       "removalGate": "Indefinite recovery capability; remove only with an explicit decision to stop direct upgrades from every covered source version.",
       "targetRelease": null,
       "recoveryPath": "Lazy-load only during verified import; never restore it as a normal live backend after the 0.13.x cutover."

--- a/src/lib/persistence/__tests__/persistence-unit.test.ts
+++ b/src/lib/persistence/__tests__/persistence-unit.test.ts
@@ -123,11 +123,11 @@ describe("persistence backend marker", () => {
 
 describe("first boot with no legacy blob", () => {
   /*
-   * A profile whose chat history predates the SQLite backend entirely — written
-   * by 0.6.3 or earlier into the Dexie `ChatDatabase`, and never migrated
-   * because that bridge only shipped in 0.6.5–0.7.3 and ran on side-panel mount.
-   * There is no sql.js blob to import, and by decision there is no Dexie reader
-   * either: such a profile starts clean.
+   * Direct upgrades are supported from 0.6.0 through the sql.js blob introduced
+   * there. A profile with only the older Dexie `ChatDatabase` — written before
+   * 0.6.0, or inherited but never copied into sql.js — is outside that support
+   * contract. There is no sql.js blob to import and, by decision, no Dexie
+   * reader: such a profile starts clean.
    *
    * What must not happen is a *failed* migration. `ensureMigrated` rejecting
    * would leave the marker on "legacy", so every boot would retry, the sql.js


### PR DESCRIPTION
## Summary

- define `0.6.0` as the supported direct-upgrade floor for chat history
- scope compatibility gates to supported sql.js sources
- retain Chrome, Firefox, and Firefox-source ZIPs from CI
- require a trusted same-commit CI run with successful critical browser gates before release
- publish CI-verified artifacts without rebuilding packages

## Why

Pre-`0.6.0` Dexie-only chat history is outside the support contract and should not block `0.12.6`. Release packaging also needed a provenance guarantee: previously the release workflow rebuilt packages after CI, so published bytes were not the bytes browser gates verified.

## Impact

Supported sql.js upgrades remain intact from `0.6.0` onward. Release attempts now fail closed when the exact commit lacks a trusted successful CI run or complete retained artifacts.

## Validation

- pre-commit typecheck, format, lint, and related tests
- 291 test files / 2,402 tests passed during pre-push
- Chrome production build passed
- docs build passed
- Chrome and Firefox package builds passed locally
- Chrome and Firefox bundle budgets passed
- workflow YAML parsed successfully
- compatibility ledger validation passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a supported sql.js upgrade floor and ensures releases publish the exact browser packages verified by trusted same-commit CI runs.
- Retains Chrome, Firefox, and Firefox source archives from CI.
- Requires successful critical browser gates for the exact release commit.
- Downloads retained CI artifacts instead of rebuilding during release.
- Documents that direct chat-history upgrades are supported from sql.js-based 0.6.0 profiles onward.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The retained artifact names and release selectors align, trusted CI selection requires successful browser gates for the exact commit, and the persistence edits document rather than alter the established no-blob migration behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Retains target-specific package archives for consumption by the release workflow. |
| .github/workflows/release.yml | Selects a trusted successful same-commit CI run and publishes its retained artifacts without rebuilding. |
| compatibility-ledger.json | Narrows documented migration coverage to supported sql.js profiles from version 0.6.0 onward. |
| src/lib/persistence/__tests__/persistence-unit.test.ts | Clarifies the intentional fresh-start behavior for unsupported Dexie-only profiles. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Commit["Release commit"] --> CI["Trusted push or workflow-dispatch CI"]
  CI --> Checks["Checks and browser gates"]
  Checks --> Artifacts["Retained Chrome, Firefox, and source ZIPs"]
  Artifacts --> Release["Release workflow for same commit"]
  Release --> GitHub["GitHub release"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): publish verified artifacts"](https://github.com/shishir435/ollama-client/commit/e7d300f6325e39f6996e1070a0e2ff84739ae697) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48319490)</sub>

**Context used:**

- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)

<!-- /greptile_comment -->