### PR TITLE
Validate typed streaming events

### DIFF
--- a/src/application/turns/__tests__/turn-service.test.ts
+++ b/src/application/turns/__tests__/turn-service.test.ts
@@ -145,7 +145,11 @@ describe("TurnService", () => {
     expect(store.create).toHaveBeenCalledTimes(1)
     expect(store.update).toHaveBeenLastCalledWith("turn-1", {
       status: "failed",
-      failure: "context unavailable"
+      failure: expect.objectContaining({
+        status: 0,
+        message: "context unavailable",
+        context: "turn-run"
+      })
     })
     expect(generation.start).not.toHaveBeenCalled()
   })

--- a/src/application/turns/turn-contract.ts
+++ b/src/application/turns/turn-contract.ts
@@ -3,6 +3,7 @@ import {
   type DurableContextOptions,
   DurableContextOptionsSchema
 } from "@/application/context/context-contract"
+import type { AppFailure } from "@/protocol/app-failure"
 import type { ChatMessage } from "@/types"
 import { ChatMessageSchema } from "@/types/chat.schemas"
 
@@ -107,6 +108,6 @@ export interface DurableTurnRun extends TurnSubmission {
   contextReceipt?: ContextReceipt
   userMessageId?: number
   assistantMessageId?: number
-  failure?: string
+  failure?: AppFailure
   updatedAt: number
 }

--- a/src/application/turns/turn-service.ts
+++ b/src/application/turns/turn-service.ts
@@ -4,6 +4,7 @@ import type {
   ContextBuildOutput,
   ContextService
 } from "@/application/context/context-service"
+import { toAppFailure } from "@/protocol/app-failure"
 import type { ChatMessage } from "@/types"
 import type { DurableTurnRun, TurnMode, TurnSubmission } from "./turn-contract"
 
@@ -23,7 +24,7 @@ export interface TurnRunStore {
         >
       >,
       "failure"
-    > & { failure?: string | null }
+    > & { failure?: DurableTurnRun["failure"] | null }
   ) => Promise<void>
 }
 
@@ -168,7 +169,10 @@ export class TurnService {
     } catch (error) {
       await this.store.update(submission.id, {
         status: "failed",
-        failure: error instanceof Error ? error.message : "Turn failed"
+        failure: toAppFailure(error, {
+          fallbackMessage: "Turn failed",
+          context: "turn-run"
+        })
       })
       throw error
     }

--- a/src/background/__tests__/durable-turn-runtime.test.ts
+++ b/src/background/__tests__/durable-turn-runtime.test.ts
@@ -6,10 +6,12 @@ const mocks = vi.hoisted(() => ({
   handleChat: vi.fn(),
   resolveRetrievalToolsActive: vi.fn(),
   appendMessage: vi.fn(),
+  getMessage: vi.fn(),
   getSession: vi.fn(),
   updateMessage: vi.fn(),
   createTurnRun: vi.fn(),
   getIncompleteTurnRuns: vi.fn(),
+  getTurnRun: vi.fn(),
   updateTurnRun: vi.fn()
 }))
 
