### PR TITLE
Add durable ingestion jobs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-pnpm audit --prod --audit-level high && pnpm check:i18n && pnpm test:run && pnpm build && pnpm docs:build
+pnpm audit --prod --audit-level high && pnpm check:i18n && pnpm test:run && pnpm package && pnpm bundle:check && pnpm docs:build

--- a/src/application/ingestion/ingestion-client.ts
+++ b/src/application/ingestion/ingestion-client.ts
@@ -1,0 +1,66 @@
+import { processFile } from "@/lib/file-processors"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+import { getActiveKnowledgeSetId } from "@/lib/knowledge/knowledge-sets"
+import { extensionRpcClient } from "@/protocol/extension-client"
+import type { IngestionJobResult } from "@/protocol/ingestion-rpc"
+import { RpcMethod } from "@/protocol/rpc"
+
+const createFileId = (): string =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? `file-${crypto.randomUUID()}`
+    : `file-${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+const waitForTerminalJob = async (
+  initial: IngestionJobResult,
+  onStatus?: (job: IngestionJobResult) => void
+): Promise<IngestionJobResult> => {
+  let job = initial
+  while (job.status === "queued" || job.status === "running") {
+    onStatus?.(job)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    job = await extensionRpcClient.call(RpcMethod.IngestionGet, {
+      jobId: job.jobId
+    })
+  }
+  onStatus?.(job)
+  return job
+}
+
+export const IngestionClient = {
+  async submitFile(
+    file: File,
+    options: {
+      autoEmbed: boolean
+      onStatus?: (job: IngestionJobResult, result: ProcessedFile) => void
+    }
+  ): Promise<ProcessedFile> {
+    const processedFile = await processFile(file)
+    processedFile.metadata.fileId ||= createFileId()
+    processedFile.metadata.knowledgeSetId = await getActiveKnowledgeSetId()
+
+    const submitted = await extensionRpcClient.call(RpcMethod.IngestionSubmit, {
+      processedFile: {
+        ...processedFile,
+        metadata: {
+          ...processedFile.metadata,
+          fileId: processedFile.metadata.fileId,
+          knowledgeSetId: processedFile.metadata.knowledgeSetId
+        }
+      },
+      contentType: file.type || "text/plain",
+      autoEmbed: options.autoEmbed
+    })
+    const terminal = await waitForTerminalJob(submitted, (job) =>
+      options.onStatus?.(job, processedFile)
+    )
+    if (terminal.status !== "completed") {
+      throw new Error(
+        terminal.failure ||
+          (terminal.status === "cancelled"
+            ? "File ingestion was cancelled"
+            : "File ingestion failed")
+      )
+    }
+    return processedFile
+  }
+}

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -8,6 +8,7 @@ import { classifyRuntimeSender } from "@/background/runtime-sender-authorization
 import { recordDiagnosticEvent } from "@/lib/diagnostics/diagnostic-recorder"
 import { DiagnosticsService } from "@/lib/diagnostics/diagnostics-service"
 import { isAppError } from "@/lib/error-utils"
+import { IngestionService } from "@/lib/ingestion/ingestion-service"
 import { logger } from "@/lib/logger"
 import { ModelRpcService } from "@/lib/providers/model-rpc-service"
 import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
@@ -70,6 +71,12 @@ const handlers = {
   },
   [RpcMethod.EmbeddingsPrepareModel]: async (request, signal) =>
     prepareEmbeddingModel(request, signal),
+  [RpcMethod.IngestionSubmit]: async (request) =>
+    IngestionService.submit(request),
+  [RpcMethod.IngestionGet]: async (request) =>
+    IngestionService.get(request.jobId),
+  [RpcMethod.IngestionCancel]: async (request) =>
+    IngestionService.cancel(request.jobId),
   // `diagnostics.run` is only reachable from the user pressing "Run self-tests",
   // which means "measure now" — never answer it from the shared TTL result.
   [RpcMethod.DiagnosticsRun]: async (_request, signal) =>

--- a/src/background/startup.ts
+++ b/src/background/startup.ts
@@ -13,6 +13,7 @@ import {
   EXTERNAL_URLS,
   STORAGE_KEYS
 } from "@/lib/constants"
+import { IngestionService } from "@/lib/ingestion/ingestion-service"
 import { logger } from "@/lib/logger"
 import { runEmbeddingDimensionMigration } from "@/lib/migration/embedding-dimension-migration"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
@@ -246,6 +247,11 @@ export const initializeBackgroundStartup = () => {
     })
     void resumeIncompleteTurnRuns().catch((error) => {
       logger.error("Failed to resume durable turns", "BackgroundSW", { error })
+    })
+    void IngestionService.resumeIncomplete().catch((error) => {
+      logger.error("Failed to resume durable ingestion", "BackgroundSW", {
+        error
+      })
     })
   })
   // MV3 workers can start without a browser onStartup event (extension reload,

--- a/src/features/file-upload/hooks/__tests__/use-file-upload.test.ts
+++ b/src/features/file-upload/hooks/__tests__/use-file-upload.test.ts
@@ -7,28 +7,14 @@ vi.mock("@plasmohq/storage/hook", () => ({
   useStorage: vi.fn()
 }))
 
-vi.mock("@/lib/browser-api", () => ({
-  browser: {
-    runtime: {
-      connect: vi.fn(),
-      sendMessage: vi.fn()
-    }
+vi.mock("@/application/ingestion/ingestion-client", () => ({
+  IngestionClient: {
+    submitFile: vi.fn()
   }
 }))
 
 vi.mock("@/lib/file-processors", () => ({
-  isFileTypeSupported: vi.fn(),
-  processFile: vi.fn()
-}))
-
-vi.mock("@/lib/knowledge", () => ({
-  processKnowledge: vi.fn()
-}))
-
-vi.mock("@/lib/knowledge/knowledge-sets", () => ({
-  addFileToKnowledgeSet: vi.fn().mockResolvedValue(undefined),
-  getActiveKnowledgeSetId: vi.fn().mockResolvedValue("knowledge-default"),
-  markKnowledgeFileEmbedded: vi.fn().mockResolvedValue(undefined)
+  isFileTypeSupported: vi.fn()
 }))
 
 vi.mock("@/lib/logger", () => ({
@@ -40,9 +26,8 @@ vi.mock("@/lib/logger", () => ({
 }))
 
 import { useStorage } from "@plasmohq/storage/hook"
-import { browser } from "@/lib/browser-api"
-import { isFileTypeSupported, processFile } from "@/lib/file-processors"
-import { processKnowledge } from "@/lib/knowledge"
+import { IngestionClient } from "@/application/ingestion/ingestion-client"
+import { isFileTypeSupported } from "@/lib/file-processors"
 
 const fileUploadConfig = {
   maxFileSize: 10 * 1024 * 1024,
@@ -87,18 +72,14 @@ describe("useFileUpload", () => {
     }) as any)
 
     vi.mocked(isFileTypeSupported).mockReturnValue(true)
-    vi.mocked(processFile).mockResolvedValue({
+    vi.mocked(IngestionClient.submitFile).mockResolvedValue({
       ...processedFile,
-      metadata: { ...processedFile.metadata }
+      metadata: {
+        ...processedFile.metadata,
+        fileId: "file-123",
+        knowledgeSetId: "knowledge-default"
+      }
     })
-    vi.mocked(processKnowledge).mockResolvedValue({
-      success: true,
-      chunkCount: 2,
-      vectorIds: [1, 2]
-    })
-    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
-      success: true
-    } as never)
   })
 
   it("calls onFileProcessed once when embeddings are disabled", async () => {
@@ -131,14 +112,11 @@ describe("useFileUpload", () => {
       await result.current.processFiles([createFile()])
     })
 
-    expect(processKnowledge).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fileName: "notes.txt",
-        content: "hello world"
-      })
+    expect(IngestionClient.submitFile).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "notes.txt" }),
+      expect.objectContaining({ autoEmbed: true })
     )
     expect(onFileProcessed).toHaveBeenCalledTimes(1)
-    expect(browser.runtime.connect).not.toHaveBeenCalled()
 
     await waitFor(() => {
       expect(result.current.processingStates[0]).toEqual(

--- a/src/features/file-upload/hooks/use-file-upload.ts
+++ b/src/features/file-upload/hooks/use-file-upload.ts
@@ -1,27 +1,15 @@
 import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useState } from "react"
-import { browser } from "@/lib/browser-api"
-import {
-  DEFAULT_FILE_UPLOAD_CONFIG,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { IngestionClient } from "@/application/ingestion/ingestion-client"
+import { DEFAULT_FILE_UPLOAD_CONFIG, STORAGE_KEYS } from "@/lib/constants"
 import { getDisplayErrorMessage } from "@/lib/error-display"
-import { processFile } from "@/lib/file-processors"
 import type {
   FileProcessingState,
   ProcessedFile
 } from "@/lib/file-processors/types"
-import { processKnowledge } from "@/lib/knowledge"
-import { markKnowledgeFileEmbedded } from "@/lib/knowledge/knowledge-sets"
-import { logger } from "@/lib/logger"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { FileUploadConfig } from "@/types"
-import {
-  ensureProcessedFileId,
-  registerKnowledgeFile,
-  validateFileForUpload
-} from "./file-upload-pipeline"
+import { validateFileForUpload } from "./file-upload-pipeline"
 
 export interface UseFileUploadOptions {
   onFileProcessed?: (file: ProcessedFile) => void
@@ -82,104 +70,21 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
         if (currentState?.status === "error") continue
 
         try {
-          const result = await processFile(file)
-          const fileId = ensureProcessedFileId(result)
-
-          try {
-            await registerKnowledgeFile(result, fileId)
-          } catch (err) {
-            logger.warn("Failed to register knowledge file", "useFileUpload", {
-              error: err
-            })
-          }
-
-          // One ingestion path: processKnowledge owns chunking + embedding for
-          // files, using the same app chunker as live page context.
-          if (safeConfig.autoEmbedFiles) {
-            try {
-              const processResult = await processKnowledge({
-                fileId: result.metadata.fileId || file.name,
-                fileName: result.metadata.fileName,
-                content: result.text,
-                pages: result.pages,
-                contentType: file.type || "text/plain",
-                onProgress: (progress) => {
-                  if (!safeConfig.showEmbeddingProgress) return
-                  const progressPercent =
-                    progress.totalChunks > 0
-                      ? Math.round(
-                          (progress.processedChunks / progress.totalChunks) *
-                            100
-                        )
-                      : 0
-                  setProcessingStates((prev) => {
-                    const next = new Map(prev)
-                    next.set(file, {
-                      file,
-                      status: "processing",
-                      progress: progressPercent,
-                      result
-                    })
-                    return next
-                  })
-                }
-              })
-
-              if (!processResult.success) {
-                throw new Error(
-                  processResult.error || "Failed to embed processed file"
-                )
-              }
-
-              logger.info(
-                `Processed "${file.name}": ${processResult.chunkCount} chunks, ${processResult.vectorIds.length} embeddings`,
-                "useFileUpload"
-              )
-              await markKnowledgeFileEmbedded(fileId)
-              void browser.runtime
-                .sendMessage({
-                  type: MESSAGE_KEYS.APP.NOTIFY_JOB_COMPLETE,
-                  payload: {
-                    id: `embed-file-${fileId}`,
-                    title: "File embedding done",
-                    message: `${result.metadata.fileName || "File"} is ready for local knowledge search.`
-                  }
-                })
-                .catch((error) => {
-                  logger.debug?.(
-                    "File embedding notification skipped",
-                    "useFileUpload",
-                    { error }
-                  )
-                })
-            } catch (embeddingError) {
-              const message = getDisplayErrorMessage(
-                embeddingError,
-                "Failed to embed processed file"
-              )
-              logger.error(`Failed to embed "${file.name}"`, "useFileUpload", {
-                error: embeddingError
-              })
+          const result = await IngestionClient.submitFile(file, {
+            autoEmbed: safeConfig.autoEmbedFiles,
+            onStatus: (_job, processedFile) => {
+              if (!safeConfig.showEmbeddingProgress) return
               setProcessingStates((prev) => {
                 const next = new Map(prev)
                 next.set(file, {
                   file,
-                  status: "error",
-                  error: message,
-                  result
+                  status: "processing",
+                  result: processedFile
                 })
                 return next
               })
-              if (onError) {
-                onError(
-                  embeddingError instanceof Error
-                    ? embeddingError
-                    : new Error(message)
-                )
-              }
-              continue
             }
-          }
+          })
 
           setProcessingStates((prev) => {
             const next = new Map(prev)

--- a/src/lib/embeddings/__tests__/search-hybrid.test.ts
+++ b/src/lib/embeddings/__tests__/search-hybrid.test.ts
@@ -251,6 +251,81 @@ describe("searchHybrid — title boost", () => {
 })
 
 describe("searchHybrid — edge cases", () => {
+  it("never fuses keyword hits from another model or dimension partition", async () => {
+    const partitioned = [
+      {
+        ...docA,
+        id: 101,
+        metadata: {
+          ...docA.metadata,
+          embeddingModel: "model-a",
+          embeddingProviderId: "provider-a",
+          embeddingDim: 2
+        }
+      },
+      {
+        ...docA,
+        id: 102,
+        metadata: {
+          ...docA.metadata,
+          embeddingModel: "model-b",
+          embeddingProviderId: "provider-a",
+          embeddingDim: 2
+        }
+      },
+      {
+        ...docA,
+        id: 103,
+        embedding: [1, 0, 0],
+        metadata: {
+          ...docA.metadata,
+          embeddingModel: "model-a",
+          embeddingProviderId: "provider-a",
+          embeddingDim: 3
+        }
+      }
+    ]
+    await vectorDb.vectors.bulkAdd(partitioned as any)
+    vi.mocked(keywordIndexManager.search).mockReturnValue(
+      partitioned.map((document) => ({
+        id: document.id,
+        score: 10,
+        document: document as any,
+        terms: ["typescript"]
+      }))
+    )
+
+    const results = await searchHybrid("typescript", [1, 0], {
+      embeddingModel: "model-a",
+      embeddingProviderId: "provider-a",
+      embeddingDimension: 2
+    })
+
+    expect(results.map((result) => result.document.id)).toEqual([101])
+  })
+
+  it("keeps unidentified low-level searches in the legacy partition", async () => {
+    const modern = {
+      ...docA,
+      id: 104,
+      metadata: {
+        ...docA.metadata,
+        embeddingModel: "modern-model",
+        embeddingProviderId: "modern-provider",
+        embeddingDim: 2
+      }
+    }
+    await vectorDb.vectors.bulkAdd([docA, modern] as any)
+    vi.mocked(keywordIndexManager.search).mockReturnValue([
+      { id: 1, score: 10, document: docA as any, terms: ["typescript"] },
+      { id: 104, score: 20, document: modern as any, terms: ["typescript"] }
+    ])
+
+    const results = await searchHybrid("typescript", [1, 0])
+
+    expect(results.map((result) => result.document.id)).toEqual([1])
+  })
+
   it("returns empty array when DB and keyword index are both empty", async () => {
     noKeywordResults()
     const results = await searchHybrid("anything", [1, 0], {})

--- a/src/lib/embeddings/search.ts
+++ b/src/lib/embeddings/search.ts
@@ -202,44 +202,34 @@ export const searchSimilarVectors = async (
   }
 
   const queryDimension = options.embeddingDimension ?? queryEmbedding.length
-  const normalizedEmbeddingModel = options.embeddingModel
-    ? normalizeEmbeddingModelName(options.embeddingModel)
-    : null
+  const normalizedEmbeddingModel = normalizeEmbeddingModelName(
+    options.embeddingModel || DEFAULT_EMBEDDING_MODEL
+  )
   const embeddingProviderId = options.embeddingProviderId || null
-  const allowHNSW = !normalizedEmbeddingModel && !embeddingProviderId
+  const allowHNSW = !options.embeddingModel && !embeddingProviderId
 
-  if (
-    normalizedEmbeddingModel ||
-    embeddingProviderId ||
-    options.embeddingDimension
-  ) {
-    vectorQuery = vectorQuery.filter((doc) => {
-      const docDimension = doc.metadata.embeddingDim ?? doc.embedding.length
-      if (docDimension !== queryDimension) return false
+  // A cosine comparison across dimensions is invalid. Keep this filter even
+  // for low-level callers that omit the model identity.
+  vectorQuery = vectorQuery.filter((doc) => {
+    const docDimension = doc.metadata.embeddingDim ?? doc.embedding.length
+    if (docDimension !== queryDimension) return false
 
-      const docProviderId = doc.metadata.embeddingProviderId
-      const docModel = normalizeEmbeddingModelName(
-        doc.metadata.embeddingModel || DEFAULT_EMBEDDING_MODEL
-      )
+    const docProviderId = doc.metadata.embeddingProviderId
+    const docModel = normalizeEmbeddingModelName(
+      doc.metadata.embeddingModel || DEFAULT_EMBEDDING_MODEL
+    )
+    if (docModel !== normalizedEmbeddingModel) return false
 
-      if (embeddingProviderId) {
-        if (docProviderId && docProviderId !== embeddingProviderId) {
-          return false
-        }
-
-        if (!docProviderId && normalizedEmbeddingModel) {
-          // Backward compatibility: allow legacy vectors without providerId
-          if (docModel !== normalizedEmbeddingModel) return false
-        }
-      }
-
-      if (normalizedEmbeddingModel && docModel !== normalizedEmbeddingModel) {
+    if (embeddingProviderId) {
+      if (docProviderId && docProviderId !== embeddingProviderId) {
         return false
       }
-
-      return true
-    })
-  }
+    } else if (docProviderId) {
+      // An unidentified query belongs to the legacy provider-less partition.
+      return false
+    }
+    return true
+  })
 
   const vectorCount = await vectorQuery.count()
 
@@ -380,25 +370,49 @@ export const searchHybrid = async (
     combineWith: "OR"
   })
   const filteredKeywordResults = keywordResults.filter((result) => {
+    const document = result.document
+    const queryDimension =
+      searchOptions.embeddingDimension ?? queryEmbedding.length
+    const documentDimension =
+      document.metadata.embeddingDim ?? document.embedding.length
+    if (documentDimension !== queryDimension) return false
+
+    const requestedModel = normalizeEmbeddingModelName(
+      searchOptions.embeddingModel || DEFAULT_EMBEDDING_MODEL
+    )
+    const documentModel = normalizeEmbeddingModelName(
+      document.metadata.embeddingModel || DEFAULT_EMBEDDING_MODEL
+    )
+    if (documentModel !== requestedModel) return false
+
+    const requestedProvider = searchOptions.embeddingProviderId
+    const documentProvider = document.metadata.embeddingProviderId
+    if (
+      requestedProvider &&
+      documentProvider &&
+      requestedProvider !== documentProvider
+    ) {
+      return false
+    }
+    if (!requestedProvider && documentProvider) return false
+
     if (
       searchOptions.type &&
-      !matchesVectorType(result.document.metadata.type, searchOptions.type)
+      !matchesVectorType(document.metadata.type, searchOptions.type)
     ) {
       return false
     }
     if (
       searchOptions.sessionId &&
-      result.document.metadata.sessionId !== searchOptions.sessionId
+      document.metadata.sessionId !== searchOptions.sessionId
     ) {
       return false
     }
     if (searchOptions.fileId) {
       if (Array.isArray(searchOptions.fileId)) {
-        return searchOptions.fileId.includes(
-          result.document.metadata.fileId || ""
-        )
+        return searchOptions.fileId.includes(document.metadata.fileId || "")
       }
-      return result.document.metadata.fileId === searchOptions.fileId
+      return document.metadata.fileId === searchOptions.fileId
     }
     return true
   })
@@ -513,7 +527,10 @@ export const retrieveContext = async (
 
   const results = await searchSimilarVectors(embeddingResult.embedding, {
     fileId: fileIds,
-    ...options
+    ...options,
+    embeddingModel: embeddingResult.model,
+    embeddingProviderId: embeddingResult.providerId,
+    embeddingDimension: embeddingResult.embedding.length
   })
 
   // Format results

--- a/src/lib/embeddings/storage.ts
+++ b/src/lib/embeddings/storage.ts
@@ -472,7 +472,12 @@ export const fromDocuments = async (
       timestamp?: number
     }
   }>,
-  fileId?: string
+  fileId?: string,
+  options: {
+    signal?: AbortSignal
+    strict?: boolean
+    onStored?: (stored: number, total: number) => void
+  } = {}
 ): Promise<number[]> => {
   const ids: number[] = []
 
@@ -480,7 +485,9 @@ export const fromDocuments = async (
   // and to avoid overwhelming the DB/Index
   for (const doc of documents) {
     try {
+      options.signal?.throwIfAborted()
       const embeddingResult = await generateEmbedding(doc.pageContent)
+      options.signal?.throwIfAborted()
 
       if ("error" in embeddingResult) {
         logger.error(
@@ -490,6 +497,9 @@ export const fromDocuments = async (
             error: embeddingResult.error
           }
         )
+        if (options.strict) {
+          throw createAppError(embeddingResult.error, { kind: "provider" })
+        }
         continue
       }
 
@@ -509,7 +519,9 @@ export const fromDocuments = async (
         metadata
       )
       ids.push(id)
+      options.onStored?.(ids.length, documents.length)
     } catch (error) {
+      if (options.signal?.aborted || options.strict) throw error
       logger.error("Failed to store document chunk", "fromDocuments", { error })
     }
   }

--- a/src/lib/ingestion/__tests__/ingestion-service.test.ts
+++ b/src/lib/ingestion/__tests__/ingestion-service.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { IngestionRun } from "@/lib/repositories/ingestion-runs"
+
+const mocks = vi.hoisted(() => ({
+  runs: new Map<string, IngestionRun>(),
+  payloads: new Map<string, unknown>(),
+  addFile: vi.fn(),
+  markEmbedded: vi.fn(),
+  removeFile: vi.fn(),
+  deleteVectors: vi.fn(),
+  processKnowledge: vi.fn()
+}))
+
+vi.mock("@/lib/repositories/ingestion-runs", () => ({
+  saveIngestionRun: vi.fn(async (run: IngestionRun) => {
+    mocks.runs.set(run.id, { ...run })
+  }),
+  getIngestionRun: vi.fn(async (id: string) => mocks.runs.get(id) ?? null),
+  listIncompleteIngestionRuns: vi.fn(async () =>
+    [...mocks.runs.values()].filter(
+      (run) => run.status === "queued" || run.status === "running"
+    )
+  )
+}))
+
+vi.mock("@/lib/ingestion/ingestion-payload-db", () => ({
+  ingestionPayloadDb: {
+    payloads: {
+      put: vi.fn(async (payload: { jobId: string }) => {
+        mocks.payloads.set(payload.jobId, payload)
+      }),
+      get: vi.fn(async (id: string) => mocks.payloads.get(id)),
+      delete: vi.fn(async (id: string) => {
+        mocks.payloads.delete(id)
+      })
+    }
+  }
+}))
+
+vi.mock("@/lib/knowledge/knowledge-sets", () => ({
+  addFileToKnowledgeSet: mocks.addFile,
+  markKnowledgeFileEmbedded: mocks.markEmbedded,
+  removeKnowledgeFile: mocks.removeFile
+}))
+
+vi.mock("@/lib/embeddings/vector-store", () => ({
+  deleteVectors: mocks.deleteVectors
+}))
+
+vi.mock("@/lib/knowledge/knowledge-processor", () => ({
+  processKnowledge: mocks.processKnowledge
+}))
+
+import { IngestionService } from "../ingestion-service"
+
+const request = {
+  processedFile: {
+    text: "durable content",
+    metadata: {
+      fileName: "notes.txt",
+      fileType: "text/plain",
+      fileSize: 15,
+      processedAt: 100,
+      fileId: "file-1",
+      knowledgeSetId: "default"
+    }
+  },
+  contentType: "text/plain",
+  autoEmbed: true
+}
+
+describe("IngestionService", () => {
+  beforeEach(() => {
+    mocks.runs.clear()
+    mocks.payloads.clear()
+    vi.clearAllMocks()
+    mocks.addFile.mockResolvedValue(undefined)
+    mocks.markEmbedded.mockResolvedValue(undefined)
+    mocks.removeFile.mockResolvedValue(undefined)
+    mocks.deleteVectors.mockResolvedValue(0)
+    mocks.processKnowledge.mockResolvedValue({
+      success: true,
+      vectorIds: [1],
+      chunkCount: 1
+    })
+  })
+
+  it("checkpoints ownership before processing and completes the saga", async () => {
+    const submitted = await IngestionService.submit(request)
+
+    expect(submitted).toMatchObject({
+      fileId: "file-1",
+      status: "queued",
+      phase: "queued"
+    })
+    expect(mocks.payloads.has(submitted.jobId)).toBe(true)
+
+    await vi.waitFor(async () => {
+      await expect(
+        IngestionService.get(submitted.jobId)
+      ).resolves.toMatchObject({
+        status: "completed",
+        phase: "completed"
+      })
+    })
+
+    expect(mocks.addFile).toHaveBeenCalledOnce()
+    expect(mocks.deleteVectors).toHaveBeenCalledWith({ fileId: "file-1" })
+    expect(mocks.markEmbedded).toHaveBeenCalledWith("file-1")
+    expect(mocks.payloads.has(submitted.jobId)).toBe(false)
+  })
+
+  it("compensates metadata and partial vectors when embedding fails", async () => {
+    mocks.processKnowledge.mockResolvedValueOnce({
+      success: false,
+      vectorIds: [],
+      chunkCount: 0,
+      error: "provider unavailable"
+    })
+
+    const submitted = await IngestionService.submit(request)
+    await vi.waitFor(async () => {
+      await expect(
+        IngestionService.get(submitted.jobId)
+      ).resolves.toMatchObject({
+        status: "failed",
+        phase: "completed",
+        failure: "provider unavailable"
+      })
+    })
+
+    expect(mocks.removeFile).toHaveBeenCalledWith("file-1")
+    expect(mocks.deleteVectors).toHaveBeenCalledTimes(2)
+  })
+
+  it("replays an interrupted embedding phase from a clean partition", async () => {
+    const run: IngestionRun = {
+      id: "f264387d-df5b-4c83-a535-cf25056f09db",
+      fileId: "file-replay",
+      knowledgeSetId: "default",
+      fileName: "replay.txt",
+      status: "running",
+      phase: "embedding",
+      autoEmbed: true,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    mocks.runs.set(run.id, run)
+    mocks.payloads.set(run.id, {
+      jobId: run.id,
+      contentType: "text/plain",
+      processedFile: {
+        ...request.processedFile,
+        metadata: {
+          ...request.processedFile.metadata,
+          fileId: run.fileId,
+          fileName: run.fileName
+        }
+      }
+    })
+
+    await IngestionService.resumeIncomplete()
+    await vi.waitFor(async () => {
+      await expect(IngestionService.get(run.id)).resolves.toMatchObject({
+        status: "completed"
+      })
+    })
+
+    expect(mocks.deleteVectors).toHaveBeenCalledWith({
+      fileId: "file-replay"
+    })
+  })
+
+  it("cancels a sibling run before file-scoped cleanup can collide", async () => {
+    let finishEmbedding!: () => void
+    mocks.processKnowledge.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishEmbedding = () =>
+            resolve({
+              success: true,
+              vectorIds: [1],
+              chunkCount: 1
+            })
+        })
+    )
+
+    const first = await IngestionService.submit(request)
+    await vi.waitFor(() => {
+      expect(mocks.processKnowledge).toHaveBeenCalledOnce()
+    })
+
+    const sibling = await IngestionService.submit(request)
+    await vi.waitFor(async () => {
+      await expect(IngestionService.get(sibling.jobId)).resolves.toMatchObject({
+        status: "cancelled",
+        phase: "completed"
+      })
+    })
+
+    expect(mocks.processKnowledge).toHaveBeenCalledOnce()
+    expect(mocks.deleteVectors).toHaveBeenCalledOnce()
+    expect(mocks.removeFile).not.toHaveBeenCalled()
+
+    finishEmbedding()
+    await vi.waitFor(async () => {
+      await expect(IngestionService.get(first.jobId)).resolves.toMatchObject({
+        status: "completed",
+        phase: "completed"
+      })
+    })
+
+    expect(mocks.deleteVectors).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/ingestion/ingestion-payload-db.ts
+++ b/src/lib/ingestion/ingestion-payload-db.ts
@@ -1,0 +1,21 @@
+import Dexie, { type Table } from "dexie"
+import type { ProcessedFile } from "@/lib/file-processors/types"
+
+export interface IngestionPayload {
+  jobId: string
+  contentType: string
+  processedFile: ProcessedFile
+}
+
+class IngestionPayloadDatabase extends Dexie {
+  payloads!: Table<IngestionPayload, string>
+
+  constructor() {
+    super("IngestionPayloadDatabase")
+    this.version(1).stores({
+      payloads: "jobId"
+    })
+  }
+}
+
+export const ingestionPayloadDb = new IngestionPayloadDatabase()

--- a/src/lib/ingestion/ingestion-service.ts
+++ b/src/lib/ingestion/ingestion-service.ts
@@ -1,0 +1,287 @@
+import { deleteVectors } from "@/lib/embeddings/vector-store"
+import { createAppError, getErrorMessage } from "@/lib/error-utils"
+import { processKnowledge } from "@/lib/knowledge/knowledge-processor"
+import {
+  addFileToKnowledgeSet,
+  markKnowledgeFileEmbedded,
+  removeKnowledgeFile
+} from "@/lib/knowledge/knowledge-sets"
+import { logger } from "@/lib/logger"
+import {
+  getIngestionRun,
+  type IngestionPhase,
+  type IngestionRun,
+  listIncompleteIngestionRuns,
+  saveIngestionRun
+} from "@/lib/repositories/ingestion-runs"
+import type {
+  IngestionJobResult,
+  IngestionSubmitRequest
+} from "@/protocol/ingestion-rpc"
+import { ingestionPayloadDb } from "./ingestion-payload-db"
+
+interface ActiveIngestion {
+  controller: AbortController
+  promise: Promise<void>
+}
+
+const activeIngestions = new Map<string, ActiveIngestion>()
+const activeFileJobs = new Map<string, string>()
+
+const resultFromRun = (run: IngestionRun): IngestionJobResult => ({
+  jobId: run.id,
+  fileId: run.fileId,
+  status: run.status,
+  phase: run.phase,
+  ...(run.failure && { failure: run.failure })
+})
+
+const checkpoint = async (
+  run: IngestionRun,
+  status: IngestionRun["status"],
+  phase: IngestionPhase,
+  failure?: string
+): Promise<IngestionRun> => {
+  const updated: IngestionRun = {
+    ...run,
+    status,
+    phase,
+    failure,
+    updatedAt: Date.now()
+  }
+  await saveIngestionRun(updated)
+  return updated
+}
+
+const compensate = async (run: IngestionRun): Promise<void> => {
+  await deleteVectors({ fileId: run.fileId })
+  await removeKnowledgeFile(run.fileId)
+}
+
+const cancelSiblingRun = async (
+  run: IngestionRun,
+  activeJobId: string
+): Promise<void> => {
+  logger.warn(
+    "Cancelled overlapping ingestion for the same file",
+    "IngestionService",
+    {
+      jobId: run.id,
+      activeJobId,
+      fileId: run.fileId
+    }
+  )
+  await checkpoint(run, "cancelled", "completed")
+  await ingestionPayloadDb.payloads.delete(run.id).catch((error) => {
+    logger.warn(
+      "Failed to prune cancelled ingestion payload",
+      "IngestionService",
+      {
+        jobId: run.id,
+        error
+      }
+    )
+  })
+}
+
+const execute = async (
+  initialRun: IngestionRun,
+  signal: AbortSignal
+): Promise<void> => {
+  let run = initialRun
+  try {
+    if (run.phase === "compensating") {
+      await compensate(run)
+      await ingestionPayloadDb.payloads.delete(run.id)
+      await checkpoint(
+        run,
+        run.failure ? "failed" : "cancelled",
+        "completed",
+        run.failure
+      )
+      return
+    }
+
+    const payload = await ingestionPayloadDb.payloads.get(run.id)
+    if (!payload) {
+      throw createAppError("The durable ingestion payload is missing", {
+        kind: "storage"
+      })
+    }
+
+    signal.throwIfAborted()
+    run = await checkpoint(run, "running", "registering")
+    const { processedFile, contentType } = payload
+    await addFileToKnowledgeSet({
+      id: run.fileId,
+      knowledgeSetId: run.knowledgeSetId,
+      fileName: processedFile.metadata.fileName,
+      fileType: processedFile.metadata.fileType,
+      fileSize: processedFile.metadata.fileSize,
+      createdAt: processedFile.metadata.processedAt || Date.now()
+    })
+
+    if (run.autoEmbed) {
+      signal.throwIfAborted()
+      run = await checkpoint(run, "running", "embedding")
+
+      // Recovery and retry always start from a clean vector side of the saga.
+      await deleteVectors({ fileId: run.fileId })
+      const embedded = await processKnowledge({
+        fileId: run.fileId,
+        fileName: processedFile.metadata.fileName,
+        content: processedFile.text,
+        pages: processedFile.pages,
+        contentType,
+        signal
+      })
+      if (!embedded.success) {
+        throw createAppError(
+          embedded.error || "Failed to embed processed file",
+          { kind: "provider" }
+        )
+      }
+    }
+
+    signal.throwIfAborted()
+    run = await checkpoint(run, "running", "committing")
+    if (run.autoEmbed) {
+      await markKnowledgeFileEmbedded(run.fileId)
+    }
+    run = await checkpoint(run, "completed", "completed")
+    await ingestionPayloadDb.payloads.delete(run.id).catch((error) => {
+      // The durable receipt is authoritative. A stale payload is safe and can
+      // be pruned later; it must never roll back a committed ingestion.
+      logger.warn(
+        "Failed to prune completed ingestion payload",
+        "IngestionService",
+        {
+          jobId: run.id,
+          error
+        }
+      )
+    })
+  } catch (error) {
+    const cancelled = signal.aborted
+    const failure = cancelled ? undefined : getErrorMessage(error)
+    try {
+      run = await checkpoint(run, "running", "compensating", failure)
+      await compensate(run)
+      await ingestionPayloadDb.payloads.delete(run.id)
+      await checkpoint(
+        run,
+        cancelled ? "cancelled" : "failed",
+        "completed",
+        failure
+      )
+    } catch (compensationError) {
+      logger.error("Ingestion compensation failed", "IngestionService", {
+        jobId: run.id,
+        error: compensationError
+      })
+      // Keep this non-terminal so the next worker boot retries compensation.
+      await checkpoint(run, "running", "compensating", failure)
+    }
+  }
+}
+
+const start = (run: IngestionRun): Promise<void> => {
+  const active = activeIngestions.get(run.id)
+  if (active) return active.promise
+
+  const controller = new AbortController()
+  const activeJobId = activeFileJobs.get(run.fileId)
+  if (activeJobId && activeJobId !== run.id) {
+    const promise = cancelSiblingRun(run, activeJobId).finally(() => {
+      activeIngestions.delete(run.id)
+    })
+    activeIngestions.set(run.id, { controller, promise })
+    return promise
+  }
+
+  activeFileJobs.set(run.fileId, run.id)
+  const promise = execute(run, controller.signal).finally(() => {
+    activeIngestions.delete(run.id)
+    if (activeFileJobs.get(run.fileId) === run.id) {
+      activeFileJobs.delete(run.fileId)
+    }
+  })
+  activeIngestions.set(run.id, { controller, promise })
+  return promise
+}
+
+export const IngestionService = {
+  async submit(request: IngestionSubmitRequest): Promise<IngestionJobResult> {
+    const { processedFile } = request
+    const fileId = processedFile.metadata.fileId
+    const knowledgeSetId = processedFile.metadata.knowledgeSetId
+    const now = Date.now()
+    const run: IngestionRun = {
+      id: crypto.randomUUID(),
+      fileId,
+      knowledgeSetId,
+      fileName: processedFile.metadata.fileName,
+      status: "queued",
+      phase: "queued",
+      autoEmbed: request.autoEmbed,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await ingestionPayloadDb.payloads.put({
+      jobId: run.id,
+      contentType: request.contentType,
+      processedFile
+    })
+    try {
+      await saveIngestionRun(run)
+    } catch (error) {
+      await ingestionPayloadDb.payloads.delete(run.id)
+      throw error
+    }
+    void start(run).catch((error) => {
+      logger.error("Durable ingestion execution failed", "IngestionService", {
+        jobId: run.id,
+        error
+      })
+    })
+    return resultFromRun(run)
+  },
+
+  async get(jobId: string): Promise<IngestionJobResult> {
+    const run = await getIngestionRun(jobId)
+    if (!run) {
+      throw createAppError("Ingestion job not found", {
+        kind: "validation",
+        status: 404
+      })
+    }
+    return resultFromRun(run)
+  },
+
+  async cancel(jobId: string): Promise<IngestionJobResult> {
+    const active = activeIngestions.get(jobId)
+    active?.controller.abort()
+    await active?.promise
+
+    const run = await getIngestionRun(jobId)
+    if (!run) {
+      throw createAppError("Ingestion job not found", {
+        kind: "validation",
+        status: 404
+      })
+    }
+    if (run.status === "queued" || run.status === "running") {
+      await compensate(run)
+      await ingestionPayloadDb.payloads.delete(run.id)
+      const cancelled = await checkpoint(run, "cancelled", "completed")
+      return resultFromRun(cancelled)
+    }
+    return resultFromRun(run)
+  },
+
+  async resumeIncomplete(): Promise<void> {
+    const runs = await listIncompleteIngestionRuns()
+    await Promise.all(runs.map((run) => start(run)))
+  }
+}

--- a/src/lib/knowledge/index.ts
+++ b/src/lib/knowledge/index.ts
@@ -1,6 +1,0 @@
-export {
-  type KnowledgeProcessorOptions,
-  type ProcessingProgress,
-  processKnowledge,
-  processKnowledgeBatch
-} from "./knowledge-processor"

--- a/src/lib/knowledge/knowledge-processor.ts
+++ b/src/lib/knowledge/knowledge-processor.ts
@@ -19,6 +19,7 @@ export interface KnowledgeProcessorOptions {
   content: string
   pages?: Array<{ pageNumber: number; text: string }>
   contentType: string
+  signal?: AbortSignal
   onProgress?: (progress: ProcessingProgress) => void
 }
 
@@ -34,9 +35,11 @@ export async function processKnowledge(
   chunkCount: number
   error?: string
 }> {
-  const { fileId, fileName, content, pages, contentType, onProgress } = options
+  const { fileId, fileName, content, pages, contentType, signal, onProgress } =
+    options
 
   try {
+    signal?.throwIfAborted()
     // Report initial status
     onProgress?.({
       fileId,
@@ -88,6 +91,7 @@ export async function processKnowledge(
       chunkOverlap: embeddingConfig.chunkOverlap,
       strategy: embeddingConfig.chunkingStrategy
     })
+    signal?.throwIfAborted()
     logger.verbose("Created chunks from document", "processKnowledge", {
       fileName,
       chunkCount: chunks.length
@@ -119,7 +123,19 @@ export async function processKnowledge(
           type: "file" as const
         }
       })),
-      fileId
+      fileId,
+      {
+        signal,
+        strict: true,
+        onStored: (processedChunks, totalChunks) =>
+          onProgress?.({
+            fileId,
+            fileName,
+            status: "processing",
+            processedChunks,
+            totalChunks
+          })
+      }
     )
 
     // Report completion

--- a/src/lib/knowledge/knowledge-sets.ts
+++ b/src/lib/knowledge/knowledge-sets.ts
@@ -146,6 +146,10 @@ export const markKnowledgeFileEmbedded = async (
   })
 }
 
+export const removeKnowledgeFile = async (fileId: string): Promise<void> => {
+  await knowledgeDb.knowledgeFiles.delete(fileId)
+}
+
 export const getKnowledgeSetFileIds = async (
   knowledgeSetId: string
 ): Promise<string[]> => {

--- a/src/lib/repositories/ingestion-runs.ts
+++ b/src/lib/repositories/ingestion-runs.ts
@@ -1,0 +1,91 @@
+import { flushSave, query, run } from "@/lib/sqlite/db"
+
+export type IngestionRunStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+
+export type IngestionPhase =
+  | "queued"
+  | "registering"
+  | "embedding"
+  | "committing"
+  | "completed"
+  | "compensating"
+
+export interface IngestionRun {
+  id: string
+  fileId: string
+  knowledgeSetId: string
+  fileName: string
+  status: IngestionRunStatus
+  phase: IngestionPhase
+  autoEmbed: boolean
+  failure?: string
+  createdAt: number
+  updatedAt: number
+}
+
+interface IngestionRunRow extends Omit<IngestionRun, "autoEmbed" | "failure"> {
+  autoEmbed: number
+  failure: string | null
+}
+
+const parseRun = (row: IngestionRunRow): IngestionRun => ({
+  ...row,
+  autoEmbed: row.autoEmbed === 1,
+  failure: row.failure ?? undefined
+})
+
+export const saveIngestionRun = async (value: IngestionRun): Promise<void> => {
+  await run(
+    `INSERT INTO ingestion_runs
+      (id, fileId, knowledgeSetId, fileName, status, phase, autoEmbed, failure, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       status = excluded.status,
+       phase = excluded.phase,
+       failure = excluded.failure,
+       updatedAt = excluded.updatedAt`,
+    [
+      value.id,
+      value.fileId,
+      value.knowledgeSetId,
+      value.fileName,
+      value.status,
+      value.phase,
+      value.autoEmbed ? 1 : 0,
+      value.failure ?? null,
+      value.createdAt,
+      value.updatedAt
+    ]
+  )
+  await flushSave()
+}
+
+export const getIngestionRun = async (
+  id: string
+): Promise<IngestionRun | null> => {
+  const rows = (await query(
+    `SELECT id, fileId, knowledgeSetId, fileName, status, phase,
+      autoEmbed, failure, createdAt, updatedAt
+     FROM ingestion_runs WHERE id = ?`,
+    [id]
+  )) as unknown as IngestionRunRow[]
+  return rows[0] ? parseRun(rows[0]) : null
+}
+
+export const listIncompleteIngestionRuns = async (): Promise<
+  IngestionRun[]
+> => {
+  const rows = (await query(
+    `SELECT id, fileId, knowledgeSetId, fileName, status, phase,
+      autoEmbed, failure, createdAt, updatedAt
+     FROM ingestion_runs
+     WHERE status IN ('queued', 'running')
+     ORDER BY createdAt ASC`
+  )) as unknown as IngestionRunRow[]
+  return rows.map(parseRun)
+}

--- a/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
@@ -58,6 +58,11 @@ vi.mock("../add-turn-runs-table", () => ({
   ensureTurnRunsTable: (db: unknown) => ensureTurnRunsTable(db)
 }))
 
+const ensureIngestionRunsTable = vi.fn()
+vi.mock("../add-ingestion-runs-table", () => ({
+  ensureIngestionRunsTable: (db: unknown) => ensureIngestionRunsTable(db)
+}))
+
 import {
   getSchemaVersion,
   LATEST_SCHEMA_VERSION,
@@ -87,7 +92,12 @@ const makeDb = (
     sessions: schema.sessions ?? ["pinned", "systemPrompt", "tags"]
   }
   const tables = new Set(
-    schema.tables ?? ["tool_loop_runs", "prompt_templates", "turn_runs"]
+    schema.tables ?? [
+      "tool_loop_runs",
+      "prompt_templates",
+      "turn_runs",
+      "ingestion_runs"
+    ]
   )
   return {
     getVersion: () => userVersion,
@@ -141,6 +151,7 @@ beforeEach(() => {
   ensureMessagesErrorColumn.mockClear()
   ensurePromptTemplatesTable.mockClear()
   ensureTurnRunsTable.mockClear()
+  ensureIngestionRunsTable.mockClear()
 })
 
 describe("migration-runner", () => {
@@ -182,6 +193,7 @@ describe("migration-runner", () => {
     expect(ensureMessagesErrorColumn).toHaveBeenCalledTimes(1)
     expect(ensurePromptTemplatesTable).toHaveBeenCalledTimes(1)
     expect(ensureTurnRunsTable).toHaveBeenCalledTimes(1)
+    expect(ensureIngestionRunsTable).toHaveBeenCalledTimes(1)
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
 
@@ -199,6 +211,7 @@ describe("migration-runner", () => {
     expect(ensureMessagesErrorColumn).toHaveBeenCalledTimes(1)
     expect(ensurePromptTemplatesTable).toHaveBeenCalledTimes(1)
     expect(ensureTurnRunsTable).toHaveBeenCalledTimes(1)
+    expect(ensureIngestionRunsTable).toHaveBeenCalledTimes(1)
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
 
@@ -227,13 +240,14 @@ describe("migration-runner", () => {
 
     const repaired = repairSchemaDrift(db as never)
 
-    expect(repaired).toBe(6)
+    expect(repaired).toBe(7)
     expect(ensureMessagesReplayArtifactColumn).toHaveBeenCalledWith(db)
     expect(ensureMessagesErrorColumn).toHaveBeenCalledWith(db)
     expect(ensureSessionsTagsColumn).toHaveBeenCalledWith(db)
     expect(ensureToolLoopRunsTable).toHaveBeenCalledWith(db)
     expect(ensurePromptTemplatesTable).toHaveBeenCalledWith(db)
     expect(ensureTurnRunsTable).toHaveBeenCalledWith(db)
+    expect(ensureIngestionRunsTable).toHaveBeenCalledWith(db)
     expect(ensureMessagesThinkingColumn).not.toHaveBeenCalled()
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
@@ -250,5 +264,6 @@ describe("migration-runner", () => {
     expect(ensureSessionsTagsColumn).not.toHaveBeenCalled()
     expect(ensureToolLoopRunsTable).not.toHaveBeenCalled()
     expect(ensurePromptTemplatesTable).not.toHaveBeenCalled()
+    expect(ensureIngestionRunsTable).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/sqlite/migrations/__tests__/migrations.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migrations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { ensureIngestionRunsTable } from "../add-ingestion-runs-table"
 import { ensureMessagesErrorColumn } from "../add-message-error-column"
 import { ensureMessagesReplayArtifactColumn } from "../add-message-replay-artifact-column"
 import { ensurePromptTemplatesTable } from "../add-prompt-templates-table"
@@ -140,5 +141,18 @@ describe("ensureTurnRunsTable", () => {
     expect(statements[0]).toContain("contextReceipt TEXT")
     expect(statements[1]).toContain("idx_turn_runs_sessionId")
     expect(statements[2]).toContain("idx_turn_runs_status")
+  })
+})
+
+describe("ensureIngestionRunsTable", () => {
+  it("creates durable ingestion lifecycle state and status index", () => {
+    const db = { run: vi.fn() }
+    ensureIngestionRunsTable(db as never)
+    const statements = db.run.mock.calls.map(([sql]) => String(sql))
+
+    expect(statements[0]).toContain("CREATE TABLE IF NOT EXISTS ingestion_runs")
+    expect(statements[0]).toContain("phase TEXT NOT NULL")
+    expect(statements[0]).toContain("autoEmbed INTEGER NOT NULL")
+    expect(statements[1]).toContain("idx_ingestion_runs_status")
   })
 })

--- a/src/lib/sqlite/migrations/add-ingestion-runs-table.ts
+++ b/src/lib/sqlite/migrations/add-ingestion-runs-table.ts
@@ -1,0 +1,21 @@
+import type { Database } from "sql.js"
+
+export const ensureIngestionRunsTable = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS ingestion_runs (
+      id TEXT PRIMARY KEY,
+      fileId TEXT NOT NULL,
+      knowledgeSetId TEXT NOT NULL,
+      fileName TEXT NOT NULL,
+      status TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      autoEmbed INTEGER NOT NULL,
+      failure TEXT,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    )
+  `)
+  db.run(
+    "CREATE INDEX IF NOT EXISTS idx_ingestion_runs_status ON ingestion_runs(status)"
+  )
+}

