### PR TITLE
Survey the legacy blob on sqlite-wasm

### DIFF
--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -72,6 +72,38 @@ describe("architecture import boundaries", () => {
     expect(rootStores).toEqual([])
   })
 
+  /**
+   * sql.js exists for one job: serving history to a profile still on the legacy
+   * blob backend. Everything else — surveying a source database, verifying an
+   * import, restoring a backup — runs on official sqlite-wasm, which reads the
+   * same file format.
+   *
+   * A new runtime import here is how the second engine comes back, and it comes
+   * back permanently: once two engines read the same file, verification is
+   * comparing engines instead of checking a migration.
+   *
+   * The three dev-only entrypoints are exempt because `config/wxt-hooks.ts`
+   * strips them from store builds. The migration-verification harness is the one
+   * place sql.js is still the right tool: its fixtures have to *write* blobs in
+   * the old topology, which is all sql.js was ever needed for. Type-only imports
+   * in the migration runner do not pull the runtime in.
+   */
+  it("keeps the sql.js runtime to the legacy fallback alone", () => {
+    const allowed = new Set([
+      "lib/sqlite/legacy-db.ts",
+      "entrypoints/benchmark/main.ts",
+      "entrypoints/spike-opfs/main.ts",
+      "entrypoints/persistence-verify/main.ts"
+    ])
+    const offenders = productionSources.filter((file) => {
+      if (allowed.has(file)) return false
+      const source = readFileSync(join(sourceRoot, file), "utf8")
+      return importsModule(source, /sql\.js\/dist\/sql-wasm\.js/)
+    })
+
+    expect(offenders).toEqual([])
+  })
+
   it("keeps application and infrastructure layers independent of features", () => {
     const lowerLayerRoots = ["application/", "background/", "lib/"]
     const offenders = productionSources.filter((file) => {

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -1,17 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { ImportResult } from "../protocol"
+import type { ImportResult, SurveyResult } from "../protocol"
 
 // Migration verification and its receipt. Each test re-imports owner-host,
 // because `ensureMigrated` memoizes the attempt for the life of the module —
 // the same reason a real owner runs it once per host.
 
 const legacyBlob = vi.hoisted(() => ({
-  readLegacyBlobBytes: vi.fn(),
-  countLegacyRows: vi.fn()
+  readLegacyBlobBytes: vi.fn()
 }))
 vi.mock("../legacy-blob-reader", () => legacyBlob)
 
 const importResults: ImportResult[] = []
+/** Queued `surveyDb` answers; falls back to a sound survey of the fixture. */
+const surveyResults: SurveyResult[] = []
 
 class StubWorker {
   onmessage: ((event: { data: unknown }) => void) | null = null
@@ -23,6 +24,16 @@ class StubWorker {
     const { id } = payload
     const op = payload.request?.op
     queueMicrotask(() => {
+      if (op === "surveyDb") {
+        this.onmessage?.({
+          data: {
+            id,
+            ok: true,
+            result: surveyResults.shift() ?? sourceSurvey
+          }
+        })
+        return
+      }
       if (op === "importDb") {
         const result = importResults.shift()
         this.onmessage?.({
@@ -73,12 +84,11 @@ describe("legacy-blob migration verification", () => {
   beforeEach(() => {
     store.clear()
     importResults.length = 0
+    surveyResults.length = 0
     legacyBlob.readLegacyBlobBytes.mockReset()
-    legacyBlob.countLegacyRows.mockReset()
     legacyBlob.readLegacyBlobBytes.mockResolvedValue(
       Uint8Array.from([1, 2, 3, 4])
     )
-    legacyBlob.countLegacyRows.mockResolvedValue(sourceSurvey)
     vi.mocked(chrome.storage.local.get as never as ReturnType<typeof vi.fn>)
       .mockReset()
       .mockImplementation(async (key: string) =>

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -242,15 +242,23 @@ const verifyImportCandidate = async (
 ): Promise<IntegrityReport> => {
   pool.unlink(PROBE_PATH)
   await ensureFreeSlots(pool, 1)
-  await pool.importDb(PROBE_PATH, new Uint8Array(bytes))
-  const probe = new pool.OpfsSAHPoolDb(PROBE_PATH)
+  // Owns the scratch file's whole lifetime, including the failure paths. The
+  // caller's cleanup ran only after the rollback copy was staged, so a payload
+  // that imported but would not open left the scratch file linked and holding
+  // one of the pool's fixed slots.
   try {
-    // Read before any schema runner sees the file: migrations write, and
-    // writing into a corrupt database turns a rejectable import into a
-    // damaged one.
-    return integrity(probe)
+    await pool.importDb(PROBE_PATH, new Uint8Array(bytes))
+    const probe = new pool.OpfsSAHPoolDb(PROBE_PATH)
+    try {
+      // Read before any schema runner sees the file: migrations write, and
+      // writing into a corrupt database turns a rejectable import into a
+      // damaged one.
+      return integrity(probe)
+    } finally {
+      probe.close()
+    }
   } finally {
-    probe.close()
+    pool.unlink(PROBE_PATH)
   }
 }
 
@@ -360,19 +368,27 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
       // for the next one to trip over.
       pool.unlink(PROBE_PATH)
       await ensureFreeSlots(pool, 1)
-      await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
-      const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+      // The unlink covers the import and the open, not just the survey: a blob
+      // that imports but cannot be opened would otherwise keep the scratch file
+      // linked and hold a pool slot until some later op happened to clear it.
+      // The pool has a fixed capacity, so a leaked slot is a resource the next
+      // import has to grow the pool to replace.
       try {
-        // Nothing writes to this handle — no schema runner, no migrations. A
-        // source blob is evidence, and evidence that has been written to is
-        // no longer the thing that was measured.
-        return {
-          ...counts(source),
-          schemaVersion: queryNumber(source, "PRAGMA user_version"),
-          integrity: integrity(source)
-        } satisfies SurveyResult
+        await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
+        const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+        try {
+          // Nothing writes to this handle — no schema runner, no migrations. A
+          // source blob is evidence, and evidence that has been written to is
+          // no longer the thing that was measured.
+          return {
+            ...counts(source),
+            schemaVersion: queryNumber(source, "PRAGMA user_version"),
+            integrity: integrity(source)
+          } satisfies SurveyResult
+        } finally {
+          source.close()
+        }
       } finally {
-        source.close()
         pool.unlink(PROBE_PATH)
       }
     }
@@ -384,9 +400,10 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
       // whenever the payload turned out to be unusable: a rejected restore
       // reported failure over an already-destroyed database. Nothing touches
       // the live file until the incoming one is known to be sound.
+      // The scratch file is gone by the time this returns, whichever way it
+      // went — verifyImportCandidate owns it end to end.
       const report = await verifyImportCandidate(pool, request.bytes)
       if (!isSoundDatabase(report)) {
-        pool.unlink(PROBE_PATH)
         throw new Error(
           `Imported database failed integrity_check: ${report.integrityCheck}`
         )
@@ -426,8 +443,6 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
           })
         }
         throw error
-      } finally {
-        pool.unlink(PROBE_PATH)
       }
     }
     case "reset": {

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -31,7 +31,8 @@ import type {
   PersistenceOp,
   QueryRow,
   RunResult,
-  SqlValue
+  SqlValue,
+  SurveyResult
 } from "./protocol"
 import { asSqlJsDatabase } from "./sqljs-compat"
 
@@ -351,6 +352,29 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
         bytes.byteOffset,
         bytes.byteOffset + bytes.byteLength
       )
+    }
+    case "surveyDb": {
+      // Read-only measurement of a candidate database, on the same engine that
+      // will import it. The live database is not touched and the scratch file is
+      // unlinked before returning, so a survey that throws leaves nothing behind
+      // for the next one to trip over.
+      pool.unlink(PROBE_PATH)
+      await ensureFreeSlots(pool, 1)
+      await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
+      const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+      try {
+        // Nothing writes to this handle — no schema runner, no migrations. A
+        // source blob is evidence, and evidence that has been written to is
+        // no longer the thing that was measured.
+        return {
+          ...counts(source),
+          schemaVersion: queryNumber(source, "PRAGMA user_version"),
+          integrity: integrity(source)
+        } satisfies SurveyResult
+      } finally {
+        source.close()
+        pool.unlink(PROBE_PATH)
+      }
     }
     case "importDb": {
       // Backup restore and legacy migration: replace the database wholesale.

--- a/src/lib/persistence/legacy-blob-reader.ts
+++ b/src/lib/persistence/legacy-blob-reader.ts
@@ -1,18 +1,12 @@
-import type { SqlJsStatic } from "sql.js"
-import initSqlJs from "sql.js/dist/sql-wasm.js"
 import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
-import {
-  countDurableTables,
-  type IntegrityReport,
-  readIntegrityReport,
-  type TableCounts,
-  tableExistsSql
-} from "./durable-tables"
 
-// Migration-time compatibility reader for the legacy sql.js IndexedDB blob.
-// Loaded lazily (dynamic import) so sql.js stays out of every startup chunk
-// once a profile has migrated. Also used by old-format backup import, which
-// carries a database.sqlite produced by sql.js.
+// Migration-time reader for the legacy IndexedDB blob. Loaded lazily so it
+// stays out of every startup chunk once a profile has migrated.
+//
+// This module holds no SQLite engine. The blob is a valid SQLite file, so the
+// database owner's worker surveys it through the `surveyDb` op on official
+// sqlite-wasm — the same engine that performs the import. Reading it here with
+// a second engine is what kept sql.js in the package for a read.
 
 export const readLegacyBlobBytes = async (): Promise<Uint8Array | null> =>
   new Promise((resolve, reject) => {
@@ -45,52 +39,3 @@ export const readLegacyBlobBytes = async (): Promise<Uint8Array | null> =>
       }
     }
   })
-
-export interface LegacySourceSurvey {
-  sessions: number
-  messages: number
-  /** Row counts for every durable table the source actually has. */
-  tables: TableCounts
-  /** `PRAGMA user_version` of the source blob — the migration receipt's
-   * record of which schema generation the data came from. */
-  schemaVersion: number
-  integrity: IntegrityReport
-}
-
-/** Open legacy bytes with sql.js and survey the rows that must survive the
- * physical import — the migration's verification source of truth. */
-export const countLegacyRows = async (
-  bytes: Uint8Array
-): Promise<LegacySourceSurvey> => {
-  const wasmUrl = chrome.runtime.getURL("assets/sql-wasm.wasm")
-  const response = await fetch(wasmUrl)
-  const wasmBinary = await response.arrayBuffer()
-  const SQL = await (
-    initSqlJs as unknown as (config: {
-      wasmBinary: Uint8Array
-    }) => Promise<SqlJsStatic>
-  )({ wasmBinary: new Uint8Array(wasmBinary) })
-
-  const db = new SQL.Database(bytes)
-  try {
-    const scalar = (sql: string): number => {
-      const result = db.exec(sql)
-      return Number(result[0]?.values?.[0]?.[0] ?? 0)
-    }
-    const rows = (sql: string): unknown[][] =>
-      (db.exec(sql)[0]?.values as unknown[][] | undefined) ?? []
-    const tables = countDurableTables(
-      scalar,
-      (table) => scalar(tableExistsSql(table)) > 0
-    )
-    return {
-      sessions: tables.sessions ?? 0,
-      messages: tables.messages ?? 0,
-      tables,
-      schemaVersion: scalar("PRAGMA user_version"),
-      integrity: readIntegrityReport(rows)
-    }
-  } finally {
-    db.close()
-  }
-}

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -12,7 +12,7 @@ import {
   isSoundDatabase,
   type TableCountMismatch
 } from "./durable-tables"
-import type { ImportResult } from "./protocol"
+import type { ImportResult, SurveyResult } from "./protocol"
 import {
   decodeBind,
   encodeRows,
@@ -184,9 +184,7 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
   if (backend === "opfs") return
 
   logger.info("Starting legacy-blob → OPFS migration", "Persistence")
-  const { readLegacyBlobBytes, countLegacyRows } = await import(
-    "./legacy-blob-reader"
-  )
+  const { readLegacyBlobBytes } = await import("./legacy-blob-reader")
   const bytes = await readLegacyBlobBytes()
 
   if (!bytes || bytes.byteLength === 0) {
@@ -198,11 +196,24 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
     return
   }
 
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer
+
   // Survey the source BEFORE the physical import — this is the verification
   // target, and it covers every durable table the blob has, not just the two
   // the chat list happens to read. The source blob itself is never modified or
   // deleted; it remains the rollback artifact.
-  const source = await countLegacyRows(bytes)
+  //
+  // Measured by the worker, on the engine that will import it. A separate
+  // reader could disagree with the importer about what the file contains, and
+  // then verification would be comparing two engines rather than checking a
+  // migration. It also means the blob is read by one SQLite, not two.
+  const source = (await callWorker({
+    op: "surveyDb",
+    bytes: buffer
+  })) as SurveyResult
   if (!isSoundDatabase(source.integrity)) {
     logger.warn(
       "Legacy blob failed integrity_check before import",
@@ -212,11 +223,6 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
       }
     )
   }
-  const buffer = bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength
-  ) as ArrayBuffer
-
   let imported: ImportResult | undefined
   let mismatches: TableCountMismatch[] = []
   try {

--- a/src/lib/persistence/protocol.ts
+++ b/src/lib/persistence/protocol.ts
@@ -23,6 +23,18 @@ export type PersistenceOp =
   | { op: "txRollback"; token: string }
   | { op: "exportDb" }
   | { op: "importDb"; bytes: ArrayBuffer }
+  /**
+   * Survey a candidate database without adopting it: row counts per durable
+   * table, `PRAGMA user_version`, and the integrity verdicts. Read-only, on a
+   * scratch file that is unlinked afterwards, so the live database and the
+   * source bytes are both untouched.
+   *
+   * This is how the legacy blob is measured before migration. It exists so the
+   * survey runs on the same engine as the import — sql.js read the blob for
+   * this, which meant carrying a second SQLite for a read that official
+   * sqlite-wasm performs natively.
+   */
+  | { op: "surveyDb"; bytes: ArrayBuffer }
   | { op: "counts" }
   | { op: "reset" }
   | { op: "ping" }
@@ -43,6 +55,12 @@ export interface CountsResult {
 
 export interface ImportResult extends CountsResult {
   integrity: IntegrityReport
+}
+
+/** What a source database says about itself before anything imports it. */
+export interface SurveyResult extends ImportResult {
+  /** `PRAGMA user_version` — which schema generation the data came from. */
+  schemaVersion: number
 }
 
 export interface PersistenceRpcRequest {


### PR DESCRIPTION
Step one of the engine unification: the migration no longer needs sql.js to read its source.

## The problem

The migration measured its source blob with sql.js (`countLegacyRows` → `initSqlJs` → `fetch(assets/sql-wasm.wasm)`) and imported it with sqlite-wasm. Two SQLite builds read the same file, and 644KB of wasm shipped for a read the engine already running in the worker performs natively.

Worse for the evidence window: verification compared what sql.js saw against what sqlite-wasm produced. A disagreement between engines would surface as a table-count mismatch — indistinguishable from a real migration defect, and the failure mode most likely to make a clean window look dirty.

## The change

A read-only `surveyDb` op on the persistence worker: import the candidate to the scratch path the import path already uses, count every durable table, read `PRAGMA user_version`, take the integrity verdicts, then close and unlink. Nothing writes to that handle — a source blob is evidence, and evidence that has been written to is no longer what was measured.

Verification now compares one engine against itself.

`legacy-blob-reader.ts` keeps only the IndexedDB read, which needs no engine at all: 96 lines → 41.

## What still uses sql.js

In production, exactly one module: `lib/sqlite/legacy-db.ts`, the live fallback that serves history to a profile still on the blob. A contract test in `architecture-boundaries.test.ts` pins that and fails on any new runtime import.

Three dev-only entrypoints are allowlisted (`config/wxt-hooks.ts` strips them from store builds). One of them — the migration-verification harness — legitimately needs sql.js, because its fixtures have to *write* blobs in the old topology. That is all sql.js was ever needed for, per §4C.

## What this does and does not unblock

- **Clears** the §4B gate "official SQLite-WASM owner replaces `countLegacyRows`". No official-owner work now stands between here and removal.
- **Does not** remove the 644KB asset. That waits on the live fallback, which is gated on the evidence window — a data decision, not an engine one.

Removal day is now: delete `legacy-db.ts`, flip a failed marker read from "answer legacy" to an explicit failure, drop the dep and the asset. No engine work left in it.

## Review note

Test harnesses that stubbed `countLegacyRows` on the reader module now queue `surveyDb` answers on the stub worker instead, since the survey crossed into the worker. Same scenarios, same assertions.

## Gates

- `pnpm typecheck` ✅
- `pnpm lint:check` / `pnpm format:check` ✅
- `pnpm test:run` ✅ 304 files, 2506 tests

The Chromium critical persistence gates exercise the real migration path against a packaged build, so they are the meaningful check on this one — unit tests stub the worker by construction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves legacy-blob surveying from sql.js into the sqlite-wasm persistence worker.
- Adds a read-only `surveyDb` worker operation that reports durable-table counts, schema version, and integrity results.
- Ensures scratch databases are closed and unlinked across import, open, survey, and cleanup failures.
- Removes sql.js-based surveying from the legacy blob reader and updates migration verification tests.
- Adds an architecture boundary test limiting production sql.js usage to the legacy fallback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the prior scratch-file leak is resolved because cleanup now encloses both candidate import and database construction.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/persistence/chat-db-worker.ts | Adds the sqlite-wasm survey operation and extends scratch-file cleanup across import and construction failures. |
| src/lib/persistence/owner-host.ts | Replaces sql.js source surveying with the worker-owned survey operation before migration. |
| src/lib/persistence/legacy-blob-reader.ts | Removes the sql.js engine and retains only the legacy IndexedDB blob read. |
| src/lib/persistence/protocol.ts | Adds the typed survey request and result contracts. |
| src/lib/persistence/__tests__/migration-verification.test.ts | Updates migration tests to provide survey results through the stub worker. |
| src/lib/__tests__/architecture-boundaries.test.ts | Enforces that runtime sql.js imports remain confined to the legacy fallback. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Host as Persistence owner
  participant Reader as Legacy blob reader
  participant Worker as SQLite worker
  participant Scratch as Scratch database
  Host->>Reader: Read legacy IndexedDB bytes
  Reader-->>Host: Uint8Array
  Host->>Worker: surveyDb(bytes)
  Worker->>Scratch: Import candidate
  Worker->>Scratch: Open and read counts/version/integrity
  Worker->>Scratch: Close and unlink
  Worker-->>Host: SurveyResult
  Host->>Worker: importDb(bytes)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(persistence): unlink the scratch dat..."](https://github.com/shishir435/ollama-client/commit/763a8bc482b33b705907ed44a06052a4a0504e9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48785678)</sub>

**Context used:**

- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)

<!-- /greptile_comment -->