@@ -29,6 +31,7 @@ vi.mock("@/background/handlers/handle-build-context", () => ({
 
 vi.mock("@/lib/repositories/chat-history", () => ({
   appendMessage: mocks.appendMessage,
+  getMessage: mocks.getMessage,
   getSession: mocks.getSession,
   updateMessage: mocks.updateMessage
 }))
@@ -36,6 +39,7 @@ vi.mock("@/lib/repositories/chat-history", () => ({
 vi.mock("@/lib/repositories/turn-runs", () => ({
   createTurnRun: mocks.createTurnRun,
   getIncompleteTurnRuns: mocks.getIncompleteTurnRuns,
+  getTurnRun: mocks.getTurnRun,
   updateTurnRun: mocks.updateTurnRun
 }))
 
@@ -48,9 +52,18 @@ import type {
   TurnSubmission
 } from "@/application/turns/turn-contract"
 import {
+  reconnectDurableTurn,
   resumeIncompleteTurnRuns,
   startDurableTurn
 } from "@/background/durable-turn-runtime"
+
+const deferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
 
 const contextResult = {
   contentWithRAG: "hello\n\ncontext",
@@ -130,6 +143,7 @@ beforeEach(() => {
     }
   })
   mocks.updateMessage.mockResolvedValue(1)
+  mocks.getMessage.mockResolvedValue(null)
   mocks.handleChat.mockImplementation(async (_message, port) => {
     mocks.order.push("generation")
     port.postMessage({ delta: "answer" })
@@ -222,7 +236,11 @@ describe("durable turn runtime", () => {
 
     expect(mocks.updateTurnRun).toHaveBeenLastCalledWith("turn-1", {
       status: "failed",
-      failure: "context unavailable"
+      failure: expect.objectContaining({
+        status: 0,
+        message: "context unavailable",
+        context: "turn-run"
+      })
     })
     expect(mocks.updateMessage).toHaveBeenLastCalledWith(
       2,
@@ -231,5 +249,185 @@ describe("durable turn runtime", () => {
         done: true
       })
     )
+  })
+
+  it("reattaches an observer with a persisted snapshot", async () => {
+    mocks.getTurnRun.mockResolvedValue({
+      ...submission,
+      status: "generating",
+      assistantMessageId: 2,
+      updatedAt: 12
+    } satisfies DurableTurnRun)
+    mocks.getMessage.mockResolvedValue({
+      id: 2,
+      role: "assistant",
+      content: "partial",
+      done: false
+    })
+    const port = { postMessage: vi.fn() } as any
+
+    await reconnectDurableTurn("turn-1", 3, {
+      port,
+      isPortClosed: () => false
+    })
+
+    expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "stream_snapshot",
+      requestId: "turn-1",
+      seq: -1,
+      sequenceReset: true,
+      status: "generating",
+      assistant: expect.objectContaining({ content: "partial" })
+    })
+  })
+
+  it("buffers live chunks until a coherent snapshot is sent", async () => {
+    const assistantRead = deferred<any>()
+    const generationStarted = deferred<void>()
+    const finishGeneration = deferred<void>()
+    mocks.getTurnRun.mockResolvedValue({
+      ...submission,
+      status: "generating",
+      assistantMessageId: 2,
+      updatedAt: 12
+    } satisfies DurableTurnRun)
+    mocks.getMessage.mockReturnValueOnce(assistantRead.promise)
+    mocks.handleChat.mockImplementationOnce(async (_message, port) => {
+      port.postMessage({ seq: 0, delta: "new" })
+      generationStarted.resolve()
+      await finishGeneration.promise
+      port.postMessage({ seq: 1, done: true })
+    })
+    const port = { postMessage: vi.fn() } as any
+
+    const reconnecting = reconnectDurableTurn("turn-1", 3, {
+      port,
+      isPortClosed: () => false
+    })
+    await vi.waitFor(() => expect(mocks.getMessage).toHaveBeenCalledOnce())
+
+    const generating = startDurableTurn(submission, 1, 2, {})
+    await generationStarted.promise
+    assistantRead.resolve({
+      id: 2,
+      role: "assistant",
+      content: "old",
+      done: false
+    })
+    await reconnecting
+
+    expect(port.postMessage.mock.calls[0][0]).toEqual({
+      version: 1,
+      type: "stream_snapshot",
+      requestId: "turn-1",
+      seq: 0,
+      sequenceReset: true,
+      status: "generating",
+      assistant: expect.objectContaining({ content: "new" })
+    })
+    expect(port.postMessage).toHaveBeenCalledTimes(1)
+
+    finishGeneration.resolve()
+    await generating
+    expect(port.postMessage.mock.calls[1][0]).toMatchObject({
+      type: "chat_chunk",
+      seq: 1,
+      done: true
+    })
+  })
+
+  it("retains the terminal snapshot until its persistence finishes", async () => {
+    const assistantRead = deferred<any>()
+    const deltaEmitted = deferred<void>()
+    const emitTerminal = deferred<void>()
+    const terminalEmitted = deferred<void>()
+    const terminalWrite = deferred<number>()
+    mocks.getTurnRun.mockResolvedValue({
+      ...submission,
+      status: "generating",
+      assistantMessageId: 2,
+      updatedAt: 12
+    } satisfies DurableTurnRun)
+    mocks.getMessage.mockReturnValueOnce(assistantRead.promise)
+    mocks.updateMessage.mockImplementation(async (_id, update) => {
+      if (update.content === "new" && update.done) {
+        return terminalWrite.promise
+      }
+      return 1
+    })
+    mocks.handleChat.mockImplementationOnce(async (_message, port) => {
+      port.postMessage({ seq: 0, delta: "new" })
+      deltaEmitted.resolve()
+      await emitTerminal.promise
+      port.postMessage({ seq: 1, done: true })
+      terminalEmitted.resolve()
+    })
+
+    const generating = startDurableTurn(submission, 1, 2, {})
+    await deltaEmitted.promise
+    const port = { postMessage: vi.fn() } as any
+    const reconnecting = reconnectDurableTurn("turn-1", 0, {
+      port,
+      isPortClosed: () => false
+    })
+    await vi.waitFor(() => expect(mocks.getMessage).toHaveBeenCalledOnce())
+
+    emitTerminal.resolve()
+    await terminalEmitted.promise
+    assistantRead.resolve({
+      id: 2,
+      role: "assistant",
+      content: "old",
+      done: false
+    })
+    await reconnecting
+
+    expect(port.postMessage).toHaveBeenCalledTimes(1)
+    expect(port.postMessage.mock.calls[0][0]).toEqual({
+      version: 1,
+      type: "stream_snapshot",
+      requestId: "turn-1",
+      seq: 1,
+      sequenceReset: false,
+      status: "generating",
+      assistant: expect.objectContaining({ content: "new", done: true })
+    })
+
+    terminalWrite.resolve(1)
+    await generating
+  })
+
+  it("detaches a closed observer before later chunks", async () => {
+    const releaseGeneration = deferred<void>()
+    mocks.handleChat.mockImplementationOnce(async (_message, port) => {
+      await releaseGeneration.promise
+      port.postMessage({ delta: "answer" })
+      port.postMessage({ done: true })
+    })
+    const disconnectListeners: Array<() => void> = []
+    const port = {
+      postMessage: vi.fn(),
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          disconnectListeners.push(listener)
+        }),
+        removeListener: vi.fn((listener: () => void) => {
+          const index = disconnectListeners.indexOf(listener)
+          if (index >= 0) disconnectListeners.splice(index, 1)
+        })
+      }
+    } as any
+
+    const generating = startDurableTurn(submission, 1, 2, {
+      port,
+      isPortClosed: () => false
+    })
+    await vi.waitFor(() => expect(mocks.handleChat).toHaveBeenCalledOnce())
+    disconnectListeners[0]?.()
+    releaseGeneration.resolve()
+    await generating
+
+    expect(port.postMessage).not.toHaveBeenCalled()
   })
 })

--- a/src/background/__tests__/durable-turn-runtime.test.ts
+++ b/src/background/__tests__/durable-turn-runtime.test.ts
@@ -324,7 +324,8 @@ describe("durable turn runtime", () => {
       seq: 0,
       sequenceReset: true,
       status: "generating",
-      assistant: expect.objectContaining({ content: "new" })
+      assistant: expect.objectContaining({ content: "new" }),
+      thinkingState: { inThinking: false, pending: "" }
     })
     expect(port.postMessage).toHaveBeenCalledTimes(1)
 
@@ -391,11 +392,55 @@ describe("durable turn runtime", () => {
       seq: 1,
       sequenceReset: false,
       status: "generating",
-      assistant: expect.objectContaining({ content: "new", done: true })
+      assistant: expect.objectContaining({ content: "new", done: true }),
+      thinkingState: { inThinking: false, pending: "" }
     })
 
     terminalWrite.resolve(1)
     await generating
+  })
+
+  it("keeps the terminal snapshot while a reconnect reads stale persistence", async () => {
+    const assistantRead = deferred<any>()
+    mocks.getTurnRun.mockResolvedValue({
+      ...submission,
+      status: "generating",
+      assistantMessageId: 2,
+      updatedAt: 12
+    } satisfies DurableTurnRun)
+    mocks.getMessage.mockReturnValueOnce(assistantRead.promise)
+    mocks.handleChat.mockImplementationOnce(async (_message, port) => {
+      port.postMessage({ seq: 0, delta: "new" })
+      port.postMessage({ seq: 1, done: true })
+    })
+    const port = { postMessage: vi.fn() } as any
+
+    const reconnecting = reconnectDurableTurn("turn-1", 0, {
+      port,
+      isPortClosed: () => false
+    })
+    await vi.waitFor(() => expect(mocks.getMessage).toHaveBeenCalledOnce())
+
+    await startDurableTurn(submission, 1, 2, {})
+    assistantRead.resolve({
+      id: 2,
+      role: "assistant",
+      content: "old",
+      done: false
+    })
+    await reconnecting
+
+    expect(port.postMessage).toHaveBeenCalledTimes(1)
+    expect(port.postMessage.mock.calls[0][0]).toEqual({
+      version: 1,
+      type: "stream_snapshot",
+      requestId: "turn-1",
+      seq: 1,
+      sequenceReset: false,
+      status: "generating",
+      assistant: expect.objectContaining({ content: "new", done: true }),
+      thinkingState: { inThinking: false, pending: "" }
+    })
   })
 
   it("detaches a closed observer before later chunks", async () => {

--- a/src/background/__tests__/index.test.ts
+++ b/src/background/__tests__/index.test.ts
@@ -258,7 +258,11 @@ describe("Background Script Entry Point", () => {
       // Get the message listener registered on the port
       const portMessageListener = port.onMessage.addListener.mock.calls[0][0]
 
-      const msg = { type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL }
+      const msg = {
+        version: 1,
+        type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
+        payload: { model: "llama2", messages: [] }
+      }
       portMessageListener(msg)
 
       expect(handleChatWithModel).toHaveBeenCalled()
@@ -278,9 +282,36 @@ describe("Background Script Entry Point", () => {
       const portMessageListener = port.onMessage.addListener.mock.calls[0][0]
       const disconnectListener = port.onDisconnect.addListener.mock.calls[0][0]
       portMessageListener({
+        version: 1,
         type: MESSAGE_KEYS.PROVIDER.START_TURN,
         payload: {
-          start: { submission: { id: "turn-1" } },
+          start: {
+            submission: {
+              id: "turn-1",
+              sessionId: "session-1",
+              mode: "new",
+              model: "llama2",
+              request: {
+                version: 1,
+                context: {
+                  rawInput: "hello",
+                  messages: [],
+                  hasTabContext: false,
+                  contextText: "",
+                  tabDocuments: [],
+                  memoryEnabled: false,
+                  maxTabContextChars: 1,
+                  maxRagContextChars: 1,
+                  groundedOnlyMode: false,
+                  selectedModel: "llama2",
+                  selectedModelRef: null
+                },
+                userMessage: { role: "user", content: "hello" }
+              },
+              createdAt: 1
+            },
+            userMessageId: 1
+          },
           assistantMessageId: 2
         }
       })
@@ -307,7 +338,11 @@ describe("Background Script Entry Point", () => {
       const calls = port.onMessage.addListener.mock.calls
       const portMessageListener = calls[calls.length - 1][0]
 
-      const msg = { name: "llama2" }
+      const msg = {
+        version: 1,
+        type: "model_pull_start",
+        payload: { model: "llama2" }
+      }
       portMessageListener(msg)
 
       expect(handleModelPull).toHaveBeenCalled()

--- a/src/background/durable-turn-runtime.ts
+++ b/src/background/durable-turn-runtime.ts
@@ -3,7 +3,6 @@ import { ContextService } from "@/application/context/context-service"
 import {
   makeStreamReducerState,
   reduceStreamEvent,
-  type StreamMessage,
   type StreamReducerState,
   type StreamTerminal
 } from "@/application/turns/chat-stream-reducer"
@@ -19,24 +18,29 @@ import {
 } from "@/application/turns/turn-service"
 import { resolveRetrievalToolsActive } from "@/background/handlers/handle-build-context"
 import { handleChatWithModel } from "@/background/handlers/handle-chat-with-model"
-import { safePostMessage } from "@/background/lib/utils"
+import { safePostChatStreamEvent } from "@/background/lib/utils"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import {
   appendMessage,
+  getMessage,
   getSession,
   updateMessage
 } from "@/lib/repositories/chat-history"
 import {
   createTurnRun,
   getIncompleteTurnRuns,
+  getTurnRun,
   updateTurnRun
 } from "@/lib/repositories/turn-runs"
+import {
+  type ChatStreamServerEvent,
+  parseChatStreamServerEvent
+} from "@/protocol/streams"
 import type {
   ActivityEvent,
   ChatMessage,
   ChatWithModelMessage,
-  ChromeMessage,
   ChromePort,
   PortStatusFunction
 } from "@/types"
@@ -46,9 +50,86 @@ interface TurnOutput {
   isPortClosed?: PortStatusFunction
 }
 
-const forward = (output: TurnOutput, message: Record<string, unknown>) => {
-  if (!output.port || output.isPortClosed?.()) return
-  safePostMessage(output.port, message as unknown as ChromeMessage)
+interface TurnObserver extends TurnOutput {
+  ready: boolean
+  pending: ChatStreamServerEvent[]
+  detach?: () => void
+}
+
+interface TurnRuntimeSnapshot {
+  assistant: ChatMessage
+  seq: number
+}
+
+const turnObservers = new Map<string, Set<TurnObserver>>()
+const turnRuntimeSnapshots = new Map<string, TurnRuntimeSnapshot>()
+
+const removeObserver = (turnId: string, observer: TurnObserver): void => {
+  const observers = turnObservers.get(turnId)
+  observers?.delete(observer)
+  if (observers?.size === 0) turnObservers.delete(turnId)
+  if (observer.detach && observer.port?.onDisconnect) {
+    observer.port.onDisconnect.removeListener(observer.detach)
+  }
+}
+
+export const attachDurableTurnObserver = (
+  turnId: string,
+  output: TurnOutput,
+  ready = true
+): TurnObserver | null => {
+  if (!output.port) return null
+  const observer: TurnObserver = { ...output, ready, pending: [] }
+  const observers = turnObservers.get(turnId) ?? new Set<TurnObserver>()
+  observers.add(observer)
+  turnObservers.set(turnId, observers)
+  if (output.port.onDisconnect) {
+    observer.detach = () => removeObserver(turnId, observer)
+    output.port.onDisconnect.addListener(observer.detach)
+  }
+  return observer
+}
+
+const isTerminalEvent = (message: ChatStreamServerEvent): boolean =>
+  message.type === "chat_chunk" &&
+  Boolean(message.done || message.error || message.aborted)
+
+const cleanupTurnObservers = (turnId: string): void => {
+  const observers = turnObservers.get(turnId)
+  if (observers) {
+    for (const observer of observers) {
+      if (observer.detach && observer.port?.onDisconnect) {
+        observer.port.onDisconnect.removeListener(observer.detach)
+      }
+    }
+  }
+  turnObservers.delete(turnId)
+}
+
+const cleanupTurnRuntimeState = (turnId: string): void => {
+  cleanupTurnObservers(turnId)
+  turnRuntimeSnapshots.delete(turnId)
+}
+
+const forwardTurn = (turnId: string, message: ChatStreamServerEvent): void => {
+  const observers = turnObservers.get(turnId)
+  if (observers) {
+    for (const observer of observers) {
+      if (!observer.port || observer.isPortClosed?.()) {
+        removeObserver(turnId, observer)
+        continue
+      }
+      if (!observer.ready) {
+        observer.pending.push(message)
+        continue
+      }
+      safePostChatStreamEvent(observer.port, message)
+    }
+    if (observers.size === 0) turnObservers.delete(turnId)
+  }
+  // Ports can detach as soon as the terminal event is queued, but the
+  // authoritative in-memory snapshot must survive until persistence settles.
+  if (isTerminalEvent(message)) cleanupTurnObservers(turnId)
 }
 
 const persistAssistant = (
@@ -64,7 +145,7 @@ const persistAssistant = (
     error: assistant.error
   })
 
-const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
+const makeGenerationOwner = (): TurnGenerationOwner => ({
   start: async ({
     submission,
     context,
@@ -108,7 +189,17 @@ const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
         done: true
       }
       await persistAssistant(resolvedAssistantId, message)
-      forward(output, { delta: message.content, done: true })
+      turnRuntimeSnapshots.set(submission.id, {
+        assistant: message,
+        seq: 0
+      })
+      forwardTurn(submission.id, {
+        version: 1,
+        type: "chat_chunk",
+        seq: 0,
+        delta: message.content,
+        done: true
+      })
       return {
         outcome: "completed",
         userMessageId,
@@ -133,9 +224,23 @@ const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
     let persistence = Promise.resolve()
 
     const receive = (raw: unknown) => {
-      const message = raw as StreamMessage
+      const parsed = parseChatStreamServerEvent(raw)
+      if (
+        !parsed.success ||
+        (parsed.data.type !== "chat_chunk" &&
+          parsed.data.type !== "rag_sources")
+      ) {
+        return
+      }
+      const message = parsed.data
       const reduction = reduceStreamEvent(state, message)
       state = reduction.state
+      if (!reduction.dropped) {
+        turnRuntimeSnapshots.set(submission.id, {
+          assistant: state.assistant,
+          seq: state.lastSeq
+        })
+      }
       if (!reduction.dropped && (reduction.changed || reduction.terminal)) {
         const durableAssistant =
           reduction.terminal?.type === "error"
@@ -154,8 +259,10 @@ const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
         })
       }
       if (reduction.terminal) completion.terminal = reduction.terminal
-      if (message.aborted) completion.aborted = true
-      forward(output, message as unknown as Record<string, unknown>)
+      if (message.type === "chat_chunk" && message.aborted) {
+        completion.aborted = true
+      }
+      forwardTurn(submission.id, message)
     }
 
     const sink = {
@@ -164,6 +271,7 @@ const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
       postMessage: receive
     } as unknown as ChromePort
     const chatMessage: ChatWithModelMessage = {
+      version: 1,
       type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
       payload: {
         model: submission.model,
@@ -196,25 +304,27 @@ const makeGenerationOwner = (output: TurnOutput): TurnGenerationOwner => ({
   }
 })
 
-const createService = (output: TurnOutput): TurnService =>
+const createService = (): TurnService =>
   new TurnService(
     { create: createTurnRun, update: updateTurnRun },
     new ContextService(),
-    makeGenerationOwner(output)
+    makeGenerationOwner()
   )
 
-const withLiveCallbacks = (submission: TurnSubmission, output: TurnOutput) => {
+const withLiveCallbacks = (submission: TurnSubmission) => {
   const context = submission.request.context
   return {
     ...context,
     onActivityEvent: (events: ActivityEvent[]) =>
-      forward(output, {
+      forwardTurn(submission.id, {
+        version: 1,
         type: "context_progress",
         requestId: submission.id,
         events
       }),
     toast: (warning: TurnToast) =>
-      forward(output, {
+      forwardTurn(submission.id, {
+        version: 1,
         type: "context_warning",
         requestId: submission.id,
         payload: warning
@@ -245,9 +355,10 @@ export const startDurableTurn = async (
   assistantMessageId: number,
   output: TurnOutput
 ): Promise<void> => {
-  const contextOptions = withLiveCallbacks(submission, output)
+  attachDurableTurnObserver(submission.id, output)
+  const contextOptions = withLiveCallbacks(submission)
   try {
-    await createService(output).start({
+    await createService().start({
       id: submission.id,
       sessionId: submission.sessionId,
       mode: submission.mode,
@@ -273,12 +384,106 @@ export const startDurableTurn = async (
       }
     }).catch(() => undefined)
     throw error
+  } finally {
+    cleanupTurnRuntimeState(submission.id)
+  }
+}
+
+export const reconnectDurableTurn = async (
+  turnId: string,
+  afterSeq: number,
+  output: TurnOutput
+): Promise<void> => {
+  if (!output.port || output.isPortClosed?.()) return
+  // Buffer first, but do not expose live chunks until the snapshot has been
+  // sent. This closes the async persistence-read race without missing events.
+  const observer = attachDurableTurnObserver(turnId, output, false)
+  if (!observer) return
+  const turn = await getTurnRun(turnId).catch((error) => {
+    removeObserver(turnId, observer)
+    throw error
+  })
+  if (!turn) {
+    safePostChatStreamEvent(output.port, {
+      version: 1,
+      type: "stream_snapshot",
+      requestId: turnId,
+      seq: -1,
+      sequenceReset: true,
+      status: "failed",
+      failure: {
+        status: 404,
+        message: "Durable turn not found",
+        kind: "storage"
+      }
+    })
+    cleanupTurnRuntimeState(turnId)
+    return
+  }
+
+  const persistedAssistant =
+    turn.assistantMessageId === undefined
+      ? null
+      : await getMessage(turn.assistantMessageId).catch((error) => {
+          removeObserver(turnId, observer)
+          throw error
+        })
+  if (!output.port || output.isPortClosed?.()) {
+    removeObserver(turnId, observer)
+    return
+  }
+  const runtimeSnapshot = turnRuntimeSnapshots.get(turnId)
+  const assistant = runtimeSnapshot?.assistant ?? persistedAssistant
+  const seq = runtimeSnapshot?.seq ?? -1
+  // A lower producer cursor means the worker restarted and began a fresh
+  // sequence epoch. The snapshot remains authoritative for accumulated text.
+  const sequenceReset = runtimeSnapshot === undefined || seq < afterSeq
+  safePostChatStreamEvent(output.port, {
+    version: 1,
+    type: "stream_snapshot",
+    requestId: turnId,
+    seq,
+    sequenceReset,
+    status: turn.status,
+    ...(assistant ? { assistant } : {}),
+    ...(turn.failure
+      ? {
+          failure: turn.failure
+        }
+      : {})
+  })
+  observer.ready = true
+  const buffered = observer.pending.splice(0)
+  for (const message of buffered) {
+    if (
+      message.type === "chat_chunk" &&
+      message.seq !== undefined &&
+      message.seq <= seq
+    ) {
+      continue
+    }
+    safePostChatStreamEvent(output.port, message)
+  }
+  if (
+    assistant?.done ||
+    turn.status === "completed" ||
+    turn.status === "failed" ||
+    turn.status === "cancelled" ||
+    buffered.some(isTerminalEvent)
+  ) {
+    cleanupTurnObservers(turnId)
   }
 }
 
 const resumeTurn = async (turn: DurableTurnRun): Promise<void> => {
-  const service = createService({})
-  await service.resume(turn, (options) => withRetrievalToolState(turn, options))
+  try {
+    const service = createService()
+    await service.resume(turn, (options) =>
+      withRetrievalToolState(turn, options)
+    )
+  } finally {
+    cleanupTurnRuntimeState(turn.id)
+  }
 }
 
 export const resumeIncompleteTurnRuns = async (): Promise<void> => {

--- a/src/background/durable-turn-runtime.ts
+++ b/src/background/durable-turn-runtime.ts
@@ -33,6 +33,7 @@ import {
   getTurnRun,
   updateTurnRun
 } from "@/lib/repositories/turn-runs"
+import type { ThinkingParserState } from "@/lib/thinking-parser"
 import {
   type ChatStreamServerEvent,
   parseChatStreamServerEvent
@@ -58,11 +59,14 @@ interface TurnObserver extends TurnOutput {
 
 interface TurnRuntimeSnapshot {
   assistant: ChatMessage
+  thinkingState: ThinkingParserState
   seq: number
 }
 
 const turnObservers = new Map<string, Set<TurnObserver>>()
 const turnRuntimeSnapshots = new Map<string, TurnRuntimeSnapshot>()
+const turnReconnectLeases = new Map<string, number>()
+const pendingRuntimeCleanup = new Set<string>()
 
 const removeObserver = (turnId: string, observer: TurnObserver): void => {
   const observers = turnObservers.get(turnId)
@@ -108,7 +112,26 @@ const cleanupTurnObservers = (turnId: string): void => {
 
 const cleanupTurnRuntimeState = (turnId: string): void => {
   cleanupTurnObservers(turnId)
+  if ((turnReconnectLeases.get(turnId) ?? 0) > 0) {
+    pendingRuntimeCleanup.add(turnId)
+    return
+  }
   turnRuntimeSnapshots.delete(turnId)
+}
+
+const retainTurnRuntimeSnapshot = (turnId: string): (() => void) => {
+  turnReconnectLeases.set(turnId, (turnReconnectLeases.get(turnId) ?? 0) + 1)
+  return () => {
+    const remaining = (turnReconnectLeases.get(turnId) ?? 1) - 1
+    if (remaining > 0) {
+      turnReconnectLeases.set(turnId, remaining)
+      return
+    }
+    turnReconnectLeases.delete(turnId)
+    if (pendingRuntimeCleanup.delete(turnId)) {
+      turnRuntimeSnapshots.delete(turnId)
+    }
+  }
 }
 
 const forwardTurn = (turnId: string, message: ChatStreamServerEvent): void => {
@@ -191,6 +214,7 @@ const makeGenerationOwner = (): TurnGenerationOwner => ({
       await persistAssistant(resolvedAssistantId, message)
       turnRuntimeSnapshots.set(submission.id, {
         assistant: message,
+        thinkingState: makeStreamReducerState(message).thinkingState,
         seq: 0
       })
       forwardTurn(submission.id, {
@@ -238,6 +262,7 @@ const makeGenerationOwner = (): TurnGenerationOwner => ({
       if (!reduction.dropped) {
         turnRuntimeSnapshots.set(submission.id, {
           assistant: state.assistant,
+          thinkingState: state.thinkingState,
           seq: state.lastSeq
         })
       }
@@ -395,83 +420,91 @@ export const reconnectDurableTurn = async (
   output: TurnOutput
 ): Promise<void> => {
   if (!output.port || output.isPortClosed?.()) return
-  // Buffer first, but do not expose live chunks until the snapshot has been
-  // sent. This closes the async persistence-read race without missing events.
-  const observer = attachDurableTurnObserver(turnId, output, false)
-  if (!observer) return
-  const turn = await getTurnRun(turnId).catch((error) => {
-    removeObserver(turnId, observer)
-    throw error
-  })
-  if (!turn) {
+  const releaseSnapshot = retainTurnRuntimeSnapshot(turnId)
+  try {
+    // Buffer first, but do not expose live chunks until the snapshot has been
+    // sent. This closes the async persistence-read race without missing events.
+    const observer = attachDurableTurnObserver(turnId, output, false)
+    if (!observer) return
+    const turn = await getTurnRun(turnId).catch((error) => {
+      removeObserver(turnId, observer)
+      throw error
+    })
+    if (!turn) {
+      safePostChatStreamEvent(output.port, {
+        version: 1,
+        type: "stream_snapshot",
+        requestId: turnId,
+        seq: -1,
+        sequenceReset: true,
+        status: "failed",
+        failure: {
+          status: 404,
+          message: "Durable turn not found",
+          kind: "storage"
+        }
+      })
+      cleanupTurnRuntimeState(turnId)
+      return
+    }
+
+    const persistedAssistant =
+      turn.assistantMessageId === undefined
+        ? null
+        : await getMessage(turn.assistantMessageId).catch((error) => {
+            removeObserver(turnId, observer)
+            throw error
+          })
+    if (!output.port || output.isPortClosed?.()) {
+      removeObserver(turnId, observer)
+      return
+    }
+    const runtimeSnapshot = turnRuntimeSnapshots.get(turnId)
+    const assistant = runtimeSnapshot?.assistant ?? persistedAssistant
+    const seq = runtimeSnapshot?.seq ?? -1
+    // A lower producer cursor means the worker restarted and began a fresh
+    // sequence epoch. The snapshot remains authoritative for accumulated text.
+    const sequenceReset = runtimeSnapshot === undefined || seq < afterSeq
     safePostChatStreamEvent(output.port, {
       version: 1,
       type: "stream_snapshot",
       requestId: turnId,
-      seq: -1,
-      sequenceReset: true,
-      status: "failed",
-      failure: {
-        status: 404,
-        message: "Durable turn not found",
-        kind: "storage"
-      }
+      seq,
+      sequenceReset,
+      status: turn.status,
+      ...(assistant ? { assistant } : {}),
+      ...(runtimeSnapshot
+        ? { thinkingState: runtimeSnapshot.thinkingState }
+        : {}),
+      ...(turn.failure
+        ? {
+            failure: turn.failure
+          }
+        : {})
     })
-    cleanupTurnRuntimeState(turnId)
-    return
-  }
-
-  const persistedAssistant =
-    turn.assistantMessageId === undefined
-      ? null
-      : await getMessage(turn.assistantMessageId).catch((error) => {
-          removeObserver(turnId, observer)
-          throw error
-        })
-  if (!output.port || output.isPortClosed?.()) {
-    removeObserver(turnId, observer)
-    return
-  }
-  const runtimeSnapshot = turnRuntimeSnapshots.get(turnId)
-  const assistant = runtimeSnapshot?.assistant ?? persistedAssistant
-  const seq = runtimeSnapshot?.seq ?? -1
-  // A lower producer cursor means the worker restarted and began a fresh
-  // sequence epoch. The snapshot remains authoritative for accumulated text.
-  const sequenceReset = runtimeSnapshot === undefined || seq < afterSeq
-  safePostChatStreamEvent(output.port, {
-    version: 1,
-    type: "stream_snapshot",
-    requestId: turnId,
-    seq,
-    sequenceReset,
-    status: turn.status,
-    ...(assistant ? { assistant } : {}),
-    ...(turn.failure
-      ? {
-          failure: turn.failure
-        }
-      : {})
-  })
-  observer.ready = true
-  const buffered = observer.pending.splice(0)
-  for (const message of buffered) {
-    if (
-      message.type === "chat_chunk" &&
-      message.seq !== undefined &&
-      message.seq <= seq
-    ) {
-      continue
+    observer.ready = true
+    const buffered = observer.pending.splice(0)
+    for (const message of buffered) {
+      if (
+        message.type === "chat_chunk" &&
+        message.seq !== undefined &&
+        message.seq <= seq
+      ) {
+        continue
+      }
+      safePostChatStreamEvent(output.port, message)
     }
-    safePostChatStreamEvent(output.port, message)
-  }
-  if (
-    assistant?.done ||
-    turn.status === "completed" ||
-    turn.status === "failed" ||
-    turn.status === "cancelled" ||
-    buffered.some(isTerminalEvent)
-  ) {
-    cleanupTurnObservers(turnId)
+    if (
+      assistant?.done ||
+      turn.status === "completed" ||
+      turn.status === "failed" ||
+      turn.status === "cancelled" ||
+      buffered.some(isTerminalEvent)
+    ) {
+      cleanupTurnObservers(turnId)
+    }
+  } finally {
+    releaseSnapshot()
   }
 }
 

--- a/src/background/handlers/__tests__/handle-build-context.test.ts
+++ b/src/background/handlers/__tests__/handle-build-context.test.ts
@@ -148,7 +148,7 @@ describe("handleBuildContext", () => {
       expect.objectContaining({
         type: "context_error",
         requestId: "req-1",
-        error: "boom"
+        failure: expect.objectContaining({ message: "boom" })
       })
     )
     expect(posts.some((p) => p.type === "context_result")).toBe(false)

--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -111,6 +111,9 @@ describe("handleChatWithModel", () => {
 
       expect(mockStreamChat).not.toHaveBeenCalled()
       expect(mockPort.postMessage).toHaveBeenCalledWith({
+        version: 1,
+        type: "chat_chunk",
+        seq: 0,
         error: expect.objectContaining({
           status: 409,
           kind: "validation",
@@ -574,6 +577,9 @@ describe("handleChatWithModel", () => {
       await handleChatWithModel(message, mockPort, mockIsPortClosed)
 
       expect(mockPort.postMessage).toHaveBeenCalledWith({
+        version: 1,
+        type: "chat_chunk",
+        seq: 0,
         error: expect.objectContaining({
           status: 500,
           kind: "provider",

--- a/src/background/handlers/__tests__/handle-model-pull.test.ts
+++ b/src/background/handlers/__tests__/handle-model-pull.test.ts
@@ -4,7 +4,7 @@ import {
   abortAndClearController,
   setAbortController
 } from "@/background/lib/abort-controller-registry"
-import { safePostMessage } from "@/background/lib/utils"
+import { safePostModelPullEvent } from "@/background/lib/utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
 import type { ModelPullMessage } from "@/types"
@@ -29,7 +29,7 @@ vi.mock("@/background/lib/abort-controller-registry", () => ({
 vi.mock("@/background/lib/utils", () => ({
   getBaseUrl: vi.fn().mockResolvedValue("http://localhost:11434"),
   getPullAbortControllerKey: vi.fn().mockReturnValue("key"),
-  safePostMessage: vi.fn()
+  safePostModelPullEvent: vi.fn()
 }))
 vi.mock("@/lib/providers/factory", () => ({
   ProviderFactory: {
@@ -127,8 +127,10 @@ describe("Handle Model Pull", () => {
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
-    expect(safePostMessage).toHaveBeenCalledWith(mockPort, {
-      error: { status: 404, message: "Not Found" }
+    expect(safePostModelPullEvent).toHaveBeenCalledWith(mockPort, {
+      version: 1,
+      type: "model_pull_error",
+      failure: { status: 404, message: "Not Found" }
     })
     expect(handlePullStream).not.toHaveBeenCalled()
   })
@@ -140,8 +142,10 @@ describe("Handle Model Pull", () => {
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
-    expect(safePostMessage).toHaveBeenCalledWith(mockPort, {
-      error: "No response body received"
+    expect(safePostModelPullEvent).toHaveBeenCalledWith(mockPort, {
+      version: 1,
+      type: "model_pull_error",
+      failure: { status: 0, message: "No response body received" }
     })
   })
 
@@ -152,8 +156,10 @@ describe("Handle Model Pull", () => {
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
-    expect(safePostMessage).toHaveBeenCalledWith(mockPort, {
-      error: { status: 0, message: "Network Error" }
+    expect(safePostModelPullEvent).toHaveBeenCalledWith(mockPort, {
+      version: 1,
+      type: "model_pull_error",
+      failure: { status: 0, message: "Network Error" }
     })
   })
 
@@ -166,8 +172,10 @@ describe("Handle Model Pull", () => {
 
     await handleModelPull(msg, mockPort, isPortClosed)
 
-    expect(safePostMessage).toHaveBeenCalledWith(mockPort, {
-      error: "Download cancelled"
+    expect(safePostModelPullEvent).toHaveBeenCalledWith(mockPort, {
+      version: 1,
+      type: "model_pull_error",
+      failure: { status: 499, message: "Download cancelled" }
     })
   })
 })

--- a/src/background/handlers/__tests__/handle-pull-stream.test.ts
+++ b/src/background/handlers/__tests__/handle-pull-stream.test.ts
@@ -9,9 +9,8 @@ vi.mock("@/background/lib/abort-controller-registry", () => ({
 
 vi.mock("@/background/lib/utils", () => ({
   getPullAbortControllerKey: vi.fn().mockReturnValue("key"),
-  // safePostMessage is NOT mocked, so it uses the real implementation which calls port.postMessage
-  safePostMessage: vi.fn().mockImplementation(async (port, message) => {
-    console.log("safePostMessage called with:", message)
+  safePostModelPullEvent: vi.fn().mockImplementation(async (port, message) => {
+    console.log("safePostModelPullEvent called with:", message)
     try {
       port.postMessage(message)
     } catch (e) {
@@ -82,13 +81,21 @@ describe("Handle Pull Stream", () => {
     await handlePullStream(res, mockPort, isPortClosed, "llama2")
 
     expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_progress",
       status: "pulling manifest"
     })
     expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_progress",
       status: "Downloading: 10%",
       progress: 10
     })
-    expect(mockPort.postMessage).toHaveBeenCalledWith({ done: true })
+    expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_complete",
+      status: "success"
+    })
     expect(clearAbortController).toHaveBeenCalled()
   })
 
@@ -98,7 +105,11 @@ describe("Handle Pull Stream", () => {
 
     await handlePullStream(res, mockPort, isPortClosed, "llama2")
 
-    expect(mockPort.postMessage).toHaveBeenCalledWith({ error: "Pull failed" })
+    expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_error",
+      failure: { status: 0, message: "Pull failed" }
+    })
     expect(clearAbortController).toHaveBeenCalled()
   })
 
@@ -138,7 +149,11 @@ describe("Handle Pull Stream", () => {
 
     await handlePullStream(res, mockPort, isPortClosed, "llama2")
 
-    expect(mockPort.postMessage).toHaveBeenCalledWith({ done: true })
+    expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_complete",
+      status: "success"
+    })
   })
 
   it("should ignore empty lines", async () => {
@@ -149,7 +164,11 @@ describe("Handle Pull Stream", () => {
 
     await handlePullStream(res, mockPort, isPortClosed, "llama2")
 
-    expect(mockPort.postMessage).toHaveBeenCalledWith({ done: true })
+    expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_complete",
+      status: "success"
+    })
   })
 
   it("should handle invalid JSON gracefully", async () => {
@@ -162,6 +181,10 @@ describe("Handle Pull Stream", () => {
     await handlePullStream(res, mockPort, isPortClosed, "llama2")
 
     expect(consoleSpy).toHaveBeenCalled()
-    expect(mockPort.postMessage).toHaveBeenCalledWith({ done: true })
+    expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_complete",
+      status: "success"
+    })
   })
 })

--- a/src/background/handlers/__tests__/handle-selection-action.test.ts
+++ b/src/background/handlers/__tests__/handle-selection-action.test.ts
@@ -99,10 +99,12 @@ describe("handleSelectionAction", () => {
       expect.any(AbortSignal)
     )
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK,
       payload: { delta: "Clean text", thinkingDelta: "" }
     })
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE
     })
   })
@@ -161,8 +163,9 @@ describe("handleSelectionAction", () => {
     await handleSelectionAction(message, port, createMockIsPortClosed(false))
 
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: {
+      failure: {
         status: 400,
         message: "Select a model before running Selection Actions"
       }
@@ -184,8 +187,9 @@ describe("handleSelectionAction", () => {
 
     expect(mockStreamChat).not.toHaveBeenCalled()
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: expect.objectContaining({
+      failure: expect.objectContaining({
         status: 409,
         kind: "validation",
         message:

--- a/src/background/handlers/handle-build-context.ts
+++ b/src/background/handlers/handle-build-context.ts
@@ -1,13 +1,14 @@
 import { ContextService } from "@/application/context/context-service"
 import { resolveModelTools } from "@/background/lib/resolve-model-tools"
 import { hasRetrievalTool } from "@/background/lib/retrieval-tools"
-import { safePostMessage } from "@/background/lib/utils"
+import { safePostChatStreamEvent } from "@/background/lib/utils"
 import { logger } from "@/lib/logger"
 import { ProviderFactory } from "@/lib/providers/factory"
+import { toAppFailure } from "@/protocol/app-failure"
+import type { ChatStreamServerEvent } from "@/protocol/streams"
 import type {
   ActivityEvent,
   BuildContextMessage,
-  ChromeMessage,
   ChromePort,
   PortStatusFunction
 } from "@/types"
@@ -59,9 +60,9 @@ export const handleBuildContext = async (
   isPortClosed: PortStatusFunction
 ): Promise<void> => {
   const p = msg.payload
-  const post = (message: Record<string, unknown>): void => {
+  const post = (message: ChatStreamServerEvent): void => {
     if (isPortClosed()) return
-    safePostMessage(port, message as unknown as ChromeMessage)
+    safePostChatStreamEvent(port, message)
   }
 
   try {
@@ -95,12 +96,14 @@ export const handleBuildContext = async (
         customModel: p.customModel,
         onActivityEvent: (events: ActivityEvent[]) =>
           post({
+            version: 1,
             type: "context_progress",
             requestId: p.requestId,
             events
           }),
         toast: (warning) =>
           post({
+            version: 1,
             type: "context_warning",
             requestId: p.requestId,
             payload: warning
@@ -109,6 +112,7 @@ export const handleBuildContext = async (
     })
 
     post({
+      version: 1,
       type: "context_result",
       requestId: p.requestId,
       result: output.result,
@@ -117,9 +121,13 @@ export const handleBuildContext = async (
   } catch (error) {
     logger.error("Failed to build context", "handleBuildContext", { error })
     post({
+      version: 1,
       type: "context_error",
       requestId: p.requestId,
-      error: error instanceof Error ? error.message : "Context build failed"
+      failure: toAppFailure(error, {
+        fallbackMessage: "Context build failed",
+        context: "context-build"
+      })
     })
   }
 }

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -8,7 +8,7 @@ import { resolveModelTools } from "@/background/lib/resolve-model-tools"
 import { hasRetrievalTool } from "@/background/lib/retrieval-tools"
 import { streamChatWithNonNativeTools } from "@/background/lib/stream-chat-with-non-native-tools"
 import { streamChatWithTools } from "@/background/lib/stream-chat-with-tools"
-import { safePostMessage } from "@/background/lib/utils"
+import { safePostChatStreamEvent } from "@/background/lib/utils"
 import {
   DEFAULT_MAX_RAG_CONTEXT_CHARS,
   DEFAULT_MEMORY_ENABLED,
@@ -194,7 +194,8 @@ export const handleChatWithModel = withErrorContext(
           )
 
           try {
-            port.postMessage({
+            safePostChatStreamEvent(port, {
+              version: 1,
               type: "rag_sources",
               payload: { sources, query: lastUserMessage.content }
             })
@@ -261,7 +262,7 @@ export const handleChatWithModel = withErrorContext(
     // reducer can drop duplicates/out-of-order and resume from the last applied
     // sequence. Resets to 0 on a fresh SW instance (including after a restart),
     // so the UI resets its counter when it reconnects.
-    let nextSeq = 0
+    port.streamSequence = 0
     const onChunk = (chunk: ChatStreamMessage) => {
       if (isPortClosed()) return
 
@@ -279,7 +280,14 @@ export const handleChatWithModel = withErrorContext(
           error: chunk.error
         })
       }
-      safePostMessage(port, { ...chunk, seq: nextSeq++ })
+      const seq = port.streamSequence ?? 0
+      port.streamSequence = seq + 1
+      safePostChatStreamEvent(port, {
+        version: 1,
+        type: "chat_chunk",
+        ...chunk,
+        seq
+      })
     }
 
     try {

--- a/src/background/handlers/handle-model-pull.ts
+++ b/src/background/handlers/handle-model-pull.ts
@@ -11,12 +11,13 @@ import {
 } from "@/background/lib/fetch-timeout"
 import {
   getPullAbortControllerKey,
-  safePostMessage
+  safePostModelPullEvent
 } from "@/background/lib/utils"
 import { isAbortError } from "@/lib/error-utils"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
+import { toAppFailure } from "@/protocol/app-failure"
 import type {
   ChromePort,
   DefaultProviderPullRequest,
@@ -44,8 +45,10 @@ export const handleModelPull = async (
     providerId
   )
   if (!provider.capabilities.modelPull) {
-    safePostMessage(port, {
-      error: {
+    safePostModelPullEvent(port, {
+      version: 1,
+      type: "model_pull_error",
+      failure: {
         status: 400,
         message: "Model download is not supported by this provider"
       }
@@ -81,22 +84,29 @@ export const handleModelPull = async (
     connectTimeout.clear()
 
     if (!res.ok) {
-      safePostMessage(port, {
-        error: { status: res.status, message: res.statusText }
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_error",
+        failure: { status: res.status, message: res.statusText }
       })
       return
     }
 
     if (isLmStudio) {
-      safePostMessage(port, {
-        status: "Download requested",
-        done: true
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_complete",
+        status: "Download requested"
       })
       return
     }
 
     if (!res.body) {
-      safePostMessage(port, { error: "No response body received" })
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_error",
+        failure: toAppFailure("No response body received")
+      })
       return
     }
 
@@ -104,8 +114,10 @@ export const handleModelPull = async (
   } catch (err) {
     connectTimeout.clear()
     if (connectTimeout.timedOut()) {
-      safePostMessage(port, {
-        error: {
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_error",
+        failure: {
           status: 408,
           message: `Connection timed out after ${
             PULL_CONNECT_TIMEOUT_MS / 1000
@@ -113,10 +125,18 @@ export const handleModelPull = async (
         }
       })
     } else if (isAbortError(err)) {
-      safePostMessage(port, { error: "Download cancelled" })
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_error",
+        failure: toAppFailure("Download cancelled", { status: 499 })
+      })
     } else {
-      safePostMessage(port, {
-        error: normalizeError(err, { fallbackMessage: "Failed to pull model" })
+      safePostModelPullEvent(port, {
+        version: 1,
+        type: "model_pull_error",
+        failure: normalizeError(err, {
+          fallbackMessage: "Failed to pull model"
+        })
       })
     }
     clearAbortController(controllerKey)

--- a/src/background/handlers/handle-pull-stream.ts
+++ b/src/background/handlers/handle-pull-stream.ts
@@ -1,9 +1,10 @@
 import { clearAbortController } from "@/background/lib/abort-controller-registry"
 import {
   getPullAbortControllerKey,
-  safePostMessage
+  safePostModelPullEvent
 } from "@/background/lib/utils"
 import { logger } from "@/lib/logger"
+import { toAppFailure } from "@/protocol/app-failure"
 import type {
   ChromePort,
   DefaultProviderPullResponse,
@@ -50,26 +51,40 @@ export const handlePullStream = async (
           const data: DefaultProviderPullResponse = JSON.parse(trimmedLine)
 
           if (data.status) {
-            safePostMessage(port, { status: data.status })
+            safePostModelPullEvent(port, {
+              version: 1,
+              type: "model_pull_progress",
+              status: data.status
+            })
 
             if (data.status === "success") {
-              safePostMessage(port, { done: true })
+              safePostModelPullEvent(port, {
+                version: 1,
+                type: "model_pull_complete",
+                status: data.status
+              })
               clearAbortController(controllerKey)
               return
             }
           }
 
           if (data.error) {
-            safePostMessage(port, { error: data.error })
+            safePostModelPullEvent(port, {
+              version: 1,
+              type: "model_pull_error",
+              failure: toAppFailure(data.error)
+            })
             clearAbortController(controllerKey)
             return
           }
 
           if (data.completed !== undefined && data.total !== undefined) {
             const progress = Math.round((data.completed / data.total) * 100)
-            safePostMessage(port, {
+            safePostModelPullEvent(port, {
+              version: 1,
+              type: "model_pull_progress",
               status: `Downloading: ${progress}%`,
-              progress: progress
+              progress
             })
           }
         } catch (parseError) {
@@ -85,7 +100,11 @@ export const handlePullStream = async (
       try {
         const data: DefaultProviderPullResponse = JSON.parse(buffer.trim())
         if (data.status === "success") {
-          safePostMessage(port, { done: true })
+          safePostModelPullEvent(port, {
+            version: 1,
+            type: "model_pull_complete",
+            status: data.status
+          })
         }
       } catch (parseError) {
         logger.warn("Failed to parse final buffer", "handlePullStream", {

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -2,7 +2,7 @@ import { buildSelectionActionPrompt } from "@/application/selection-actions/prom
 import type { SelectionActionMessage } from "@/application/selection-actions/types"
 import { setAbortController } from "@/background/lib/abort-controller-registry"
 import { normalizeError } from "@/background/lib/error-handler"
-import { safePostMessage } from "@/background/lib/utils"
+import { safePostChatStreamEvent } from "@/background/lib/utils"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import { resolveModelConfig } from "@/lib/model-config-utils"
@@ -32,9 +32,10 @@ export const handleSelectionAction = async (
     (isSelectedModelRef(selectedRef) ? selectedRef.providerId : undefined)
 
   if (!model) {
-    safePostMessage(port, {
+    safePostChatStreamEvent(port, {
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: {
+      failure: {
         status: 400,
         message: "Select a model before running Selection Actions"
       }
@@ -92,14 +93,16 @@ export const handleSelectionAction = async (
       (chunk) => {
         if (isPortClosed()) return
         if (chunk.error) {
-          safePostMessage(port, {
+          safePostChatStreamEvent(port, {
+            version: 1,
             type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-            error: chunk.error
+            failure: chunk.error
           })
           return
         }
         if (chunk.delta || chunk.thinkingDelta) {
-          safePostMessage(port, {
+          safePostChatStreamEvent(port, {
+            version: 1,
             type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK,
             payload: {
               delta: chunk.delta ?? "",
@@ -108,7 +111,8 @@ export const handleSelectionAction = async (
           })
         }
         if (chunk.done) {
-          safePostMessage(port, {
+          safePostChatStreamEvent(port, {
+            version: 1,
             type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE
           })
         }
@@ -117,9 +121,10 @@ export const handleSelectionAction = async (
     )
   } catch (error) {
     logger.error("Selection action failed", "handleSelectionAction", { error })
-    safePostMessage(port, {
+    safePostChatStreamEvent(port, {
+      version: 1,
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: normalizeError(error)
+      failure: normalizeError(error)
     })
   } finally {
     setAbortController(abortKey, null)

--- a/src/background/lib/__tests__/error-handler.test.ts
+++ b/src/background/lib/__tests__/error-handler.test.ts
@@ -149,6 +149,9 @@ describe("error-handler", () => {
     await handler({} as never, port, () => false)
 
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "chat_chunk",
+      seq: 0,
       error: {
         status: 503,
         message: "Provider failed",
@@ -186,6 +189,9 @@ describe("error-handler", () => {
     await handler({} as never, port, () => false)
 
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "chat_chunk",
+      seq: 0,
       error: expect.objectContaining({
         status: 500,
         kind: "provider",

--- a/src/background/lib/__tests__/stream-chat-with-tools.test.ts
+++ b/src/background/lib/__tests__/stream-chat-with-tools.test.ts
@@ -55,6 +55,32 @@ const registryWithTools = (
 }
 
 describe("streamChatWithTools", () => {
+  it("retries once when a model emits only reasoning, then runs its tool", async () => {
+    const provider = scriptedProvider([
+      [{ thinkingDelta: "I should call echo." }, { done: true }],
+      [
+        { toolCalls: [{ id: "c1", name: "echo", arguments: { x: 1 } }] },
+        { done: true }
+      ],
+      [{ delta: "final answer" }, { done: true }]
+    ])
+    const registry = registryWith(async () => ({ content: "tool result" }))
+    const chunks: ChatStreamMessage[] = []
+
+    await streamChatWithTools({
+      provider,
+      request: { model: "m", messages: [{ role: "user", content: "hi" }] },
+      registry,
+      onChunk: (chunk) => chunks.push(chunk),
+      ctx: {}
+    })
+
+    expect(provider.streamChat).toHaveBeenCalledTimes(3)
+    expect(chunks.some((chunk) => chunk.toolRuns?.length)).toBe(true)
+    expect(chunks.find((chunk) => chunk.delta === "final answer")).toBeTruthy()
+    expect(chunks.filter((chunk) => chunk.done)).toHaveLength(1)
+  })
+
   it("runs a tool, re-streams, and finalizes with the answer + trace", async () => {
     const provider = scriptedProvider([
       [

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -5,13 +5,14 @@ import {
   applyProviderErrorContext,
   type ProviderErrorContext
 } from "@/lib/providers/provider-errors"
+import { type AppFailure, toAppFailure } from "@/protocol/app-failure"
 import type {
   ChromePort,
   ChromeResponse,
   NetworkError,
   PortStatusFunction
 } from "@/types"
-import { safePostMessage } from "./utils"
+import { safePostChatStreamEvent } from "./utils"
 
 type HandlerFunction<T> = (
   msg: T,
@@ -30,8 +31,6 @@ interface ErrorContext<T> {
   resolveDiagnosticSessionId?: (msg: T) => string | undefined
 }
 
-type ErrorEnvelope = NonNullable<ChromeResponse["error"]>
-
 type ErrorEnvelopeOptions = {
   status?: number
   fallbackMessage?: string
@@ -42,51 +41,7 @@ type ErrorEnvelopeOptions = {
 export const normalizeError = (
   error: unknown,
   options: ErrorEnvelopeOptions = {}
-): ErrorEnvelope => {
-  const networkError =
-    error && typeof error === "object" ? (error as Partial<NetworkError>) : {}
-  const message =
-    isAppError(error) && error.userMessage
-      ? error.userMessage.trim()
-      : getErrorMessage(error, options.fallbackMessage).trim()
-
-  return {
-    status: options.status ?? networkError.status ?? 0,
-    message,
-    ...(isAppError(error) && { kind: error.kind }),
-    ...(isAppError(error) &&
-      error.messageKey && { messageKey: error.messageKey }),
-    ...(isAppError(error) &&
-      error.userMessage && { userMessage: error.userMessage }),
-    ...(isAppError(error) &&
-      error.retryable !== undefined && { retryable: error.retryable }),
-    ...(isAppError(error) &&
-      error.retryAfterMs !== undefined && { retryAfterMs: error.retryAfterMs }),
-    ...(options.context && { context: options.context }),
-    ...(!options.context &&
-      isAppError(error) &&
-      error.context && {
-        context: error.context
-      }),
-    ...(options.providerId && { providerId: options.providerId }),
-    ...(!options.providerId &&
-      isAppError(error) &&
-      error.providerId && {
-        providerId: error.providerId
-      }),
-    ...(isAppError(error) &&
-      error.providerName && { providerName: error.providerName }),
-    ...(isAppError(error) && error.model && { model: error.model }),
-    ...(isAppError(error) && error.baseUrl && { baseUrl: error.baseUrl }),
-    ...(isAppError(error) && { code: error.code }),
-    ...(isAppError(error) && { phase: error.phase }),
-    ...(isAppError(error) && { incidentId: error.incidentId }),
-    ...(isAppError(error) &&
-      error.durationMs !== undefined && { durationMs: error.durationMs }),
-    ...(isAppError(error) &&
-      error.recoveryAction && { recoveryAction: error.recoveryAction })
-  }
-}
+): AppFailure => toAppFailure(error, options)
 
 export const createErrorResponse = (
   error: unknown,
@@ -119,7 +74,13 @@ export const withErrorContext = <T>(
       // 3. Handle AbortError specifically
       if (isAbortError(err)) {
         if (!isPortClosed()) {
-          safePostMessage(port, { done: true, aborted: true })
+          safePostChatStreamEvent(port, {
+            version: 1,
+            type: "chat_chunk",
+            seq: port.streamSequence ?? 0,
+            done: true,
+            aborted: true
+          })
         }
         return
       }
@@ -197,7 +158,12 @@ export const withErrorContext = <T>(
             }
           }).catch(() => undefined)
         }
-        safePostMessage(port, { error: response.error })
+        safePostChatStreamEvent(port, {
+          version: 1,
+          type: "chat_chunk",
+          seq: port.streamSequence ?? 0,
+          error: response.error
+        })
       }
     }
   }

--- a/src/background/lib/stream-chat-with-tools.ts
+++ b/src/background/lib/stream-chat-with-tools.ts
@@ -42,6 +42,10 @@ const DEFAULT_MAX_ITERATIONS = 5
 
 const TOOL_LIMIT_FALLBACK_MESSAGE =
   "I reached the tool-call limit while gathering context. Please try again with a narrower request."
+const EMPTY_NATIVE_RETRY_MESSAGE =
+  "Continue the previous turn. If current information is insufficient, call one of the provided tools now using the native tool-call interface. Otherwise, answer the user directly. Do not return reasoning without either a tool call or a visible answer."
+const EMPTY_NATIVE_FALLBACK_MESSAGE =
+  "The model finished without making the requested tool call or producing an answer. Please retry, or enable the non-native tool fallback for this model."
 
 interface ExecutedToolCall {
   /** The `tool`-role reply fed back for this call. */
@@ -112,6 +116,7 @@ export const streamChatWithTools = async ({
       let iterationContent = ""
       let finalMetrics: ChatStreamMessage["metrics"] | undefined
       let iterationReplayArtifact: ChatStreamMessage["replayArtifact"]
+      let sawThinking = false
       let stopped = false
 
       await provider.streamChat(
@@ -133,6 +138,12 @@ export const streamChatWithTools = async ({
             onChunk(chunk)
             return
           }
+          if (
+            typeof chunk.thinkingDelta === "string" &&
+            chunk.thinkingDelta.length > 0
+          ) {
+            sawThinking = true
+          }
           if (typeof chunk.delta === "string") {
             iterationContent += chunk.delta
           }
@@ -145,6 +156,22 @@ export const streamChatWithTools = async ({
       if (finalMetrics) lastFinalMetrics = finalMetrics
 
       if (pendingToolCalls.length === 0) {
+        if (
+          sawThinking &&
+          iterationContent.trim().length === 0 &&
+          (state.emptyModelRetries ?? 0) < 1
+        ) {
+          state.emptyModelRetries = (state.emptyModelRetries ?? 0) + 1
+          workingMessages.push({
+            role: "user",
+            content: EMPTY_NATIVE_RETRY_MESSAGE
+          })
+          if (onCheckpoint) await checkpoint()
+          continue
+        }
+        if (sawThinking && iterationContent.trim().length === 0) {
+          onChunk({ delta: EMPTY_NATIVE_FALLBACK_MESSAGE })
+        }
         onChunk({
           done: true,
           metrics: finalMetrics,

--- a/src/background/lib/utils.ts
+++ b/src/background/lib/utils.ts
@@ -3,6 +3,11 @@ import { logger } from "@/lib/logger"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderManager } from "@/lib/providers/manager"
 import { ProviderId } from "@/lib/providers/types"
+import {
+  ChatStreamServerEventSchema,
+  type ModelPullServerEvent,
+  ModelPullServerEventSchema
+} from "@/protocol/streams"
 import type {
   ChatStreamMessage,
   ChromeMessage,
@@ -41,6 +46,42 @@ export const safePostMessage = (
       })
     }
   }
+}
+
+export const safePostChatStreamEvent = (
+  port: ChromePort,
+  event: unknown
+): void => {
+  const parsed = ChatStreamServerEventSchema.safeParse(event)
+  if (!parsed.success) {
+    logger.error("Refused invalid chat stream event", "StreamProtocol", {
+      type:
+        event &&
+        typeof event === "object" &&
+        "type" in event &&
+        typeof event.type === "string"
+          ? event.type
+          : "invalid",
+      issues: parsed.error.issues.length
+    })
+    return
+  }
+  safePostMessage(port, parsed.data)
+}
+
+export const safePostModelPullEvent = (
+  port: ChromePort,
+  event: ModelPullServerEvent
+): void => {
+  const parsed = ModelPullServerEventSchema.safeParse(event)
+  if (!parsed.success) {
+    logger.error("Refused invalid model-pull event", "StreamProtocol", {
+      type: event.type,
+      issues: parsed.error.issues.length
+    })
+    return
+  }
+  safePostMessage(port, parsed.data)
 }
 
 /**

--- a/src/background/port-router.ts
+++ b/src/background/port-router.ts
@@ -1,4 +1,4 @@
-import type { SelectionActionMessage } from "@/application/selection-actions/types"
+import { reconnectDurableTurn } from "@/background/durable-turn-runtime"
 import { handleBuildContext } from "@/background/handlers/handle-build-context"
 import { handleChatWithModel } from "@/background/handlers/handle-chat-with-model"
 import { handleModelPull } from "@/background/handlers/handle-model-pull"
@@ -17,15 +17,11 @@ import {
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import type {
-  BuildContextMessage,
-  ChatWithModelMessage,
-  ChromeMessage,
-  ChromePort,
-  ModelPullMessage,
-  PortStatusFunction,
-  StartTurnMessage
-} from "@/types"
+import {
+  parseChatStreamClientEvent,
+  parseModelPullClientEvent
+} from "@/protocol/streams"
+import type { ChromePort, PortStatusFunction } from "@/types"
 
 const extensionUrlPrefix = browser.runtime.getURL("")
 
@@ -81,8 +77,14 @@ export const registerPortRouter = () => {
     })
 
     port.onMessage.addListener(async (message) => {
-      const msg = message as ChromeMessage
-      const messageType = typeof msg?.type === "string" ? msg.type : ""
+      const parsed = parseChatStreamClientEvent(message)
+      const messageType =
+        message &&
+        typeof message === "object" &&
+        "type" in message &&
+        typeof message.type === "string"
+          ? message.type
+          : ""
       if (
         !isRuntimePortMessageAllowed(
           port.name,
@@ -110,36 +112,48 @@ export const registerPortRouter = () => {
         return
       }
 
+      if (!parsed.success) {
+        logger.warn("Blocked invalid runtime port message", "StreamProtocol", {
+          portName: port.name,
+          type: messageType || "invalid",
+          issues: parsed.error.issues.length
+        })
+        port.disconnect()
+        return
+      }
+
+      const msg = parsed.data
       if (msg.type === MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL) {
         abortCurrentOnDisconnect = true
-        currentAbortKey = (msg as ChatWithModelMessage).payload?.requestId
-        await handleChatWithModel(
-          msg as ChatWithModelMessage,
-          port,
-          getPortStatus
-        )
+        currentAbortKey = msg.payload.requestId
+        await handleChatWithModel(msg, port, getPortStatus)
       }
 
       if (msg.type === MESSAGE_KEYS.PROVIDER.START_TURN) {
-        const startMessage = msg as unknown as StartTurnMessage
-        currentAbortKey = startMessage.payload.start.submission.id
+        currentAbortKey = msg.payload.start.submission.id
         // The sidepanel is an observer after submission. Closing it must not
         // cancel background-owned context building or generation.
         abortCurrentOnDisconnect = false
-        await handleStartTurn(startMessage, port, getPortStatus)
+        await handleStartTurn(msg, port, getPortStatus)
+      }
+
+      if (msg.type === MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM) {
+        currentAbortKey = msg.payload.requestId
+        abortCurrentOnDisconnect = false
+        await reconnectDurableTurn(
+          msg.payload.requestId,
+          msg.payload.afterSeq,
+          { port, isPortClosed: getPortStatus }
+        )
       }
 
       if (msg.type === MESSAGE_KEYS.PROVIDER.BUILD_CONTEXT) {
-        await handleBuildContext(
-          msg as unknown as BuildContextMessage,
-          port,
-          getPortStatus
-        )
+        await handleBuildContext(msg, port, getPortStatus)
       }
 
       if (msg.type === MESSAGE_KEYS.PROVIDER.STOP_GENERATION) {
         logger.info("Stop generation requested", "BackgroundSW")
-        const requestedKey = (msg as ChatWithModelMessage).payload?.requestId
+        const requestedKey = msg.payload?.requestId
         abortAndClearController(
           requestedKey ?? currentAbortKey ?? port.abortScopeKey ?? port.name
         )
@@ -147,11 +161,7 @@ export const registerPortRouter = () => {
       }
 
       if (msg.type === MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION) {
-        await handleSelectionAction(
-          msg as unknown as SelectionActionMessage,
-          port,
-          getPortStatus
-        )
+        await handleSelectionAction(msg, port, getPortStatus)
       }
 
       if (msg.type === MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION) {
@@ -165,8 +175,14 @@ export const registerPortRouter = () => {
       port.name === MESSAGE_KEYS.OLLAMA.PULL_MODEL
     ) {
       port.onMessage.addListener(async (message) => {
-        const msg = message as ChromeMessage
-        const messageType = typeof msg?.type === "string" ? msg.type : ""
+        const parsed = parseModelPullClientEvent(message)
+        const messageType =
+          message &&
+          typeof message === "object" &&
+          "type" in message &&
+          typeof message.type === "string"
+            ? message.type
+            : ""
         if (
           !isRuntimePortMessageAllowed(
             port.name,
@@ -193,7 +209,23 @@ export const registerPortRouter = () => {
           port.disconnect()
           return
         }
-        await handleModelPull(msg as ModelPullMessage, port, getPortStatus)
+        if (!parsed.success) {
+          logger.warn("Blocked invalid model-pull message", "StreamProtocol", {
+            portName: port.name,
+            type: messageType || "invalid",
+            issues: parsed.error.issues.length
+          })
+          port.disconnect()
+          return
+        }
+        const event = parsed.data
+        await handleModelPull(
+          event.type === "model_pull_cancel"
+            ? { payload: event.payload.model, cancel: true }
+            : { payload: event.payload },
+          port,
+          getPortStatus
+        )
       })
     }
   })

--- a/src/features/chat/hooks/__tests__/use-build-context.test.ts
+++ b/src/features/chat/hooks/__tests__/use-build-context.test.ts
@@ -100,7 +100,17 @@ describe("useBuildContext", () => {
         contentWithRAG: "hi",
         ragSources: null,
         pageContextAdded: false,
-        promptContextStats: {}
+        promptContextStats: {
+          promptInputLength: 2,
+          promptAugmentedLength: 2,
+          tabContextLength: 0,
+          ragContextLength: 0,
+          tabContextTruncated: false,
+          groundedOnlyMode: false,
+          insufficientContext: false,
+          usedContextChunks: [],
+          activityEvents: []
+        }
       },
       receipt
     })

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -922,25 +922,27 @@ describe("useChatStream", () => {
         version: 1,
         type: "stream_snapshot",
         requestId: "turn-reconnect",
-        seq: -1,
-        sequenceReset: true,
+        seq: 3,
+        sequenceReset: false,
         status: "generating",
         assistant: {
           role: "assistant",
           content: "persisted ",
           done: false
-        }
+        },
+        thinkingState: { inThinking: false, pending: "<thi" }
       })
       resumedListener({
         version: 1,
         type: "chat_chunk",
-        seq: 0,
-        delta: "answer",
+        seq: 4,
+        delta: "nk>hidden</think>answer",
         done: true
       })
     })
     const lastMessages = (setMessages as any).mock.calls.at(-1)[0]
     expect(lastMessages.at(-1).content).toBe("persisted answer")
+    expect(lastMessages.at(-1).thinking).toBe("hidden")
     expect(setIsLoading).toHaveBeenLastCalledWith(false)
     vi.useRealTimers()
   })

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -139,6 +139,7 @@ describe("useChatStream", () => {
     })
 
     expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: PROVIDER_MESSAGE_KEYS.START_TURN,
       payload: {
         start: {
@@ -570,7 +571,7 @@ describe("useChatStream", () => {
         error: {
           status: 503,
           message: "connection refused",
-          kind: "provider-unavailable",
+          kind: "provider",
           retryable: true
         }
       })
@@ -777,6 +778,7 @@ describe("useChatStream", () => {
     })
 
     expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: PROVIDER_MESSAGE_KEYS.STOP_GENERATION,
       payload: { requestId: expect.any(String) }
     })
@@ -836,10 +838,110 @@ describe("useChatStream", () => {
 
     const originalPayload = mockPort.postMessage.mock.calls[0][0].payload
     expect(resumedPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: PROVIDER_MESSAGE_KEYS.CHAT_WITH_MODEL,
       payload: originalPayload
     })
     expect(setIsLoading).not.toHaveBeenLastCalledWith(false)
+    vi.useRealTimers()
+  })
+
+  it("reconnects durable turns with a snapshot cursor", () => {
+    vi.useFakeTimers()
+    const resumedPort = {
+      postMessage: vi.fn(),
+      onMessage: {
+        addListener: vi.fn(),
+        removeListener: vi.fn()
+      },
+      onDisconnect: {
+        addListener: vi.fn(),
+        removeListener: vi.fn()
+      },
+      disconnect: vi.fn()
+    } as any
+    vi.mocked(browser.runtime.connect)
+      .mockReturnValueOnce(mockPort)
+      .mockReturnValueOnce(resumedPort)
+
+    const { result } = renderHook(() =>
+      useChatStream({ setMessages, setIsLoading, setIsStreaming })
+    )
+    const durableTurn = {
+      submission: {
+        id: "turn-reconnect",
+        sessionId: "session-1",
+        mode: "new" as const,
+        model: "llama2",
+        request: {
+          version: 1 as const,
+          context: {
+            rawInput: "Hello",
+            messages: [],
+            hasTabContext: false,
+            contextText: "",
+            tabDocuments: [],
+            memoryEnabled: false,
+            maxTabContextChars: 1000,
+            maxRagContextChars: 1000,
+            groundedOnlyMode: false,
+            selectedModel: "llama2",
+            selectedModelRef: null
+          },
+          userMessage: { role: "user" as const, content: "Hello" }
+        },
+        createdAt: 1
+      },
+      userMessageId: 1,
+      assistantMessageId: 2
+    }
+
+    act(() => {
+      result.current.startStream({
+        model: "llama2",
+        messages: [{ role: "user", content: "Hello" }],
+        durableTurn
+      })
+    })
+    const streamListener = mockPort.onMessage.addListener.mock.calls[0][0]
+    act(() => {
+      streamListener({ seq: 3, delta: "partial" })
+      mockPort.onDisconnect.addListener.mock.calls[0][0]()
+      vi.advanceTimersByTime(250)
+    })
+
+    expect(resumedPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: PROVIDER_MESSAGE_KEYS.RECONNECT_STREAM,
+      payload: { requestId: "turn-reconnect", afterSeq: 3 }
+    })
+
+    const resumedListener = resumedPort.onMessage.addListener.mock.calls[0][0]
+    act(() => {
+      resumedListener({
+        version: 1,
+        type: "stream_snapshot",
+        requestId: "turn-reconnect",
+        seq: -1,
+        sequenceReset: true,
+        status: "generating",
+        assistant: {
+          role: "assistant",
+          content: "persisted ",
+          done: false
+        }
+      })
+      resumedListener({
+        version: 1,
+        type: "chat_chunk",
+        seq: 0,
+        delta: "answer",
+        done: true
+      })
+    })
+    const lastMessages = (setMessages as any).mock.calls.at(-1)[0]
+    expect(lastMessages.at(-1).content).toBe("persisted answer")
+    expect(setIsLoading).toHaveBeenLastCalledWith(false)
     vi.useRealTimers()
   })
 

--- a/src/features/chat/hooks/use-build-context.ts
+++ b/src/features/chat/hooks/use-build-context.ts
@@ -1,12 +1,12 @@
 import { useCallback } from "react"
-import type { BuildRagContextResult } from "@/application/context/build-context"
 import type { ContextBuildOutput } from "@/application/context/context-service"
-import type {
-  ContextReceipt,
-  TurnToast
-} from "@/application/turns/turn-contract"
+import type { TurnToast } from "@/application/turns/turn-contract"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
+import {
+  parseChatStreamServerEvent,
+  STREAM_PROTOCOL_VERSION
+} from "@/protocol/streams"
 import type { ActivityEvent, BuildContextRequestPayload } from "@/types"
 
 interface BuildContextCallbacks {
@@ -18,17 +18,6 @@ interface BuildContextCallbacks {
    */
   toast?: (input: TurnToast) => void
 }
-
-type BuildContextPortMessage =
-  | { type: "context_progress"; requestId: string; events: ActivityEvent[] }
-  | { type: "context_warning"; requestId: string; payload: TurnToast }
-  | {
-      type: "context_result"
-      requestId: string
-      result: BuildRagContextResult
-      receipt: ContextReceipt
-    }
-  | { type: "context_error"; requestId: string; error: string }
 
 /**
  * Runs turn context building in the background over the provider stream port
@@ -64,8 +53,10 @@ export const useBuildContext = () => {
         }
 
         const listener = (raw: unknown) => {
-          const msg = raw as BuildContextPortMessage
-          if (!msg?.type || msg.requestId !== requestId) return
+          const parsed = parseChatStreamServerEvent(raw)
+          if (!parsed.success) return
+          const msg = parsed.data
+          if (!("requestId" in msg) || msg.requestId !== requestId) return
           switch (msg.type) {
             case "context_progress":
               callbacks?.onActivityEvent?.(msg.events)
@@ -79,7 +70,11 @@ export const useBuildContext = () => {
               )
               break
             case "context_error":
-              finish(() => reject(new Error(msg.error)))
+              finish(() =>
+                reject(
+                  new Error(msg.failure.userMessage || msg.failure.message)
+                )
+              )
               break
           }
         }
@@ -92,6 +87,7 @@ export const useBuildContext = () => {
         )
 
         port.postMessage({
+          version: STREAM_PROTOCOL_VERSION,
           type: MESSAGE_KEYS.PROVIDER.BUILD_CONTEXT,
           payload: { ...request, requestId }
         })

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -189,6 +189,7 @@ export const useChatStream = ({
         if (msg.assistant) {
           state = {
             ...makeStreamReducerState(msg.assistant),
+            ...(msg.thinkingState ? { thinkingState: msg.thinkingState } : {}),
             lastSeq: msg.seq,
             started: Boolean(msg.assistant.content || msg.assistant.thinking)
           }

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next"
 import {
   makeStreamReducerState,
   reduceStreamEvent,
-  type StreamMessage,
   type StreamReducerState
 } from "@/application/turns/chat-stream-reducer"
 import type { DurableTurnStart } from "@/application/turns/turn-contract"
@@ -18,6 +17,10 @@ import { buildErrorReportUrl } from "@/lib/error-report"
 import { logger } from "@/lib/logger"
 import { providerErrorUserMessage } from "@/lib/providers/provider-errors"
 import { getProviderDisplayName } from "@/lib/providers/registry"
+import {
+  parseChatStreamServerEvent,
+  STREAM_PROTOCOL_VERSION
+} from "@/protocol/streams"
 import type { ChatMessage } from "@/types"
 
 interface StreamOptions {
@@ -129,6 +132,7 @@ export const useChatStream = ({
     }
     const requestMessage = durableTurn
       ? {
+          version: STREAM_PROTOCOL_VERSION,
           type: MESSAGE_KEYS.PROVIDER.START_TURN,
           payload: {
             start: {
@@ -139,6 +143,7 @@ export const useChatStream = ({
           }
         }
       : {
+          version: STREAM_PROTOCOL_VERSION,
           type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
           payload: requestPayload
         }
@@ -157,18 +162,16 @@ export const useChatStream = ({
 
     const listener = (rawMsg: unknown) => {
       if (streamSettled) return
-      const msg = rawMsg as StreamMessage
+      const parsed = parseChatStreamServerEvent(rawMsg)
+      if (!parsed.success) {
+        logger.warn("Dropped invalid chat stream event", "StreamProtocol", {
+          issues: parsed.error.issues.length
+        })
+        return
+      }
+      const msg = parsed.data
       if (msg.type === "context_warning") {
-        const warning = (
-          rawMsg as {
-            payload?: {
-              variant?: "default" | "destructive"
-              titleKey?: string
-              descriptionKey?: string
-              descriptionValues?: Record<string, string>
-            }
-          }
-        ).payload
+        const warning = msg.payload
         if (warning?.titleKey) {
           toast({
             variant: warning.variant,
@@ -181,13 +184,46 @@ export const useChatStream = ({
         return
       }
       if (msg.type === "context_progress") return
+      if (msg.type === "stream_snapshot") {
+        if (!msg.sequenceReset && msg.seq < state.lastSeq) return
+        if (msg.assistant) {
+          state = {
+            ...makeStreamReducerState(msg.assistant),
+            lastSeq: msg.seq,
+            started: Boolean(msg.assistant.content || msg.assistant.thinking)
+          }
+          renderAssistant(msg.assistant)
+        } else {
+          state = { ...state, lastSeq: msg.seq }
+        }
+        if (
+          msg.assistant?.done ||
+          msg.status === "completed" ||
+          msg.status === "failed" ||
+          msg.status === "cancelled"
+        ) {
+          setIsLoading(false)
+          setIsStreaming(false)
+          cleanupPort()
+        }
+        return
+      }
+      if (
+        msg.type === "context_result" ||
+        msg.type === "context_error" ||
+        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK ||
+        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE ||
+        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR
+      ) {
+        return
+      }
 
       // Fold the chunk into turn state purely; the hook only performs effects.
       const result = reduceStreamEvent(state, msg)
       state = result.state
       if (result.dropped) return
 
-      if (DEBUG_THINKING_STREAM) {
+      if (DEBUG_THINKING_STREAM && msg.type === "chat_chunk") {
         logger.debug("Stream msg", "useChatStream", {
           type: msg.type,
           hasDelta: typeof msg.delta === "string" && msg.delta.length > 0,
@@ -358,7 +394,7 @@ export const useChatStream = ({
       if (
         !streamSettled &&
         !state.assistant.done &&
-        awaitingConfirmation &&
+        (durableTurn !== undefined || awaitingConfirmation) &&
         currentRequestIdRef.current === requestId &&
         resumeAttempts < 3
       ) {
@@ -371,15 +407,27 @@ export const useChatStream = ({
           ) {
             return
           }
-          // Restarted worker restarts its sequence at 0 — accept it afresh.
-          state = { ...state, lastSeq: -1 }
+          // Legacy tool-loop reconnects restart their sequence at 0. Durable
+          // turns request a snapshot and keep their last accepted sequence.
+          if (!durableTurn) state = { ...state, lastSeq: -1 }
           port = browser.runtime.connect({
             name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
           })
           portRef.current = port
           port.onMessage.addListener(listener)
           port.onDisconnect.addListener(handleDisconnect)
-          port.postMessage(requestMessage)
+          port.postMessage(
+            durableTurn
+              ? {
+                  version: STREAM_PROTOCOL_VERSION,
+                  type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
+                  payload: {
+                    requestId,
+                    afterSeq: state.lastSeq
+                  }
+                }
+              : requestMessage
+          )
         }, 250)
         return
       }
@@ -434,6 +482,7 @@ export const useChatStream = ({
       finalizeCleanRef.current?.()
       currentRequestIdRef.current = null
       portRef.current.postMessage({
+        version: STREAM_PROTOCOL_VERSION,
         type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION,
         payload: requestId ? { requestId } : undefined
       })

--- a/src/features/model/hooks/__tests__/use-model-pull.test.ts
+++ b/src/features/model/hooks/__tests__/use-model-pull.test.ts
@@ -46,6 +46,8 @@ describe("useModelPull", () => {
     expect(result.current.pullingModel).toBe("llama2")
     expect(result.current.progress).toBe("Starting...")
     expect(mockPort.postMessage).toHaveBeenCalledWith({
+      version: 1,
+      type: "model_pull_start",
       payload: { model: "llama2", providerId: undefined }
     })
   })

--- a/src/features/model/hooks/use-model-pull.ts
+++ b/src/features/model/hooks/use-model-pull.ts
@@ -4,7 +4,10 @@ import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import { formatErrorForDisplay } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
-import type { PullStreamMessage } from "@/types"
+import {
+  parseModelPullServerEvent,
+  STREAM_PROTOCOL_VERSION
+} from "@/protocol/streams"
 
 export const useModelPull = () => {
   const [progress, setProgress] = useState<string | null>(null)
@@ -22,6 +25,8 @@ export const useModelPull = () => {
     portRef.current = port
 
     port.postMessage({
+      version: STREAM_PROTOCOL_VERSION,
+      type: "model_pull_start",
       payload: {
         model: modelName,
         providerId
@@ -29,15 +34,22 @@ export const useModelPull = () => {
     })
 
     port.onMessage.addListener((msg: unknown) => {
-      const message = msg as PullStreamMessage
-      if (message.status) setProgress(message.status)
-      if (message.done) {
+      const parsed = parseModelPullServerEvent(msg)
+      if (!parsed.success) {
+        logger.warn("Dropped invalid model-pull event", "StreamProtocol", {
+          issues: parsed.error.issues.length
+        })
+        return
+      }
+      const message = parsed.data
+      if (message.type === "model_pull_progress") setProgress(message.status)
+      if (message.type === "model_pull_complete") {
         setProgress("✅ Success")
         setPullingModel(null)
         port.disconnect()
       }
-      if (message.error) {
-        const errorMessage = formatErrorForDisplay(message.error).message
+      if (message.type === "model_pull_error") {
+        const errorMessage = formatErrorForDisplay(message.failure).message
         setProgress(`❌ Failed: ${errorMessage}`)
         setPullingModel(null)
         port.disconnect()
@@ -47,7 +59,11 @@ export const useModelPull = () => {
 
   const cancelPull = () => {
     if (pullingModel && portRef.current) {
-      portRef.current.postMessage({ cancel: true, payload: pullingModel })
+      portRef.current.postMessage({
+        version: STREAM_PROTOCOL_VERSION,
+        type: "model_pull_cancel",
+        payload: { model: pullingModel }
+      })
       setProgress("❌ Cancelled")
       setPullingModel(null)
       portRef.current.disconnect()

--- a/src/features/selection-actions/__tests__/content-stream.test.ts
+++ b/src/features/selection-actions/__tests__/content-stream.test.ts
@@ -207,7 +207,7 @@ describe("startSelectionActionStream", () => {
 
     port._emit({
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: { message: "Model not loaded" }
+      error: { status: 0, message: "Model not loaded" }
     })
 
     expect(dispatch).toHaveBeenCalledWith({
@@ -245,6 +245,7 @@ describe("stopSelectionStream", () => {
     stopSelectionStream(port as unknown as chrome.runtime.Port)
 
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION
     })
     expect(port.disconnect).toHaveBeenCalledOnce()

--- a/src/features/selection-actions/__tests__/overlay-stream.test.ts
+++ b/src/features/selection-actions/__tests__/overlay-stream.test.ts
@@ -64,6 +64,7 @@ describe("connectSelectionStream", () => {
       name: MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION
     })
     expect(port.postMessage).toHaveBeenCalledWith({
+      version: 1,
       type: MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
       payload: request
     })
@@ -127,7 +128,7 @@ describe("connectSelectionStream", () => {
 
     port._emit({
       type: MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR,
-      error: { message: "Model not loaded" }
+      error: { status: 0, message: "Model not loaded" }
     })
 
     expect(onError).toHaveBeenCalledWith("Model not loaded")

--- a/src/features/selection-actions/content-stream.ts
+++ b/src/features/selection-actions/content-stream.ts
@@ -1,4 +1,5 @@
 import { MESSAGE_KEYS } from "@/lib/constants"
+import { STREAM_PROTOCOL_VERSION } from "@/protocol/streams/version"
 import { type SelectionCapture, toSelectionPayload } from "./dom"
 import type {
   SelectionOverlayEvent,
@@ -11,6 +12,7 @@ export function stopSelectionStream(port: chrome.runtime.Port | null) {
   if (!port) return null
 
   port.postMessage({
+    version: STREAM_PROTOCOL_VERSION,
     type: MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION
   })
   port.disconnect()

--- a/src/features/selection-actions/overlay-stream.ts
+++ b/src/features/selection-actions/overlay-stream.ts
@@ -4,7 +4,8 @@ import {
   splitThinkingDelta,
   type ThinkingParserState
 } from "@/lib/thinking-parser"
-import type { ChromeMessage } from "@/types"
+import { parseSelectionStreamServerEvent } from "@/protocol/streams/selection-stream"
+import { STREAM_PROTOCOL_VERSION } from "@/protocol/streams/version"
 import type { SelectionActionRequest } from "./types"
 
 export interface StreamChunkResult {
@@ -37,15 +38,13 @@ export function connectSelectionStream(
   })
 
   port.onMessage.addListener((raw) => {
-    const message = raw as ChromeMessage
+    const parsed = parseSelectionStreamServerEvent(raw)
+    if (!parsed.success) return
+    const message = parsed.data
 
     if (message.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK) {
-      const payload = message.payload as
-        | { delta?: string; thinkingDelta?: string }
-        | undefined
-
-      const rawDelta = payload?.delta ?? ""
-      const rawThinkingDelta = payload?.thinkingDelta ?? ""
+      const rawDelta = message.payload.delta
+      const rawThinkingDelta = message.payload.thinkingDelta
       const { visible, thinking: inlineThinking } = splitThinkingDelta(
         rawDelta,
         thinkingState
@@ -68,14 +67,15 @@ export function connectSelectionStream(
 
     if (message.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR) {
       callbacks.onError(
-        message.error?.userMessage ??
-          message.error?.message ??
+        message.failure.userMessage ??
+          message.failure.message ??
           "Selection action failed. Try again."
       )
     }
   })
 
   port.postMessage({
+    version: STREAM_PROTOCOL_VERSION,
     type: MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION,
     payload: request
   })

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -12,6 +12,7 @@ export const PROVIDER_MESSAGE_KEYS = {
   START_TURN: "start-turn",
   BUILD_CONTEXT: "build-context",
   STREAM_RESPONSE: "provider-stream-response",
+  RECONNECT_STREAM: "stream-reconnect",
   STOP_GENERATION: "stop-generation",
   PULL_MODEL: "PROVIDER.PULL_MODEL",
   START_SELECTION_ACTION: "start-selection-action",

--- a/src/lib/providers/__tests__/contract.test.ts
+++ b/src/lib/providers/__tests__/contract.test.ts
@@ -188,6 +188,73 @@ describe("provider contracts", () => {
     }
   })
 
+  it("shares terminal SSE handling across compatible provider classes", async () => {
+    const providers = [
+      new OpenAICompatibleProvider({
+        id: "custom:openai:test",
+        name: "Custom",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://custom.test/v1"
+      }),
+      new LMStudioProvider({
+        id: ProviderId.LM_STUDIO,
+        name: "LM Studio",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://lmstudio.test/v1"
+      }),
+      new LlamaCppProvider({
+        id: ProviderId.LLAMA_CPP,
+        name: "llama.cpp",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://llamacpp.test/v1"
+      }),
+      new VllmProvider({
+        id: ProviderId.VLLM,
+        name: "vLLM",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://vllm.test/v1"
+      }),
+      new LocalAIProvider({
+        id: ProviderId.LOCALAI,
+        name: "LocalAI",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://localai.test/v1"
+      }),
+      new KoboldCppProvider({
+        id: ProviderId.KOBOLDCPP,
+        name: "KoboldCPP",
+        type: ProviderType.OPENAI,
+        enabled: true,
+        baseUrl: "http://kobold.test/v1"
+      })
+    ]
+
+    for (const provider of providers) {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamResponse([
+          'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n',
+          "data: [DONE]\n"
+        ])
+      )
+      const chunks: unknown[] = []
+      await provider.streamChat(
+        { model: "chat-model", messages: [{ role: "user", content: "hi" }] },
+        (chunk) => chunks.push(chunk)
+      )
+      expect(chunks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ delta: "ok", done: false }),
+          expect.objectContaining({ done: true })
+        ])
+      )
+    }
+  })
+
   it("OpenAI surfaces useful model-list and chat errors", async () => {
     const provider = new OpenAICompatibleProvider({
       id: ProviderId.OPENAI,

--- a/src/lib/providers/__tests__/provider-tools.test.ts
+++ b/src/lib/providers/__tests__/provider-tools.test.ts
@@ -416,9 +416,9 @@ describe("provider tool calling — stream parsing", () => {
     ])
   })
 
-  it("finishes and cancels a persistent SSE stream at finish_reason", async () => {
+  it("flushes a final tool call without a newline on persistent SSE", async () => {
     const persistent = persistentStreamResponse(
-      'data: {"choices":[{"delta":{"reasoning":"I should call a tool."},"finish_reason":"stop"}]}\n'
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}]},"finish_reason":"tool_calls"}]}'
     )
     vi.spyOn(globalThis, "fetch").mockResolvedValue(persistent.response)
 
@@ -428,9 +428,35 @@ describe("provider tool calling — stream parsing", () => {
       collect(chunks)
     )
 
-    expect(chunks.some((chunk) => chunk.thinkingDelta)).toBe(true)
+    expect(chunks.find((chunk) => chunk.toolCalls)?.toolCalls).toEqual([
+      { id: "c1", name: "get_weather", arguments: { city: "Paris" } }
+    ])
     expect(chunks.filter((chunk) => chunk.done)).toHaveLength(1)
     expect(persistent.wasCancelled()).toBe(true)
+  })
+
+  it("keeps usage sent after finish_reason before [DONE]", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      streamResponse([
+        'data: {"choices":[{"delta":{"content":"answer"},"finish_reason":"stop"}]}\n',
+        'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":2}}\n',
+        "data: [DONE]\n"
+      ])
+    )
+
+    const chunks: ChatStreamMessage[] = []
+    await new OpenAICompatibleProvider(openaiConfig).streamChat(
+      baseRequest,
+      collect(chunks)
+    )
+
+    expect(chunks.find((chunk) => chunk.metrics?.eval_count)?.metrics).toEqual(
+      expect.objectContaining({
+        prompt_eval_count: 7,
+        eval_count: 2
+      })
+    )
+    expect(chunks.filter((chunk) => chunk.done)).toHaveLength(1)
   })
 
   it("preserves fragmented OpenRouter reasoning details across a tool turn", async () => {

--- a/src/lib/providers/__tests__/provider-tools.test.ts
+++ b/src/lib/providers/__tests__/provider-tools.test.ts
@@ -28,11 +28,41 @@ const streamResponse = (chunks: string[]) => {
             ? { done: false, value: encoder.encode(chunks[i++]) }
             : { done: true, value: undefined }
         ),
+        cancel: vi.fn(async () => undefined),
         releaseLock: vi.fn()
       })
     },
     text: async () => ""
   } as unknown as Response
+}
+
+/** A stream that sends one chunk and then never closes unless cancelled. */
+const persistentStreamResponse = (chunk: string) => {
+  let sent = false
+  let cancelled = false
+  return {
+    response: {
+      ok: true,
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: vi.fn(async () => {
+            if (!sent) {
+              sent = true
+              return { done: false, value: encoder.encode(chunk) }
+            }
+            return await new Promise<never>(() => {})
+          }),
+          cancel: vi.fn(async () => {
+            cancelled = true
+          }),
+          releaseLock: vi.fn()
+        })
+      },
+      text: async () => ""
+    } as unknown as Response,
+    wasCancelled: () => cancelled
+  }
 }
 
 const bodyOf = (fetchMock: ReturnType<typeof vi.spyOn>) =>
@@ -384,6 +414,23 @@ describe("provider tool calling — stream parsing", () => {
     expect(toolChunk?.toolCalls).toEqual([
       { id: "c1", name: "get_weather", arguments: { city: "Paris" } }
     ])
+  })
+
+  it("finishes and cancels a persistent SSE stream at finish_reason", async () => {
+    const persistent = persistentStreamResponse(
+      'data: {"choices":[{"delta":{"reasoning":"I should call a tool."},"finish_reason":"stop"}]}\n'
+    )
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(persistent.response)
+
+    const chunks: ChatStreamMessage[] = []
+    await new OpenAICompatibleProvider(openaiConfig).streamChat(
+      baseRequest,
+      collect(chunks)
+    )
+
+    expect(chunks.some((chunk) => chunk.thinkingDelta)).toBe(true)
+    expect(chunks.filter((chunk) => chunk.done)).toHaveLength(1)
+    expect(persistent.wasCancelled()).toBe(true)
   })
 
   it("preserves fragmented OpenRouter reasoning details across a tool turn", async () => {

--- a/src/lib/providers/capability-probe.ts
+++ b/src/lib/providers/capability-probe.ts
@@ -5,7 +5,7 @@ import {
   setPlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
 import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
-import type { ToolCall } from "@/lib/tools"
+import { runToolCallingProbe } from "./tool-calling-probe"
 import type { LLMProvider } from "./types"
 
 /**
@@ -178,20 +178,6 @@ export const clearCapabilityProbesForProvider = (
     if (changed) await setPlasmoStoredValue(STORAGE_KEY, all)
   })
 
-/** The trivial tool offered during a probe. */
-const PROBE_TOOL = {
-  name: "ping",
-  description:
-    "Test tool. When asked to verify tool support, call this with value set to 'pong'.",
-  parameters: {
-    type: "object" as const,
-    properties: {
-      value: { type: "string", description: "Echo value" }
-    },
-    required: ["value"]
-  }
-}
-
 /**
  * Send a minimal tool call and then return its result to the model. Prefer the
  * standard `tool` role. Some llama.cpp templates can emit native calls but only
@@ -203,151 +189,8 @@ export const probeToolCalling = async (
   provider: LLMProvider,
   modelName: string,
   externalSignal?: AbortSignal
-): Promise<CapabilityProbeResult> => {
-  const scope = createProbeAbortScope(externalSignal)
-
-  const probePrompt =
-    "Call the ping tool with value 'pong' to verify tool support. Do not answer in text."
-  let probeCall: ToolCall | undefined
-  let streamError: string | undefined
-  let standardFollowUpFailed = false
-  streamError = undefined
-  try {
-    await provider.streamChat(
-      {
-        model: modelName,
-        messages: [{ role: "user", content: probePrompt }],
-        tools: [PROBE_TOOL],
-        think: false,
-        num_predict: 256
-      },
-      (chunk) => {
-        if (chunk.error) {
-          streamError = chunk.error.message || "Probe request failed"
-        }
-        if (!probeCall && chunk.toolCalls && chunk.toolCalls.length > 0) {
-          probeCall = chunk.toolCalls[0]
-        }
-      },
-      scope.signal
-    )
-  } catch (error) {
-    logger.debug("Tool-calling probe request failed", "capabilityProbe", {
-      model: modelName,
-      error
-    })
-    scope.cleanup()
-    throw error
-  }
-
-  // A failed request proves nothing about the model — surface it instead of
-  // recording a misleading `toolCalling: false`.
-  if (streamError) {
-    scope.cleanup()
-    throw new Error(streamError)
-  }
-  if (!probeCall) {
-    scope.cleanup()
-    return { toolCalling: false, probedAt: Date.now() }
-  }
-
-  try {
-    await provider.streamChat(
-      {
-        model: modelName,
-        messages: [
-          { role: "user", content: probePrompt },
-          { role: "assistant", content: "", toolCalls: [probeCall] },
-          {
-            role: "tool",
-            content: '{"value":"pong"}',
-            toolName: probeCall.name,
-            toolCallId: probeCall.id
-          }
-        ],
-        tools: [PROBE_TOOL],
-        tool_choice: "none",
-        think: false,
-        num_predict: 32
-      },
-      (chunk) => {
-        if (chunk.error) {
-          streamError = chunk.error.message || "Probe follow-up failed"
-        }
-      },
-      scope.signal
-    )
-  } catch (error) {
-    logger.debug(
-      "Tool-calling probe follow-up is incompatible",
-      "capabilityProbe",
-      { model: modelName, error }
-    )
-    standardFollowUpFailed = true
-  }
-
-  if (!standardFollowUpFailed && !streamError) {
-    scope.cleanup()
-    return {
-      toolCalling: true,
-      toolCallingMode: "native",
-      probedAt: Date.now()
-    }
-  }
-
-  if (scope.signal.aborted) {
-    scope.cleanup()
-    scope.signal.throwIfAborted()
-  }
-
-  streamError = undefined
-  try {
-    await provider.streamChat(
-      {
-        model: modelName,
-        messages: [
-          { role: "user", content: probePrompt },
-          { role: "assistant", content: "", toolCalls: [probeCall] },
-          {
-            role: "user",
-            content:
-              "Tool result for ping (call id: " +
-              `${probeCall.id}):\n{"value":"pong"}\n` +
-              "Use this result to finish the original request."
-          }
-        ],
-        tools: [PROBE_TOOL],
-        tool_choice: "none",
-        think: false,
-        num_predict: 32
-      },
-      (chunk) => {
-        if (chunk.error) {
-          streamError = chunk.error.message || "Probe follow-up failed"
-        }
-      },
-      scope.signal
-    )
-  } catch (error) {
-    if (scope.signal.aborted) scope.signal.throwIfAborted()
-    logger.debug(
-      "Tool-calling alternating-role follow-up is incompatible",
-      "capabilityProbe",
-      { model: modelName, error }
-    )
-    return { toolCalling: false, probedAt: Date.now() }
-  } finally {
-    scope.cleanup()
-  }
-
-  return streamError
-    ? { toolCalling: false, probedAt: Date.now() }
-    : {
-        toolCalling: true,
-        toolCallingMode: "native-user-results",
-        probedAt: Date.now()
-      }
-}
+): Promise<CapabilityProbeResult> =>
+  runToolCallingProbe(provider, modelName, externalSignal)
 
 /** Matches the error Ollama returns when `think` is sent to a non-thinking model. */
 const THINKING_UNSUPPORTED = /does not support think/i

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -412,11 +412,12 @@ export class OpenAICompatibleProvider implements LLMProvider {
       })
     }
 
-    const processLine = (line: string): boolean => {
+    type TerminalMarker = "finish-reason" | "done" | null
+    const processLine = (line: string): TerminalMarker => {
       const trimmed = line.trim()
-      if (!trimmed) return false
-      if (trimmed === "data: [DONE]") return true
-      if (!trimmed.startsWith("data: ")) return false
+      if (!trimmed) return null
+      if (trimmed === "data: [DONE]") return "done"
+      if (!trimmed.startsWith("data: ")) return null
 
       let data: {
         error?: unknown
@@ -442,7 +443,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           "OpenAICompatibleProvider",
           { error: e }
         )
-        return false
+        return null
       }
 
       // Mid-stream provider error (HTTP 200 already sent — vLLM/LiteLLM/etc.).
@@ -561,6 +562,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
         })
       }
       return typeof finishReason === "string" && finishReason.length > 0
+        ? "finish-reason"
+        : null
     }
 
     const finishStream = () => {
@@ -576,14 +579,59 @@ export class OpenAICompatibleProvider implements LLMProvider {
       })
     }
 
+    const bufferedTerminalMarker = (): TerminalMarker => {
+      const trimmed = buffer.trim()
+      if (trimmed === "data: [DONE]") return "done"
+      if (!trimmed.startsWith("data: ")) return null
+      try {
+        const data = JSON.parse(trimmed.slice(6)) as {
+          choices?: Array<{ finish_reason?: unknown }>
+        }
+        const finishReason = data.choices?.[0]?.finish_reason
+        return typeof finishReason === "string" && finishReason.length > 0
+          ? "finish-reason"
+          : null
+      } catch {
+        // A fetch chunk may split one SSE JSON object at any byte. Keep
+        // buffering partial JSON without logging a parse warning.
+        return null
+      }
+    }
+
+    const TERMINAL_GRACE_MS = 250
+    let terminalMarker: TerminalMarker = null
+    let terminalDeadline = 0
+    const readNextChunk = async () => {
+      const read = readProviderStreamChunk(reader, {
+        providerId: this.id,
+        providerName: this.config.name,
+        model,
+        baseUrl: resolveProviderBaseUrl(this.config)
+      })
+      if (terminalMarker !== "finish-reason") {
+        return { timedOut: false as const, result: await read }
+      }
+      const remaining = Math.max(0, terminalDeadline - Date.now())
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      const timed = await Promise.race([
+        read.then((result) => ({ timedOut: false as const, result })),
+        new Promise<{ timedOut: true }>((resolve) => {
+          timeoutId = setTimeout(() => resolve({ timedOut: true }), remaining)
+        })
+      ])
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+      return timed
+    }
+
     try {
       while (true) {
-        const { done, value } = await readProviderStreamChunk(reader, {
-          providerId: this.id,
-          providerName: this.config.name,
-          model,
-          baseUrl: resolveProviderBaseUrl(this.config)
-        })
+        const next = await readNextChunk()
+        if (next.timedOut) {
+          finishStream()
+          await reader.cancel()
+          break
+        }
+        const { done, value } = next.result
         if (done) {
           // Flush a final data line left without a trailing newline at EOF.
           if (buffer.trim()) processLine(buffer)
@@ -596,17 +644,32 @@ export class OpenAICompatibleProvider implements LLMProvider {
         const lines = buffer.split("\n")
         buffer = lines.pop() || ""
 
-        let streamFinished = false
+        let chunkMarker: TerminalMarker = null
         for (const line of lines) {
-          streamFinished = processLine(line) || streamFinished
+          const marker = processLine(line)
+          if (marker === "done" || (marker && !chunkMarker)) {
+            chunkMarker = marker
+          }
         }
-        if (streamFinished) {
-          // `finish_reason` and `[DONE]` are protocol terminals. Some local
-          // OpenAI-compatible servers keep the HTTP connection alive after
-          // either marker, so waiting for EOF strands the UI indefinitely.
+        // Some local servers flush the final SSE record but omit its trailing
+        // newline and keep the HTTP connection alive. Once the buffered JSON
+        // itself carries a finish reason, it is a complete protocol record.
+        const bufferedMarker = bufferedTerminalMarker()
+        if (!chunkMarker && bufferedMarker) {
+          chunkMarker = processLine(buffer)
+          buffer = ""
+        }
+        if (chunkMarker === "done") {
           finishStream()
           await reader.cancel()
           break
+        }
+        if (chunkMarker === "finish-reason" && terminalMarker === null) {
+          // Preserve standard usage chunks that follow `finish_reason`, but
+          // bound the wait because several local servers never send [DONE] or
+          // close the socket.
+          terminalMarker = chunkMarker
+          terminalDeadline = Date.now() + TERMINAL_GRACE_MS
         }
       }
     } finally {

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -412,10 +412,11 @@ export class OpenAICompatibleProvider implements LLMProvider {
       })
     }
 
-    const processLine = (line: string) => {
+    const processLine = (line: string): boolean => {
       const trimmed = line.trim()
-      if (!trimmed || trimmed === "data: [DONE]") return
-      if (!trimmed.startsWith("data: ")) return
+      if (!trimmed) return false
+      if (trimmed === "data: [DONE]") return true
+      if (!trimmed.startsWith("data: ")) return false
 
       let data: {
         error?: unknown
@@ -441,7 +442,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           "OpenAICompatibleProvider",
           { error: e }
         )
-        return
+        return false
       }
 
       // Mid-stream provider error (HTTP 200 already sent — vLLM/LiteLLM/etc.).
@@ -531,7 +532,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
       // Most providers set finish_reason "tool_calls" before usage; some
       // omit it, so the stream-done path also flushes.
-      if (data.choices?.[0]?.finish_reason === "tool_calls") {
+      const finishReason = data.choices?.[0]?.finish_reason
+      if (finishReason === "tool_calls") {
         emitToolCalls()
       }
 
@@ -558,6 +560,20 @@ export class OpenAICompatibleProvider implements LLMProvider {
           metrics: latestMetrics
         })
       }
+      return typeof finishReason === "string" && finishReason.length > 0
+    }
+
+    const finishStream = () => {
+      emitToolCalls()
+      const totalDurationNs = (Date.now() - startTime) * 1_000_000
+      onChunk({
+        done: true,
+        replayArtifact: replayArtifact(),
+        metrics: {
+          ...latestMetrics,
+          total_duration: totalDurationNs
+        }
+      })
     }
 
     try {
@@ -572,16 +588,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           // Flush a final data line left without a trailing newline at EOF.
           if (buffer.trim()) processLine(buffer)
           buffer = ""
-          emitToolCalls()
-          const totalDurationNs = (Date.now() - startTime) * 1_000_000
-          onChunk({
-            done: true,
-            replayArtifact: replayArtifact(),
-            metrics: {
-              ...latestMetrics,
-              total_duration: totalDurationNs
-            }
-          })
+          finishStream()
           break
         }
 
@@ -589,7 +596,18 @@ export class OpenAICompatibleProvider implements LLMProvider {
         const lines = buffer.split("\n")
         buffer = lines.pop() || ""
 
-        for (const line of lines) processLine(line)
+        let streamFinished = false
+        for (const line of lines) {
+          streamFinished = processLine(line) || streamFinished
+        }
+        if (streamFinished) {
+          // `finish_reason` and `[DONE]` are protocol terminals. Some local
+          // OpenAI-compatible servers keep the HTTP connection alive after
+          // either marker, so waiting for EOF strands the UI indefinitely.
+          finishStream()
+          await reader.cancel()
+          break
+        }
       }
     } finally {
       reader.releaseLock()

--- a/src/lib/providers/tool-calling-probe.ts
+++ b/src/lib/providers/tool-calling-probe.ts
@@ -1,0 +1,194 @@
+import { logger } from "@/lib/logger"
+import type { ToolCall } from "@/lib/tools"
+import type { LLMProvider } from "./types"
+
+export type ToolCallingMode = "native" | "native-user-results"
+
+export interface ToolCallingProbeResult {
+  toolCalling: boolean
+  toolCallingMode?: ToolCallingMode
+  probedAt: number
+}
+
+const PROBE_TIMEOUT_MS = 30_000
+
+const createProbeAbortScope = (externalSignal?: AbortSignal) => {
+  const controller = new AbortController()
+  const abortFromCaller = () => controller.abort(externalSignal?.reason)
+  if (externalSignal?.aborted) abortFromCaller()
+  else
+    externalSignal?.addEventListener("abort", abortFromCaller, { once: true })
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeout)
+      externalSignal?.removeEventListener("abort", abortFromCaller)
+    }
+  }
+}
+
+const PROBE_TOOL = {
+  name: "ping",
+  description:
+    "Test tool. When asked to verify tool support, call this with value set to 'pong'.",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      value: { type: "string", description: "Echo value" }
+    },
+    required: ["value"]
+  }
+}
+
+/**
+ * Run a complete native tool-call round trip without accessing extension state.
+ * Prefer the standard `tool` role, then try an alternating user-result message
+ * for llama.cpp templates that reject consecutive assistant/tool roles.
+ */
+export const runToolCallingProbe = async (
+  provider: LLMProvider,
+  modelName: string,
+  externalSignal?: AbortSignal
+): Promise<ToolCallingProbeResult> => {
+  const scope = createProbeAbortScope(externalSignal)
+  const probePrompt =
+    "Call the ping tool with value 'pong' to verify tool support. Do not answer in text."
+  let probeCall: ToolCall | undefined
+  let streamError: string | undefined
+
+  try {
+    await provider.streamChat(
+      {
+        model: modelName,
+        messages: [{ role: "user", content: probePrompt }],
+        tools: [PROBE_TOOL],
+        think: false,
+        num_predict: 256
+      },
+      (chunk) => {
+        if (chunk.error) {
+          streamError = chunk.error.message || "Probe request failed"
+        }
+        if (!probeCall && chunk.toolCalls && chunk.toolCalls.length > 0) {
+          probeCall = chunk.toolCalls[0]
+        }
+      },
+      scope.signal
+    )
+  } catch (error) {
+    logger.debug("Tool-calling probe request failed", "capabilityProbe", {
+      model: modelName,
+      error
+    })
+    scope.cleanup()
+    throw error
+  }
+
+  if (streamError) {
+    scope.cleanup()
+    throw new Error(streamError)
+  }
+  if (!probeCall) {
+    scope.cleanup()
+    return { toolCalling: false, probedAt: Date.now() }
+  }
+
+  let standardFollowUpFailed = false
+  try {
+    await provider.streamChat(
+      {
+        model: modelName,
+        messages: [
+          { role: "user", content: probePrompt },
+          { role: "assistant", content: "", toolCalls: [probeCall] },
+          {
+            role: "tool",
+            content: '{"value":"pong"}',
+            toolName: probeCall.name,
+            toolCallId: probeCall.id
+          }
+        ],
+        tools: [PROBE_TOOL],
+        tool_choice: "none",
+        think: false,
+        num_predict: 32
+      },
+      (chunk) => {
+        if (chunk.error) {
+          streamError = chunk.error.message || "Probe follow-up failed"
+        }
+      },
+      scope.signal
+    )
+  } catch (error) {
+    logger.debug(
+      "Tool-calling probe follow-up is incompatible",
+      "capabilityProbe",
+      { model: modelName, error }
+    )
+    standardFollowUpFailed = true
+  }
+
+  if (!standardFollowUpFailed && !streamError) {
+    scope.cleanup()
+    return {
+      toolCalling: true,
+      toolCallingMode: "native",
+      probedAt: Date.now()
+    }
+  }
+
+  if (scope.signal.aborted) {
+    scope.cleanup()
+    scope.signal.throwIfAborted()
+  }
+
+  streamError = undefined
+  try {
+    await provider.streamChat(
+      {
+        model: modelName,
+        messages: [
+          { role: "user", content: probePrompt },
+          { role: "assistant", content: "", toolCalls: [probeCall] },
+          {
+            role: "user",
+            content:
+              "Tool result for ping (call id: " +
+              `${probeCall.id}):\n{"value":"pong"}\n` +
+              "Use this result to finish the original request."
+          }
+        ],
+        tools: [PROBE_TOOL],
+        tool_choice: "none",
+        think: false,
+        num_predict: 32
+      },
+      (chunk) => {
+        if (chunk.error) {
+          streamError = chunk.error.message || "Probe follow-up failed"
+        }
+      },
+      scope.signal
+    )
+  } catch (error) {
+    if (scope.signal.aborted) scope.signal.throwIfAborted()
+    logger.debug(
+      "Tool-calling alternating-role follow-up is incompatible",
+      "capabilityProbe",
+      { model: modelName, error }
+    )
+    return { toolCalling: false, probedAt: Date.now() }
+  } finally {
+    scope.cleanup()
+  }
+
+  return streamError
+    ? { toolCalling: false, probedAt: Date.now() }
+    : {
+        toolCalling: true,
+        toolCallingMode: "native-user-results",
+        probedAt: Date.now()
+      }
+}

--- a/src/lib/repositories/__tests__/turn-runs.test.ts
+++ b/src/lib/repositories/__tests__/turn-runs.test.ts
@@ -119,4 +119,54 @@ describe("turn-runs repository", () => {
     )
     expect(flushSave).toHaveBeenCalledTimes(1)
   })
+
+  it("persists structured failures and reads legacy failure text", async () => {
+    await updateTurnRun("turn-1", {
+      status: "failed",
+      failure: {
+        status: 503,
+        message: "Provider unavailable",
+        kind: "provider",
+        retryable: true
+      }
+    })
+    expect(run).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE turn_runs SET"),
+      expect.arrayContaining([
+        JSON.stringify({
+          status: 503,
+          message: "Provider unavailable",
+          kind: "provider",
+          retryable: true
+        })
+      ])
+    )
+
+    query.mockResolvedValueOnce([
+      {
+        id: "turn-legacy",
+        sessionId: "session-1",
+        mode: "new",
+        model: "llama3",
+        providerId: null,
+        status: "failed",
+        request: JSON.stringify(persistedRequest),
+        contextReceipt: null,
+        userMessageId: 1,
+        assistantMessageId: 2,
+        failure: "old failure text",
+        createdAt: 10,
+        updatedAt: 11
+      }
+    ])
+    await expect(getTurnRun("turn-legacy")).resolves.toEqual(
+      expect.objectContaining({
+        failure: {
+          status: 0,
+          message: "old failure text",
+          kind: "unknown"
+        }
+      })
+    )
+  })
 })

--- a/src/lib/repositories/tool-loop-runs.ts
+++ b/src/lib/repositories/tool-loop-runs.ts
@@ -18,6 +18,8 @@ export interface DurableToolLoopState {
   imageMessages?: ChatMessage[]
   nonNativeResponseParts?: string[]
   lastMetrics?: ChatMessage["metrics"]
+  /** One recovery turn when a native model emits only reasoning and no call. */
+  emptyModelRetries?: number
 }
 
 export interface DurableToolLoopRun {

--- a/src/lib/repositories/turn-runs.ts
+++ b/src/lib/repositories/turn-runs.ts
@@ -8,6 +8,7 @@ import {
   type TurnSubmission
 } from "@/application/turns/turn-contract"
 import { flushSave, query, run } from "@/lib/sqlite/db"
+import { type AppFailure, AppFailureSchema } from "@/protocol/app-failure"
 
 interface TurnRunRow {
   id: string
@@ -33,6 +34,20 @@ const parseRow = (row: TurnRunRow): DurableTurnRun | null => {
       ? ContextReceiptSchema.parse(JSON.parse(row.contextReceipt))
       : undefined
 
+    const failure = row.failure
+      ? (() => {
+          try {
+            return AppFailureSchema.parse(JSON.parse(row.failure))
+          } catch {
+            return {
+              status: 0,
+              message: row.failure,
+              kind: "unknown" as const
+            }
+          }
+        })()
+      : undefined
+
     return {
       id: row.id,
       sessionId: row.sessionId,
@@ -44,7 +59,7 @@ const parseRow = (row: TurnRunRow): DurableTurnRun | null => {
       contextReceipt: receipt,
       userMessageId: row.userMessageId ?? undefined,
       assistantMessageId: row.assistantMessageId ?? undefined,
-      failure: row.failure ?? undefined,
+      failure,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt
     }
@@ -110,7 +125,7 @@ export const updateTurnRun = async (
     contextReceipt?: DurableTurnRun["contextReceipt"]
     userMessageId?: number
     assistantMessageId?: number
-    failure?: string | null
+    failure?: AppFailure | null
   }
 ): Promise<void> => {
   const fields: string[] = []
@@ -134,7 +149,9 @@ export const updateTurnRun = async (
   }
   if (updates.failure !== undefined) {
     fields.push("failure = ?")
-    values.push(updates.failure)
+    values.push(
+      updates.failure === null ? null : JSON.stringify(updates.failure)
+    )
   }
   if (fields.length === 0) return
 

--- a/src/protocol/app-failure.ts
+++ b/src/protocol/app-failure.ts
@@ -1,0 +1,126 @@
+import { z } from "zod"
+import { getErrorMessage, isAbortError, isAppError } from "@/lib/error-utils"
+
+export const AppFailureSchema = z.object({
+  status: z.number().int().nonnegative(),
+  message: z.string(),
+  kind: z
+    .enum(["network", "provider", "storage", "validation", "abort", "unknown"])
+    .optional(),
+  messageKey: z.string().optional(),
+  userMessage: z.string().optional(),
+  retryable: z.boolean().optional(),
+  retryAfterMs: z.number().nonnegative().optional(),
+  context: z.string().optional(),
+  providerId: z.string().optional(),
+  providerName: z.string().optional(),
+  model: z.string().optional(),
+  baseUrl: z.string().optional(),
+  code: z
+    .enum([
+      "OLC-PROVIDER-DISABLED",
+      "OLC-PROVIDER-UNREACHABLE",
+      "OLC-PROVIDER-HTTP",
+      "OLC-MODEL-NOT-FOUND",
+      "OLC-RESOURCE-NOT-FOUND",
+      "OLC-MODEL-NOT-LOADED",
+      "OLC-CORS-BLOCKED",
+      "OLC-AUTH-FAILED",
+      "OLC-PAYMENT-REQUIRED",
+      "OLC-CONTEXT-TOO-LARGE",
+      "OLC-INPUT-UNSUPPORTED",
+      "OLC-OUT-OF-MEMORY",
+      "OLC-MODEL-LOADING",
+      "OLC-RATE-LIMITED",
+      "OLC-PROVIDER-OVERLOADED",
+      "OLC-PROVIDER-TIMEOUT",
+      "OLC-STREAM-DROPPED",
+      "OLC-UNKNOWN"
+    ])
+    .optional(),
+  phase: z
+    .enum([
+      "configuration",
+      "connect",
+      "response",
+      "read-stream",
+      "tool",
+      "persistence",
+      "unknown"
+    ])
+    .optional(),
+  incidentId: z.string().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  recoveryAction: z
+    .enum([
+      "retry",
+      "enable-provider",
+      "test-connection",
+      "choose-model",
+      "reduce-input",
+      "wait-retry",
+      "open-diagnostics"
+    ])
+    .optional()
+})
+
+export type AppFailure = z.infer<typeof AppFailureSchema>
+
+interface ToAppFailureOptions {
+  status?: number
+  fallbackMessage?: string
+  context?: string
+  providerId?: string
+}
+
+export const toAppFailure = (
+  error: unknown,
+  options: ToAppFailureOptions = {}
+): AppFailure => {
+  const status =
+    error &&
+    typeof error === "object" &&
+    "status" in error &&
+    typeof error.status === "number"
+      ? error.status
+      : undefined
+  const message =
+    isAppError(error) && error.userMessage
+      ? error.userMessage.trim()
+      : getErrorMessage(error, options.fallbackMessage).trim()
+
+  return {
+    status: options.status ?? status ?? 0,
+    message,
+    ...(isAppError(error) && { kind: error.kind }),
+    ...(isAbortError(error) &&
+      !isAppError(error) && { kind: "abort" as const }),
+    ...(isAppError(error) &&
+      error.messageKey && { messageKey: error.messageKey }),
+    ...(isAppError(error) &&
+      error.userMessage && { userMessage: error.userMessage }),
+    ...(isAppError(error) &&
+      error.retryable !== undefined && { retryable: error.retryable }),
+    ...(isAppError(error) &&
+      error.retryAfterMs !== undefined && { retryAfterMs: error.retryAfterMs }),
+    ...((options.context || (isAppError(error) && error.context)) && {
+      context:
+        options.context || (isAppError(error) ? error.context : undefined)
+    }),
+    ...((options.providerId || (isAppError(error) && error.providerId)) && {
+      providerId:
+        options.providerId || (isAppError(error) ? error.providerId : undefined)
+    }),
+    ...(isAppError(error) &&
+      error.providerName && { providerName: error.providerName }),
+    ...(isAppError(error) && error.model && { model: error.model }),
+    ...(isAppError(error) && error.baseUrl && { baseUrl: error.baseUrl }),
+    ...(isAppError(error) && { code: error.code }),
+    ...(isAppError(error) && { phase: error.phase }),
+    ...(isAppError(error) && { incidentId: error.incidentId }),
+    ...(isAppError(error) &&
+      error.durationMs !== undefined && { durationMs: error.durationMs }),
+    ...(isAppError(error) &&
+      error.recoveryAction && { recoveryAction: error.recoveryAction })
+  }
+}

--- a/src/protocol/runtime-transport-registry.ts
+++ b/src/protocol/runtime-transport-registry.ts
@@ -60,6 +60,12 @@ export const RUNTIME_TRANSPORT_DEFINITIONS = [
     allowedSources: extensionPage
   },
   {
+    type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
+    transport: "port-message",
+    operation: "command",
+    allowedSources: extensionPage
+  },
+  {
     type: MESSAGE_KEYS.PROVIDER.PULL_MODEL,
     transport: "port",
     operation: "stream",

--- a/src/protocol/streams/__tests__/stream-contract.test.ts
+++ b/src/protocol/streams/__tests__/stream-contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import {
+  ChatStreamClientEventSchema,
+  ChatStreamServerEventSchema,
+  parseChatStreamServerEvent
+} from "@/protocol/streams"
+
+describe("stream protocol", () => {
+  it("defines cancellation and reconnect as versioned client commands", () => {
+    expect(
+      ChatStreamClientEventSchema.safeParse({
+        version: 1,
+        type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION,
+        payload: { requestId: "turn-1" }
+      }).success
+    ).toBe(true)
+    expect(
+      ChatStreamClientEventSchema.safeParse({
+        version: 1,
+        type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
+        payload: { requestId: "turn-1", afterSeq: 4 }
+      }).success
+    ).toBe(true)
+  })
+
+  it("defines a durable snapshot with the last accepted sequence", () => {
+    expect(
+      ChatStreamServerEventSchema.safeParse({
+        version: 1,
+        type: "stream_snapshot",
+        requestId: "turn-1",
+        seq: 4,
+        sequenceReset: false,
+        status: "generating",
+        assistant: {
+          role: "assistant",
+          content: "partial",
+          done: false
+        }
+      }).success
+    ).toBe(true)
+  })
+
+  it("rejects unknown versions and malformed events", () => {
+    expect(
+      ChatStreamServerEventSchema.safeParse({
+        version: 2,
+        type: "chat_chunk",
+        seq: 0,
+        delta: "no"
+      }).success
+    ).toBe(false)
+    expect(
+      ChatStreamServerEventSchema.safeParse({
+        version: 1,
+        type: "chat_chunk",
+        seq: 0
+      }).success
+    ).toBe(false)
+  })
+
+  it("normalizes one legacy boundary event into v1", () => {
+    const parsed = parseChatStreamServerEvent({ seq: 2, delta: "hello" })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    expect(parsed.data).toMatchObject({
+      version: 1,
+      type: "chat_chunk",
+      seq: 2,
+      delta: "hello"
+    })
+  })
+})

--- a/src/protocol/streams/__tests__/stream-contract.test.ts
+++ b/src/protocol/streams/__tests__/stream-contract.test.ts
@@ -37,7 +37,8 @@ describe("stream protocol", () => {
           role: "assistant",
           content: "partial",
           done: false
-        }
+        },
+        thinkingState: { inThinking: true, pending: "</thi" }
       }).success
     ).toBe(true)
   })

--- a/src/protocol/streams/__tests__/stream-contract.test.ts
+++ b/src/protocol/streams/__tests__/stream-contract.test.ts
@@ -42,6 +42,40 @@ describe("stream protocol", () => {
     ).toBe(true)
   })
 
+  it("preserves approval state in tool-run events", () => {
+    const parsed = parseChatStreamServerEvent({
+      version: 1,
+      type: "chat_chunk",
+      seq: 3,
+      toolRuns: [
+        {
+          toolId: "delete_item",
+          label: "Delete item",
+          risk: "critical",
+          taintGeneration: 2,
+          origin: "https://example.com",
+          status: "awaiting-confirmation",
+          callId: "call-7",
+          startedAt: 123
+        }
+      ]
+    })
+
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    expect(parsed.data).toMatchObject({
+      type: "chat_chunk",
+      toolRuns: [
+        {
+          risk: "critical",
+          taintGeneration: 2,
+          origin: "https://example.com",
+          callId: "call-7"
+        }
+      ]
+    })
+  })
+
   it("rejects unknown versions and malformed events", () => {
     expect(
       ChatStreamServerEventSchema.safeParse({

--- a/src/protocol/streams/chat-stream.ts
+++ b/src/protocol/streams/chat-stream.ts
@@ -1,0 +1,376 @@
+import { z } from "zod"
+import {
+  ContextReceiptSchema,
+  type PersistedTurnRequest,
+  PersistedTurnRequestSchema,
+  TurnModeSchema
+} from "@/application/turns/turn-contract"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import { AppFailureSchema } from "@/protocol/app-failure"
+import type { ChatMessage, ProviderReplayArtifact, ToolRun } from "@/types"
+import {
+  ChatMessageSchema,
+  ProviderReplayArtifactSchema,
+  ToolRunSchema
+} from "@/types/chat.schemas"
+import {
+  SelectionStreamClientEventSchemas,
+  SelectionStreamServerEventSchemas
+} from "./selection-stream"
+import { STREAM_PROTOCOL_VERSION } from "./version"
+
+const version = z.literal(STREAM_PROTOCOL_VERSION)
+
+const SelectedModelRefSchema = z.object({
+  providerId: z.string().min(1),
+  modelId: z.string().min(1)
+})
+
+const ContextFileSchema = z.object({
+  text: z.string(),
+  metadata: z.object({
+    fileName: z.string(),
+    fileId: z.string().optional()
+  })
+})
+
+const toRuntimeChatMessage = (
+  message: z.infer<typeof ChatMessageSchema>
+): ChatMessage => {
+  const { attachments, ...rest } = message
+  return {
+    ...rest,
+    ...(attachments
+      ? {
+          attachments: attachments.map((attachment) => {
+            const { data, ...attachmentRest } = attachment
+            return {
+              ...attachmentRest,
+              ...(data
+                ? {
+                    data:
+                      data instanceof Uint8Array
+                        ? data
+                        : Uint8Array.from(
+                            Array.isArray(data) ? data : Object.values(data)
+                          )
+                  }
+                : {})
+            }
+          })
+        }
+      : {})
+  }
+}
+
+const RuntimeChatMessageSchema =
+  ChatMessageSchema.transform(toRuntimeChatMessage)
+
+const ContextRequestPayloadSchema = z.object({
+  requestId: z.string().min(1),
+  turnId: z.string().min(1).optional(),
+  mode: TurnModeSchema.optional(),
+  rawInput: z.string(),
+  messages: z.array(RuntimeChatMessageSchema),
+  hasTabContext: z.boolean(),
+  contextText: z.string(),
+  tabDocuments: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      content: z.string()
+    })
+  ),
+  memoryEnabled: z.boolean(),
+  maxTabContextChars: z.number(),
+  maxRagContextChars: z.number(),
+  groundedOnlyMode: z.boolean(),
+  selectedModel: z.string(),
+  selectedModelRef: SelectedModelRefSchema.nullable(),
+  customModel: z.string().optional(),
+  files: z.array(ContextFileSchema).optional()
+})
+
+export const ChatStreamClientEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL),
+    payload: z.object({
+      model: z.string().min(1),
+      providerId: z.string().optional(),
+      messages: z.array(RuntimeChatMessageSchema),
+      sessionId: z.string().optional(),
+      chatId: z.string().optional(),
+      requestId: z.string().optional(),
+      clientContextPrepared: z.boolean().optional()
+    })
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.START_TURN),
+    payload: z.object({
+      start: z.object({
+        submission: z.object({
+          id: z.string().min(1),
+          sessionId: z.string().min(1),
+          mode: TurnModeSchema,
+          model: z.string().min(1),
+          providerId: z.string().optional(),
+          request: PersistedTurnRequestSchema.transform(
+            (request): PersistedTurnRequest => ({
+              ...request,
+              context: {
+                ...request.context,
+                messages: request.context.messages.map(toRuntimeChatMessage)
+              },
+              userMessage: toRuntimeChatMessage(request.userMessage)
+            })
+          ),
+          createdAt: z.number().int().nonnegative()
+        }),
+        userMessageId: z.number().int().nonnegative()
+      }),
+      assistantMessageId: z.number().int().nonnegative()
+    })
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.BUILD_CONTEXT),
+    payload: ContextRequestPayloadSchema
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.STOP_GENERATION),
+    payload: z.object({ requestId: z.string().min(1) }).optional()
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM),
+    payload: z.object({
+      requestId: z.string().min(1),
+      afterSeq: z.number().int().min(-1)
+    })
+  }),
+  ...SelectionStreamClientEventSchemas
+])
+
+const ActivityEventSchema = z.object({
+  id: z.string(),
+  kind: z.enum([
+    "preparing_context",
+    "query_rewrite",
+    "searching_memory",
+    "searching_files",
+    "reading_page",
+    "calling_tool",
+    "generating_answer"
+  ]),
+  label: z.string(),
+  status: z.enum(["running", "done", "error"]),
+  startedAt: z.number(),
+  finishedAt: z.number().optional(),
+  inputPreview: z.string().optional(),
+  outputPreview: z.string().optional(),
+  resultCount: z.number().optional(),
+  sourceTitles: z.array(z.string()).optional(),
+  error: z.string().optional()
+})
+
+const TurnToastSchema = z.object({
+  variant: z.enum(["default", "destructive"]).optional(),
+  titleKey: z.string(),
+  descriptionKey: z.string().optional(),
+  descriptionValues: z.record(z.string(), z.string()).optional()
+})
+
+const RagSourceSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  title: z.string(),
+  content: z.string(),
+  score: z.number(),
+  source: z.string().optional(),
+  chunkIndex: z.number().int().optional(),
+  fileId: z.string().optional(),
+  type: z.string().optional()
+})
+
+const UsedContextChunkSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  title: z.string(),
+  excerpt: z.string(),
+  score: z.number(),
+  sectionPath: z.string().optional(),
+  source: z.string().optional(),
+  chunkIndex: z.number().int().optional()
+})
+
+const BuildContextResultSchema = z.object({
+  contentWithRAG: z.string(),
+  ragSources: z
+    .object({
+      sources: z.array(RagSourceSchema),
+      query: z.string()
+    })
+    .nullable(),
+  promptContextStats: z.object({
+    promptInputLength: z.number().int().nonnegative(),
+    promptAugmentedLength: z.number().int().nonnegative(),
+    tabContextLength: z.number().int().nonnegative(),
+    ragContextLength: z.number().int().nonnegative(),
+    tabContextTruncated: z.boolean(),
+    groundedOnlyMode: z.boolean(),
+    insufficientContext: z.boolean(),
+    usedContextChunks: z.array(UsedContextChunkSchema),
+    activityEvents: z.array(ActivityEventSchema)
+  }),
+  pageContextAdded: z.boolean()
+})
+
+const ChatChunkSchema = z
+  .object({
+    version,
+    type: z.literal("chat_chunk"),
+    seq: z.number().int().nonnegative().optional(),
+    delta: z.string().optional(),
+    thinkingDelta: z.string().optional(),
+    replayArtifact: ProviderReplayArtifactSchema.transform(
+      (artifact) => artifact as ProviderReplayArtifact
+    ).optional(),
+    toolRuns: z
+      .array(ToolRunSchema)
+      .transform((runs) => runs as ToolRun[])
+      .optional(),
+    done: z.boolean().optional(),
+    aborted: z.boolean().optional(),
+    error: AppFailureSchema.optional(),
+    metrics: z.record(z.string(), z.unknown()).optional(),
+    message: z
+      .object({
+        content: z.string().optional(),
+        thinking: z.string().optional(),
+        reasoning: z.string().optional(),
+        reasoning_content: z.string().optional()
+      })
+      .optional()
+  })
+  .refine(
+    (event) =>
+      event.delta !== undefined ||
+      event.thinkingDelta !== undefined ||
+      event.replayArtifact !== undefined ||
+      event.toolRuns !== undefined ||
+      event.done === true ||
+      event.aborted === true ||
+      event.error !== undefined ||
+      event.metrics !== undefined ||
+      event.message !== undefined,
+    "Chat chunk has no payload"
+  )
+
+export const ChatStreamServerEventSchema = z.discriminatedUnion("type", [
+  ChatChunkSchema,
+  z.object({
+    version,
+    type: z.literal("rag_sources"),
+    seq: z.number().int().nonnegative().optional(),
+    payload: z.object({
+      sources: z.array(RagSourceSchema),
+      query: z.string().optional()
+    })
+  }),
+  z.object({
+    version,
+    type: z.literal("context_progress"),
+    requestId: z.string().min(1),
+    events: z.array(ActivityEventSchema)
+  }),
+  z.object({
+    version,
+    type: z.literal("context_warning"),
+    requestId: z.string().min(1),
+    payload: TurnToastSchema
+  }),
+  z.object({
+    version,
+    type: z.literal("context_result"),
+    requestId: z.string().min(1),
+    result: BuildContextResultSchema,
+    receipt: ContextReceiptSchema
+  }),
+  z.object({
+    version,
+    type: z.literal("context_error"),
+    requestId: z.string().min(1),
+    failure: AppFailureSchema
+  }),
+  z.object({
+    version,
+    type: z.literal("stream_snapshot"),
+    requestId: z.string().min(1),
+    seq: z.number().int().min(-1),
+    sequenceReset: z.boolean(),
+    status: z.enum([
+      "submitted",
+      "building-context",
+      "generating",
+      "completed",
+      "failed",
+      "cancelled"
+    ]),
+    assistant: RuntimeChatMessageSchema.optional(),
+    failure: AppFailureSchema.optional()
+  }),
+  ...SelectionStreamServerEventSchemas
+])
+
+export type ChatStreamClientEvent = z.infer<typeof ChatStreamClientEventSchema>
+export type ChatStreamServerEvent = z.infer<typeof ChatStreamServerEventSchema>
+
+export const parseChatStreamClientEvent = (value: unknown) =>
+  ChatStreamClientEventSchema.safeParse(normalizeLegacyClientEvent(value))
+
+export const parseChatStreamServerEvent = (value: unknown) =>
+  ChatStreamServerEventSchema.safeParse(normalizeLegacyServerEvent(value))
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value)
+
+/**
+ * One-boundary compatibility shim for an extension page and worker that were
+ * already connected while the extension updated. Everything beyond this
+ * function sees v1. New emitters always send v1.
+ */
+const normalizeLegacyClientEvent = (value: unknown): unknown => {
+  if (!isRecord(value) || value.version !== undefined) return value
+  return { ...value, version: STREAM_PROTOCOL_VERSION }
+}
+
+const normalizeLegacyServerEvent = (value: unknown): unknown => {
+  if (!isRecord(value)) return value
+  const versioned =
+    value.version === undefined
+      ? { ...value, version: STREAM_PROTOCOL_VERSION }
+      : value
+
+  if (typeof versioned.type !== "string") {
+    return { ...versioned, type: "chat_chunk" }
+  }
+  if (
+    versioned.type === "context_error" &&
+    typeof versioned.error === "string"
+  ) {
+    const { error: message, ...rest } = versioned
+    return {
+      ...rest,
+      failure: { status: 0, message }
+    }
+  }
+  if (versioned.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR) {
+    const { error, ...rest } = versioned
+    const failure = isRecord(error)
+      ? error
+      : { status: 0, message: "Selection action failed. Try again." }
+    return { ...rest, failure }
+  }
+  return versioned
+}

--- a/src/protocol/streams/chat-stream.ts
+++ b/src/protocol/streams/chat-stream.ts
@@ -318,6 +318,12 @@ export const ChatStreamServerEventSchema = z.discriminatedUnion("type", [
       "cancelled"
     ]),
     assistant: RuntimeChatMessageSchema.optional(),
+    thinkingState: z
+      .object({
+        inThinking: z.boolean(),
+        pending: z.string()
+      })
+      .optional(),
     failure: AppFailureSchema.optional()
   }),
   ...SelectionStreamServerEventSchemas

--- a/src/protocol/streams/index.ts
+++ b/src/protocol/streams/index.ts
@@ -1,0 +1,4 @@
+export * from "./chat-stream"
+export * from "./model-pull-stream"
+export * from "./selection-stream"
+export * from "./version"

--- a/src/protocol/streams/model-pull-stream.ts
+++ b/src/protocol/streams/model-pull-stream.ts
@@ -1,0 +1,110 @@
+import { z } from "zod"
+import { AppFailureSchema } from "@/protocol/app-failure"
+import { STREAM_PROTOCOL_VERSION } from "./version"
+
+const version = z.literal(STREAM_PROTOCOL_VERSION)
+
+export const ModelPullClientEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    version,
+    type: z.literal("model_pull_start"),
+    payload: z.object({
+      model: z.string().min(1),
+      providerId: z.string().optional()
+    })
+  }),
+  z.object({
+    version,
+    type: z.literal("model_pull_cancel"),
+    payload: z.object({ model: z.string().min(1) })
+  })
+])
+
+export const ModelPullServerEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    version,
+    type: z.literal("model_pull_progress"),
+    status: z.string(),
+    progress: z.number().optional()
+  }),
+  z.object({
+    version,
+    type: z.literal("model_pull_complete"),
+    status: z.string().optional()
+  }),
+  z.object({
+    version,
+    type: z.literal("model_pull_error"),
+    failure: AppFailureSchema
+  })
+])
+
+export type ModelPullClientEvent = z.infer<typeof ModelPullClientEventSchema>
+export type ModelPullServerEvent = z.infer<typeof ModelPullServerEventSchema>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value)
+
+export const parseModelPullClientEvent = (value: unknown) => {
+  if (!isRecord(value)) return ModelPullClientEventSchema.safeParse(value)
+  const payload = value.payload
+  const normalized =
+    value.type !== undefined
+      ? value
+      : value.cancel
+        ? {
+            version: STREAM_PROTOCOL_VERSION,
+            type: "model_pull_cancel",
+            payload: {
+              model:
+                typeof payload === "string"
+                  ? payload
+                  : isRecord(payload) && typeof payload.model === "string"
+                    ? payload.model
+                    : ""
+            }
+          }
+        : {
+            version: STREAM_PROTOCOL_VERSION,
+            type: "model_pull_start",
+            payload: typeof payload === "string" ? { model: payload } : payload
+          }
+  return ModelPullClientEventSchema.safeParse({
+    ...normalized,
+    version:
+      isRecord(normalized) && normalized.version !== undefined
+        ? normalized.version
+        : STREAM_PROTOCOL_VERSION
+  })
+}
+
+export const parseModelPullServerEvent = (value: unknown) => {
+  if (!isRecord(value)) return ModelPullServerEventSchema.safeParse(value)
+  const version = value.version ?? STREAM_PROTOCOL_VERSION
+  if (typeof value.type === "string") {
+    return ModelPullServerEventSchema.safeParse({ ...value, version })
+  }
+  if (value.error !== undefined) {
+    const failure =
+      typeof value.error === "string"
+        ? { status: 0, message: value.error }
+        : value.error
+    return ModelPullServerEventSchema.safeParse({
+      version,
+      type: "model_pull_error",
+      failure
+    })
+  }
+  if (value.done === true) {
+    return ModelPullServerEventSchema.safeParse({
+      version,
+      type: "model_pull_complete",
+      ...(typeof value.status === "string" ? { status: value.status } : {})
+    })
+  }
+  return ModelPullServerEventSchema.safeParse({
+    ...value,
+    version,
+    type: "model_pull_progress"
+  })
+}

--- a/src/protocol/streams/selection-stream.ts
+++ b/src/protocol/streams/selection-stream.ts
@@ -1,0 +1,113 @@
+import { z } from "zod"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import { AppFailureSchema } from "@/protocol/app-failure"
+import { STREAM_PROTOCOL_VERSION } from "./version"
+
+const version = z.literal(STREAM_PROTOCOL_VERSION)
+
+export const SelectionActionRequestSchema = z.object({
+  actionId: z.enum([
+    "summarize",
+    "rewrite",
+    "shorten",
+    "fix-grammar",
+    "explain",
+    "action-items",
+    "translate-english",
+    "custom"
+  ]),
+  selection: z.object({
+    selectedText: z.string(),
+    pageUrl: z.string(),
+    pageTitle: z.string(),
+    selectionType: z.enum([
+      "plain-text",
+      "input",
+      "textarea",
+      "contenteditable",
+      "unknown"
+    ]),
+    canReplace: z.boolean(),
+    canInsert: z.boolean(),
+    surroundingText: z.string().optional()
+  }),
+  customInstruction: z.string().optional(),
+  model: z.string().optional(),
+  providerId: z.string().optional()
+})
+
+export const SelectionStreamClientEventSchemas = [
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION),
+    payload: SelectionActionRequestSchema
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.PROVIDER.CANCEL_SELECTION_ACTION)
+  })
+] as const
+
+export const SelectionStreamServerEventSchemas = [
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK),
+    payload: z.object({
+      delta: z.string(),
+      thinkingDelta: z.string()
+    })
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE)
+  }),
+  z.object({
+    version,
+    type: z.literal(MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR),
+    failure: AppFailureSchema
+  })
+] as const
+
+export const SelectionStreamClientEventSchema = z.discriminatedUnion(
+  "type",
+  SelectionStreamClientEventSchemas
+)
+
+export const SelectionStreamServerEventSchema = z.discriminatedUnion(
+  "type",
+  SelectionStreamServerEventSchemas
+)
+
+export type SelectionStreamClientEvent = z.infer<
+  typeof SelectionStreamClientEventSchema
+>
+export type SelectionStreamServerEvent = z.infer<
+  typeof SelectionStreamServerEventSchema
+>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value)
+
+export const parseSelectionStreamServerEvent = (value: unknown) => {
+  if (!isRecord(value)) return SelectionStreamServerEventSchema.safeParse(value)
+
+  const versioned: Record<string, unknown> = {
+    ...value,
+    version: value.version ?? STREAM_PROTOCOL_VERSION
+  }
+  if (
+    versioned.type !== MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR ||
+    versioned.failure !== undefined
+  ) {
+    return SelectionStreamServerEventSchema.safeParse(versioned)
+  }
+
+  const { error, ...rest } = versioned
+  const failure = isRecord(error)
+    ? { status: typeof error.status === "number" ? error.status : 0, ...error }
+    : {
+        status: 0,
+        message: "Selection action failed. Try again."
+      }
+  return SelectionStreamServerEventSchema.safeParse({ ...rest, failure })
+}

--- a/src/protocol/streams/version.ts
+++ b/src/protocol/streams/version.ts
@@ -1,0 +1,1 @@
+export const STREAM_PROTOCOL_VERSION = 1 as const

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { AppFailureSchema } from "@/protocol/app-failure"
 
 const optionalString = z.preprocess(
   (value) => (value === null ? undefined : value),
@@ -38,7 +39,7 @@ const UsedContextChunkSchema = z.object({
   chunkIndex: z.number().optional()
 })
 
-const ToolRunSchema = z.object({
+export const ToolRunSchema = z.object({
   toolId: z.string(),
   label: z.string(),
   displayNameKey: z.string().optional(),
@@ -55,7 +56,13 @@ const ToolRunSchema = z.object({
     ])
     .optional(),
   risk: z.enum(["low", "medium", "high"]).optional(),
-  status: z.enum(["pending", "running", "done", "error"]),
+  status: z.enum([
+    "pending",
+    "running",
+    "done",
+    "error",
+    "awaiting-confirmation"
+  ]),
   startedAt: z.number(),
   completedAt: z.number().optional(),
   sources: z
@@ -214,7 +221,7 @@ export const ChatMessageMetricsSchema = z.object({
 
 // ---- FileAttachment ----
 
-const FileAttachmentSchema = z.object({
+export const FileAttachmentSchema = z.object({
   id: z.number().optional(),
   fileId: z.string(),
   fileName: z.string(),
@@ -229,7 +236,11 @@ const FileAttachmentSchema = z.object({
   // Accept both so one stray byte field can't fail validation and silently
   // skip the whole session on import.
   data: z
-    .union([z.array(z.number()), z.record(z.string(), z.number())])
+    .union([
+      z.instanceof(Uint8Array),
+      z.array(z.number()),
+      z.record(z.string(), z.number())
+    ])
     .optional()
 })
 
@@ -250,65 +261,7 @@ const ImageAttachmentSchema = z.object({
 
 // ---- ChatMessage ----
 
-export const ChatMessageErrorSchema = z.object({
-  status: z.number().optional(),
-  kind: z
-    .enum(["network", "provider", "storage", "validation", "abort", "unknown"])
-    .optional(),
-  retryable: z.boolean().optional(),
-  retryAfterMs: z.number().optional(),
-  userMessage: z.string().optional(),
-  providerId: z.string().optional(),
-  providerName: z.string().optional(),
-  model: z.string().optional(),
-  baseUrl: z.string().optional(),
-  code: z
-    .enum([
-      "OLC-PROVIDER-DISABLED",
-      "OLC-PROVIDER-UNREACHABLE",
-      "OLC-PROVIDER-HTTP",
-      "OLC-MODEL-NOT-FOUND",
-      "OLC-RESOURCE-NOT-FOUND",
-      "OLC-MODEL-NOT-LOADED",
-      "OLC-CORS-BLOCKED",
-      "OLC-AUTH-FAILED",
-      "OLC-PAYMENT-REQUIRED",
-      "OLC-CONTEXT-TOO-LARGE",
-      "OLC-INPUT-UNSUPPORTED",
-      "OLC-OUT-OF-MEMORY",
-      "OLC-MODEL-LOADING",
-      "OLC-RATE-LIMITED",
-      "OLC-PROVIDER-OVERLOADED",
-      "OLC-PROVIDER-TIMEOUT",
-      "OLC-STREAM-DROPPED",
-      "OLC-UNKNOWN"
-    ])
-    .optional(),
-  phase: z
-    .enum([
-      "configuration",
-      "connect",
-      "response",
-      "read-stream",
-      "tool",
-      "persistence",
-      "unknown"
-    ])
-    .optional(),
-  incidentId: z.string().optional(),
-  durationMs: z.number().nonnegative().optional(),
-  recoveryAction: z
-    .enum([
-      "retry",
-      "enable-provider",
-      "test-connection",
-      "choose-model",
-      "reduce-input",
-      "wait-retry",
-      "open-diagnostics"
-    ])
-    .optional()
-})
+export const ChatMessageErrorSchema = AppFailureSchema.partial()
 
 export const ChatMessageSchema = z.object({
   id: z.union([z.number(), z.string()]).optional(),

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -55,7 +55,9 @@ export const ToolRunSchema = z.object({
       "external"
     ])
     .optional(),
-  risk: z.enum(["low", "medium", "high"]).optional(),
+  risk: z.enum(["low", "medium", "high", "critical"]).optional(),
+  taintGeneration: z.number().int().nonnegative().optional(),
+  origin: z.string().optional(),
   status: z.enum([
     "pending",
     "running",
@@ -63,6 +65,7 @@ export const ToolRunSchema = z.object({
     "error",
     "awaiting-confirmation"
   ]),
+  callId: z.string().optional(),
   startedAt: z.number(),
   completedAt: z.number().optional(),
   sources: z

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,4 +1,5 @@
 import type { ToolCall } from "@/lib/tools/types"
+import type { AppFailure } from "@/protocol/app-failure"
 import type { SelectedModelRef } from "@/types/model"
 
 export type Role = "user" | "assistant" | "system" | "tool"
@@ -128,22 +129,7 @@ export interface ChatMessage {
    * Terminal error for this assistant turn. Set when the stream ends in an
    * error so the UI can offer an inline retry for retryable failures.
    */
-  error?: {
-    status?: number
-    kind?: import("./errors").AppErrorKind
-    retryable?: boolean
-    retryAfterMs?: number
-    userMessage?: string
-    providerId?: string
-    providerName?: string
-    model?: string
-    baseUrl?: string
-    code?: import("./errors").AppErrorCode
-    phase?: import("./errors").AppErrorPhase
-    incidentId?: string
-    durationMs?: number
-    recoveryAction?: import("./errors").AppErrorRecoveryAction
-  }
+  error?: Partial<AppFailure>
   timestamp?: number
   metrics?: {
     total_duration?: number
@@ -283,25 +269,7 @@ export interface ChatStreamMessage {
    * trace updates live as tools run.
    */
   toolRuns?: ToolRun[]
-  error?: {
-    status: number
-    message: string
-    kind?: import("./errors").AppErrorKind
-    messageKey?: string
-    userMessage?: string
-    retryable?: boolean
-    retryAfterMs?: number
-    context?: string
-    providerId?: string
-    providerName?: string
-    model?: string
-    baseUrl?: string
-    code?: import("./errors").AppErrorCode
-    phase?: import("./errors").AppErrorPhase
-    incidentId?: string
-    durationMs?: number
-    recoveryAction?: import("./errors").AppErrorRecoveryAction
-  }
+  error?: AppFailure
   metrics?: {
     total_duration?: number
     load_duration?: number
@@ -316,6 +284,7 @@ export interface ChatStreamMessage {
 
 export interface ChatWithModelMessage {
   type: string
+  version?: 1
   payload: {
     model: string
     providerId?: string
@@ -340,6 +309,7 @@ export interface ChatWithModelMessage {
 
 export interface StartTurnMessage {
   type: string
+  version?: 1
   payload: {
     start: import("@/application/turns/turn-contract").DurableTurnStart
     assistantMessageId: number
@@ -381,6 +351,7 @@ export interface BuildContextRequestPayload {
 
 export interface BuildContextMessage {
   type: string
+  version?: 1
   payload: BuildContextRequestPayload
 }
 

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -1,4 +1,5 @@
 import type browser from "webextension-polyfill"
+import type { AppFailure } from "@/protocol/app-failure"
 
 export interface EmbeddingStatusMessage {
   status: string
@@ -20,31 +21,15 @@ export interface PendingOmniboxQuery {
 
 export interface ChromeMessage {
   type: string
+  version?: number
   payload?: unknown
   disposition?: string
   query?: string
   name?: string
   cancel?: boolean
   fromBackground?: boolean
-  error?: {
-    status: number
-    message: string
-    kind?: import("./errors").AppErrorKind
-    messageKey?: string
-    userMessage?: string
-    retryable?: boolean
-    retryAfterMs?: number
-    context?: string
-    providerId?: string
-    providerName?: string
-    model?: string
-    baseUrl?: string
-    code?: import("./errors").AppErrorCode
-    phase?: import("./errors").AppErrorPhase
-    incidentId?: string
-    durationMs?: number
-    recoveryAction?: import("./errors").AppErrorRecoveryAction
-  }
+  error?: AppFailure
+  failure?: AppFailure
 }
 
 // Omit the members we deliberately narrow: the base `postMessage`/`onMessage`
@@ -64,6 +49,8 @@ export interface ChromePort
    * if keyed by name alone.
    */
   abortScopeKey?: string
+  /** Next monotonic event sequence for the active chat stream. */
+  streamSequence?: number
 }
 
 export interface ChromeSidePanel {
@@ -76,25 +63,7 @@ export interface ChromeSidePanel {
 export interface ChromeResponse {
   success: boolean
   data?: unknown
-  error?: {
-    status: number
-    message: string
-    kind?: import("./errors").AppErrorKind
-    messageKey?: string
-    userMessage?: string
-    retryable?: boolean
-    retryAfterMs?: number
-    context?: string
-    providerId?: string
-    providerName?: string
-    model?: string
-    baseUrl?: string
-    code?: import("./errors").AppErrorCode
-    phase?: import("./errors").AppErrorPhase
-    incidentId?: string
-    durationMs?: number
-    recoveryAction?: import("./errors").AppErrorRecoveryAction
-  }
+  error?: AppFailure
   tabs?: browser.Tabs.Tab[]
   html?: string
   title?: string

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,3 +1,4 @@
+import type { AppFailure } from "@/protocol/app-failure"
 import type { ChatMessage } from "./chat"
 import type { ChromeResponse } from "./messaging"
 
@@ -198,19 +199,7 @@ export interface PullStreamMessage {
   status?: string
   progress?: number
   done?: boolean
-  error?:
-    | string
-    | {
-        status: number
-        message: string
-        kind?: import("./errors").AppErrorKind
-        messageKey?: string
-        userMessage?: string
-        retryable?: boolean
-        retryAfterMs?: number
-        context?: string
-        providerId?: string
-      }
+  error?: string | AppFailure
 }
 
 export interface ModelPullMessage {


### PR DESCRIPTION
## Summary
- add versioned Zod contracts for chat, context, selection, and model-pull streams
- parse events once at port boundaries and safely reject malformed input
- add durable reconnect snapshots and observer reattachment
- unify wire and persisted failures under AppFailure while retaining legacy-row compatibility

## Validation
- pnpm typecheck
- pnpm lint:check
- pnpm test:run (2,422 tests)
- pnpm build
- pnpm build:firefox

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds validated, versioned streaming contracts and durable reconnect support across the extension.
- Parses chat, context, selection-action, and model-pull events at transport boundaries.
- Standardizes streamed and persisted errors as `AppFailure` while retaining legacy-row compatibility.
- Reattaches durable-turn observers through coherent assistant, sequence, and thinking-parser snapshots.
- Adds contract, reconnect-race, persistence, provider, and UI-hook coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/background/durable-turn-runtime.ts | Adds observer reattachment, reconnect leases, coherent runtime snapshots, parser-state restoration, and terminal cleanup without leaving a blocking lifecycle failure. |
| src/features/chat/hooks/use-chat-stream.ts | Validates incoming events and rebuilds durable stream state from versioned snapshots, including sequence and thinking-parser state. |
| src/background/port-router.ts | Validates versioned port requests before dispatching chat, context, reconnect, selection, and model-pull operations. |
| src/protocol/streams/chat-stream.ts | Defines the versioned Zod contracts for chat chunks, context events, and durable snapshots. |
| src/protocol/app-failure.ts | Introduces the shared normalized failure contract used by wire events and persisted turn state. |
| src/lib/repositories/turn-runs.ts | Persists typed failures while decoding legacy string failure rows for backward compatibility. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Sidepanel
  participant Port as Typed Port Boundary
  participant BG as Durable Turn Runtime
  participant Provider as Model Provider
  participant DB as SQLite Persistence

  UI->>Port: Versioned start/reconnect event
  Port->>BG: Validated request
  BG->>Provider: Start or resume generation
  Provider-->>BG: Raw stream chunks
  BG->>BG: Validate and reduce event
  BG->>DB: Persist assistant and turn state
  BG-->>UI: Versioned typed stream event

  UI->>BG: Reconnect(turnId, afterSeq)
  BG->>DB: Read persisted turn and assistant
  BG-->>UI: Coherent stream snapshot
  BG-->>UI: Buffered events after snapshot cursor
```
</details>

<sub>Reviews (11): Last reviewed commit: ["fix(streams): preserve reconnect state"](https://github.com/shishir435/ollama-client/commit/18a1e5ccfdb9802b471ee440ec0f83b83c30b173) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48380479)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)
- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)
</details>

<!-- /greptile_comment -->