### PR TITLE
Centralize stream event types

### DIFF
--- a/src/application/turns/chat-stream-reducer.ts
+++ b/src/application/turns/chat-stream-reducer.ts
@@ -3,6 +3,7 @@ import {
   splitThinkingDelta,
   type ThinkingParserState
 } from "@/lib/thinking-parser"
+import { CHAT_STREAM_EVENT_TYPES } from "@/protocol/streams"
 import type { ChatMessage, ProviderReplayArtifact, ToolRun } from "@/types"
 
 /**
@@ -162,7 +163,10 @@ export const reduceStreamEvent = (
 
   // `rag_sources` side channel: fold retrieval metadata into metrics silently
   // (no visible change, no token), matching the legacy early-return.
-  if (msg.type === "rag_sources" && msg.payload?.sources) {
+  if (
+    msg.type === CHAT_STREAM_EVENT_TYPES.RAG_SOURCES &&
+    msg.payload?.sources
+  ) {
     assistant = {
       ...assistant,
       metrics: {

--- a/src/background/durable-turn-runtime.ts
+++ b/src/background/durable-turn-runtime.ts
@@ -35,6 +35,7 @@ import {
 } from "@/lib/repositories/turn-runs"
 import type { ThinkingParserState } from "@/lib/thinking-parser"
 import {
+  CHAT_STREAM_EVENT_TYPES,
   type ChatStreamServerEvent,
   parseChatStreamServerEvent
 } from "@/protocol/streams"
@@ -95,7 +96,7 @@ export const attachDurableTurnObserver = (
 }
 
 const isTerminalEvent = (message: ChatStreamServerEvent): boolean =>
-  message.type === "chat_chunk" &&
+  message.type === CHAT_STREAM_EVENT_TYPES.CHUNK &&
   Boolean(message.done || message.error || message.aborted)
 
 const cleanupTurnObservers = (turnId: string): void => {
@@ -219,7 +220,7 @@ const makeGenerationOwner = (): TurnGenerationOwner => ({
       })
       forwardTurn(submission.id, {
         version: 1,
-        type: "chat_chunk",
+        type: CHAT_STREAM_EVENT_TYPES.CHUNK,
         seq: 0,
         delta: message.content,
         done: true
@@ -251,8 +252,8 @@ const makeGenerationOwner = (): TurnGenerationOwner => ({
       const parsed = parseChatStreamServerEvent(raw)
       if (
         !parsed.success ||
-        (parsed.data.type !== "chat_chunk" &&
-          parsed.data.type !== "rag_sources")
+        (parsed.data.type !== CHAT_STREAM_EVENT_TYPES.CHUNK &&
+          parsed.data.type !== CHAT_STREAM_EVENT_TYPES.RAG_SOURCES)
       ) {
         return
       }
@@ -284,7 +285,7 @@ const makeGenerationOwner = (): TurnGenerationOwner => ({
         })
       }
       if (reduction.terminal) completion.terminal = reduction.terminal
-      if (message.type === "chat_chunk" && message.aborted) {
+      if (message.type === CHAT_STREAM_EVENT_TYPES.CHUNK && message.aborted) {
         completion.aborted = true
       }
       forwardTurn(submission.id, message)
@@ -343,14 +344,14 @@ const withLiveCallbacks = (submission: TurnSubmission) => {
     onActivityEvent: (events: ActivityEvent[]) =>
       forwardTurn(submission.id, {
         version: 1,
-        type: "context_progress",
+        type: CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS,
         requestId: submission.id,
         events
       }),
     toast: (warning: TurnToast) =>
       forwardTurn(submission.id, {
         version: 1,
-        type: "context_warning",
+        type: CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING,
         requestId: submission.id,
         payload: warning
       })
@@ -433,7 +434,7 @@ export const reconnectDurableTurn = async (
     if (!turn) {
       safePostChatStreamEvent(output.port, {
         version: 1,
-        type: "stream_snapshot",
+        type: CHAT_STREAM_EVENT_TYPES.SNAPSHOT,
         requestId: turnId,
         seq: -1,
         sequenceReset: true,
@@ -467,7 +468,7 @@ export const reconnectDurableTurn = async (
     const sequenceReset = runtimeSnapshot === undefined || seq < afterSeq
     safePostChatStreamEvent(output.port, {
       version: 1,
-      type: "stream_snapshot",
+      type: CHAT_STREAM_EVENT_TYPES.SNAPSHOT,
       requestId: turnId,
       seq,
       sequenceReset,
@@ -486,7 +487,7 @@ export const reconnectDurableTurn = async (
     const buffered = observer.pending.splice(0)
     for (const message of buffered) {
       if (
-        message.type === "chat_chunk" &&
+        message.type === CHAT_STREAM_EVENT_TYPES.CHUNK &&
         message.seq !== undefined &&
         message.seq <= seq
       ) {

--- a/src/background/handlers/handle-build-context.ts
+++ b/src/background/handlers/handle-build-context.ts
@@ -5,7 +5,10 @@ import { safePostChatStreamEvent } from "@/background/lib/utils"
 import { logger } from "@/lib/logger"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { toAppFailure } from "@/protocol/app-failure"
-import type { ChatStreamServerEvent } from "@/protocol/streams"
+import {
+  CHAT_STREAM_EVENT_TYPES,
+  type ChatStreamServerEvent
+} from "@/protocol/streams"
 import type {
   ActivityEvent,
   BuildContextMessage,
@@ -97,14 +100,14 @@ export const handleBuildContext = async (
         onActivityEvent: (events: ActivityEvent[]) =>
           post({
             version: 1,
-            type: "context_progress",
+            type: CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS,
             requestId: p.requestId,
             events
           }),
         toast: (warning) =>
           post({
             version: 1,
-            type: "context_warning",
+            type: CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING,
             requestId: p.requestId,
             payload: warning
           })
@@ -113,7 +116,7 @@ export const handleBuildContext = async (
 
     post({
       version: 1,
-      type: "context_result",
+      type: CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT,
       requestId: p.requestId,
       result: output.result,
       receipt: output.receipt
@@ -122,7 +125,7 @@ export const handleBuildContext = async (
     logger.error("Failed to build context", "handleBuildContext", { error })
     post({
       version: 1,
-      type: "context_error",
+      type: CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR,
       requestId: p.requestId,
       failure: toAppFailure(error, {
         fallbackMessage: "Context build failed",

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -27,6 +27,7 @@ import {
   saveToolLoopRun,
   type ToolLoopMode
 } from "@/lib/repositories/tool-loop-runs"
+import { CHAT_STREAM_EVENT_TYPES } from "@/protocol/streams"
 import type {
   ChatMessage,
   ChatStreamMessage,
@@ -196,7 +197,7 @@ export const handleChatWithModel = withErrorContext(
           try {
             safePostChatStreamEvent(port, {
               version: 1,
-              type: "rag_sources",
+              type: CHAT_STREAM_EVENT_TYPES.RAG_SOURCES,
               payload: { sources, query: lastUserMessage.content }
             })
           } catch (e) {
@@ -284,7 +285,7 @@ export const handleChatWithModel = withErrorContext(
       port.streamSequence = seq + 1
       safePostChatStreamEvent(port, {
         version: 1,
-        type: "chat_chunk",
+        type: CHAT_STREAM_EVENT_TYPES.CHUNK,
         ...chunk,
         seq
       })

--- a/src/background/handlers/handle-model-pull.ts
+++ b/src/background/handlers/handle-model-pull.ts
@@ -18,6 +18,7 @@ import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderId } from "@/lib/providers/types"
 import { toAppFailure } from "@/protocol/app-failure"
+import { MODEL_PULL_EVENT_TYPES } from "@/protocol/streams"
 import type {
   ChromePort,
   DefaultProviderPullRequest,
@@ -47,7 +48,7 @@ export const handleModelPull = async (
   if (!provider.capabilities.modelPull) {
     safePostModelPullEvent(port, {
       version: 1,
-      type: "model_pull_error",
+      type: MODEL_PULL_EVENT_TYPES.ERROR,
       failure: {
         status: 400,
         message: "Model download is not supported by this provider"
@@ -86,7 +87,7 @@ export const handleModelPull = async (
     if (!res.ok) {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_error",
+        type: MODEL_PULL_EVENT_TYPES.ERROR,
         failure: { status: res.status, message: res.statusText }
       })
       return
@@ -95,7 +96,7 @@ export const handleModelPull = async (
     if (isLmStudio) {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_complete",
+        type: MODEL_PULL_EVENT_TYPES.COMPLETE,
         status: "Download requested"
       })
       return
@@ -104,7 +105,7 @@ export const handleModelPull = async (
     if (!res.body) {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_error",
+        type: MODEL_PULL_EVENT_TYPES.ERROR,
         failure: toAppFailure("No response body received")
       })
       return
@@ -116,7 +117,7 @@ export const handleModelPull = async (
     if (connectTimeout.timedOut()) {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_error",
+        type: MODEL_PULL_EVENT_TYPES.ERROR,
         failure: {
           status: 408,
           message: `Connection timed out after ${
@@ -127,13 +128,13 @@ export const handleModelPull = async (
     } else if (isAbortError(err)) {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_error",
+        type: MODEL_PULL_EVENT_TYPES.ERROR,
         failure: toAppFailure("Download cancelled", { status: 499 })
       })
     } else {
       safePostModelPullEvent(port, {
         version: 1,
-        type: "model_pull_error",
+        type: MODEL_PULL_EVENT_TYPES.ERROR,
         failure: normalizeError(err, {
           fallbackMessage: "Failed to pull model"
         })

--- a/src/background/handlers/handle-pull-stream.ts
+++ b/src/background/handlers/handle-pull-stream.ts
@@ -5,6 +5,7 @@ import {
 } from "@/background/lib/utils"
 import { logger } from "@/lib/logger"
 import { toAppFailure } from "@/protocol/app-failure"
+import { MODEL_PULL_EVENT_TYPES } from "@/protocol/streams"
 import type {
   ChromePort,
   DefaultProviderPullResponse,
@@ -53,14 +54,14 @@ export const handlePullStream = async (
           if (data.status) {
             safePostModelPullEvent(port, {
               version: 1,
-              type: "model_pull_progress",
+              type: MODEL_PULL_EVENT_TYPES.PROGRESS,
               status: data.status
             })
 
             if (data.status === "success") {
               safePostModelPullEvent(port, {
                 version: 1,
-                type: "model_pull_complete",
+                type: MODEL_PULL_EVENT_TYPES.COMPLETE,
                 status: data.status
               })
               clearAbortController(controllerKey)
@@ -71,7 +72,7 @@ export const handlePullStream = async (
           if (data.error) {
             safePostModelPullEvent(port, {
               version: 1,
-              type: "model_pull_error",
+              type: MODEL_PULL_EVENT_TYPES.ERROR,
               failure: toAppFailure(data.error)
             })
             clearAbortController(controllerKey)
@@ -82,7 +83,7 @@ export const handlePullStream = async (
             const progress = Math.round((data.completed / data.total) * 100)
             safePostModelPullEvent(port, {
               version: 1,
-              type: "model_pull_progress",
+              type: MODEL_PULL_EVENT_TYPES.PROGRESS,
               status: `Downloading: ${progress}%`,
               progress
             })
@@ -102,7 +103,7 @@ export const handlePullStream = async (
         if (data.status === "success") {
           safePostModelPullEvent(port, {
             version: 1,
-            type: "model_pull_complete",
+            type: MODEL_PULL_EVENT_TYPES.COMPLETE,
             status: data.status
           })
         }

--- a/src/background/lib/error-handler.ts
+++ b/src/background/lib/error-handler.ts
@@ -6,6 +6,7 @@ import {
   type ProviderErrorContext
 } from "@/lib/providers/provider-errors"
 import { type AppFailure, toAppFailure } from "@/protocol/app-failure"
+import { CHAT_STREAM_EVENT_TYPES } from "@/protocol/streams"
 import type {
   ChromePort,
   ChromeResponse,
@@ -76,7 +77,7 @@ export const withErrorContext = <T>(
         if (!isPortClosed()) {
           safePostChatStreamEvent(port, {
             version: 1,
-            type: "chat_chunk",
+            type: CHAT_STREAM_EVENT_TYPES.CHUNK,
             seq: port.streamSequence ?? 0,
             done: true,
             aborted: true
@@ -160,7 +161,7 @@ export const withErrorContext = <T>(
         }
         safePostChatStreamEvent(port, {
           version: 1,
-          type: "chat_chunk",
+          type: CHAT_STREAM_EVENT_TYPES.CHUNK,
           seq: port.streamSequence ?? 0,
           error: response.error
         })

--- a/src/background/lib/utils.ts
+++ b/src/background/lib/utils.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderManager } from "@/lib/providers/manager"
 import { ProviderId } from "@/lib/providers/types"
+import { getMessageType } from "@/protocol/message-type"
 import {
   ChatStreamServerEventSchema,
   type ModelPullServerEvent,
@@ -55,13 +56,7 @@ export const safePostChatStreamEvent = (
   const parsed = ChatStreamServerEventSchema.safeParse(event)
   if (!parsed.success) {
     logger.error("Refused invalid chat stream event", "StreamProtocol", {
-      type:
-        event &&
-        typeof event === "object" &&
-        "type" in event &&
-        typeof event.type === "string"
-          ? event.type
-          : "invalid",
+      type: getMessageType(event) ?? "invalid",
       issues: parsed.error.issues.length
     })
     return

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -22,6 +22,7 @@ import {
   SELECTION_OVERLAY_REQUEST_ID_GLOBAL,
   type SelectionOverlayLoadResult
 } from "@/protocol/content-messages"
+import { getMessageType } from "@/protocol/message-type"
 import {
   RPC_CANCEL_MESSAGE_TYPE,
   RPC_REQUEST_MESSAGE_TYPE
@@ -232,20 +233,17 @@ export const registerMessageRouter = () => {
     const response = sendResponse as SendResponseFunction
     const message = rawMessage as ChromeMessage
 
+    const messageType = getMessageType(message)
     if (
-      typeof message?.type !== "string" ||
+      !messageType ||
       !isRuntimeMessageAllowed(
-        message.type,
+        messageType,
         sender,
         browser.runtime.id,
         extensionUrlPrefix
       )
     ) {
-      respondForbidden(
-        typeof message?.type === "string" ? message.type : "invalid",
-        sender,
-        response
-      )
+      respondForbidden(messageType ?? "invalid", sender, response)
       return true
     }
 

--- a/src/background/port-router.ts
+++ b/src/background/port-router.ts
@@ -17,7 +17,9 @@ import {
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
+import { getMessageType } from "@/protocol/message-type"
 import {
+  MODEL_PULL_EVENT_TYPES,
   parseChatStreamClientEvent,
   parseModelPullClientEvent
 } from "@/protocol/streams"
@@ -78,13 +80,7 @@ export const registerPortRouter = () => {
 
     port.onMessage.addListener(async (message) => {
       const parsed = parseChatStreamClientEvent(message)
-      const messageType =
-        message &&
-        typeof message === "object" &&
-        "type" in message &&
-        typeof message.type === "string"
-          ? message.type
-          : ""
+      const messageType = getMessageType(message) ?? ""
       if (
         !isRuntimePortMessageAllowed(
           port.name,
@@ -176,13 +172,7 @@ export const registerPortRouter = () => {
     ) {
       port.onMessage.addListener(async (message) => {
         const parsed = parseModelPullClientEvent(message)
-        const messageType =
-          message &&
-          typeof message === "object" &&
-          "type" in message &&
-          typeof message.type === "string"
-            ? message.type
-            : ""
+        const messageType = getMessageType(message) ?? ""
         if (
           !isRuntimePortMessageAllowed(
             port.name,
@@ -220,7 +210,7 @@ export const registerPortRouter = () => {
         }
         const event = parsed.data
         await handleModelPull(
-          event.type === "model_pull_cancel"
+          event.type === MODEL_PULL_EVENT_TYPES.CANCEL
             ? { payload: event.payload.model, cancel: true }
             : { payload: event.payload },
           port,

--- a/src/features/chat/hooks/use-build-context.ts
+++ b/src/features/chat/hooks/use-build-context.ts
@@ -4,6 +4,7 @@ import type { TurnToast } from "@/application/turns/turn-contract"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import {
+  CHAT_STREAM_EVENT_TYPES,
   parseChatStreamServerEvent,
   STREAM_PROTOCOL_VERSION
 } from "@/protocol/streams"
@@ -58,18 +59,18 @@ export const useBuildContext = () => {
           const msg = parsed.data
           if (!("requestId" in msg) || msg.requestId !== requestId) return
           switch (msg.type) {
-            case "context_progress":
+            case CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS:
               callbacks?.onActivityEvent?.(msg.events)
               break
-            case "context_warning":
+            case CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING:
               callbacks?.toast?.(msg.payload)
               break
-            case "context_result":
+            case CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT:
               finish(() =>
                 resolve({ result: msg.result, receipt: msg.receipt })
               )
               break
-            case "context_error":
+            case CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR:
               finish(() =>
                 reject(
                   new Error(msg.failure.userMessage || msg.failure.message)

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -18,6 +18,7 @@ import { logger } from "@/lib/logger"
 import { providerErrorUserMessage } from "@/lib/providers/provider-errors"
 import { getProviderDisplayName } from "@/lib/providers/registry"
 import {
+  CHAT_STREAM_EVENT_TYPES,
   parseChatStreamServerEvent,
   STREAM_PROTOCOL_VERSION
 } from "@/protocol/streams"
@@ -170,7 +171,7 @@ export const useChatStream = ({
         return
       }
       const msg = parsed.data
-      if (msg.type === "context_warning") {
+      if (msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING) {
         const warning = msg.payload
         if (warning?.titleKey) {
           toast({
@@ -183,8 +184,8 @@ export const useChatStream = ({
         }
         return
       }
-      if (msg.type === "context_progress") return
-      if (msg.type === "stream_snapshot") {
+      if (msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS) return
+      if (msg.type === CHAT_STREAM_EVENT_TYPES.SNAPSHOT) {
         if (!msg.sequenceReset && msg.seq < state.lastSeq) return
         if (msg.assistant) {
           state = {
@@ -210,8 +211,8 @@ export const useChatStream = ({
         return
       }
       if (
-        msg.type === "context_result" ||
-        msg.type === "context_error" ||
+        msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT ||
+        msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR ||
         msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK ||
         msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE ||
         msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR
@@ -224,7 +225,7 @@ export const useChatStream = ({
       state = result.state
       if (result.dropped) return
 
-      if (DEBUG_THINKING_STREAM && msg.type === "chat_chunk") {
+      if (DEBUG_THINKING_STREAM && msg.type === CHAT_STREAM_EVENT_TYPES.CHUNK) {
         logger.debug("Stream msg", "useChatStream", {
           type: msg.type,
           hasDelta: typeof msg.delta === "string" && msg.delta.length > 0,

--- a/src/features/model/hooks/use-model-pull.ts
+++ b/src/features/model/hooks/use-model-pull.ts
@@ -5,6 +5,7 @@ import { MESSAGE_KEYS } from "@/lib/constants"
 import { formatErrorForDisplay } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
 import {
+  MODEL_PULL_EVENT_TYPES,
   parseModelPullServerEvent,
   STREAM_PROTOCOL_VERSION
 } from "@/protocol/streams"
@@ -26,7 +27,7 @@ export const useModelPull = () => {
 
     port.postMessage({
       version: STREAM_PROTOCOL_VERSION,
-      type: "model_pull_start",
+      type: MODEL_PULL_EVENT_TYPES.START,
       payload: {
         model: modelName,
         providerId
@@ -42,13 +43,15 @@ export const useModelPull = () => {
         return
       }
       const message = parsed.data
-      if (message.type === "model_pull_progress") setProgress(message.status)
-      if (message.type === "model_pull_complete") {
+      if (message.type === MODEL_PULL_EVENT_TYPES.PROGRESS) {
+        setProgress(message.status)
+      }
+      if (message.type === MODEL_PULL_EVENT_TYPES.COMPLETE) {
         setProgress("✅ Success")
         setPullingModel(null)
         port.disconnect()
       }
-      if (message.type === "model_pull_error") {
+      if (message.type === MODEL_PULL_EVENT_TYPES.ERROR) {
         const errorMessage = formatErrorForDisplay(message.failure).message
         setProgress(`❌ Failed: ${errorMessage}`)
         setPullingModel(null)
@@ -61,7 +64,7 @@ export const useModelPull = () => {
     if (pullingModel && portRef.current) {
       portRef.current.postMessage({
         version: STREAM_PROTOCOL_VERSION,
-        type: "model_pull_cancel",
+        type: MODEL_PULL_EVENT_TYPES.CANCEL,
         payload: { model: pullingModel }
       })
       setProgress("❌ Cancelled")

--- a/src/protocol/__tests__/message-type.test.ts
+++ b/src/protocol/__tests__/message-type.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { getMessageType } from "@/protocol/message-type"
+
+describe("getMessageType", () => {
+  it("returns string discriminators", () => {
+    expect(getMessageType({ type: "chat_chunk" })).toBe("chat_chunk")
+  })
+
+  it.each([
+    null,
+    [],
+    {},
+    { type: 1 },
+    "chat_chunk"
+  ])("rejects malformed input %#", (value) => {
+    expect(getMessageType(value)).toBeUndefined()
+  })
+})

--- a/src/protocol/message-type.ts
+++ b/src/protocol/message-type.ts
@@ -1,0 +1,8 @@
+export const getMessageType = (value: unknown): string | undefined => {
+  if (!value || typeof value !== "object" || !("type" in value)) {
+    return undefined
+  }
+
+  const type = value.type
+  return typeof type === "string" ? type : undefined
+}

--- a/src/protocol/streams/chat-stream.ts
+++ b/src/protocol/streams/chat-stream.ts
@@ -13,6 +13,7 @@ import {
   ProviderReplayArtifactSchema,
   ToolRunSchema
 } from "@/types/chat.schemas"
+import { CHAT_STREAM_EVENT_TYPES } from "./event-types"
 import {
   SelectionStreamClientEventSchemas,
   SelectionStreamServerEventSchemas
@@ -229,7 +230,7 @@ const BuildContextResultSchema = z.object({
 const ChatChunkSchema = z
   .object({
     version,
-    type: z.literal("chat_chunk"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.CHUNK),
     seq: z.number().int().nonnegative().optional(),
     delta: z.string().optional(),
     thinkingDelta: z.string().optional(),
@@ -271,7 +272,7 @@ export const ChatStreamServerEventSchema = z.discriminatedUnion("type", [
   ChatChunkSchema,
   z.object({
     version,
-    type: z.literal("rag_sources"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.RAG_SOURCES),
     seq: z.number().int().nonnegative().optional(),
     payload: z.object({
       sources: z.array(RagSourceSchema),
@@ -280,32 +281,32 @@ export const ChatStreamServerEventSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     version,
-    type: z.literal("context_progress"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS),
     requestId: z.string().min(1),
     events: z.array(ActivityEventSchema)
   }),
   z.object({
     version,
-    type: z.literal("context_warning"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING),
     requestId: z.string().min(1),
     payload: TurnToastSchema
   }),
   z.object({
     version,
-    type: z.literal("context_result"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT),
     requestId: z.string().min(1),
     result: BuildContextResultSchema,
     receipt: ContextReceiptSchema
   }),
   z.object({
     version,
-    type: z.literal("context_error"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR),
     requestId: z.string().min(1),
     failure: AppFailureSchema
   }),
   z.object({
     version,
-    type: z.literal("stream_snapshot"),
+    type: z.literal(CHAT_STREAM_EVENT_TYPES.SNAPSHOT),
     requestId: z.string().min(1),
     seq: z.number().int().min(-1),
     sequenceReset: z.boolean(),
@@ -359,10 +360,10 @@ const normalizeLegacyServerEvent = (value: unknown): unknown => {
       : value
 
   if (typeof versioned.type !== "string") {
-    return { ...versioned, type: "chat_chunk" }
+    return { ...versioned, type: CHAT_STREAM_EVENT_TYPES.CHUNK }
   }
   if (
-    versioned.type === "context_error" &&
+    versioned.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR &&
     typeof versioned.error === "string"
   ) {
     const { error: message, ...rest } = versioned

--- a/src/protocol/streams/event-types.ts
+++ b/src/protocol/streams/event-types.ts
@@ -1,0 +1,17 @@
+export const CHAT_STREAM_EVENT_TYPES = {
+  CHUNK: "chat_chunk",
+  RAG_SOURCES: "rag_sources",
+  CONTEXT_PROGRESS: "context_progress",
+  CONTEXT_WARNING: "context_warning",
+  CONTEXT_RESULT: "context_result",
+  CONTEXT_ERROR: "context_error",
+  SNAPSHOT: "stream_snapshot"
+} as const
+
+export const MODEL_PULL_EVENT_TYPES = {
+  START: "model_pull_start",
+  CANCEL: "model_pull_cancel",
+  PROGRESS: "model_pull_progress",
+  COMPLETE: "model_pull_complete",
+  ERROR: "model_pull_error"
+} as const

--- a/src/protocol/streams/index.ts
+++ b/src/protocol/streams/index.ts
@@ -1,4 +1,5 @@
 export * from "./chat-stream"
+export * from "./event-types"
 export * from "./model-pull-stream"
 export * from "./selection-stream"
 export * from "./version"

--- a/src/protocol/streams/model-pull-stream.ts
+++ b/src/protocol/streams/model-pull-stream.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { AppFailureSchema } from "@/protocol/app-failure"
+import { MODEL_PULL_EVENT_TYPES } from "./event-types"
 import { STREAM_PROTOCOL_VERSION } from "./version"
 
 const version = z.literal(STREAM_PROTOCOL_VERSION)
@@ -7,7 +8,7 @@ const version = z.literal(STREAM_PROTOCOL_VERSION)
 export const ModelPullClientEventSchema = z.discriminatedUnion("type", [
   z.object({
     version,
-    type: z.literal("model_pull_start"),
+    type: z.literal(MODEL_PULL_EVENT_TYPES.START),
     payload: z.object({
       model: z.string().min(1),
       providerId: z.string().optional()
@@ -15,7 +16,7 @@ export const ModelPullClientEventSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     version,
-    type: z.literal("model_pull_cancel"),
+    type: z.literal(MODEL_PULL_EVENT_TYPES.CANCEL),
     payload: z.object({ model: z.string().min(1) })
   })
 ])
@@ -23,18 +24,18 @@ export const ModelPullClientEventSchema = z.discriminatedUnion("type", [
 export const ModelPullServerEventSchema = z.discriminatedUnion("type", [
   z.object({
     version,
-    type: z.literal("model_pull_progress"),
+    type: z.literal(MODEL_PULL_EVENT_TYPES.PROGRESS),
     status: z.string(),
     progress: z.number().optional()
   }),
   z.object({
     version,
-    type: z.literal("model_pull_complete"),
+    type: z.literal(MODEL_PULL_EVENT_TYPES.COMPLETE),
     status: z.string().optional()
   }),
   z.object({
     version,
-    type: z.literal("model_pull_error"),
+    type: z.literal(MODEL_PULL_EVENT_TYPES.ERROR),
     failure: AppFailureSchema
   })
 ])
@@ -45,30 +46,40 @@ export type ModelPullServerEvent = z.infer<typeof ModelPullServerEventSchema>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === "object" && !Array.isArray(value)
 
+const legacyModelName = (payload: unknown): string => {
+  if (typeof payload === "string") return payload
+  if (isRecord(payload) && typeof payload.model === "string") {
+    return payload.model
+  }
+  return ""
+}
+
+const normalizeLegacyModelPullClientEvent = (
+  value: Record<string, unknown>
+): Record<string, unknown> => {
+  if (value.type !== undefined) return value
+
+  if (value.cancel) {
+    return {
+      version: STREAM_PROTOCOL_VERSION,
+      type: MODEL_PULL_EVENT_TYPES.CANCEL,
+      payload: { model: legacyModelName(value.payload) }
+    }
+  }
+
+  return {
+    version: STREAM_PROTOCOL_VERSION,
+    type: MODEL_PULL_EVENT_TYPES.START,
+    payload:
+      typeof value.payload === "string"
+        ? { model: value.payload }
+        : value.payload
+  }
+}
+
 export const parseModelPullClientEvent = (value: unknown) => {
   if (!isRecord(value)) return ModelPullClientEventSchema.safeParse(value)
-  const payload = value.payload
-  const normalized =
-    value.type !== undefined
-      ? value
-      : value.cancel
-        ? {
-            version: STREAM_PROTOCOL_VERSION,
-            type: "model_pull_cancel",
-            payload: {
-              model:
-                typeof payload === "string"
-                  ? payload
-                  : isRecord(payload) && typeof payload.model === "string"
-                    ? payload.model
-                    : ""
-            }
-          }
-        : {
-            version: STREAM_PROTOCOL_VERSION,
-            type: "model_pull_start",
-            payload: typeof payload === "string" ? { model: payload } : payload
-          }
+  const normalized = normalizeLegacyModelPullClientEvent(value)
   return ModelPullClientEventSchema.safeParse({
     ...normalized,
     version:
@@ -91,20 +102,20 @@ export const parseModelPullServerEvent = (value: unknown) => {
         : value.error
     return ModelPullServerEventSchema.safeParse({
       version,
-      type: "model_pull_error",
+      type: MODEL_PULL_EVENT_TYPES.ERROR,
       failure
     })
   }
   if (value.done === true) {
     return ModelPullServerEventSchema.safeParse({
       version,
-      type: "model_pull_complete",
+      type: MODEL_PULL_EVENT_TYPES.COMPLETE,
       ...(typeof value.status === "string" ? { status: value.status } : {})
     })
   }
   return ModelPullServerEventSchema.safeParse({
     ...value,
     version,
-    type: "model_pull_progress"
+    type: MODEL_PULL_EVENT_TYPES.PROGRESS
   })
 }


### PR DESCRIPTION
## Summary

- centralize chat and model-pull stream discriminants in protocol-local `as const` objects
- replace repeated runtime message-type guards with `getMessageType`
- rewrite legacy model-pull normalization with early returns instead of nested ternaries
- keep raw wire strings in contract tests while production code consumes shared constants

## Why

The typed streaming merge left protocol discriminants duplicated across schemas, producers, and consumers. A typo could compile in one layer and fail only at runtime validation. Runtime authorization and validation logging also repeated the same nested discriminator check.

This refactor keeps wire values unchanged while giving production code one source of truth and a small reusable boundary helper.

## Validation

- `pnpm test:run` — 2,437 tests
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm check:dead`
- Chrome production build
- docs build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes unchanged chat and model-pull stream discriminants while preserving existing protocol behavior.
- Adds protocol-local constants for chat and model-pull event types.
- Reuses a boundary helper for extracting message discriminants during authorization, validation logging, and routing.
- Rewrites legacy model-pull normalization into equivalent early-return helpers.
- Updates stream schemas, producers, reducers, routers, and UI consumers to use the shared constants.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the centralized constants preserve all existing wire values and no reachable behavioral regression was identified.

Producers, schemas, routers, compatibility shims, reducers, and UI consumers remain aligned on identical discriminant values, while the new message-type helper preserves behavior for structured-cloned runtime inputs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/protocol/streams/event-types.ts | Defines shared chat and model-pull discriminants with values identical to the existing wire protocol. |
| src/protocol/streams/chat-stream.ts | Replaces duplicated chat event literals in schemas and compatibility normalization without changing accepted wire shapes. |
| src/protocol/streams/model-pull-stream.ts | Uses shared model-pull constants and extracts legacy normalization into behaviorally equivalent helpers. |
| src/protocol/message-type.ts | Adds a defensive discriminator extractor whose behavior matches the replaced checks for structured-cloned runtime messages. |
| src/background/message-router.ts | Reuses the discriminator helper while preserving authorization-before-dispatch behavior. |
| src/background/port-router.ts | Reuses shared extraction and model-pull constants without changing validation, authorization, or handler dispatch. |
| src/application/turns/chat-stream-reducer.ts | Consumes the centralized RAG event discriminator without changing reducer behavior. |
| src/features/chat/hooks/use-chat-stream.ts | Replaces chat stream literals with matching shared constants across snapshot, context, and chunk handling. |
| src/features/model/hooks/use-model-pull.ts | Uses centralized model-pull discriminants while preserving start, progress, completion, error, and cancellation behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Producers["Background stream producers"] --> Constants["Shared event-type constants"]
  Constants --> Schemas["Zod protocol schemas"]
  Schemas --> Routers["Message and port routers"]
  Routers --> Consumers["Chat reducer and model-pull hooks"]
  Legacy["Legacy model-pull payloads"] --> Normalize["Compatibility normalization"]
  Normalize --> Schemas
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(protocol): centralize stream ev..."](https://github.com/shishir435/ollama-client/commit/191a1958a106881e165391c46003e31e2cf1003c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48675670)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)
- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)
</details>

<!-- /greptile_comment -->