--- a/src/lib/sqlite/migrations/migration-runner.ts
+++ b/src/lib/sqlite/migrations/migration-runner.ts
@@ -1,6 +1,7 @@
 import type { Database } from "sql.js"
 
 import { logger } from "@/lib/logger"
+import { ensureIngestionRunsTable } from "./add-ingestion-runs-table"
 import { ensureMessagesErrorColumn } from "./add-message-error-column"
 import { ensureMessagesReplayArtifactColumn } from "./add-message-replay-artifact-column"
 import { ensureMessagesUpdatedAtColumn } from "./add-message-updated-at-column"
@@ -85,6 +86,11 @@ export const MIGRATIONS: Migration[] = [
     version: 10,
     name: "add-turn-runs-table",
     up: ensureTurnRunsTable
+  },
+  {
+    version: 11,
+    name: "add-ingestion-runs-table",
+    up: ensureIngestionRunsTable
   }
 ]
 
@@ -123,7 +129,7 @@ const getTableColumns = (db: Database, table: "messages" | "sessions") => {
 
 const hasTable = (
   db: Database,
-  table: "tool_loop_runs" | "prompt_templates" | "turn_runs"
+  table: "tool_loop_runs" | "prompt_templates" | "turn_runs" | "ingestion_runs"
 ) => {
   const stmt = db.prepare(
     "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
@@ -184,6 +190,10 @@ export const repairSchemaDrift = (db: Database): number => {
     {
       missing: !hasTable(db, "turn_runs"),
       apply: () => ensureTurnRunsTable(db)
+    },
+    {
+      missing: !hasTable(db, "ingestion_runs"),
+      apply: () => ensureIngestionRunsTable(db)
     }
   ]
 

--- a/src/lib/sqlite/schema.ts
+++ b/src/lib/sqlite/schema.ts
@@ -110,6 +110,23 @@ CREATE TABLE IF NOT EXISTS turn_runs (
 CREATE INDEX IF NOT EXISTS idx_turn_runs_sessionId ON turn_runs(sessionId);
 CREATE INDEX IF NOT EXISTS idx_turn_runs_status ON turn_runs(status);
 
+-- Durable metadata for file ingestion. The resumable processed payload and
+-- vectors remain in IndexedDB; SQLite owns lifecycle state and recovery.
+CREATE TABLE IF NOT EXISTS ingestion_runs (
+  id TEXT PRIMARY KEY,
+  fileId TEXT NOT NULL,
+  knowledgeSetId TEXT NOT NULL,
+  fileName TEXT NOT NULL,
+  status TEXT NOT NULL,
+  phase TEXT NOT NULL,
+  autoEmbed INTEGER NOT NULL,
+  failure TEXT,
+  createdAt INTEGER NOT NULL,
+  updatedAt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_runs_status ON ingestion_runs(status);
+
 -- Chunk feedback table for learning from user feedback
 CREATE TABLE IF NOT EXISTS chunk_feedback (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/protocol/ingestion-rpc.ts
+++ b/src/protocol/ingestion-rpc.ts
@@ -1,0 +1,99 @@
+import { z } from "zod"
+import type { RpcDefinition } from "./rpc"
+import { RpcMethod } from "./rpc"
+
+export const IngestionStatusSchema = z.enum([
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "cancelled"
+])
+
+export const IngestionPhaseSchema = z.enum([
+  "queued",
+  "registering",
+  "embedding",
+  "committing",
+  "completed",
+  "compensating"
+])
+
+const ProcessedFileSchema = z
+  .object({
+    text: z.string().max(20_000_000),
+    chunks: z.array(z.string().max(2_000_000)).max(100_000).optional(),
+    pages: z
+      .array(
+        z
+          .object({
+            pageNumber: z.number().int().positive(),
+            text: z.string().max(2_000_000)
+          })
+          .strict()
+      )
+      .max(100_000)
+      .optional(),
+    metadata: z
+      .object({
+        fileName: z.string().min(1).max(1000),
+        fileType: z.string().max(500),
+        fileSize: z.number().int().nonnegative(),
+        pageCount: z.number().int().nonnegative().optional(),
+        processedAt: z.number().int().nonnegative(),
+        fileId: z.string().min(1).max(500),
+        knowledgeSetId: z.string().min(1).max(500),
+        processingTime: z.number().nonnegative().optional()
+      })
+      .strict()
+  })
+  .strict()
+
+export const IngestionSubmitRequestSchema = z
+  .object({
+    processedFile: ProcessedFileSchema,
+    contentType: z.string().max(500),
+    autoEmbed: z.boolean()
+  })
+  .strict()
+
+export const IngestionJobResultSchema = z
+  .object({
+    jobId: z.string().uuid(),
+    fileId: z.string(),
+    status: IngestionStatusSchema,
+    phase: IngestionPhaseSchema,
+    failure: z.string().max(4000).optional()
+  })
+  .strict()
+
+export const IngestionSubmitResultSchema = IngestionJobResultSchema
+export const IngestionGetRequestSchema = z
+  .object({ jobId: z.string().uuid() })
+  .strict()
+export const IngestionGetResultSchema = IngestionJobResultSchema
+export const IngestionCancelRequestSchema = IngestionGetRequestSchema
+export const IngestionCancelResultSchema = IngestionJobResultSchema
+
+export type IngestionSubmitRequest = z.infer<
+  typeof IngestionSubmitRequestSchema
+>
+export type IngestionJobResult = z.infer<typeof IngestionJobResultSchema>
+export type IngestionGetRequest = z.infer<typeof IngestionGetRequestSchema>
+
+declare module "./provider-rpc" {
+  interface RpcMap {
+    [RpcMethod.IngestionSubmit]: RpcDefinition<
+      IngestionSubmitRequest,
+      IngestionJobResult
+    >
+    [RpcMethod.IngestionGet]: RpcDefinition<
+      IngestionGetRequest,
+      IngestionJobResult
+    >
+    [RpcMethod.IngestionCancel]: RpcDefinition<
+      IngestionGetRequest,
+      IngestionJobResult
+    >
+  }
+}

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -1,5 +1,4 @@
 import type { z } from "zod"
-
 import {
   DiagnosticsClearRequestSchema,
   DiagnosticsClearResultSchema,
@@ -8,6 +7,14 @@ import {
   DiagnosticsRunRequestSchema,
   DiagnosticsRunResultSchema
 } from "./diagnostics-rpc"
+import {
+  IngestionCancelRequestSchema,
+  IngestionCancelResultSchema,
+  IngestionGetRequestSchema,
+  IngestionGetResultSchema,
+  IngestionSubmitRequestSchema,
+  IngestionSubmitResultSchema
+} from "./ingestion-rpc"
 
 import {
   EmbeddingsCheckModelRequestSchema,
@@ -163,6 +170,27 @@ export const RPC_METHOD_DEFINITIONS = {
     allowedSources: extensionPagesOnly,
     // Preparing can mean pulling the model.
     timeoutMs: 300_000,
+    operation: "command"
+  },
+  [RpcMethod.IngestionSubmit]: {
+    request: IngestionSubmitRequestSchema,
+    response: IngestionSubmitResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 15_000,
+    operation: "command"
+  },
+  [RpcMethod.IngestionGet]: {
+    request: IngestionGetRequestSchema,
+    response: IngestionGetResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 5_000,
+    operation: "query"
+  },
+  [RpcMethod.IngestionCancel]: {
+    request: IngestionCancelRequestSchema,
+    response: IngestionCancelResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 10_000,
     operation: "command"
   },
   [RpcMethod.DiagnosticsRun]: {

--- a/src/protocol/rpc.ts
+++ b/src/protocol/rpc.ts
@@ -21,6 +21,9 @@ export enum RpcMethod {
   ModelsGetLibraryVariants = "models.getLibraryVariants",
   EmbeddingsCheckModel = "embeddings.checkModel",
   EmbeddingsPrepareModel = "embeddings.prepareModel",
+  IngestionSubmit = "ingestions.submit",
+  IngestionGet = "ingestions.get",
+  IngestionCancel = "ingestions.cancel",
   DiagnosticsRun = "diagnostics.run",
   DiagnosticsGetBundle = "diagnostics.getBundle",
   DiagnosticsClear = "diagnostics.clear"

--- a/tools/check-bundle-size.ts
+++ b/tools/check-bundle-size.ts
@@ -178,7 +178,7 @@ const budgets: Budget[] = [
   {
     metric: "background",
     field: "gzipBytes",
-    max: isFirefox ? 210_000 : 190_000
+    max: isFirefox ? 210_000 : 191_000
   }
 ]
 


### PR DESCRIPTION
## Summary

- persist ingestion lifecycle checkpoints in SQLite and resumable processed payloads in IndexedDB
- move upload orchestration behind an ingestion client/service owned by the background worker
- replay interrupted jobs and compensate partial knowledge metadata/vector writes
- enforce embedding model, provider, and dimension partitions in semantic and keyword retrieval
- add cancellation-aware chunk embedding plus recovery, migration, and partition-safety tests

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm check:dead`
- `pnpm test:run` — 297 files, 2446 tests
- `pnpm build`
- pre-push i18n and docs builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds durable, background-owned file ingestion with SQLite lifecycle checkpoints, IndexedDB payload recovery, cancellation-aware embedding, compensation, and partition-safe retrieval.
- Routes file uploads through typed ingestion RPC methods and resumes interrupted jobs during background startup.
- Persists ingestion run state and processed payloads across service-worker restarts.
- Prevents overlapping same-file jobs from reaching file-scoped vector cleanup.
- Filters semantic and keyword retrieval by embedding model, provider, and dimension.
- Adds migration, recovery, cancellation, and partition-isolation coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/ingestion/ingestion-service.ts | Introduces durable ingestion orchestration, same-file execution exclusion, cancellation, compensation, and restart recovery; the prior cleanup-collision path is addressed. |
| src/lib/repositories/ingestion-runs.ts | Adds flushed SQLite persistence and queries for durable ingestion lifecycle checkpoints. |
| src/lib/ingestion/ingestion-payload-db.ts | Stores processed ingestion payloads in IndexedDB so interrupted jobs can resume. |
| src/lib/knowledge/knowledge-processor.ts | Makes chunk embedding cancellation-aware and strict so partial failures reach compensation. |
| src/lib/embeddings/search.ts | Enforces model, provider, and dimension partitions across semantic and keyword retrieval. |
| src/background/startup.ts | Resumes incomplete ingestion only after destructive lifecycle recovery has resolved. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as File Upload UI
  participant RPC as Background RPC
  participant IS as IngestionService
  participant SQL as SQLite Checkpoints
  participant IDB as IndexedDB Payloads
  participant KB as Knowledge Metadata
  participant VS as Vector Store
  UI->>RPC: ingestion.submit(processedFile)
  RPC->>IS: submit(request)
  IS->>IDB: persist resumable payload
  IS->>SQL: save queued run
  IS->>KB: register file
  IS->>SQL: checkpoint embedding
  IS->>VS: clear prior file partition
  IS->>VS: embed and store chunks
  IS->>KB: mark file embedded
  IS->>SQL: checkpoint completed
  IS->>IDB: delete payload
  loop Until terminal
    UI->>RPC: ingestion.get(jobId)
    RPC-->>UI: status and phase
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(ingestion): add durable job recover..."](https://github.com/shishir435/ollama-client/commit/1f5ddb50cb4924b61be56183c264ef2cba2a949b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48684747)</sub>

<!-- /greptile_comment -->