### PR TITLE
Verify chat-history migration per table in 0.12.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,116 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  persistence-migration:
+    name: Persistence migration gates (chrome)
+    # The evidence gate for retiring the legacy sql.js backend: a packaged
+    # Chromium profile migrates a real legacy blob, is interrupted mid-flight,
+    # and is verified table by table. The report is uploaded on success too —
+    # a gate whose evidence only exists on a laptop cannot be reviewed.
+    needs: [checks, build]
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       !contains(github.event.pull_request.labels.*.name, 'skip-e2e'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download packaged builds
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: chrome-e2e-builds
+          path: build
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      # Under xvfb so the runner's own headless→headful retry has a display to
+      # fall back to when extension-id resolution fails headless.
+      - name: Verify OPFS migration
+        run: xvfb-run --auto-servernum pnpm verify:opfs-migration
+
+      - name: Upload migration evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: persistence-migration-evidence-chrome
+          path: artifacts/persistence-benchmark
+          retention-days: 30
+          if-no-files-found: error
+
+  persistence-migration-firefox:
+    name: Persistence migration gates (firefox)
+    # Opt-in: the Firefox runner drives geckodriver against a temporary add-on
+    # and a pinned extension UUID, which is slower and more fragile than the
+    # Chromium path. Dispatch it before a release, or when persistence changes.
+    needs: [checks, build]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Downloaded from Mozilla rather than installed through a third-party
+      # action or the snap package: the snap build cannot use an arbitrary
+      # profile directory, which the restart scenario depends on.
+      - name: Install Firefox
+        run: |
+          curl -fsSL -o /tmp/firefox.tar.xz \
+            "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US"
+          mkdir -p "$HOME/firefox"
+          tar -xJf /tmp/firefox.tar.xz -C "$HOME"
+          "$HOME/firefox/firefox" --version
+
+      - name: Build the Firefox benchmark target
+        run: pnpm benchmark:build:firefox
+
+      - name: Verify OPFS migration
+        run: |
+          export FIREFOX_BIN="$HOME/firefox/firefox"
+          xvfb-run --auto-servernum pnpm verify:firefox-opfs-migration
+
+      - name: Upload migration evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: persistence-migration-evidence-firefox
+          path: artifacts/persistence-benchmark
+          retention-days: 30
+          if-no-files-found: error
+
   e2e:
     name: Critical browser gates
     # Runs last and only on green: these are the most expensive minutes in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   into the prompt, and gains a select-all control scoped to whatever the search
   filter is showing — so a filtered selection never silently includes tabs you
   cannot see. Once every listed tab is selected, the same control clears them.
+- Upgrading from an older chat-history format now verifies every kind of stored
+  data — chats, messages, attachments, prompt templates, saved tool runs — and
+  checks the imported database for damage before it becomes the one in use.
+  Anything that does not arrive intact leaves your history on the previous
+  store, untouched, rather than switching over to an incomplete copy. A
+  half-finished upgrade interrupted by a browser restart is rolled back and
+  retried from the original on the next launch.
+- A support report from a device that went through that upgrade now says how it
+  went — whether it succeeded, which check failed, and how many attempts it
+  took. Row counts stay on your device; only the fact that a table arrived short
+  is included, and a device that never had an older store says nothing at all.
+  Nothing is sent anywhere unless you open a report yourself.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   retried from the original on the next launch.
 - A support report from a device that went through that upgrade now says how it
   went — whether it succeeded, which check failed, and how many attempts it
-  took. Row counts stay on your device; only the fact that a table arrived short
+  took. Row counts stay on your device; only how many rows a table came up short
   is included, and a device that never had an older store says nothing at all.
   Nothing is sent anywhere unless you open a report yourself.
 
@@ -72,6 +72,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Chat-history storage now fills in any table it is missing when it opens.
+  Profiles first created on 0.6.0–0.9.x never got the retrieval-feedback table
+  added in 0.10.0, because the schema was only applied to a database that had no
+  chats yet — so on those profiles anything writing to it failed silently.
 - A reply that finishes without any answer now says so and offers a retry.
   Providers report a model unloaded mid-turn — or a conversation with no room
   left to answer in — as a successful, empty response, which used to leave a

--- a/compatibility-ledger.json
+++ b/compatibility-ledger.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-29",
+  "lastReviewed": "2026-07-30",
   "entries": [
     {
       "id": "legacy-sqljs-live-fallback",
@@ -10,9 +10,9 @@
         "0.6.0-0.12.2 sql.js profiles",
         "unmarked sql.js profiles"
       ],
-      "removalGate": "Supported sql.js/OPFS migration fixtures pass in packaged Chrome and Firefox, including offscreen eviction and integrity verification; a migration receipt and operator rollback switch exist; rollback evidence is retained; and the fallback has completed its evidence window.",
+      "removalGate": "Migration fixtures pass in packaged Chrome and Firefox with per-table verification, integrity checks, and host loss during migration; a migration receipt and the operator rollback switch exist (both shipped); CI retains the evidence; and the fallback has completed its evidence window.",
       "targetRelease": "0.13.x",
-      "recoveryPath": "Keep a lazy sql.js migration-only reader and the untouched source blob so supported skipped upgrades from 0.6.0 onward remain recoverable. Pre-0.6.0 Dexie-only chat history is outside the direct-upgrade contract."
+      "recoveryPath": "Keep a lazy migration-only reader and the untouched source blob so supported skipped upgrades from 0.6.0 onward remain recoverable, plus the persistence_legacy_override_v1 switch to serve history from the blob again. Pre-0.6.0 Dexie-only chat history is outside the direct-upgrade contract."
     },
     {
       "id": "legacy-sqljs-import-generation-guard",
@@ -22,6 +22,15 @@
       "removalGate": "Remove with legacy-sqljs-live-fallback; no production writer may retain the old import-generation concept.",
       "targetRelease": "0.13.x",
       "recoveryPath": "Migration receipts and the single OPFS owner replace the guard."
+    },
+    {
+      "id": "persistence-legacy-override-switch",
+      "owner": "src/lib/persistence/backend.ts",
+      "introducedIn": "0.12.6",
+      "sourceVersions": ["0.12.6+ profiles migrated to the OPFS backend"],
+      "removalGate": "The legacy blob itself is no longer retained, so there is nothing left for the switch to return to.",
+      "targetRelease": null,
+      "recoveryPath": "Set persistence_legacy_override_v1 in device-local storage to serve chat history from the retained sql.js blob again; the migration stays skipped and records a skipped receipt while it is set."
     },
     {
       "id": "legacy-chat-blob-reader",

--- a/e2e/chromium/critical/persistence.spec.ts
+++ b/e2e/chromium/critical/persistence.spec.ts
@@ -7,6 +7,10 @@ import {
 interface Counts {
   sessions: number
   messages: number
+  /** Row counts for every durable table, which is what the migration verifies.
+   * Matched with toMatchObject so a new table does not fail these assertions on
+   * its way in. */
+  tables: Record<string, number>
 }
 
 test("@critical fresh OPFS profile survives a browser restart", async ({
@@ -14,13 +18,13 @@ test("@critical fresh OPFS profile survives a browser restart", async ({
 }) => {
   let { page, call } = await openPersistenceVerifyPage(extension)
   await waitForOpfsMarker(call)
-  expect((await call("counts")) as Counts).toEqual({
+  expect((await call("counts")) as Counts).toMatchObject({
     sessions: 0,
     messages: 0
   })
 
   await call("appendViaFacade", "fresh-profile", 2)
-  expect((await call("counts")) as Counts).toEqual({
+  expect((await call("counts")) as Counts).toMatchObject({
     sessions: 1,
     messages: 2
   })
@@ -29,7 +33,7 @@ test("@critical fresh OPFS profile survives a browser restart", async ({
   await extension.restart()
   ;({ page, call } = await openPersistenceVerifyPage(extension))
   await waitForOpfsMarker(call)
-  expect((await call("counts")) as Counts).toEqual({
+  expect((await call("counts")) as Counts).toMatchObject({
     sessions: 1,
     messages: 2
   })
@@ -53,6 +57,7 @@ test("@critical sql.js migration is durable, idempotent, and preserves source", 
     sessions: number
     messages: number
     blobBytes: number
+    tables: Record<string, number>
   }
   const sourceDigest = (await call("readLegacyBlobDigest")) as string
   await call("clearMarker")
@@ -66,10 +71,16 @@ test("@critical sql.js migration is durable, idempotent, and preserves source", 
     sessions: fixtureSessions,
     messages: fixtureMessages
   })
-  expect((await call("counts")) as Counts).toEqual({
+  const migratedCounts = (await call("counts")) as Counts
+  expect(migratedCounts).toMatchObject({
     sessions: fixtureSessions,
     messages: fixtureMessages
   })
+  // Every table the blob populated, not just the two the chat list reads.
+  expect(migratedCounts.tables).toMatchObject(seeded.tables)
+  expect(
+    (await call("migrationReceipt")) as { outcome?: string }
+  ).toMatchObject({ outcome: "migrated" })
   expect(await call("readLegacyBlobLength")).toBe(seeded.blobBytes)
   expect(await call("readLegacyBlobDigest")).toBe(sourceDigest)
 
@@ -77,7 +88,7 @@ test("@critical sql.js migration is durable, idempotent, and preserves source", 
   await extension.restart()
   ;({ page, call } = await openPersistenceVerifyPage(extension))
   await waitForOpfsMarker(call)
-  expect((await call("counts")) as Counts).toEqual({
+  expect((await call("counts")) as Counts).toMatchObject({
     sessions: fixtureSessions,
     messages: fixtureMessages
   })
@@ -86,7 +97,7 @@ test("@critical sql.js migration is durable, idempotent, and preserves source", 
   await page.close()
   await extension.restart()
   ;({ page, call } = await openPersistenceVerifyPage(extension))
-  expect((await call("counts")) as Counts).toEqual({
+  expect((await call("counts")) as Counts).toMatchObject({
     sessions: fixtureSessions + 1,
     messages: fixtureMessages + 2
   })

--- a/src/entrypoints/persistence-verify/main.ts
+++ b/src/entrypoints/persistence-verify/main.ts
@@ -7,12 +7,21 @@ import {
   SQLITE_DB_STORE,
   STORAGE_KEYS
 } from "@/lib/constants"
+import {
+  invalidateBackendCache,
+  readPersistenceBackend
+} from "@/lib/persistence/backend"
+import { DURABLE_TABLES } from "@/lib/persistence/durable-tables"
 import * as chatHistory from "@/lib/repositories/sqlite-chat-history"
 import {
   createFixture,
   type Scale
 } from "@/lib/sqlite/benchmark/persistence-benchmark-core"
-import { exportPersistedDatabaseBytes, query } from "@/lib/sqlite/db"
+import {
+  exportPersistedDatabaseBytes,
+  importDatabaseBytes,
+  query
+} from "@/lib/sqlite/db"
 import { LATEST_SCHEMA_VERSION } from "@/lib/sqlite/migrations/migration-runner"
 
 // Dev-only verification surface for the production OPFS migration. Every
@@ -25,6 +34,11 @@ import { LATEST_SCHEMA_VERSION } from "@/lib/sqlite/migrations/migration-runner"
 // the `chrome` namespace is callback-only, so `await chrome.storage.local.get`
 // resolves to undefined rather than the stored value. That made every hook
 // here silently unusable on the Firefox runner while working on Chromium.
+
+// Rows the fixture adds outside sessions/messages, so per-table migration
+// verification has something to verify.
+const PROMPT_TEMPLATE_SEED = 7
+const KV_SEED = 3
 
 const putLegacyBlob = async (bytes: Uint8Array): Promise<void> =>
   new Promise((resolve, reject) => {
@@ -123,12 +137,47 @@ const verifyApi = {
     await browser.storage.local.remove(STORAGE_KEYS.PERSISTENCE.BACKEND)
   },
 
+  async migrationReceipt(): Promise<unknown> {
+    const stored = await browser.storage.local.get(
+      STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT
+    )
+    return stored[STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT] ?? null
+  },
+
+  async clearMigrationReceipt(): Promise<void> {
+    await browser.storage.local.remove(
+      STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT
+    )
+  },
+
+  /** Operator recovery switch, written the way an operator would: device-local
+   * storage only. Read back through the production backend resolver. */
+  async setLegacyOverride(enabled: boolean): Promise<void> {
+    if (enabled) {
+      await browser.storage.local.set({
+        [STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE]: true
+      })
+      return
+    }
+    await browser.storage.local.remove(STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE)
+  },
+
+  async activeBackend(): Promise<string> {
+    invalidateBackendCache()
+    return readPersistenceBackend()
+  },
+
   /** Reproduce an unmigrated profile: build a real sql.js database with the
    * section 9.8 fixture generator and persist it as the legacy blob. */
   async seedLegacyBlob(
     chats: number,
     messages: number
-  ): Promise<{ sessions: number; messages: number; blobBytes: number }> {
+  ): Promise<{
+    sessions: number
+    messages: number
+    blobBytes: number
+    tables: Record<string, number>
+  }> {
     const wasmUrl = browser.runtime.getURL("assets/sql-wasm.wasm")
     const wasmBinary = await (await fetch(wasmUrl)).arrayBuffer()
     const SQL = await (
@@ -145,9 +194,43 @@ const verifyApi = {
       // detect migration writes to the rollback blob instead of observing the
       // legacy backend's expected one-time schema-version stamp.
       fixture.run(`PRAGMA user_version = ${LATEST_SCHEMA_VERSION}`)
+      // Seed beyond sessions/messages so migration verification is exercised
+      // on tables the chat list never reads: a blob that only ever carries
+      // chats cannot prove per-table verification works.
+      for (let index = 0; index < PROMPT_TEMPLATE_SEED; index += 1) {
+        fixture.run(
+          `INSERT INTO prompt_templates
+             (id, title, userPrompt, createdAt, usageCount, sortOrder)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            `verify-template-${index}`,
+            `Template ${index}`,
+            "prompt",
+            1,
+            0,
+            index
+          ]
+        )
+      }
+      for (let index = 0; index < KV_SEED; index += 1) {
+        fixture.run("INSERT INTO kv_store (key, value) VALUES (?, ?)", [
+          `verify-key-${index}`,
+          `value-${index}`
+        ])
+      }
+      const tables: Record<string, number> = {}
+      for (const table of DURABLE_TABLES) {
+        const result = fixture.exec(`SELECT COUNT(*) FROM "${table}"`)
+        tables[table] = Number(result[0]?.values?.[0]?.[0] ?? 0)
+      }
       const bytes = fixture.export()
       await putLegacyBlob(bytes)
-      return { sessions: chats, messages, blobBytes: bytes.byteLength }
+      return {
+        sessions: chats,
+        messages,
+        blobBytes: bytes.byteLength,
+        tables
+      }
     } finally {
       fixture.close()
     }
@@ -157,12 +240,37 @@ const verifyApi = {
   readLegacyBlobDigest,
 
   /** Row counts through the production path (facade → RPC → owner). */
-  async counts(): Promise<{ sessions: number; messages: number }> {
-    const sessions = await query("SELECT COUNT(*) AS n FROM sessions")
-    const messages = await query("SELECT COUNT(*) AS n FROM messages")
+  async counts(): Promise<{
+    sessions: number
+    messages: number
+    tables: Record<string, number>
+  }> {
+    const tables: Record<string, number> = {}
+    for (const table of DURABLE_TABLES) {
+      const rows = await query(`SELECT COUNT(*) AS n FROM "${table}"`)
+      tables[table] = Number(rows[0]?.n ?? 0)
+    }
     return {
-      sessions: Number(sessions[0]?.n ?? 0),
-      messages: Number(messages[0]?.n ?? 0)
+      sessions: tables.sessions ?? 0,
+      messages: tables.messages ?? 0,
+      tables
+    }
+  },
+
+  /** Integrity of the live database, read through the production path. */
+  async integrityInfo(): Promise<{
+    integrityCheck: string
+    foreignKeyViolations: number
+  }> {
+    const integrityRows = await query("PRAGMA integrity_check")
+    const fkRows = await query("PRAGMA foreign_key_check")
+    return {
+      integrityCheck:
+        integrityRows
+          .map((row) => String(Object.values(row)[0] ?? ""))
+          .filter((line) => line.length > 0)
+          .join("; ") || "ok",
+      foreignKeyViolations: fkRows.length
     }
   },
 
@@ -187,6 +295,20 @@ const verifyApi = {
       })
     }
     return lastId
+  },
+
+  /** Restore a payload that is not a usable database, through the production
+   * import path. The live database must survive a rejected restore. */
+  async importCorruptBackup(): Promise<{ error: string }> {
+    const bytes = new TextEncoder().encode(
+      "SQLite format 3 this is not a database".repeat(40)
+    )
+    try {
+      await importDatabaseBytes(bytes)
+      return { error: "" }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) }
+    }
   },
 
   async exportInfo(): Promise<{ byteLength: number; magic: string }> {

--- a/src/lib/__tests__/error-report.test.ts
+++ b/src/lib/__tests__/error-report.test.ts
@@ -191,6 +191,66 @@ describe("buildDiagnosticIssueUrl", () => {
     expect(body).toContain("**Privacy**")
   })
 
+  it("says nothing about migration when the profile never had a legacy blob", () => {
+    const body = bodyOf(buildDiagnosticIssueUrl(bundle))
+
+    expect(body).not.toContain("Chat migration")
+  })
+
+  it("reports a failed migration in the detail a maintainer needs", () => {
+    const body = bodyOf(
+      buildDiagnosticIssueUrl({
+        ...bundle,
+        storage: {
+          ...bundle.storage,
+          backend: "legacy",
+          migration: {
+            outcome: "verification-failed",
+            attempts: 3,
+            recordedAt: 1,
+            extensionVersion: "0.12.6",
+            sourceSchemaVersion: 11,
+            importedIntegrity: "ok",
+            foreignKeyViolations: 2,
+            mismatches: ["messages:39204→39199"],
+            failure: "imported message count short by 5"
+          }
+        }
+      })
+    )
+
+    expect(body).toContain("Chat migration: verification-failed (attempt 3")
+    expect(body).toContain("schema v11")
+    expect(body).toContain("messages:39204→39199")
+    expect(body).toContain("imported message count short by 5")
+    expect(body).toContain("Migration orphan rows: 2")
+  })
+
+  it("keeps a clean migration to a single line", () => {
+    const body = bodyOf(
+      buildDiagnosticIssueUrl({
+        ...bundle,
+        storage: {
+          ...bundle.storage,
+          migration: {
+            outcome: "migrated",
+            attempts: 1,
+            recordedAt: 1,
+            extensionVersion: "0.12.6",
+            sourceSchemaVersion: 11,
+            importedIntegrity: "ok",
+            foreignKeyViolations: 0
+          }
+        }
+      })
+    )
+
+    expect(body).toContain("Chat migration: migrated (attempt 1")
+    expect(body).not.toContain("Migration integrity")
+    expect(body).not.toContain("Migration orphan rows")
+    expect(body).not.toContain("Migration failure")
+  })
+
   it("stays inside the URL limit when every self-test fails", () => {
     const url = buildDiagnosticIssueUrl({
       ...bundle,

--- a/src/lib/__tests__/error-report.test.ts
+++ b/src/lib/__tests__/error-report.test.ts
@@ -212,8 +212,8 @@ describe("buildDiagnosticIssueUrl", () => {
             sourceSchemaVersion: 11,
             importedIntegrity: "ok",
             foreignKeyViolations: 2,
-            mismatches: ["messages:39204→39199"],
-            failure: "imported message count short by 5"
+            mismatches: ["messages short by 5"],
+            failure: "Migration verification failed: messages short by 5"
           }
         }
       })
@@ -221,9 +221,12 @@ describe("buildDiagnosticIssueUrl", () => {
 
     expect(body).toContain("Chat migration: verification-failed (attempt 3")
     expect(body).toContain("schema v11")
-    expect(body).toContain("messages:39204→39199")
-    expect(body).toContain("imported message count short by 5")
+    expect(body).toContain("messages short by 5")
     expect(body).toContain("Migration orphan rows: 2")
+    // The shortfall is diagnosable; the row counts it came from are not in the
+    // draft a reporter would submit.
+    expect(body).not.toContain("39204")
+    expect(body).not.toContain("39199")
   })
 
   it("keeps a clean migration to a single line", () => {

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -81,7 +81,20 @@ export const STORAGE_KEYS = {
      * profile runs on ("legacy" sql.js blob vs "opfs" single owner). Flips
      * exactly once, after the migration verifies row counts.
      */
-    BACKEND: "persistence_backend_v1"
+    BACKEND: "persistence_backend_v1",
+    /**
+     * Raw chrome.storage.local record of the last chat-history migration
+     * attempt: source schema version, per-table counts, integrity results,
+     * and outcome. Written on success and on failure, so a profile that never
+     * migrated can say why.
+     */
+    MIGRATION_RECEIPT: "persistence_migration_receipt_v1",
+    /**
+     * Raw chrome.storage.local operator switch: pin this device to the
+     * retained legacy sql.js blob regardless of the backend marker. Recovery
+     * path for a migration that verified but produced wrong data.
+     */
+    LEGACY_OVERRIDE: "persistence_legacy_override_v1"
   },
   APP_LIFECYCLE: {
     /**

--- a/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   providerConfig: vi.fn(),
   listModels: vi.fn(),
   backend: vi.fn(),
+  receipt: vi.fn(),
   txBegin: vi.fn(),
   txRollback: vi.fn(),
   query: vi.fn(),
@@ -42,7 +43,8 @@ vi.mock("@/lib/providers/provider-rpc-service", () => ({
   ProviderRpcService: { listModels: mocks.listModels }
 }))
 vi.mock("@/lib/persistence/backend", () => ({
-  readPersistenceBackend: mocks.backend
+  readPersistenceBackend: mocks.backend,
+  readMigrationReceipt: mocks.receipt
 }))
 vi.mock("@/lib/persistence/client", () => ({
   rpcTxBegin: mocks.txBegin,
@@ -109,6 +111,7 @@ beforeEach(() => {
     failures: []
   })
   mocks.backend.mockResolvedValue("opfs")
+  mocks.receipt.mockResolvedValue(null)
   mocks.txBegin.mockResolvedValue(undefined)
   mocks.txRollback.mockResolvedValue(undefined)
   mocks.run.mockResolvedValue({ changes: 1 })
@@ -402,5 +405,48 @@ describe("DiagnosticsService", () => {
       status: "action",
       code: "OLC-STORAGE-MIGRATION-001"
     })
+  })
+
+  it("omits migration evidence for a profile that never had a legacy blob", async () => {
+    mocks.receipt.mockResolvedValue(null)
+    const { bundle } = await DiagnosticsService.getBundle()
+
+    expect(bundle?.storage.migration).toBeUndefined()
+  })
+
+  it("reports migration failure evidence without any row counts", async () => {
+    mocks.backend.mockResolvedValue("legacy")
+    mocks.receipt.mockResolvedValue({
+      version: 1,
+      outcome: "verification-failed",
+      recordedAt: 1_700_000_000_000,
+      extensionVersion: "0.12.6",
+      attempts: 3,
+      sourceSchemaVersion: 11,
+      sourceBytes: 8_400_000,
+      // Counts describe how much a person has said. They must not leave.
+      sourceCounts: { sessions: 1482, messages: 39_204 },
+      importedCounts: { sessions: 1482, messages: 39_199 },
+      sourceIntegrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
+      importedIntegrity: { integrityCheck: "ok", foreignKeyViolations: 2 },
+      mismatches: [{ table: "messages", source: 39_204, imported: 39_199 }],
+      failure: "imported message count short by 5"
+    })
+
+    const { bundle } = await DiagnosticsService.getBundle()
+    const migration = bundle?.storage.migration
+    const serialized = JSON.stringify(migration)
+
+    expect(migration).toMatchObject({
+      outcome: "verification-failed",
+      attempts: 3,
+      sourceSchemaVersion: 11,
+      foreignKeyViolations: 2,
+      mismatches: ["messages:39204→39199"],
+      failure: "imported message count short by 5"
+    })
+    expect(serialized).not.toContain("1482")
+    expect(serialized).not.toContain("sourceCounts")
+    expect(serialized).not.toContain("sourceBytes")
   })
 })

--- a/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
@@ -430,7 +430,7 @@ describe("DiagnosticsService", () => {
       sourceIntegrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
       importedIntegrity: { integrityCheck: "ok", foreignKeyViolations: 2 },
       mismatches: [{ table: "messages", source: 39_204, imported: 39_199 }],
-      failure: "imported message count short by 5"
+      failure: "Migration verification failed: messages short by 5"
     })
 
     const { bundle } = await DiagnosticsService.getBundle()
@@ -442,10 +442,16 @@ describe("DiagnosticsService", () => {
       attempts: 3,
       sourceSchemaVersion: 11,
       foreignKeyViolations: 2,
-      mismatches: ["messages:39204→39199"],
-      failure: "imported message count short by 5"
+      // The shortfall, which is the diagnosable half.
+      mismatches: ["messages short by 5"]
     })
-    expect(serialized).not.toContain("1482")
+    // Not one of the four row counts in that receipt, through any field. An
+    // earlier version of this summary formatted `table:source→imported`, and
+    // this assertion named only the sessions count — so it passed while both
+    // message counts travelled.
+    for (const count of ["1482", "39204", "39199"]) {
+      expect(serialized).not.toContain(count)
+    }
     expect(serialized).not.toContain("sourceCounts")
     expect(serialized).not.toContain("sourceBytes")
   })

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -5,7 +5,11 @@ import {
 } from "@/lib/dnr-rules"
 import { vectorDb } from "@/lib/embeddings/db"
 import { getSafeClientEnvironment } from "@/lib/error-report"
-import { readPersistenceBackend } from "@/lib/persistence/backend"
+import {
+  type MigrationReceipt,
+  readMigrationReceipt,
+  readPersistenceBackend
+} from "@/lib/persistence/backend"
 import {
   rpcQuery,
   rpcRun,
@@ -18,6 +22,7 @@ import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
 import { ProviderId } from "@/lib/providers/types"
 import { countMessages } from "@/lib/repositories/chat-history"
 import type {
+  DiagnosticStorageMigration,
   DiagnosticsGetBundleResult,
   DiagnosticsRunResult,
   DiagnosticTestResult
@@ -118,6 +123,43 @@ const runMigrationTest = async (): Promise<DiagnosticTestResult> => {
     }
   }
   return result
+}
+
+/**
+ * Reduce a migration receipt to the evidence a maintainer needs and nothing
+ * more. Row counts per table are dropped: a mismatch is the fact worth
+ * reporting, and `sessions: 1482` describes how much someone has said. Only
+ * tables that arrived short survive, as `table:source→imported`.
+ *
+ * `integrity_check` output can be long on a damaged file, so each verdict is
+ * clamped and the whole list is capped.
+ */
+const MAX_REPORTED_MISMATCHES = 10
+
+export const summarizeMigrationReceipt = (
+  receipt: MigrationReceipt | null
+): DiagnosticStorageMigration | undefined => {
+  if (!receipt) return undefined
+  const verdict = (value?: string) =>
+    value === undefined ? undefined : value.slice(0, 120)
+  const mismatches = receipt.mismatches
+    ?.slice(0, MAX_REPORTED_MISMATCHES)
+    .map(
+      (mismatch) =>
+        `${mismatch.table}:${mismatch.source}→${mismatch.imported}` as const
+    )
+  return {
+    outcome: receipt.outcome,
+    attempts: receipt.attempts,
+    recordedAt: receipt.recordedAt,
+    extensionVersion: receipt.extensionVersion,
+    sourceSchemaVersion: receipt.sourceSchemaVersion,
+    sourceIntegrity: verdict(receipt.sourceIntegrity?.integrityCheck),
+    importedIntegrity: verdict(receipt.importedIntegrity?.integrityCheck),
+    foreignKeyViolations: receipt.importedIntegrity?.foreignKeyViolations,
+    ...(mismatches && mismatches.length > 0 ? { mismatches } : {}),
+    failure: receipt.failure ? receipt.failure.slice(0, 200) : undefined
+  }
 }
 
 /**
@@ -513,6 +555,7 @@ export const DiagnosticsService = {
     ])
     signal?.throwIfAborted()
     const backend = await readPersistenceBackend()
+    const migration = summarizeMigrationReceipt(await readMigrationReceipt())
     const environment = getSafeClientEnvironment()
     return {
       bundle: {
@@ -528,7 +571,12 @@ export const DiagnosticsService = {
           wire: String(provider.type),
           enabled: provider.enabled
         })),
-        storage: { backend, messageCount, vectorCount },
+        storage: {
+          backend,
+          messageCount,
+          vectorCount,
+          ...(migration ? { migration } : {})
+        },
         events: sessionId
           ? events.filter((event) => event.sessionId === sessionId)
           : events,

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -127,12 +127,16 @@ const runMigrationTest = async (): Promise<DiagnosticTestResult> => {
 
 /**
  * Reduce a migration receipt to the evidence a maintainer needs and nothing
- * more. Row counts per table are dropped: a mismatch is the fact worth
- * reporting, and `sessions: 1482` describes how much someone has said. Only
- * tables that arrived short survive, as `table:source→imported`.
+ * more.
+ *
+ * Row counts stay on the device. `messages: 39204` describes how much someone
+ * has said, and a shortfall is diagnosable without it: `messages short by 5`
+ * says a table lost five rows, which is the actionable half. An absolute pair
+ * would have disclosed history volume out of a support report, which is the one
+ * thing this summary exists to avoid.
  *
  * `integrity_check` output can be long on a damaged file, so each verdict is
- * clamped and the whole list is capped.
+ * clamped and the list of shortfalls is capped.
  */
 const MAX_REPORTED_MISMATCHES = 10
 
@@ -144,10 +148,12 @@ export const summarizeMigrationReceipt = (
     value === undefined ? undefined : value.slice(0, 120)
   const mismatches = receipt.mismatches
     ?.slice(0, MAX_REPORTED_MISMATCHES)
-    .map(
-      (mismatch) =>
-        `${mismatch.table}:${mismatch.source}→${mismatch.imported}` as const
-    )
+    .map((mismatch) => {
+      const delta = mismatch.source - mismatch.imported
+      return delta > 0
+        ? (`${mismatch.table} short by ${delta}` as const)
+        : (`${mismatch.table} over by ${-delta}` as const)
+    })
   return {
     outcome: receipt.outcome,
     attempts: receipt.attempts,

--- a/src/lib/error-report.ts
+++ b/src/lib/error-report.ts
@@ -172,6 +172,40 @@ export const buildGenericIssueReportUrl = (
 }
 
 /**
+ * Chat-history migration evidence, when this profile has any. Omitted entirely
+ * for a profile that never held a legacy blob, so a normal report does not carry
+ * three lines about a migration that never happened.
+ *
+ * A clean result stays one line. Detail appears only when something went wrong,
+ * because that is the only case a maintainer needs to read.
+ */
+const migrationLines = (
+  migration: NonNullable<DiagnosticBundle>["storage"]["migration"]
+): string[] => {
+  if (!migration) return []
+  const lines = [
+    `- Chat migration: ${clampLine(migration.outcome, 40)} (attempt ${migration.attempts}, from schema v${migration.sourceSchemaVersion ?? "?"}, on ${clampLine(migration.extensionVersion, 20)})`
+  ]
+  if (migration.importedIntegrity && migration.importedIntegrity !== "ok") {
+    lines.push(
+      `- Migration integrity: ${clampLine(migration.importedIntegrity, 120)}`
+    )
+  }
+  if (migration.foreignKeyViolations) {
+    lines.push(`- Migration orphan rows: ${migration.foreignKeyViolations}`)
+  }
+  if (migration.mismatches?.length) {
+    lines.push(
+      `- Migration table mismatches: ${clampLine(migration.mismatches.join(", "), 200)}`
+    )
+  }
+  if (migration.failure) {
+    lines.push(`- Migration failure: ${clampLine(migration.failure, 200)}`)
+  }
+  return lines
+}
+
+/**
  * Draft opened from Settings → Help → Diagnostics & support, where the reporter
  * already has a bundle in hand. Shares the composer above, so this draft carries
  * the same paste block, privacy statement, and length guarantee as a chat-error
@@ -195,6 +229,7 @@ export const buildDiagnosticIssueUrl = (
       `- Browser: ${clampLine(bundle.browserFamily, 100)}`,
       `- OS: ${clampLine(bundle.osFamily, 100)}`,
       `- Storage backend: ${clampLine(bundle.storage.backend, 100)}`,
+      ...migrationLines(bundle.storage.migration),
       ...(failed.length > 0 ? failed : ["- Self-tests: passed"])
     ].join("\n")
   )

--- a/src/lib/persistence/__tests__/durable-tables.test.ts
+++ b/src/lib/persistence/__tests__/durable-tables.test.ts
@@ -5,6 +5,7 @@ import {
   countDurableTables,
   DURABLE_TABLES,
   describeMismatches,
+  findMissingDurableTables,
   findTableCountMismatches,
   isSoundDatabase,
   readIntegrityReport,
@@ -71,9 +72,32 @@ describe("table count verification", () => {
       { table: "messages", source: 9, imported: 8 },
       { table: "prompt_templates", source: 7, imported: 0 }
     ])
+    // Shortfalls, not count pairs: this text reaches the receipt's `failure`,
+    // which a support report can carry.
     expect(describeMismatches(mismatches)).toBe(
-      "messages 8/9, prompt_templates 0/7"
+      "messages short by 1, prompt_templates short by 7"
     )
+    expect(describeMismatches(mismatches)).not.toMatch(/\b9\b/)
+  })
+
+  it("names a durable table the destination does not have at all", () => {
+    // Absent from both sides, so no count can disagree — chunk_feedback reached
+    // the schema in 0.10.0 without a migration, and a database predating it
+    // passed verification while lacking the table.
+    expect(findMissingDurableTables({ sessions: 2, messages: 9 })).toContain(
+      "chunk_feedback"
+    )
+    expect(
+      findMissingDurableTables({
+        sessions: 0,
+        messages: 0,
+        files: 0,
+        kv_store: 0,
+        prompt_templates: 0,
+        tool_loop_runs: 0,
+        chunk_feedback: 0
+      })
+    ).toEqual([])
   })
 })
 

--- a/src/lib/persistence/__tests__/durable-tables.test.ts
+++ b/src/lib/persistence/__tests__/durable-tables.test.ts
@@ -1,0 +1,105 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+  countDurableTables,
+  DURABLE_TABLES,
+  describeMismatches,
+  findTableCountMismatches,
+  isSoundDatabase,
+  readIntegrityReport,
+  tableExistsSql
+} from "../durable-tables"
+
+const readTableNames = (source: string): string[] =>
+  [
+    ...source.matchAll(
+      /CREATE TABLE (?:IF NOT EXISTS )?([A-Za-z_][A-Za-z0-9_]*)/g
+    )
+  ].map((match) => match[1])
+
+describe("durable table inventory", () => {
+  it("names every table the schema and its migrations create", () => {
+    const schemaDir = resolve(__dirname, "../../sqlite")
+    const migrationsDir = resolve(schemaDir, "migrations")
+    const sources = [
+      readFileSync(resolve(schemaDir, "schema.ts"), "utf8"),
+      ...readdirSync(migrationsDir)
+        .filter((entry) => entry.endsWith(".ts"))
+        .map((entry) => readFileSync(resolve(migrationsDir, entry), "utf8"))
+    ]
+
+    const declared = new Set(sources.flatMap(readTableNames))
+    // A table that lands in the schema without landing in DURABLE_TABLES would
+    // migrate unverified — the row counts nobody compares are the ones that go
+    // missing.
+    expect([...declared].sort()).toEqual([...DURABLE_TABLES].sort())
+  })
+})
+
+describe("table count verification", () => {
+  it("counts only the tables the database actually has", () => {
+    const present = new Set(["sessions", "messages"])
+    const counts = countDurableTables(
+      (sql) => (sql.includes("sessions") ? 3 : 40),
+      (table) => present.has(table)
+    )
+    expect(counts).toEqual({ sessions: 3, messages: 40 })
+  })
+
+  it("quotes table names in the existence probe", () => {
+    expect(tableExistsSql("sessions")).toContain("name = 'sessions'")
+  })
+
+  it("ignores destination tables the source never had", () => {
+    // Forward migrations create tables during the import; gaining an empty
+    // chunk_feedback is correct, not data loss.
+    expect(
+      findTableCountMismatches(
+        { sessions: 2, messages: 9 },
+        { sessions: 2, messages: 9, chunk_feedback: 0 }
+      )
+    ).toEqual([])
+  })
+
+  it("reports a source table that arrived short or missing", () => {
+    const mismatches = findTableCountMismatches(
+      { sessions: 2, messages: 9, prompt_templates: 7 },
+      { sessions: 2, messages: 8 }
+    )
+    expect(mismatches).toEqual([
+      { table: "messages", source: 9, imported: 8 },
+      { table: "prompt_templates", source: 7, imported: 0 }
+    ])
+    expect(describeMismatches(mismatches)).toBe(
+      "messages 8/9, prompt_templates 0/7"
+    )
+  })
+})
+
+describe("integrity reporting", () => {
+  it("reads a sound database as ok with no violations", () => {
+    const report = readIntegrityReport((sql) =>
+      sql.includes("integrity_check") ? [["ok"]] : []
+    )
+    expect(report).toEqual({ integrityCheck: "ok", foreignKeyViolations: 0 })
+    expect(isSoundDatabase(report)).toBe(true)
+  })
+
+  it("joins every reported problem and counts foreign-key violations", () => {
+    const report = readIntegrityReport((sql) =>
+      sql.includes("integrity_check")
+        ? [["row 3 missing from index"], ["page 7 is never used"]]
+        : [["messages", 4, "sessions", 0]]
+    )
+    expect(report).toEqual({
+      integrityCheck: "row 3 missing from index; page 7 is never used",
+      foreignKeyViolations: 1
+    })
+    expect(isSoundDatabase(report)).toBe(false)
+  })
+
+  it("treats an empty integrity_check result as ok", () => {
+    expect(readIntegrityReport(() => []).integrityCheck).toBe("ok")
+  })
+})

--- a/src/lib/persistence/__tests__/import-rollback.test.ts
+++ b/src/lib/persistence/__tests__/import-rollback.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  clearRollbackCopy,
+  ROLLBACK_PATH,
+  type RollbackPool,
+  recoverFailedReplacement,
+  recoverInterruptedImport,
+  restoreRollbackCopy,
+  stageRollbackCopy
+} from "../import-rollback"
+
+const DB_PATH = "/chat-history.sqlite"
+
+const bytes = (label: string): Uint8Array => new TextEncoder().encode(label)
+
+/** Stands in for the opfs-sahpool utility: a path→bytes map. */
+const createPool = (
+  initial: Record<string, Uint8Array> = {}
+): RollbackPool & { files: Map<string, Uint8Array> } => {
+  const files = new Map(Object.entries(initial))
+  return {
+    files,
+    getFileNames: () => [...files.keys()],
+    unlink: (path) => {
+      files.delete(path)
+    },
+    exportFile: async (path) => {
+      const found = files.get(path)
+      if (!found) throw new Error(`no such file: ${path}`)
+      return found
+    },
+    importDb: (path, value) => {
+      files.set(path, value)
+    }
+  }
+}
+
+describe("staging a rollback copy", () => {
+  it("copies the live database aside", async () => {
+    const pool = createPool({ [DB_PATH]: bytes("live history") })
+
+    const staged = await stageRollbackCopy(pool, DB_PATH)
+
+    expect(staged).toEqual(bytes("live history"))
+    expect(pool.files.get(ROLLBACK_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("stages nothing on a profile with no database yet", async () => {
+    const pool = createPool()
+
+    await expect(stageRollbackCopy(pool, DB_PATH)).resolves.toBeNull()
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+
+  it("replaces a copy left over from an earlier attempt", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("current"),
+      [ROLLBACK_PATH]: bytes("stale")
+    })
+
+    await stageRollbackCopy(pool, DB_PATH)
+
+    expect(pool.files.get(ROLLBACK_PATH)).toEqual(bytes("current"))
+  })
+
+  it("refuses to continue when a database exists but cannot be read", async () => {
+    // The dangerous case: answering "nothing to protect" here would let the
+    // caller replace the only copy of data that does exist.
+    const pool = createPool({
+      [DB_PATH]: bytes("live history"),
+      [ROLLBACK_PATH]: bytes("older copy")
+    })
+    pool.exportFile = async () => {
+      throw new Error("read failed")
+    }
+
+    await expect(stageRollbackCopy(pool, DB_PATH)).rejects.toThrow(
+      "Cannot stage a rollback copy of the chat database: read failed"
+    )
+    // And the earlier copy is still there to recover from.
+    expect(pool.files.get(ROLLBACK_PATH)).toEqual(bytes("older copy"))
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("stages nothing when the live database is empty", async () => {
+    const pool = createPool({
+      [DB_PATH]: new Uint8Array(),
+      [ROLLBACK_PATH]: bytes("stale")
+    })
+
+    await expect(stageRollbackCopy(pool, DB_PATH)).resolves.toBeNull()
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+})
+
+describe("undoing a failed replacement", () => {
+  it("puts the pre-replacement database back and drops the copy", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("half-written"),
+      [ROLLBACK_PATH]: bytes("live history")
+    })
+
+    await restoreRollbackCopy(pool, DB_PATH, bytes("live history"))
+
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+
+  it("keeps the copy when the restore itself fails", async () => {
+    const pool = createPool({ [ROLLBACK_PATH]: bytes("live history") })
+    pool.importDb = () => {
+      throw new Error("pool is out of slots")
+    }
+
+    await expect(
+      restoreRollbackCopy(pool, DB_PATH, bytes("live history"))
+    ).rejects.toThrow("pool is out of slots")
+    // Startup recovery is the last chance to save this data; deleting the copy
+    // here would spend it.
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(true)
+  })
+})
+
+describe("recovering from a failed replacement", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  it("puts the pre-replacement database back and allows reopening", async () => {
+    const pool = createPool({ [DB_PATH]: bytes("half-written") })
+
+    await expect(
+      recoverFailedReplacement(pool, DB_PATH, bytes("live history"))
+    ).resolves.toBe(true)
+
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+
+  it("allows reopening when there was nothing to protect", async () => {
+    const pool = createPool({ [DB_PATH]: bytes("imported") })
+
+    await expect(recoverFailedReplacement(pool, DB_PATH, null)).resolves.toBe(
+      true
+    )
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("imported"))
+  })
+
+  it("falls back to the copy on disk when the in-memory restore fails", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("half-written"),
+      [ROLLBACK_PATH]: bytes("live history")
+    })
+    let attempts = 0
+    const write = pool.importDb
+    pool.importDb = (path, value) => {
+      attempts += 1
+      // The restore from memory fails; reading the copy back off disk works.
+      if (attempts === 1) throw new Error("write failed")
+      write(path, value)
+    }
+
+    await expect(
+      recoverFailedReplacement(pool, DB_PATH, bytes("live history"))
+    ).resolves.toBe(true)
+
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+
+  it("refuses reopening while an unrestored copy is still on disk", async () => {
+    // The dangerous case: the live file is the failed import and the copy that
+    // startup recovery will restore is still there. Serving that file would let
+    // writes land on a database the next boot discards.
+    const pool = createPool({
+      [DB_PATH]: bytes("half-written"),
+      [ROLLBACK_PATH]: bytes("live history")
+    })
+    pool.importDb = () => {
+      throw new Error("pool is out of slots")
+    }
+
+    await expect(
+      recoverFailedReplacement(pool, DB_PATH, bytes("live history"))
+    ).resolves.toBe(false)
+
+    expect(pool.files.get(ROLLBACK_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("allows reopening once an unusable copy is discarded", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("imported"),
+      [ROLLBACK_PATH]: new Uint8Array()
+    })
+    const write = pool.importDb
+    let attempts = 0
+    pool.importDb = (path, value) => {
+      attempts += 1
+      if (attempts === 1) throw new Error("write failed")
+      write(path, value)
+    }
+
+    await expect(
+      recoverFailedReplacement(pool, DB_PATH, bytes("live history"))
+    ).resolves.toBe(true)
+
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("imported"))
+  })
+})
+
+describe("startup recovery", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  it("does nothing when no replacement was in flight", async () => {
+    const pool = createPool({ [DB_PATH]: bytes("live history") })
+
+    await expect(recoverInterruptedImport(pool, DB_PATH)).resolves.toBe(false)
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("restores the copy a killed replacement left behind", async () => {
+    // The worker died between staging and completing the replacement, so the
+    // live file is whatever the interrupted write produced.
+    const pool = createPool({
+      [DB_PATH]: bytes("truncated"),
+      [ROLLBACK_PATH]: bytes("live history")
+    })
+
+    await expect(recoverInterruptedImport(pool, DB_PATH)).resolves.toBe(true)
+
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+
+  it("discards an unreadable copy instead of retrying it forever", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("live history"),
+      [ROLLBACK_PATH]: bytes("x")
+    })
+    pool.exportFile = async () => {
+      throw new Error("slot is gone")
+    }
+
+    await expect(recoverInterruptedImport(pool, DB_PATH)).resolves.toBe(false)
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("rejects when a readable copy cannot be written back", async () => {
+    // The caller (worker startup) turns this into a failed open. Resolving here
+    // would let it open the half-replaced file while the copy that outranks it
+    // is still on disk.
+    const pool = createPool({
+      [DB_PATH]: bytes("half-written"),
+      [ROLLBACK_PATH]: bytes("live history")
+    })
+    pool.importDb = () => {
+      throw new Error("pool is out of slots")
+    }
+
+    await expect(recoverInterruptedImport(pool, DB_PATH)).rejects.toThrow(
+      "pool is out of slots"
+    )
+    expect(pool.files.get(ROLLBACK_PATH)).toEqual(bytes("live history"))
+  })
+
+  it("discards an empty copy", async () => {
+    const pool = createPool({
+      [DB_PATH]: bytes("live history"),
+      [ROLLBACK_PATH]: new Uint8Array()
+    })
+
+    await expect(recoverInterruptedImport(pool, DB_PATH)).resolves.toBe(false)
+    expect(pool.files.get(DB_PATH)).toEqual(bytes("live history"))
+  })
+})
+
+describe("clearing the copy", () => {
+  it("removes it once a replacement completed", () => {
+    const pool = createPool({ [ROLLBACK_PATH]: bytes("live history") })
+
+    clearRollbackCopy(pool)
+
+    expect(pool.files.has(ROLLBACK_PATH)).toBe(false)
+  })
+})

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ImportResult } from "../protocol"
+
+// Migration verification and its receipt. Each test re-imports owner-host,
+// because `ensureMigrated` memoizes the attempt for the life of the module —
+// the same reason a real owner runs it once per host.
+
+const legacyBlob = vi.hoisted(() => ({
+  readLegacyBlobBytes: vi.fn(),
+  countLegacyRows: vi.fn()
+}))
+vi.mock("../legacy-blob-reader", () => legacyBlob)
+
+const importResults: ImportResult[] = []
+
+class StubWorker {
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  onmessageerror: ((event: unknown) => void) | null = null
+
+  postMessage(payload: { id?: number; request?: { op?: string } }) {
+    if (typeof payload.id !== "number") return
+    const { id } = payload
+    const op = payload.request?.op
+    queueMicrotask(() => {
+      if (op === "importDb") {
+        const result = importResults.shift()
+        this.onmessage?.({
+          data: result
+            ? { id, ok: true, result }
+            : { id, ok: false, error: "no stubbed import result" }
+        })
+        return
+      }
+      this.onmessage?.({ data: { id, ok: true, result: "pong" } })
+    })
+  }
+
+  terminate() {}
+}
+
+const BACKEND_KEY = "persistence_backend_v1"
+const RECEIPT_KEY = "persistence_migration_receipt_v1"
+const OVERRIDE_KEY = "persistence_legacy_override_v1"
+
+const store = new Map<string, unknown>()
+
+const sourceSurvey = {
+  sessions: 2,
+  messages: 9,
+  tables: { sessions: 2, messages: 9, prompt_templates: 7 },
+  schemaVersion: 11,
+  integrity: { integrityCheck: "ok", foreignKeyViolations: 0 }
+}
+
+const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => ({
+  sessions: 2,
+  messages: 9,
+  tables: { sessions: 2, messages: 9, prompt_templates: 7, chunk_feedback: 0 },
+  integrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
+  ...overrides
+})
+
+const receipt = (): Record<string, unknown> =>
+  (store.get(RECEIPT_KEY) ?? {}) as Record<string, unknown>
+
+const loadHost = async () => {
+  vi.resetModules()
+  return import("../owner-host")
+}
+
+describe("legacy-blob migration verification", () => {
+  beforeEach(() => {
+    store.clear()
+    importResults.length = 0
+    legacyBlob.readLegacyBlobBytes.mockReset()
+    legacyBlob.countLegacyRows.mockReset()
+    legacyBlob.readLegacyBlobBytes.mockResolvedValue(
+      Uint8Array.from([1, 2, 3, 4])
+    )
+    legacyBlob.countLegacyRows.mockResolvedValue(sourceSurvey)
+    vi.mocked(chrome.storage.local.get as never as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation(async (key: string) =>
+        store.has(key) ? { [key]: store.get(key) } : {}
+      )
+    vi.mocked(chrome.storage.local.set as never as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation(async (items: Record<string, unknown>) => {
+        for (const [key, value] of Object.entries(items)) store.set(key, value)
+      })
+    vi.stubGlobal("Worker", StubWorker)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8))
+      })
+    )
+  })
+
+  it("flips the marker and records a receipt when every table survives", async () => {
+    importResults.push(importResult())
+    const { ensureMigrated } = await loadHost()
+
+    await expect(ensureMigrated()).resolves.toBeUndefined()
+
+    expect(store.get(BACKEND_KEY)).toMatchObject({ backend: "opfs" })
+    expect(receipt()).toMatchObject({
+      outcome: "migrated",
+      attempts: 1,
+      sourceSchemaVersion: 11,
+      sourceBytes: 4,
+      sourceCounts: sourceSurvey.tables,
+      importedIntegrity: { integrityCheck: "ok" },
+      mismatches: []
+    })
+  })
+
+  it("fails and stays on legacy when a table the source had arrives short", async () => {
+    // prompt_templates is the case the old sessions/messages-only check could
+    // not see: chats look complete while the user's templates are gone.
+    importResults.push(
+      importResult({
+        tables: { sessions: 2, messages: 9, prompt_templates: 6 }
+      })
+    )
+    const { ensureMigrated } = await loadHost()
+
+    await expect(ensureMigrated()).rejects.toThrow(
+      "Migration verification failed: prompt_templates 6/7"
+    )
+
+    expect(store.has(BACKEND_KEY)).toBe(false)
+    expect(receipt()).toMatchObject({
+      outcome: "failed",
+      failure: expect.stringContaining("prompt_templates 6/7"),
+      mismatches: [{ table: "prompt_templates", source: 7, imported: 6 }]
+    })
+  })
+
+  it("records an import failure the worker reported", async () => {
+    const { ensureMigrated } = await loadHost()
+
+    await expect(ensureMigrated()).rejects.toThrow("no stubbed import result")
+
+    expect(store.has(BACKEND_KEY)).toBe(false)
+    expect(receipt()).toMatchObject({
+      outcome: "failed",
+      importedCounts: undefined,
+      failure: "no stubbed import result"
+    })
+  })
+
+  it("counts attempts across boots", async () => {
+    importResults.push(
+      importResult({ tables: { sessions: 2, messages: 8 } }),
+      importResult()
+    )
+
+    const first = await loadHost()
+    await expect(first.ensureMigrated()).rejects.toThrow()
+    expect(receipt()).toMatchObject({ outcome: "failed", attempts: 1 })
+
+    const second = await loadHost()
+    await expect(second.ensureMigrated()).resolves.toBeUndefined()
+    expect(receipt()).toMatchObject({ outcome: "migrated", attempts: 2 })
+  })
+
+  it("migrates despite foreign-key violations, and records them", async () => {
+    // Orphan rows in a years-old blob are a fact about the source. Refusing to
+    // migrate would strand that history on the backend being retired.
+    importResults.push(
+      importResult({
+        integrity: { integrityCheck: "ok", foreignKeyViolations: 3 }
+      })
+    )
+    const { ensureMigrated } = await loadHost()
+
+    await expect(ensureMigrated()).resolves.toBeUndefined()
+
+    expect(store.get(BACKEND_KEY)).toMatchObject({ backend: "opfs" })
+    expect(receipt()).toMatchObject({
+      outcome: "migrated",
+      importedIntegrity: { foreignKeyViolations: 3 }
+    })
+  })
+
+  it("skips the migration while the operator override is set", async () => {
+    store.set(OVERRIDE_KEY, true)
+    const { ensureMigrated } = await loadHost()
+
+    await expect(ensureMigrated()).resolves.toBeUndefined()
+
+    expect(store.has(BACKEND_KEY)).toBe(false)
+    expect(legacyBlob.readLegacyBlobBytes).not.toHaveBeenCalled()
+    expect(receipt()).toMatchObject({ outcome: "skipped" })
+  })
+
+  it("records the skip once instead of on every boot", async () => {
+    store.set(OVERRIDE_KEY, true)
+    const first = await loadHost()
+    await first.ensureMigrated()
+    const second = await loadHost()
+    await second.ensureMigrated()
+
+    expect(receipt()).toMatchObject({ outcome: "skipped", attempts: 1 })
+  })
+})
+
+describe("operator override", () => {
+  beforeEach(() => {
+    store.clear()
+    vi.mocked(chrome.storage.local.get as never as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation(async (key: string) =>
+        store.has(key) ? { [key]: store.get(key) } : {}
+      )
+    vi.mocked(chrome.storage.local.set as never as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation(async (items: Record<string, unknown>) => {
+        for (const [key, value] of Object.entries(items)) store.set(key, value)
+      })
+  })
+
+  it("returns a migrated profile to the legacy blob", async () => {
+    const backend = await import("../backend")
+    backend.invalidateBackendCache()
+    store.set(BACKEND_KEY, { backend: "opfs" })
+
+    await expect(backend.readPersistenceBackend()).resolves.toBe("opfs")
+
+    await backend.setLegacyOverride(true)
+    // Read again in the same context: a switch that only takes effect after a
+    // reload is not a recovery path.
+    await expect(backend.readPersistenceBackend()).resolves.toBe("legacy")
+    expect(store.get(OVERRIDE_KEY)).toBe(true)
+
+    await backend.setLegacyOverride(false)
+    await expect(backend.readPersistenceBackend()).resolves.toBe("opfs")
+  })
+
+  it("stays off when the override read fails", async () => {
+    const backend = await import("../backend")
+    backend.invalidateBackendCache()
+    vi.mocked(
+      chrome.storage.local.get as never as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("storage gone"))
+
+    // A storage glitch must not send a migrated profile back to a stale blob.
+    await expect(backend.readPersistenceBackend()).resolves.toBe("legacy")
+    await expect(backend.readLegacyOverride()).resolves.toBe(false)
+  })
+})

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -53,10 +53,22 @@ const sourceSurvey = {
   integrity: { integrityCheck: "ok", foreignKeyViolations: 0 }
 }
 
+/** Every durable table, since SCHEMA_SQL creates them all on open. Tables the
+ * source never had arrive empty, which is correct rather than data loss. */
+const importedTables = {
+  sessions: 2,
+  messages: 9,
+  prompt_templates: 7,
+  files: 0,
+  kv_store: 0,
+  tool_loop_runs: 0,
+  chunk_feedback: 0
+}
+
 const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => ({
   sessions: 2,
   messages: 9,
-  tables: { sessions: 2, messages: 9, prompt_templates: 7, chunk_feedback: 0 },
+  tables: importedTables,
   integrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
   ...overrides
 })
@@ -122,19 +134,19 @@ describe("legacy-blob migration verification", () => {
     // not see: chats look complete while the user's templates are gone.
     importResults.push(
       importResult({
-        tables: { sessions: 2, messages: 9, prompt_templates: 6 }
+        tables: { ...importedTables, prompt_templates: 6 }
       })
     )
     const { ensureMigrated } = await loadHost()
 
     await expect(ensureMigrated()).rejects.toThrow(
-      "Migration verification failed: prompt_templates 6/7"
+      "Migration verification failed: prompt_templates short by 1"
     )
 
     expect(store.has(BACKEND_KEY)).toBe(false)
     expect(receipt()).toMatchObject({
       outcome: "failed",
-      failure: expect.stringContaining("prompt_templates 6/7"),
+      failure: expect.stringContaining("prompt_templates short by 1"),
       mismatches: [{ table: "prompt_templates", source: 7, imported: 6 }]
     })
   })
@@ -154,7 +166,7 @@ describe("legacy-blob migration verification", () => {
 
   it("counts attempts across boots", async () => {
     importResults.push(
-      importResult({ tables: { sessions: 2, messages: 8 } }),
+      importResult({ tables: { ...importedTables, messages: 8 } }),
       importResult()
     )
 

--- a/src/lib/persistence/backend.ts
+++ b/src/lib/persistence/backend.ts
@@ -1,13 +1,25 @@
 import { browser } from "@/lib/browser-api"
 import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import { PERSISTENCE_MARKER } from "./protocol"
+import type {
+  IntegrityReport,
+  TableCountMismatch,
+  TableCounts
+} from "./durable-tables"
+import { PERSISTENCE_MARKER, type PersistenceStateScope } from "./protocol"
 
 // Which persistence backend this profile runs on. "legacy" is the historical
 // in-memory sql.js database persisted as one IndexedDB blob; "opfs" is the
 // single-owner sqlite-wasm database. The marker flips exactly once, after the
 // owner has physically imported and verified the legacy blob. The legacy blob
 // itself is never deleted by the migration — it is the rollback artifact.
+//
+// Two records sit beside the marker, both device-local:
+//   - the migration receipt, written on every attempt including failures, so
+//     an unmigrated profile can state why it is still on the blob;
+//   - the operator override, which pins this device to the blob regardless of
+//     the marker. That is the recovery path for a migration that passed
+//     verification and still produced the wrong data.
 
 export type PersistenceBackend = "legacy" | "opfs"
 
@@ -17,6 +29,32 @@ interface BackendMarker {
   sourceCounts?: { sessions: number; messages: number }
 }
 
+export type MigrationOutcome = "migrated" | "fresh" | "failed" | "skipped"
+
+export interface MigrationReceipt {
+  version: 1
+  outcome: MigrationOutcome
+  recordedAt: number
+  /** Extension version that performed the attempt. */
+  extensionVersion: string
+  /** How many attempts this profile has recorded, including this one. */
+  attempts: number
+  sourceSchemaVersion?: number
+  sourceBytes?: number
+  sourceCounts?: TableCounts
+  importedCounts?: TableCounts
+  sourceIntegrity?: IntegrityReport
+  importedIntegrity?: IntegrityReport
+  mismatches?: TableCountMismatch[]
+  failure?: string
+}
+
+const STORAGE_KEY_BY_SCOPE: Record<PersistenceStateScope, string> = {
+  backend: STORAGE_KEYS.PERSISTENCE.BACKEND,
+  receipt: STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT,
+  override: STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE
+}
+
 // Only "opfs" is cached permanently — it is the terminal state. "legacy" is
 // transitional (the owner may flip the marker at any moment), so it is
 // re-read on demand and the cache is invalidated live through
@@ -24,6 +62,7 @@ interface BackendMarker {
 // lifetime would keep it writing the rollback blob after migration —
 // split-brain history.
 let cachedBackend: PersistenceBackend | null = null
+let cachedOverride: boolean | null = null
 
 let watcherRegistered = false
 const registerMarkerWatcher = (): void => {
@@ -31,8 +70,10 @@ const registerMarkerWatcher = (): void => {
   watcherRegistered = true
   try {
     browser.storage?.onChanged?.addListener((changes, areaName) => {
-      if (areaName === "local" && STORAGE_KEYS.PERSISTENCE.BACKEND in changes) {
-        cachedBackend = null
+      if (areaName !== "local") return
+      if (STORAGE_KEYS.PERSISTENCE.BACKEND in changes) cachedBackend = null
+      if (STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE in changes) {
+        cachedOverride = null
       }
     })
   } catch {
@@ -42,7 +83,7 @@ const registerMarkerWatcher = (): void => {
 }
 
 // Offscreen documents expose runtime messaging but not storage; the background
-// answers marker reads/writes on their behalf.
+// answers these reads/writes on their behalf.
 //
 // Probed through `browser` — the promise-based polyfill — and not the `chrome`
 // alias. On Firefox `chrome` is callback-only, so `await chrome.storage.local
@@ -51,45 +92,80 @@ const registerMarkerWatcher = (): void => {
 // "legacy", and Firefox therefore never left the sql.js blob backend.
 const hasStorageApi = (): boolean => Boolean(browser.storage?.local)
 
-const readMarkerRaw = async (): Promise<BackendMarker | undefined> => {
+const readState = async <T>(
+  scope: PersistenceStateScope
+): Promise<T | undefined> => {
+  const key = STORAGE_KEY_BY_SCOPE[scope]
   if (hasStorageApi()) {
-    const stored = await browser.storage.local.get(
-      STORAGE_KEYS.PERSISTENCE.BACKEND
-    )
-    return stored[STORAGE_KEYS.PERSISTENCE.BACKEND] as BackendMarker | undefined
+    const stored = await browser.storage.local.get(key)
+    return stored[key] as T | undefined
   }
   const response = (await browser.runtime.sendMessage({
     type: PERSISTENCE_MARKER,
-    action: "get"
-  })) as { ok: boolean; marker?: BackendMarker; error?: string } | undefined
+    action: "get",
+    scope
+  })) as { ok: boolean; value?: unknown; error?: string } | undefined
   if (!response?.ok) {
-    throw new Error(response?.error ?? "Marker read message dropped")
+    throw new Error(response?.error ?? `${scope} read message dropped`)
   }
-  return response.marker
+  return response.value as T | undefined
 }
 
-const writeMarkerRaw = async (marker: BackendMarker): Promise<void> => {
+const writeState = async (
+  scope: PersistenceStateScope,
+  value: unknown
+): Promise<void> => {
   if (hasStorageApi()) {
-    await browser.storage.local.set({
-      [STORAGE_KEYS.PERSISTENCE.BACKEND]: marker
-    })
+    await browser.storage.local.set({ [STORAGE_KEY_BY_SCOPE[scope]]: value })
     return
   }
   const response = (await browser.runtime.sendMessage({
     type: PERSISTENCE_MARKER,
     action: "set",
-    marker
+    scope,
+    value
   })) as { ok: boolean; error?: string } | undefined
   if (!response?.ok) {
-    throw new Error(response?.error ?? "Marker write message dropped")
+    throw new Error(response?.error ?? `${scope} write message dropped`)
   }
+}
+
+/**
+ * Whether the operator switch pins this device to the legacy blob.
+ *
+ * A failed read answers false: absent is the normal state, and answering true
+ * on a transient storage error would send a migrated profile back to a stale
+ * blob — split-brain history from a glitch.
+ */
+export const readLegacyOverride = async (): Promise<boolean> => {
+  if (cachedOverride !== null) return cachedOverride
+  try {
+    cachedOverride = (await readState<boolean>("override")) === true
+    return cachedOverride
+  } catch (error) {
+    logger.warn("Failed to read persistence legacy override", "Persistence", {
+      error
+    })
+    return false
+  }
+}
+
+/** Operator recovery switch. Enabling it returns this device to the retained
+ * legacy blob; the migration stays skipped for as long as it is set. */
+export const setLegacyOverride = async (enabled: boolean): Promise<void> => {
+  await writeState("override", enabled)
+  cachedOverride = enabled
+  cachedBackend = null
 }
 
 export const readPersistenceBackend = async (): Promise<PersistenceBackend> => {
   registerMarkerWatcher()
+  // Checked before the "opfs" cache: the switch has to take effect in a
+  // context that already resolved the terminal state.
+  if (await readLegacyOverride()) return "legacy"
   if (cachedBackend === "opfs") return cachedBackend
   try {
-    const marker = await readMarkerRaw()
+    const marker = await readState<BackendMarker>("backend")
     cachedBackend = marker?.backend === "opfs" ? "opfs" : "legacy"
     return cachedBackend
   } catch (error) {
@@ -110,12 +186,65 @@ export const markOpfsBackend = async (details: {
     migratedAt: Date.now(),
     sourceCounts: details.sourceCounts
   }
-  await writeMarkerRaw(marker)
+  await writeState("backend", marker)
   cachedBackend = "opfs"
+}
+
+export const readMigrationReceipt =
+  async (): Promise<MigrationReceipt | null> => {
+    try {
+      return (await readState<MigrationReceipt>("receipt")) ?? null
+    } catch (error) {
+      logger.warn("Failed to read migration receipt", "Persistence", { error })
+      return null
+    }
+  }
+
+// Read through the `chrome` alias: getManifest is synchronous, so the
+// callback-vs-promise split that forces `browser` elsewhere does not apply, and
+// the polyfill did not answer it in the offscreen owner — every receipt written
+// there recorded the version as "unknown".
+const extensionVersion = (): string => {
+  try {
+    return chrome.runtime.getManifest().version
+  } catch {
+    try {
+      return browser.runtime.getManifest().version
+    } catch {
+      return "unknown"
+    }
+  }
+}
+
+/**
+ * Record a migration attempt. Never throws: a receipt is evidence, and losing
+ * it must not fail an otherwise good migration or mask the real failure of a
+ * bad one.
+ */
+export const writeMigrationReceipt = async (
+  details: Omit<
+    MigrationReceipt,
+    "version" | "recordedAt" | "extensionVersion" | "attempts"
+  >
+): Promise<void> => {
+  try {
+    const previous = await readMigrationReceipt()
+    const receipt: MigrationReceipt = {
+      ...details,
+      version: 1,
+      recordedAt: Date.now(),
+      extensionVersion: extensionVersion(),
+      attempts: (previous?.attempts ?? 0) + 1
+    }
+    await writeState("receipt", receipt)
+  } catch (error) {
+    logger.warn("Failed to write migration receipt", "Persistence", { error })
+  }
 }
 
 /** Test hook and backup-import hook: drop the in-context cache so the next
  * read hits storage again. */
 export const invalidateBackendCache = (): void => {
   cachedBackend = null
+  cachedOverride = null
 }

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -167,8 +167,21 @@ const initializeSchema = (db: Database): void => {
       db,
       "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
     ) > 0
+  // Every statement in SCHEMA_SQL is IF NOT EXISTS, so it runs on every open:
+  // on a fresh database it creates everything, and on an existing one it fills
+  // in whatever is absent.
+  //
+  // It used to run only when `sessions` was missing, which meant a table added
+  // to the schema without a paired migration never reached a profile that
+  // already had `sessions`. chunk_feedback arrived that way in 0.10.0, so
+  // profiles created on 0.6.0-0.9.x have been missing it since — the drift
+  // repair below only knows about tool_loop_runs and prompt_templates.
+  //
+  // The version stamp stays gated: only a database that did not exist a moment
+  // ago is at the latest schema by construction. Stamping an old one would skip
+  // the forward migrations it still needs.
+  db.exec(SCHEMA_SQL)
   if (!hasSessions) {
-    db.exec(SCHEMA_SQL)
     setSchemaVersion(compat, LATEST_SCHEMA_VERSION)
   }
   db.exec("PRAGMA foreign_keys=ON")

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -11,8 +11,23 @@ import {
   setSchemaVersion
 } from "@/lib/sqlite/migrations/migration-runner"
 import { SCHEMA_SQL } from "@/lib/sqlite/schema"
+import {
+  countDurableTables,
+  type DurableTable,
+  type IntegrityReport,
+  isSoundDatabase,
+  readIntegrityReport,
+  tableExistsSql
+} from "./durable-tables"
+import {
+  clearRollbackCopy,
+  recoverFailedReplacement,
+  recoverInterruptedImport,
+  stageRollbackCopy
+} from "./import-rollback"
 import type {
   CountsResult,
+  ImportResult,
   PersistenceOp,
   QueryRow,
   RunResult,
@@ -32,6 +47,9 @@ import { asSqlJsDatabase } from "./sqljs-compat"
 // is atomic, which is what makes run's lastInsertRowid race-free.
 
 const DB_PATH = "/chat-history.sqlite"
+// Scratch path an incoming database is verified in before it is allowed to
+// replace DB_PATH. Never opened by anything but the verification probe.
+const PROBE_PATH = "/chat-history-import-probe.sqlite"
 
 interface WorkerRequest {
   id: number
@@ -100,6 +118,28 @@ const openContext = (): NonNullable<typeof contextPromise> => {
           name: "chat-history-pool",
           initialCapacity: 6
         })
+        // Before anything opens the database: a rollback copy left behind by a
+        // replacement that never finished has to win over the half-written file
+        // it was protecting.
+        //
+        // A failure here is not survivable by opening the database anyway. The
+        // copy stays on disk, so a later boot will restore it — everything read
+        // in between would be incomplete history, and everything written would
+        // be discarded. So the open fails instead. The cached context is
+        // cleared on rejection, so the next request retries the recovery, and
+        // making room first handles the one transient cause worth retrying
+        // in-line: a pool with no free slot.
+        try {
+          await ensureFreeSlots(pool, 1)
+          await recoverInterruptedImport(pool, DB_PATH)
+        } catch (error) {
+          throw new Error(
+            `Cannot restore the chat database after an interrupted replacement: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            { cause: error }
+          )
+        }
         const db = new pool.OpfsSAHPoolDb(DB_PATH)
         initializeSchema(db)
         return { db, pool }
@@ -162,10 +202,68 @@ const runStatement = (
   }
 }
 
-const counts = (db: Database): CountsResult => ({
-  sessions: queryNumber(db, "SELECT COUNT(*) FROM sessions"),
-  messages: queryNumber(db, "SELECT COUNT(*) FROM messages")
-})
+const tableExists = (db: Database, table: DurableTable): boolean =>
+  queryNumber(db, tableExistsSql(table)) > 0
+
+const counts = (db: Database): CountsResult => {
+  const tables = countDurableTables(
+    (sql) => queryNumber(db, sql),
+    (table) => tableExists(db, table)
+  )
+  return {
+    sessions: tables.sessions ?? 0,
+    messages: tables.messages ?? 0,
+    tables
+  }
+}
+
+/** An import needs room for the verification probe and the rollback copy beside
+ * the live database. The pool does not grow on its own. */
+const ensureFreeSlots = async (
+  pool: SAHPoolUtil,
+  needed: number
+): Promise<void> => {
+  const free = pool.getCapacity() - pool.getFileCount()
+  if (free >= needed) return
+  await pool.addCapacity(needed - free + 1)
+}
+
+/**
+ * Import a candidate database to the scratch path and report its integrity.
+ *
+ * Any failure here — a truncated file, a payload that is not a database at all,
+ * no room in the pool — leaves the live database untouched, which is the whole
+ * point of doing this before the replacement rather than after.
+ */
+const verifyImportCandidate = async (
+  pool: SAHPoolUtil,
+  bytes: ArrayBuffer
+): Promise<IntegrityReport> => {
+  pool.unlink(PROBE_PATH)
+  await ensureFreeSlots(pool, 1)
+  await pool.importDb(PROBE_PATH, new Uint8Array(bytes))
+  const probe = new pool.OpfsSAHPoolDb(PROBE_PATH)
+  try {
+    // Read before any schema runner sees the file: migrations write, and
+    // writing into a corrupt database turns a rejectable import into a
+    // damaged one.
+    return integrity(probe)
+  } finally {
+    probe.close()
+  }
+}
+
+const integrity = (db: Database): IntegrityReport =>
+  readIntegrityReport((sql) => {
+    const rows: unknown[][] = []
+    db.exec({
+      sql,
+      callback: (row) => {
+        rows.push(row as unknown[])
+      }
+    })
+    return rows
+  })
 
 // ---------------------------------------------------------------------------
 // Transaction lease + serial scheduler
@@ -255,17 +353,58 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
       )
     }
     case "importDb": {
-      // Backup restore: replace the database wholesale. The connection must
-      // be closed around the physical import, then reopened + migrated.
+      // Backup restore and legacy migration: replace the database wholesale.
+      //
+      // The payload is imported to a scratch path and verified there FIRST.
+      // Verifying after replacing the live file cost the user their history
+      // whenever the payload turned out to be unusable: a rejected restore
+      // reported failure over an already-destroyed database. Nothing touches
+      // the live file until the incoming one is known to be sound.
+      const report = await verifyImportCandidate(pool, request.bytes)
+      if (!isSoundDatabase(report)) {
+        pool.unlink(PROBE_PATH)
+        throw new Error(
+          `Imported database failed integrity_check: ${report.integrityCheck}`
+        )
+      }
+
       db.close()
       contextPromise = null
+      // The replacement itself can still fail or be interrupted, so the live
+      // database is copied aside until it completes. A replacement that cannot
+      // be protected does not happen: failing here leaves the database intact
+      // and the restore retryable.
+      await ensureFreeSlots(pool, 1)
+      const rollback = await stageRollbackCopy(pool, DB_PATH)
       try {
         await pool.importDb(DB_PATH, new Uint8Array(request.bytes))
+        // Held until the imported database is open, migrated by the schema
+        // runner, and counted. Reopening is where forward migrations and drift
+        // repair happen, and they write — a failure there is exactly the kind
+        // of restore that must still be undoable.
+        const { db: fresh } = await reopenContext(pool)
+        const result: ImportResult = { ...counts(fresh), integrity: report }
+        clearRollbackCopy(pool)
+        return result
+      } catch (error) {
+        // Reopening is not unconditional. While a rollback copy is still on
+        // disk it outranks the half-replaced file — startup recovery restores
+        // it — so opening that file here would serve missing history and let
+        // writes land on a database the next boot discards. When the copy
+        // cannot be put back, the worker opens nothing: the next request
+        // re-enters openContext, which recovers before anything opens.
+        if (await recoverFailedReplacement(pool, DB_PATH, rollback)) {
+          await reopenContext(pool).catch((reopenError: unknown) => {
+            console.error(
+              "[chat-db] reopen after a failed import failed",
+              reopenError
+            )
+          })
+        }
+        throw error
       } finally {
-        void reopenContext(pool)
+        pool.unlink(PROBE_PATH)
       }
-      const { db: fresh } = await openContext()
-      return counts(fresh)
     }
     case "reset": {
       db.close()

--- a/src/lib/persistence/chromium-owner.ts
+++ b/src/lib/persistence/chromium-owner.ts
@@ -1,6 +1,45 @@
 import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import { PERSISTENCE_ENSURE, PERSISTENCE_MARKER } from "./protocol"
+import {
+  PERSISTENCE_ENSURE,
+  PERSISTENCE_MARKER,
+  type PersistenceStateRequest,
+  type PersistenceStateScope
+} from "./protocol"
+
+const STORAGE_KEY_BY_SCOPE: Record<PersistenceStateScope, string> = {
+  backend: STORAGE_KEYS.PERSISTENCE.BACKEND,
+  receipt: STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT,
+  override: STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE
+}
+
+/**
+ * Fill in the extension version on a receipt the offscreen owner wrote.
+ *
+ * `runtime.getManifest()` does not answer in the offscreen document — receipts
+ * written there recorded "unknown" through both the polyfill and the `chrome`
+ * alias. The service worker can read it, and it is already handling the write.
+ */
+const stampExtensionVersion = (
+  scope: PersistenceStateScope,
+  value: unknown
+): unknown => {
+  if (scope !== "receipt" || typeof value !== "object" || value === null) {
+    return value
+  }
+  const receipt = value as { extensionVersion?: string }
+  if (receipt.extensionVersion && receipt.extensionVersion !== "unknown") {
+    return value
+  }
+  try {
+    return {
+      ...receipt,
+      extensionVersion: chrome.runtime.getManifest().version
+    }
+  } catch {
+    return value
+  }
+}
 
 // Chromium control plane for the persistence owner. The background service
 // worker never opens the database itself: it guarantees that the offscreen
@@ -73,24 +112,24 @@ export const registerChromiumPersistenceControl = (): void => {
     }
     if (type === PERSISTENCE_MARKER) {
       // The offscreen owner has no chrome.storage; read/write the backend
-      // marker on its behalf.
-      const request = message as {
-        action: "get" | "set"
-        marker?: unknown
+      // marker, migration receipt, and operator override on its behalf.
+      const request = message as PersistenceStateRequest
+      const key = STORAGE_KEY_BY_SCOPE[request.scope]
+      if (!key) {
+        sendResponse({
+          ok: false,
+          error: `Unknown persistence state scope: ${String(request.scope)}`
+        })
+        return true
       }
       ;(async () => {
         if (request.action === "get") {
-          const stored = await chrome.storage.local.get(
-            STORAGE_KEYS.PERSISTENCE.BACKEND
-          )
-          sendResponse({
-            ok: true,
-            marker: stored[STORAGE_KEYS.PERSISTENCE.BACKEND]
-          })
+          const stored = await chrome.storage.local.get(key)
+          sendResponse({ ok: true, value: stored[key] })
           return
         }
         await chrome.storage.local.set({
-          [STORAGE_KEYS.PERSISTENCE.BACKEND]: request.marker
+          [key]: stampExtensionVersion(request.scope, request.value)
         })
         sendResponse({ ok: true })
       })().catch((error: unknown) =>

--- a/src/lib/persistence/client.ts
+++ b/src/lib/persistence/client.ts
@@ -134,15 +134,15 @@ export const rpcExportDb = async (): Promise<Uint8Array> => {
 
 export const rpcImportDb = async (
   bytes: Uint8Array
-): Promise<{ sessions: number; messages: number }> => {
+): Promise<import("./protocol").ImportResult> => {
   const buffer = bytes.buffer.slice(
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength
   ) as ArrayBuffer
-  return (await send({ op: "importDb", bytes: buffer })) as {
-    sessions: number
-    messages: number
-  }
+  return (await send({
+    op: "importDb",
+    bytes: buffer
+  })) as import("./protocol").ImportResult
 }
 
 export const rpcReset = (): Promise<unknown> => send({ op: "reset" })

--- a/src/lib/persistence/durable-tables.ts
+++ b/src/lib/persistence/durable-tables.ts
@@ -1,0 +1,111 @@
+// Which tables the chat-history migration has to account for, and the
+// engine-agnostic verification helpers used on both sides of it.
+//
+// The list is explicit rather than derived at runtime, so a mismatch is a
+// review-time failure instead of a silent gap: a table that lands in
+// `schema.ts` without landing here would migrate unverified. That pairing is
+// enforced by `__tests__/durable-tables.test.ts`.
+
+export const DURABLE_TABLES = [
+  "sessions",
+  "messages",
+  "files",
+  "kv_store",
+  "prompt_templates",
+  "tool_loop_runs",
+  "chunk_feedback"
+] as const
+
+export type DurableTable = (typeof DURABLE_TABLES)[number]
+
+/** Row counts per table. Partial: a table absent from the source database is
+ * unknown, not empty — an old profile predates most of these tables and the
+ * schema runner creates them empty after the import. */
+export type TableCounts = Partial<Record<DurableTable, number>>
+
+export interface IntegrityReport {
+  /** `PRAGMA integrity_check` output, joined. "ok" when the file is sound. */
+  integrityCheck: string
+  /** `PRAGMA foreign_key_check` row count. */
+  foreignKeyViolations: number
+}
+
+export interface TableCountMismatch {
+  table: DurableTable
+  source: number
+  imported: number
+}
+
+/** Minimal reader both engines can satisfy: one scalar per statement. */
+export type ScalarReader = (sql: string) => number
+
+/** Minimal reader for the pragma checks, which return text rows. */
+export type RowReader = (sql: string) => unknown[][]
+
+const quoted = (table: string): string => `"${table.replace(/"/g, '""')}"`
+
+export const listExistingDurableTables = (
+  exists: (table: DurableTable) => boolean
+): DurableTable[] => DURABLE_TABLES.filter((table) => exists(table))
+
+export const countDurableTables = (
+  read: ScalarReader,
+  exists: (table: DurableTable) => boolean
+): TableCounts => {
+  const counts: TableCounts = {}
+  for (const table of listExistingDurableTables(exists)) {
+    counts[table] = read(`SELECT COUNT(*) FROM ${quoted(table)}`)
+  }
+  return counts
+}
+
+export const tableExistsSql = (table: string): string =>
+  `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '${table.replace(/'/g, "''")}'`
+
+/**
+ * Every table the source database had must arrive with the same row count.
+ *
+ * Only source tables are compared. The import runs forward migrations, so the
+ * destination legitimately gains tables the source never had; the reverse —
+ * a source table missing or short after the import — is data loss.
+ */
+export const findTableCountMismatches = (
+  source: TableCounts,
+  imported: TableCounts
+): TableCountMismatch[] => {
+  const mismatches: TableCountMismatch[] = []
+  for (const table of DURABLE_TABLES) {
+    const expected = source[table]
+    if (expected === undefined) continue
+    const actual = imported[table] ?? 0
+    if (actual !== expected) {
+      mismatches.push({ table, source: expected, imported: actual })
+    }
+  }
+  return mismatches
+}
+
+export const describeMismatches = (
+  mismatches: readonly TableCountMismatch[]
+): string =>
+  mismatches
+    .map(
+      (mismatch) => `${mismatch.table} ${mismatch.imported}/${mismatch.source}`
+    )
+    .join(", ")
+
+export const readIntegrityReport = (read: RowReader): IntegrityReport => {
+  const integrityRows = read("PRAGMA integrity_check")
+  const integrityCheck =
+    integrityRows
+      .map((row) => String(row[0] ?? ""))
+      .filter((line) => line.length > 0)
+      .join("; ") || "ok"
+  return {
+    integrityCheck,
+    foreignKeyViolations: read("PRAGMA foreign_key_check").length
+  }
+}
+
+export const isSoundDatabase = (report: IntegrityReport): boolean =>
+  report.integrityCheck === "ok"

--- a/src/lib/persistence/durable-tables.ts
+++ b/src/lib/persistence/durable-tables.ts
@@ -85,13 +85,43 @@ export const findTableCountMismatches = (
   return mismatches
 }
 
+/**
+ * Durable tables the destination is missing after an import.
+ *
+ * Count comparison cannot catch these: a table absent from the source is
+ * skipped, because forward migrations are expected to create it empty. That
+ * expectation is only as good as the migration set — `chunk_feedback` was added
+ * to the schema in 0.10.0 with no migration behind it, so a database that
+ * predates it stayed without the table and verification called that success.
+ *
+ * Checked against the destination's own table list rather than the source's, so
+ * the next table added without a migration fails the migration instead of
+ * shipping a profile that raises "no such table" at the first write.
+ */
+export const findMissingDurableTables = (
+  imported: TableCounts
+): DurableTable[] =>
+  DURABLE_TABLES.filter((table) => imported[table] === undefined)
+
+/**
+ * Describe a failed verification as shortfalls, not as count pairs.
+ *
+ * This text becomes the thrown error, which is stored as the receipt's `failure`
+ * and can be carried into a support report. `messages 39199/39204` would put
+ * history volume in that report; `messages short by 5` diagnoses the same defect
+ * without it. The absolute counts stay in the receipt's structured
+ * `sourceCounts`/`importedCounts`, which never leave the device.
+ */
 export const describeMismatches = (
   mismatches: readonly TableCountMismatch[]
 ): string =>
   mismatches
-    .map(
-      (mismatch) => `${mismatch.table} ${mismatch.imported}/${mismatch.source}`
-    )
+    .map((mismatch) => {
+      const delta = mismatch.source - mismatch.imported
+      return delta > 0
+        ? `${mismatch.table} short by ${delta}`
+        : `${mismatch.table} over by ${-delta}`
+    })
     .join(", ")
 
 export const readIntegrityReport = (read: RowReader): IntegrityReport => {

--- a/src/lib/persistence/import-rollback.ts
+++ b/src/lib/persistence/import-rollback.ts
@@ -1,0 +1,165 @@
+// Rollback for the one operation that replaces the whole chat database:
+// backup restore and the legacy-blob migration both go through `importDb`.
+//
+// Verifying the incoming file first (see chat-db-worker) rules out a bad
+// payload, but the physical replacement can still fail or be interrupted — the
+// offscreen host can be evicted, the worker can die, the write can fail
+// halfway. Without a retained copy the user is left with a half-written
+// database and an error message.
+//
+// So the live database is copied aside first. The copy is deleted only after
+// the replacement completes, which makes its presence at startup mean exactly
+// one thing: a replacement began and never finished, and the pre-replacement
+// database is the one to keep. Restoring is the conservative outcome — the user
+// keeps the history they had and can retry the restore.
+
+export const ROLLBACK_PATH = "/chat-history-rollback.sqlite"
+
+/** The slice of the opfs-sahpool utility this needs. */
+export interface RollbackPool {
+  exportFile: (path: string) => Promise<Uint8Array>
+  importDb: (path: string, bytes: Uint8Array) => unknown
+  unlink: (path: string) => void
+  getFileNames: () => string[]
+}
+
+const log = (message: string, detail?: unknown): void => {
+  if (detail === undefined) {
+    console.error(`[chat-db] ${message}`)
+    return
+  }
+  console.error(`[chat-db] ${message}`, detail)
+}
+
+/**
+ * Copy the live database aside before it is replaced.
+ *
+ * Returns the bytes so a failure in the same session can undo the replacement
+ * without reading OPFS again, or null when there is genuinely nothing to
+ * protect — a fresh profile has no database yet, and that is not an error.
+ *
+ * A database that exists but cannot be read is the dangerous case, and it
+ * throws: answering null there would report "nothing to protect" about data
+ * that does exist, and the caller would go on to replace the only copy of it.
+ * Nothing is deleted until the new copy is in hand, so a copy left by an
+ * earlier interrupted replacement also survives this failing.
+ */
+export const stageRollbackCopy = async (
+  pool: RollbackPool,
+  dbPath: string
+): Promise<Uint8Array | null> => {
+  let bytes: Uint8Array
+  try {
+    bytes = await pool.exportFile(dbPath)
+  } catch (error) {
+    if (!pool.getFileNames().includes(dbPath)) {
+      log("no live database to stage for rollback", error)
+      pool.unlink(ROLLBACK_PATH)
+      return null
+    }
+    throw new Error(
+      `Cannot stage a rollback copy of the chat database: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    )
+  }
+  if (bytes.byteLength === 0) {
+    pool.unlink(ROLLBACK_PATH)
+    return null
+  }
+  // Overwrites any earlier copy in place, so the previous one is only lost once
+  // this one exists.
+  await pool.importDb(ROLLBACK_PATH, bytes)
+  return bytes
+}
+
+/**
+ * Put the pre-replacement database back and drop the copy.
+ *
+ * A failure here leaves the copy in place on purpose: startup recovery will
+ * find it and try again, which is the only remaining chance to save the data.
+ */
+export const restoreRollbackCopy = async (
+  pool: RollbackPool,
+  dbPath: string,
+  bytes: Uint8Array
+): Promise<void> => {
+  await pool.importDb(dbPath, bytes)
+  pool.unlink(ROLLBACK_PATH)
+}
+
+/** Drop the copy after a replacement completed. */
+export const clearRollbackCopy = (pool: RollbackPool): void => {
+  pool.unlink(ROLLBACK_PATH)
+}
+
+/**
+ * Decide what may be opened after a replacement failed, and put the database
+ * back in that state. Returns whether the file at `dbPath` is safe to open.
+ *
+ * A rollback copy still on disk outranks the file it was protecting, because
+ * startup recovery will restore it: opening the half-replaced database while
+ * the copy exists would let writes land on data the next boot discards. So the
+ * copy is put back first — from memory, then, failing that, from disk through
+ * the same recovery a boot would run. Only when no copy survives is the
+ * replaced file openable, and then only because it is the only database left.
+ */
+export const recoverFailedReplacement = async (
+  pool: RollbackPool,
+  dbPath: string,
+  rollback: Uint8Array | null
+): Promise<boolean> => {
+  if (!rollback) {
+    // Nothing existed to protect — a fresh profile — so whatever landed at
+    // dbPath is the only database there is.
+    clearRollbackCopy(pool)
+    return true
+  }
+  try {
+    await restoreRollbackCopy(pool, dbPath, rollback)
+    return true
+  } catch (error) {
+    log("rollback restore failed; retrying from the copy on disk", error)
+  }
+  try {
+    await recoverInterruptedImport(pool, dbPath)
+    // Either the pre-replacement database is back, or the copy turned out to be
+    // unusable and is gone. Both leave dbPath as the only database.
+    return true
+  } catch (error) {
+    log("rollback recovery failed; leaving the database closed", error)
+    return false
+  }
+}
+
+/**
+ * Startup recovery. A rollback copy that outlived its replacement means the
+ * replacement never finished, so the copy is the database to keep.
+ *
+ * Returns whether anything was restored.
+ */
+export const recoverInterruptedImport = async (
+  pool: RollbackPool,
+  dbPath: string
+): Promise<boolean> => {
+  if (!pool.getFileNames().includes(ROLLBACK_PATH)) return false
+  let bytes: Uint8Array
+  try {
+    bytes = await pool.exportFile(ROLLBACK_PATH)
+  } catch (error) {
+    // Unreadable copy: nothing to restore from, and keeping it would make every
+    // future boot try again.
+    log("rollback copy could not be read; discarding it", error)
+    pool.unlink(ROLLBACK_PATH)
+    return false
+  }
+  if (bytes.byteLength === 0) {
+    pool.unlink(ROLLBACK_PATH)
+    return false
+  }
+  await pool.importDb(dbPath, bytes)
+  pool.unlink(ROLLBACK_PATH)
+  log("restored the pre-import database after an interrupted replacement")
+  return true
+}

--- a/src/lib/persistence/legacy-blob-reader.ts
+++ b/src/lib/persistence/legacy-blob-reader.ts
@@ -1,6 +1,13 @@
 import type { SqlJsStatic } from "sql.js"
 import initSqlJs from "sql.js/dist/sql-wasm.js"
 import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
+import {
+  countDurableTables,
+  type IntegrityReport,
+  readIntegrityReport,
+  type TableCounts,
+  tableExistsSql
+} from "./durable-tables"
 
 // Migration-time compatibility reader for the legacy sql.js IndexedDB blob.
 // Loaded lazily (dynamic import) so sql.js stays out of every startup chunk
@@ -39,11 +46,22 @@ export const readLegacyBlobBytes = async (): Promise<Uint8Array | null> =>
     }
   })
 
-/** Open legacy bytes with sql.js and count the rows that must survive the
+export interface LegacySourceSurvey {
+  sessions: number
+  messages: number
+  /** Row counts for every durable table the source actually has. */
+  tables: TableCounts
+  /** `PRAGMA user_version` of the source blob — the migration receipt's
+   * record of which schema generation the data came from. */
+  schemaVersion: number
+  integrity: IntegrityReport
+}
+
+/** Open legacy bytes with sql.js and survey the rows that must survive the
  * physical import — the migration's verification source of truth. */
 export const countLegacyRows = async (
   bytes: Uint8Array
-): Promise<{ sessions: number; messages: number }> => {
+): Promise<LegacySourceSurvey> => {
   const wasmUrl = chrome.runtime.getURL("assets/sql-wasm.wasm")
   const response = await fetch(wasmUrl)
   const wasmBinary = await response.arrayBuffer()
@@ -55,13 +73,22 @@ export const countLegacyRows = async (
 
   const db = new SQL.Database(bytes)
   try {
-    const count = (sql: string): number => {
+    const scalar = (sql: string): number => {
       const result = db.exec(sql)
       return Number(result[0]?.values?.[0]?.[0] ?? 0)
     }
+    const rows = (sql: string): unknown[][] =>
+      (db.exec(sql)[0]?.values as unknown[][] | undefined) ?? []
+    const tables = countDurableTables(
+      scalar,
+      (table) => scalar(tableExistsSql(table)) > 0
+    )
     return {
-      sessions: count("SELECT COUNT(*) FROM sessions"),
-      messages: count("SELECT COUNT(*) FROM messages")
+      sessions: tables.sessions ?? 0,
+      messages: tables.messages ?? 0,
+      tables,
+      schemaVersion: scalar("PRAGMA user_version"),
+      integrity: readIntegrityReport(rows)
     }
   } finally {
     db.close()

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -1,5 +1,18 @@
 import { logger } from "@/lib/logger"
-import { markOpfsBackend, readPersistenceBackend } from "./backend"
+import {
+  markOpfsBackend,
+  readLegacyOverride,
+  readMigrationReceipt,
+  readPersistenceBackend,
+  writeMigrationReceipt
+} from "./backend"
+import {
+  describeMismatches,
+  findTableCountMismatches,
+  isSoundDatabase,
+  type TableCountMismatch
+} from "./durable-tables"
+import type { ImportResult } from "./protocol"
 import {
   decodeBind,
   encodeRows,
@@ -152,6 +165,21 @@ export const callWorker = (request: PersistenceOp): Promise<unknown> => {
 let migrationPromise: Promise<void> | null = null
 
 const migrateLegacyBlobOnce = async (): Promise<void> => {
+  if (await readLegacyOverride()) {
+    logger.warn(
+      "Persistence legacy override is set; staying on the legacy blob",
+      "Persistence"
+    )
+    // Recorded once, not on every boot: the override is a standing operator
+    // decision, and an attempt counter climbing while nothing happens says
+    // nothing.
+    const previous = await readMigrationReceipt()
+    if (previous?.outcome !== "skipped") {
+      await writeMigrationReceipt({ outcome: "skipped" })
+    }
+    return
+  }
+
   const backend = await readPersistenceBackend()
   if (backend === "opfs") return
 
@@ -165,38 +193,89 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
     // Fresh profile: nothing to migrate; the worker creates an empty schema.
     await callWorker({ op: "ping" })
     await markOpfsBackend({})
+    await writeMigrationReceipt({ outcome: "fresh" })
     logger.info("No legacy blob; OPFS backend initialized fresh", "Persistence")
     return
   }
 
-  // Count the source rows BEFORE the physical import — this is the
-  // verification target. The source blob itself is never modified or
+  // Survey the source BEFORE the physical import — this is the verification
+  // target, and it covers every durable table the blob has, not just the two
+  // the chat list happens to read. The source blob itself is never modified or
   // deleted; it remains the rollback artifact.
-  const sourceCounts = await countLegacyRows(bytes)
+  const source = await countLegacyRows(bytes)
+  if (!isSoundDatabase(source.integrity)) {
+    logger.warn(
+      "Legacy blob failed integrity_check before import",
+      "Persistence",
+      {
+        integrityCheck: source.integrity.integrityCheck
+      }
+    )
+  }
   const buffer = bytes.buffer.slice(
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength
   ) as ArrayBuffer
 
-  const imported = (await callWorker({
-    op: "importDb",
-    bytes: buffer
-  })) as { sessions: number; messages: number }
+  let imported: ImportResult | undefined
+  let mismatches: TableCountMismatch[] = []
+  try {
+    imported = (await callWorker({
+      op: "importDb",
+      bytes: buffer
+    })) as ImportResult
 
-  if (
-    imported.sessions !== sourceCounts.sessions ||
-    imported.messages !== sourceCounts.messages
-  ) {
-    throw new Error(
-      `Migration verification failed: sessions ${imported.sessions}/${sourceCounts.sessions}, messages ${imported.messages}/${sourceCounts.messages}`
+    mismatches = findTableCountMismatches(source.tables, imported.tables)
+    if (mismatches.length > 0) {
+      throw new Error(
+        `Migration verification failed: ${describeMismatches(mismatches)}`
+      )
+    }
+
+    if (imported.integrity.foreignKeyViolations > 0) {
+      // Recorded, not fatal. Orphan rows in a years-old blob are a data-quality
+      // fact about the source; refusing to migrate would strand that history on
+      // a backend that is being retired.
+      logger.warn(
+        "Migrated database has foreign-key violations",
+        "Persistence",
+        {
+          foreignKeyViolations: imported.integrity.foreignKeyViolations
+        }
+      )
+    }
+
+    await markOpfsBackend({
+      sourceCounts: { sessions: source.sessions, messages: source.messages }
+    })
+    await writeMigrationReceipt({
+      outcome: "migrated",
+      sourceSchemaVersion: source.schemaVersion,
+      sourceBytes: bytes.byteLength,
+      sourceCounts: source.tables,
+      importedCounts: imported.tables,
+      sourceIntegrity: source.integrity,
+      importedIntegrity: imported.integrity,
+      mismatches
+    })
+    logger.info(
+      `Legacy blob migrated and verified: ${source.sessions} sessions, ${source.messages} messages`,
+      "Persistence"
     )
+  } catch (error) {
+    await writeMigrationReceipt({
+      outcome: "failed",
+      sourceSchemaVersion: source.schemaVersion,
+      sourceBytes: bytes.byteLength,
+      sourceCounts: source.tables,
+      importedCounts: imported?.tables,
+      sourceIntegrity: source.integrity,
+      importedIntegrity: imported?.integrity,
+      mismatches,
+      failure: error instanceof Error ? error.message : String(error)
+    })
+    throw error
   }
-
-  await markOpfsBackend({ sourceCounts })
-  logger.info(
-    `Legacy blob migrated and verified: ${sourceCounts.sessions} sessions, ${sourceCounts.messages} messages`,
-    "Persistence"
-  )
 }
 
 /** Idempotent; safe to call on every host boot. A failed attempt clears the

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -8,6 +8,7 @@ import {
 } from "./backend"
 import {
   describeMismatches,
+  findMissingDurableTables,
   findTableCountMismatches,
   isSoundDatabase,
   type TableCountMismatch
@@ -229,6 +230,17 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
     if (mismatches.length > 0) {
       throw new Error(
         `Migration verification failed: ${describeMismatches(mismatches)}`
+      )
+    }
+
+    // Row counts only prove that what the source had arrived. They say nothing
+    // about a durable table the destination is supposed to have and does not —
+    // that one is invisible to a comparison, because an absent source table is
+    // skipped on the assumption a forward migration creates it.
+    const missing = findMissingDurableTables(imported.tables)
+    if (missing.length > 0) {
+      throw new Error(
+        `Migration verification failed: imported database is missing ${missing.join(", ")}`
       )
     }
 

--- a/src/lib/persistence/protocol.ts
+++ b/src/lib/persistence/protocol.ts
@@ -10,6 +10,8 @@ export const PERSISTENCE_ENSURE = "persistence-ensure"
 // marker reads/writes to the background service worker with this message.
 export const PERSISTENCE_MARKER = "persistence-marker"
 
+import type { IntegrityReport, TableCounts } from "./durable-tables"
+
 export type SqlValue = string | number | null | Uint8Array
 export type QueryRow = Record<string, SqlValue>
 
@@ -33,11 +35,34 @@ export interface RunResult {
 export interface CountsResult {
   sessions: number
   messages: number
+  /** Every durable table present in the database. `sessions`/`messages` stay
+   * as named fields because callers log them, but migration verification
+   * compares the whole map. */
+  tables: TableCounts
+}
+
+export interface ImportResult extends CountsResult {
+  integrity: IntegrityReport
 }
 
 export interface PersistenceRpcRequest {
   type: typeof PERSISTENCE_RPC
   request: PersistenceOp
+}
+
+/**
+ * Device-local persistence state the offscreen owner cannot reach itself.
+ *
+ * `backend` is the backend marker, `receipt` the migration receipt, and
+ * `override` the operator switch that pins a profile to the legacy blob.
+ */
+export type PersistenceStateScope = "backend" | "receipt" | "override"
+
+export interface PersistenceStateRequest {
+  type: typeof PERSISTENCE_MARKER
+  action: "get" | "set"
+  scope: PersistenceStateScope
+  value?: unknown
 }
 
 export type PersistenceRpcResponse =

--- a/src/lib/storage/storage-key-registry.ts
+++ b/src/lib/storage/storage-key-registry.ts
@@ -20,6 +20,18 @@ export const STORAGE_KEY_REGISTRY: Record<string, StorageKeyMetadata> = {
     reason:
       "Which chat-history backend this device runs on; migration state never syncs."
   },
+  [STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT]: {
+    key: STORAGE_KEYS.PERSISTENCE.MIGRATION_RECEIPT,
+    scope: "device-local",
+    reason:
+      "Evidence of this device's chat-history migration attempt; counts and failures describe one profile only."
+  },
+  [STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE]: {
+    key: STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE,
+    scope: "device-local",
+    reason:
+      "Operator recovery switch pinning this device to the legacy blob; syncing it would strand other profiles on a retired backend."
+  },
   [STORAGE_KEYS.APP_LIFECYCLE.PENDING_RESET]: {
     key: STORAGE_KEYS.APP_LIFECYCLE.PENDING_RESET,
     scope: "device-local",

--- a/src/protocol/diagnostics-rpc.ts
+++ b/src/protocol/diagnostics-rpc.ts
@@ -89,7 +89,29 @@ export const DiagnosticsGetBundleResultSchema = z
         storage: z.object({
           backend: z.string(),
           messageCount: z.number().int().nonnegative(),
-          vectorCount: z.number().int().nonnegative()
+          vectorCount: z.number().int().nonnegative(),
+          /**
+           * Chat-history migration evidence, absent on a profile that never had
+           * a legacy blob. Counts and integrity verdicts only — no chat content,
+           * no table contents, nothing user-identifying. This is the only way
+           * receipt evidence leaves a device, and it leaves it because the
+           * reporter chose to send it.
+           */
+          migration: z
+            .object({
+              outcome: z.string(),
+              attempts: z.number().int().nonnegative(),
+              recordedAt: z.number().int().nonnegative(),
+              extensionVersion: z.string(),
+              sourceSchemaVersion: z.number().int().optional(),
+              sourceIntegrity: z.string().optional(),
+              importedIntegrity: z.string().optional(),
+              foreignKeyViolations: z.number().int().nonnegative().optional(),
+              /** `table:source→imported` per short table, already clamped. */
+              mismatches: z.array(z.string()).optional(),
+              failure: z.string().optional()
+            })
+            .optional()
         }),
         events: z.array(DiagnosticEventSchema),
         selfTests: z.array(DiagnosticTestResultSchema)
@@ -118,6 +140,10 @@ export type DiagnosticsClearResult = z.infer<
   typeof DiagnosticsClearResultSchema
 >
 export type DiagnosticEvent = z.infer<typeof DiagnosticEventSchema>
+/** Migration evidence as it appears in a bundle — the schema is the contract. */
+export type DiagnosticStorageMigration = NonNullable<
+  DiagnosticsGetBundleResult["bundle"]
+>["storage"]["migration"]
 export type DiagnosticTestResult = z.infer<typeof DiagnosticTestResultSchema>
 
 declare module "./provider-rpc" {

--- a/src/protocol/diagnostics-rpc.ts
+++ b/src/protocol/diagnostics-rpc.ts
@@ -107,7 +107,11 @@ export const DiagnosticsGetBundleResultSchema = z
               sourceIntegrity: z.string().optional(),
               importedIntegrity: z.string().optional(),
               foreignKeyViolations: z.number().int().nonnegative().optional(),
-              /** `table:source→imported` per short table, already clamped. */
+              /**
+               * One entry per table that did not arrive intact, as
+               * `table short by N`. A shortfall, never the row counts it was
+               * derived from — those describe how much history a person has.
+               */
               mismatches: z.array(z.string()).optional(),
               failure: z.string().optional()
             })

--- a/tools/verify-firefox-opfs-migration.ts
+++ b/tools/verify-firefox-opfs-migration.ts
@@ -393,9 +393,11 @@ const runScenarios = async (): Promise<void> => {
       sessions: number
       messages: number
       blobBytes: number
+      tables: Record<string, number>
     }>(driver, "seedLegacyBlob", FIXTURE_SESSIONS, FIXTURE_MESSAGES)
     const sourceDigest = await call<string>(driver, "readLegacyBlobDigest")
     await call<void>(driver, "clearMarker")
+    await call<void>(driver, "clearMigrationReceipt")
 
     // A full restart on the same profile, matching the Chromium runner's
     // choice: the migration has to run on a cold boot, not on a soft reload.
@@ -405,10 +407,21 @@ const runScenarios = async (): Promise<void> => {
     firstTab = await openVerifyTab(driver)
 
     const migratedMarker = await waitForOpfsMarker(driver, 60000)
-    const migratedCounts = await call<{ sessions: number; messages: number }>(
-      driver,
-      "counts"
-    )
+    const migratedCounts = await call<{
+      sessions: number
+      messages: number
+      tables: Record<string, number>
+    }>(driver, "counts")
+    const migratedIntegrity = await call<{
+      integrityCheck: string
+      foreignKeyViolations: number
+    }>(driver, "integrityInfo")
+    const migratedReceipt = await call<{
+      outcome?: string
+      sourceSchemaVersion?: number
+      sourceCounts?: Record<string, number>
+      importedIntegrity?: { integrityCheck?: string }
+    }>(driver, "migrationReceipt")
     const blobAfter = await call<number>(driver, "readLegacyBlobLength")
     const digestAfter = await call<string>(driver, "readLegacyBlobDigest")
     record(
@@ -419,6 +432,27 @@ const runScenarios = async (): Promise<void> => {
       { seeded, migratedMarker, migratedCounts }
     )
     record(
+      "every-durable-table-migrated",
+      Object.entries(seeded.tables).every(
+        ([table, count]) => count === 0 || migratedCounts.tables[table] === count
+      ),
+      { seeded: seeded.tables, migrated: migratedCounts.tables }
+    )
+    record(
+      "migrated-database-is-sound",
+      migratedIntegrity.integrityCheck === "ok" &&
+        migratedIntegrity.foreignKeyViolations === 0,
+      migratedIntegrity
+    )
+    record(
+      "migration-receipt-recorded",
+      migratedReceipt?.outcome === "migrated" &&
+        typeof migratedReceipt.sourceSchemaVersion === "number" &&
+        migratedReceipt.sourceCounts?.sessions === FIXTURE_SESSIONS &&
+        migratedReceipt.importedIntegrity?.integrityCheck === "ok",
+      migratedReceipt
+    )
+    record(
       "rollback-blob-untouched",
       blobAfter === seeded.blobBytes && digestAfter === sourceDigest,
       {
@@ -427,6 +461,20 @@ const runScenarios = async (): Promise<void> => {
         digestAfter,
         sourceDigest
       }
+    )
+
+    // ---- 3b. Operator override returns this profile to the retained blob ----
+    await call<void>(driver, "setLegacyOverride", true)
+    const overriddenBackend = await call<string>(driver, "activeBackend")
+    const overriddenCounts = await call<{ sessions: number }>(driver, "counts")
+    await call<void>(driver, "setLegacyOverride", false)
+    const restoredBackend = await call<string>(driver, "activeBackend")
+    record(
+      "override-serves-legacy-blob",
+      overriddenBackend === "legacy" &&
+        overriddenCounts.sessions === FIXTURE_SESSIONS &&
+        restoredBackend === "opfs",
+      { overriddenBackend, overriddenCounts, restoredBackend }
     )
 
     // ---- 4. Backup export served by the OPFS owner ----

--- a/tools/verify-opfs-migration.ts
+++ b/tools/verify-opfs-migration.ts
@@ -12,9 +12,17 @@
 //      counts are exact (single-owner, no lost update).
 //   3. Real migration: seed a legacy sql.js blob (section 9.8 fixture),
 //      clear the backend marker, reload the extension; the owner migrates
-//      the blob, verifies row counts, flips the marker — and the blob stays
-//      untouched as the rollback artifact.
-//   4. Backup export comes from the OPFS owner and is a valid SQLite file.
+//      the blob, verifies every durable table, records a receipt, flips the
+//      marker — and the blob stays untouched as the rollback artifact.
+//   4. Host loss during migration: the browser (and with it the offscreen
+//      owner) is torn down while the migration is in flight. The next boot
+//      must complete it with exact per-table counts and a sound database.
+//   5. Operator override: with the device-local switch set, the profile serves
+//      chat history from the retained blob again and the migration stays
+//      skipped; clearing it migrates on the next boot.
+//   6. A restore whose payload is not a usable database is rejected with the
+//      existing chat history still in place.
+//   7. Backup export comes from the OPFS owner and is a valid SQLite file.
 //
 // Usage: pnpm verify:opfs-migration [--headful]
 // Requires: pnpm benchmark:build (the verify page is dev-gated).
@@ -153,6 +161,31 @@ const waitForOpfsMarker = async (
   }
 }
 
+interface TableCounts {
+  sessions: number
+  messages: number
+  tables: Record<string, number>
+}
+
+interface MigrationReceipt {
+  outcome?: string
+  attempts?: number
+  sourceSchemaVersion?: number
+  sourceCounts?: Record<string, number>
+  importedCounts?: Record<string, number>
+  importedIntegrity?: { integrityCheck?: string; foreignKeyViolations?: number }
+  failure?: string
+}
+
+/** Every table the source blob populated must arrive with the same count. */
+const tableCountsMatch = (
+  seeded: Record<string, number>,
+  migrated: Record<string, number>
+): boolean =>
+  Object.entries(seeded).every(
+    ([table, count]) => count === 0 || migrated[table] === count
+  )
+
 const runScenarios = async (visible: boolean): Promise<void> => {
   if (!existsSync(resolve(buildPath, "persistence-verify.html"))) {
     throw new Error(
@@ -178,14 +211,20 @@ const runScenarios = async (visible: boolean): Promise<void> => {
     // ---- 1. Fresh profile boots straight onto the OPFS backend ----
     let { page, call } = await openVerifyPage(context, extensionId)
     const freshMarker = await waitForOpfsMarker(call, 20000)
-    const freshCounts = (await call("counts")) as {
-      sessions: number
-      messages: number
-    }
+    const freshCounts = (await call("counts")) as TableCounts
+    const freshReceipt = (await call("migrationReceipt")) as MigrationReceipt
+    // A fresh profile can still have a legacy blob: whichever context reads the
+    // marker first sees "legacy" and stamps an empty sql.js database before the
+    // owner migrates. So the receipt is either "fresh" (no blob at all) or
+    // "migrated" with nothing in it — both mean the same thing here.
     record(
       "fresh-profile-opfs-init",
-      freshCounts.sessions === 0 && freshCounts.messages === 0,
-      { freshMarker, freshCounts }
+      freshCounts.sessions === 0 &&
+        freshCounts.messages === 0 &&
+        (freshReceipt?.outcome === "fresh" ||
+          (freshReceipt?.outcome === "migrated" &&
+            freshReceipt.sourceCounts?.sessions === 0)),
+      { freshMarker, freshCounts, freshReceipt }
     )
 
     // ---- 2. Concurrent facade writes from two pages, exact counts ----
@@ -195,10 +234,7 @@ const runScenarios = async (visible: boolean): Promise<void> => {
       call("appendViaFacade", "verify-a", APPENDS),
       second.call("appendViaFacade", "verify-b", APPENDS)
     ])
-    const afterWrites = (await call("counts")) as {
-      sessions: number
-      messages: number
-    }
+    const afterWrites = (await call("counts")) as TableCounts
     record(
       "concurrent-facade-writes",
       afterWrites.sessions === 2 && afterWrites.messages === APPENDS * 2,
@@ -211,9 +247,11 @@ const runScenarios = async (visible: boolean): Promise<void> => {
       sessions: number
       messages: number
       blobBytes: number
+      tables: Record<string, number>
     }
     const sourceDigest = (await call("readLegacyBlobDigest")) as string
     await call("clearMarker")
+    await call("clearMigrationReceipt")
     // Restart the whole browser with the same profile — runtime.reload() on
     // an unpacked extension leaves it blocked under Playwright, and a real
     // browser restart is the stronger claim anyway: the migration must run
@@ -227,9 +265,13 @@ const runScenarios = async (visible: boolean): Promise<void> => {
     const migratedMarker = (await waitForOpfsMarker(call, 30000)) as {
       sourceCounts?: { sessions: number; messages: number }
     }
-    const migratedCounts = (await call("counts")) as {
-      sessions: number
-      messages: number
+    const migratedCounts = (await call("counts")) as TableCounts
+    const migratedReceipt = (await call(
+      "migrationReceipt"
+    )) as MigrationReceipt
+    const migratedIntegrity = (await call("integrityInfo")) as {
+      integrityCheck: string
+      foreignKeyViolations: number
     }
     const blobAfter = (await call("readLegacyBlobLength")) as number
     const digestAfter = (await call("readLegacyBlobDigest")) as string
@@ -239,6 +281,25 @@ const runScenarios = async (visible: boolean): Promise<void> => {
         migratedCounts.messages === FIXTURE_MESSAGES &&
         migratedMarker.sourceCounts?.sessions === FIXTURE_SESSIONS,
       { seeded, migratedMarker, migratedCounts }
+    )
+    record(
+      "every-durable-table-migrated",
+      tableCountsMatch(seeded.tables, migratedCounts.tables),
+      { seeded: seeded.tables, migrated: migratedCounts.tables }
+    )
+    record(
+      "migrated-database-is-sound",
+      migratedIntegrity.integrityCheck === "ok" &&
+        migratedIntegrity.foreignKeyViolations === 0,
+      migratedIntegrity
+    )
+    record(
+      "migration-receipt-recorded",
+      migratedReceipt?.outcome === "migrated" &&
+        typeof migratedReceipt.sourceSchemaVersion === "number" &&
+        migratedReceipt.sourceCounts?.sessions === FIXTURE_SESSIONS &&
+        migratedReceipt.importedIntegrity?.integrityCheck === "ok",
+      migratedReceipt
     )
     record(
       "rollback-blob-untouched",
@@ -251,7 +312,100 @@ const runScenarios = async (visible: boolean): Promise<void> => {
       }
     )
 
-    // ---- 4. Backup export served by the OPFS owner ----
+    // ---- 4. The owner is destroyed mid-migration; the next boot finishes ----
+    // Tearing down the browser takes the offscreen host with it, which is the
+    // eviction case that matters: the migration is interrupted after the
+    // physical import has begun and before the marker flips.
+    const bigSeed = (await call(
+      "seedLegacyBlob",
+      FIXTURE_SESSIONS * 4,
+      FIXTURE_MESSAGES * 6
+    )) as { sessions: number; messages: number; tables: Record<string, number> }
+    await call("clearMarker")
+    await call("clearMigrationReceipt")
+    await page.close().catch(() => {})
+    await context.close()
+
+    // Boot far enough to start the migration, then kill the host. No page is
+    // opened: the background creates the owner eagerly at startup.
+    context = await launch()
+    await new Promise((resolvePause) => setTimeout(resolvePause, 400))
+    await context.close()
+
+    context = await launch()
+    await new Promise((resolvePause) => setTimeout(resolvePause, 1500))
+    ;({ page, call } = await openVerifyPage(context, extensionId))
+    await waitForOpfsMarker(call, 45000)
+    const resumedCounts = (await call("counts")) as TableCounts
+    const resumedIntegrity = (await call("integrityInfo")) as {
+      integrityCheck: string
+      foreignKeyViolations: number
+    }
+    const resumedReceipt = (await call("migrationReceipt")) as MigrationReceipt
+    record(
+      "interrupted-migration-resumes-exactly",
+      resumedCounts.sessions === bigSeed.sessions &&
+        resumedCounts.messages === bigSeed.messages &&
+        tableCountsMatch(bigSeed.tables, resumedCounts.tables) &&
+        resumedIntegrity.integrityCheck === "ok" &&
+        resumedReceipt?.outcome === "migrated",
+      { bigSeed, resumedCounts, resumedIntegrity, resumedReceipt }
+    )
+
+    // ---- 5. Operator override returns the profile to the retained blob ----
+    await call("setLegacyOverride", true)
+    const overriddenBackend = (await call("activeBackend")) as string
+    const overriddenCounts = (await call("counts")) as TableCounts
+    record(
+      "override-serves-legacy-blob",
+      overriddenBackend === "legacy" &&
+        overriddenCounts.sessions === bigSeed.sessions,
+      { overriddenBackend, overriddenCounts }
+    )
+
+    await call("clearMarker")
+    await call("clearMigrationReceipt")
+    await page.close().catch(() => {})
+    await context.close()
+    context = await launch()
+    await new Promise((resolvePause) => setTimeout(resolvePause, 2500))
+    ;({ page, call } = await openVerifyPage(context, extensionId))
+    const skippedBackend = (await call("activeBackend")) as string
+    const skippedReceipt = (await call("migrationReceipt")) as MigrationReceipt
+    record(
+      "override-skips-migration-on-boot",
+      skippedBackend === "legacy" && skippedReceipt?.outcome === "skipped",
+      { skippedBackend, skippedReceipt }
+    )
+
+    await call("setLegacyOverride", false)
+    await page.close().catch(() => {})
+    await context.close()
+    context = await launch()
+    await new Promise((resolvePause) => setTimeout(resolvePause, 1500))
+    ;({ page, call } = await openVerifyPage(context, extensionId))
+    await waitForOpfsMarker(call, 45000)
+    const restoredCounts = (await call("counts")) as TableCounts
+    record(
+      "cleared-override-migrates-again",
+      ((await call("activeBackend")) as string) === "opfs" &&
+        restoredCounts.messages === bigSeed.messages,
+      { restoredCounts }
+    )
+
+    // ---- 6. A rejected restore leaves the live database intact ----
+    const beforeRestore = (await call("counts")) as TableCounts
+    const rejected = (await call("importCorruptBackup")) as { error: string }
+    const afterRestore = (await call("counts")) as TableCounts
+    record(
+      "rejected-restore-preserves-database",
+      rejected.error.length > 0 &&
+        afterRestore.messages === beforeRestore.messages &&
+        afterRestore.sessions === beforeRestore.sessions,
+      { rejected, beforeRestore, afterRestore }
+    )
+
+    // ---- 7. Backup export served by the OPFS owner ----
     const exportInfo = (await call("exportInfo")) as {
       byteLength: number
       magic: string


### PR DESCRIPTION
Backports #227 to the 0.12.6 line and makes its evidence readable, so the evidence clock for retiring the sql.js fallback starts with the release shipping tomorrow instead of with 0.13.0.

## Why into 0.12.6 rather than waiting

The removal gate in `compatibility-ledger.json` requires the fallback to "complete its evidence window" — 2–3 months of clean field receipts. That window cannot start until the code that writes receipts reaches real profiles. Landing it here rather than in 0.13.0 moves the earliest possible removal forward by roughly the length of the 0.12.6 → 0.13.0 gap, at no cost to the 0.13.x plan.

## Commits

1. **`feat(persistence): verify chat-history migration per table`** — cherry-pick of #227, applied clean with no conflicts.
2. **`feat(diagnostics): make migration evidence readable`** — new here, not in #227.
3. **`docs(changelog): record migration verification in 0.12.6`**

## The table-list difference from #227

`DURABLE_TABLES` names the **seven** tables 0.12.6's schema creates, not the ten on `release/0.13.x`. `turn_runs`, `ingestion_runs`, and `model_pull_runs` are all 0.13.x tables, so a legacy blob from 0.6.0–0.12.2 cannot contain rows in them — they are created empty after import either way. Verifying seven tables here verifies exactly as much real history as verifying ten does.

The contract test derives the expected list from `schema.ts` plus its migrations, so this cannot drift: adding a table without adding it to `DURABLE_TABLES` fails the test. Two fixtures that used a 0.13-only table as their "destination gained an empty table" example now use `chunk_feedback`, which 0.12.6 has.

## Why commit 2 exists

Without it, this release starts a clock nobody can read. `writeMigrationReceipt` wrote to device-local storage and **nothing outside `src/lib/persistence` read it**. A profile could fail verification, get served from the retained blob, and the only outward signal was `Storage backend: legacy` in a report — which reads identically to a migration that never started. Three months of that produces silence, not evidence.

The diagnostics bundle now carries a migration summary and the support draft prints it: outcome, attempts, source schema version, integrity verdicts, orphan rows, per-table shortfalls, failure text.

**Row counts do not leave the device.** `sessions: 1482` describes how much someone has said. The summary keeps only tables that arrived *short*, as `table:source→imported`, capped at ten; integrity output is clamped since a damaged file can produce a long report. A test asserts the counts are absent from the serialized summary. A clean migration is one line; a profile that never had a legacy blob reports nothing.

## Ledger

`persistence-legacy-override-switch` is recorded as `introducedIn: 0.12.6` rather than `0.13.0`, since that is now where it ships.

## Gates

- `pnpm typecheck` ✅
- `pnpm lint:check` / `pnpm format:check` ✅
- `pnpm test:run` ✅ 294 files, 2442 tests
- `pnpm generate:resources` ✅

**Needs before release:** the Critical Chromium browser gates on this exact commit, per release rule 2 — this PR brings #227's CI workflow additions with it, so those gates run here for the first time on the 0.12.6 line.

## Not in this PR

The engine unification (sqlite-wasm replacing sql.js for reading the legacy blob) stays out of a release shipping tomorrow — it rewrites the live path for exactly the profiles already in a failure state, and it needs its own soak. That is 0.13.x work, and it does not need the evidence window.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens legacy chat-history migration verification and exposes privacy-reduced migration evidence in diagnostics.

- Verifies row counts across all seven durable 0.12.6 tables and rejects imported databases missing required tables.
- Repairs missing tables when opening existing databases and adds rollback protection around database replacement.
- Records migration outcomes and adds a redacted summary to diagnostic bundles and support reports.
- Adds packaged Chromium and opt-in Firefox migration gates with retained evidence.
- Updates the compatibility ledger and 0.12.6 changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the required-table verification now repairs and checks missing durable tables, while diagnostic migration summaries expose only count deltas rather than absolute history volumes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/persistence/owner-host.ts | Extends migration verification to compare every source table, reject missing destination tables, and record migration receipts. |
| src/lib/persistence/chat-db-worker.ts | Initializes missing schema objects on existing databases and protects database imports with staged rollback and integrity verification. |
| src/lib/persistence/durable-tables.ts | Defines the 0.12.6 durable-table inventory and centralizes count, presence, integrity, and mismatch checks. |
| src/lib/persistence/import-rollback.ts | Adds rollback staging and interrupted-import recovery for OPFS database replacement. |
| src/lib/diagnostics/diagnostics-service.ts | Reduces local migration receipts to bounded diagnostic evidence without exposing absolute source or imported row counts. |
| src/lib/error-report.ts | Adds concise migration outcomes and failure details to user-initiated support reports. |
| .github/workflows/ci.yml | Adds packaged Chromium migration verification and an opt-in Firefox migration workflow with retained evidence. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Host as Persistence owner
  participant Legacy as Legacy sql.js blob
  participant Worker as OPFS SQLite worker
  participant Receipt as Local migration receipt
  participant Diagnostics as Diagnostics bundle

  Host->>Legacy: Read blob, table counts, and integrity
  Host->>Worker: Import database bytes
  Worker->>Worker: Stage rollback copy
  Worker->>Worker: Replace and reopen database
  Worker->>Worker: Create missing schema objects
  Worker-->>Host: Imported table counts and integrity
  Host->>Host: Compare every durable table
  alt Verification succeeds
    Host->>Receipt: Record migrated outcome
    Host->>Host: Select OPFS backend
  else Verification fails
    Worker->>Worker: Restore rollback copy
    Host->>Receipt: Record failure evidence
    Host->>Host: Retain legacy backend
  end
  Diagnostics->>Receipt: Read device-local receipt
  Diagnostics->>Diagnostics: Remove absolute row counts
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(persistence): apply the schema on ev..."](https://github.com/shishir435/ollama-client/commit/63c277bf3860d52e774eec655c19f80d54f85f92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48783370)</sub>

**Context used:**

- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)
- Knowledge Base — [Diagnostics and Error Reporting](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/diagnostics-error-reporting.md)

<!-- /greptile_comment -->