### PR TITLE
Carry the 0.12.6 migration fixes onto 0.13.x

### DIFF
--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -72,6 +72,38 @@ describe("architecture import boundaries", () => {
     expect(rootStores).toEqual([])
   })
 
+  /**
+   * sql.js exists for one job: serving history to a profile still on the legacy
+   * blob backend. Everything else — surveying a source database, verifying an
+   * import, restoring a backup — runs on official sqlite-wasm, which reads the
+   * same file format.
+   *
+   * A new runtime import here is how the second engine comes back, and it comes
+   * back permanently: once two engines read the same file, verification is
+   * comparing engines instead of checking a migration.
+   *
+   * The three dev-only entrypoints are exempt because `config/wxt-hooks.ts`
+   * strips them from store builds. The migration-verification harness is the one
+   * place sql.js is still the right tool: its fixtures have to *write* blobs in
+   * the old topology, which is all sql.js was ever needed for. Type-only imports
+   * in the migration runner do not pull the runtime in.
+   */
+  it("keeps the sql.js runtime to the legacy fallback alone", () => {
+    const allowed = new Set([
+      "lib/sqlite/legacy-db.ts",
+      "entrypoints/benchmark/main.ts",
+      "entrypoints/spike-opfs/main.ts",
+      "entrypoints/persistence-verify/main.ts"
+    ])
+    const offenders = productionSources.filter((file) => {
+      if (allowed.has(file)) return false
+      const source = readFileSync(join(sourceRoot, file), "utf8")
+      return importsModule(source, /sql\.js\/dist\/sql-wasm\.js/)
+    })
+
+    expect(offenders).toEqual([])
+  })
+
   it("keeps application and infrastructure layers independent of features", () => {
     const lowerLayerRoots = ["application/", "background/", "lib/"]
     const offenders = productionSources.filter((file) => {

--- a/src/lib/__tests__/error-report.test.ts
+++ b/src/lib/__tests__/error-report.test.ts
@@ -191,6 +191,69 @@ describe("buildDiagnosticIssueUrl", () => {
     expect(body).toContain("**Privacy**")
   })
 
+  it("says nothing about migration when the profile never had a legacy blob", () => {
+    const body = bodyOf(buildDiagnosticIssueUrl(bundle))
+
+    expect(body).not.toContain("Chat migration")
+  })
+
+  it("reports a failed migration in the detail a maintainer needs", () => {
+    const body = bodyOf(
+      buildDiagnosticIssueUrl({
+        ...bundle,
+        storage: {
+          ...bundle.storage,
+          backend: "legacy",
+          migration: {
+            outcome: "verification-failed",
+            attempts: 3,
+            recordedAt: 1,
+            extensionVersion: "0.12.6",
+            sourceSchemaVersion: 11,
+            importedIntegrity: "ok",
+            foreignKeyViolations: 2,
+            mismatches: ["messages short by 5"],
+            failure: "Migration verification failed: messages short by 5"
+          }
+        }
+      })
+    )
+
+    expect(body).toContain("Chat migration: verification-failed (attempt 3")
+    expect(body).toContain("schema v11")
+    expect(body).toContain("messages short by 5")
+    expect(body).toContain("Migration orphan rows: 2")
+    // The shortfall is diagnosable; the row counts it came from are not in the
+    // draft a reporter would submit.
+    expect(body).not.toContain("39204")
+    expect(body).not.toContain("39199")
+  })
+
+  it("keeps a clean migration to a single line", () => {
+    const body = bodyOf(
+      buildDiagnosticIssueUrl({
+        ...bundle,
+        storage: {
+          ...bundle.storage,
+          migration: {
+            outcome: "migrated",
+            attempts: 1,
+            recordedAt: 1,
+            extensionVersion: "0.12.6",
+            sourceSchemaVersion: 11,
+            importedIntegrity: "ok",
+            foreignKeyViolations: 0
+          }
+        }
+      })
+    )
+
+    expect(body).toContain("Chat migration: migrated (attempt 1")
+    expect(body).not.toContain("Migration integrity")
+    expect(body).not.toContain("Migration orphan rows")
+    expect(body).not.toContain("Migration failure")
+  })
+
   it("stays inside the URL limit when every self-test fails", () => {
     const url = buildDiagnosticIssueUrl({
       ...bundle,

--- a/src/lib/client-environment.ts
+++ b/src/lib/client-environment.ts
@@ -1,0 +1,68 @@
+/**
+ * Coarse browser/OS identification for support reports.
+ *
+ * Its own module because the background bundle needs exactly this and nothing
+ * else from `error-report`. Importing it from there pulled the issue-draft
+ * composition — templates, URL length budgeting, the privacy tail — into the
+ * background chunk, which has a size budget and no use for any of it.
+ */
+type NavigatorWithBrands = Navigator & {
+  brave?: unknown
+  userAgentData?: {
+    brands?: Array<{ brand: string; version: string }>
+    platform?: string
+  }
+}
+
+const majorVersion = (userAgent: string, pattern: RegExp): string | undefined =>
+  userAgent.match(pattern)?.[1]
+
+export const getSafeClientEnvironment = (): {
+  browser: string
+  os: string
+} => {
+  if (typeof navigator === "undefined") {
+    return { browser: "unknown", os: "unknown" }
+  }
+
+  const nav = navigator as NavigatorWithBrands
+  const userAgent = nav.userAgent || ""
+  const brands = nav.userAgentData?.brands ?? []
+  const chromiumVersion =
+    brands.find(({ brand }) => /Chromium/i.test(brand))?.version ||
+    majorVersion(userAgent, /(?:Chrome|CriOS)\/(\d+)/i)
+  const isBrave =
+    Boolean(nav.brave) || brands.some(({ brand }) => /Brave/i.test(brand))
+
+  const browser = /Firefox\/(\d+)/i.test(userAgent)
+    ? `Firefox ${majorVersion(userAgent, /Firefox\/(\d+)/i)}`
+    : /Edg(?:e|A|iOS)?\/(\d+)/i.test(userAgent)
+      ? `Edge ${majorVersion(userAgent, /Edg(?:e|A|iOS)?\/(\d+)/i)}`
+      : /OPR\/(\d+)/i.test(userAgent)
+        ? `Opera ${majorVersion(userAgent, /OPR\/(\d+)/i)}`
+        : isBrave
+          ? `Brave${chromiumVersion ? ` (Chromium ${chromiumVersion})` : ""}`
+          : /(?:Chrome|CriOS)\/(\d+)/i.test(userAgent)
+            ? `Chrome/Chromium ${majorVersion(userAgent, /(?:Chrome|CriOS)\/(\d+)/i)}`
+            : /Version\/(\d+).+Safari\//i.test(userAgent)
+              ? `Safari ${majorVersion(userAgent, /Version\/(\d+)/i)}`
+              : "unknown"
+
+  const platform = nav.userAgentData?.platform || nav.platform || ""
+  const osSource = `${userAgent} ${platform}`
+  const os = /Android/i.test(osSource)
+    ? "Android"
+    : /iPhone|iPad|iPod/i.test(osSource)
+      ? "iOS/iPadOS"
+      : /Windows/i.test(osSource)
+        ? "Windows"
+        : /CrOS/i.test(osSource)
+          ? "ChromeOS"
+          : /Mac OS|Macintosh|MacIntel/i.test(osSource)
+            ? "macOS"
+            : /Linux/i.test(osSource)
+              ? "Linux"
+              : "unknown"
+
+  return { browser, os }
+}

--- a/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
@@ -455,4 +455,50 @@ describe("DiagnosticsService", () => {
     expect(serialized).not.toContain("sourceCounts")
     expect(serialized).not.toContain("sourceBytes")
   })
+
+  it("strips count pairs a previous release wrote into the receipt", async () => {
+    mocks.backend.mockResolvedValue("legacy")
+    mocks.receipt.mockResolvedValue({
+      version: 1,
+      outcome: "verification-failed",
+      recordedAt: 1,
+      extensionVersion: "0.13.0",
+      attempts: 1,
+      // A receipt is written once and then persists, so this text can come from
+      // a build that formatted count pairs. The summary cannot assume its own
+      // formatter produced it.
+      failure: "Migration verification failed: messages 39199/39204",
+      importedIntegrity: {
+        integrityCheck: "row 39204 missing from index idx_messages_session",
+        foreignKeyViolations: 0
+      }
+    })
+
+    const { bundle } = await DiagnosticsService.getBundle()
+    const serialized = JSON.stringify(bundle?.storage.migration)
+
+    expect(serialized).not.toContain("39199")
+    expect(serialized).not.toContain("39204")
+    expect(bundle?.storage.migration?.failure).toContain("[counts removed]")
+  })
+
+  it("names an empty table instead of a shortfall equal to its count", async () => {
+    mocks.backend.mockResolvedValue("legacy")
+    mocks.receipt.mockResolvedValue({
+      version: 1,
+      outcome: "verification-failed",
+      recordedAt: 1,
+      extensionVersion: "0.13.0",
+      attempts: 1,
+      // Nothing arrived, so "short by 39204" would be the total row count.
+      mismatches: [{ table: "messages", source: 39_204, imported: 0 }]
+    })
+
+    const { bundle } = await DiagnosticsService.getBundle()
+
+    expect(bundle?.storage.migration?.mismatches).toEqual([
+      "messages arrived empty"
+    ])
+    expect(JSON.stringify(bundle?.storage.migration)).not.toContain("39204")
+  })
 })

--- a/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
+++ b/src/lib/diagnostics/__tests__/diagnostics-service.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   providerConfig: vi.fn(),
   listModels: vi.fn(),
   backend: vi.fn(),
+  receipt: vi.fn(),
   txBegin: vi.fn(),
   txRollback: vi.fn(),
   query: vi.fn(),
@@ -42,7 +43,8 @@ vi.mock("@/lib/providers/provider-rpc-service", () => ({
   ProviderRpcService: { listModels: mocks.listModels }
 }))
 vi.mock("@/lib/persistence/backend", () => ({
-  readPersistenceBackend: mocks.backend
+  readPersistenceBackend: mocks.backend,
+  readMigrationReceipt: mocks.receipt
 }))
 vi.mock("@/lib/persistence/client", () => ({
   rpcTxBegin: mocks.txBegin,
@@ -109,6 +111,7 @@ beforeEach(() => {
     failures: []
   })
   mocks.backend.mockResolvedValue("opfs")
+  mocks.receipt.mockResolvedValue(null)
   mocks.txBegin.mockResolvedValue(undefined)
   mocks.txRollback.mockResolvedValue(undefined)
   mocks.run.mockResolvedValue({ changes: 1 })
@@ -402,5 +405,54 @@ describe("DiagnosticsService", () => {
       status: "action",
       code: "OLC-STORAGE-MIGRATION-001"
     })
+  })
+
+  it("omits migration evidence for a profile that never had a legacy blob", async () => {
+    mocks.receipt.mockResolvedValue(null)
+    const { bundle } = await DiagnosticsService.getBundle()
+
+    expect(bundle?.storage.migration).toBeUndefined()
+  })
+
+  it("reports migration failure evidence without any row counts", async () => {
+    mocks.backend.mockResolvedValue("legacy")
+    mocks.receipt.mockResolvedValue({
+      version: 1,
+      outcome: "verification-failed",
+      recordedAt: 1_700_000_000_000,
+      extensionVersion: "0.12.6",
+      attempts: 3,
+      sourceSchemaVersion: 11,
+      sourceBytes: 8_400_000,
+      // Counts describe how much a person has said. They must not leave.
+      sourceCounts: { sessions: 1482, messages: 39_204 },
+      importedCounts: { sessions: 1482, messages: 39_199 },
+      sourceIntegrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
+      importedIntegrity: { integrityCheck: "ok", foreignKeyViolations: 2 },
+      mismatches: [{ table: "messages", source: 39_204, imported: 39_199 }],
+      failure: "Migration verification failed: messages short by 5"
+    })
+
+    const { bundle } = await DiagnosticsService.getBundle()
+    const migration = bundle?.storage.migration
+    const serialized = JSON.stringify(migration)
+
+    expect(migration).toMatchObject({
+      outcome: "verification-failed",
+      attempts: 3,
+      sourceSchemaVersion: 11,
+      foreignKeyViolations: 2,
+      // The shortfall, which is the diagnosable half.
+      mismatches: ["messages short by 5"]
+    })
+    // Not one of the four row counts in that receipt, through any field. An
+    // earlier version of this summary formatted `table:source→imported`, and
+    // this assertion named only the sessions count — so it passed while both
+    // message counts travelled.
+    for (const count of ["1482", "39204", "39199"]) {
+      expect(serialized).not.toContain(count)
+    }
+    expect(serialized).not.toContain("sourceCounts")
+    expect(serialized).not.toContain("sourceBytes")
   })
 })

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -1,10 +1,10 @@
 import { browser, supportsDNR } from "@/lib/browser-api"
+import { getSafeClientEnvironment } from "@/lib/client-environment"
 import {
   localProviderOriginRuleMatches,
   readLocalProviderOriginRule
 } from "@/lib/dnr-rules"
 import { vectorDb } from "@/lib/embeddings/db"
-import { getSafeClientEnvironment } from "@/lib/error-report"
 import {
   type MigrationReceipt,
   readMigrationReceipt,

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -16,6 +16,7 @@ import {
   rpcTxBegin,
   rpcTxRollback
 } from "@/lib/persistence/client"
+import { describeMismatch } from "@/lib/persistence/durable-tables"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderManager } from "@/lib/providers/manager"
 import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
@@ -131,29 +132,49 @@ const runMigrationTest = async (): Promise<DiagnosticTestResult> => {
  *
  * Row counts stay on the device. `messages: 39204` describes how much someone
  * has said, and a shortfall is diagnosable without it: `messages short by 5`
- * says a table lost five rows, which is the actionable half. An absolute pair
- * would have disclosed history volume out of a support report, which is the one
- * thing this summary exists to avoid.
+ * says a table lost five rows, which is the actionable half.
  *
- * `integrity_check` output can be long on a damaged file, so each verdict is
- * clamped and the list of shortfalls is capped.
+ * Structured fields are re-derived here rather than trusted. A receipt is
+ * written once per migration and then persists, so this function reads text
+ * produced by whichever version performed the attempt — including versions that
+ * formatted `messages 39199/39204`. Free-form text is therefore treated as
+ * untrusted input: count pairs and any large standalone number are stripped
+ * before it is forwarded.
+ *
+ * `integrity_check` output gets the same treatment on top of its length clamp:
+ * a damaged file makes SQLite print rowids, and a rowid is a lower bound on how
+ * many rows exist.
  */
 const MAX_REPORTED_MISMATCHES = 10
+
+/** `39199/39204` and the like, in text an older release wrote. */
+const COUNT_PAIR_PATTERN = /\d+\s*\/\s*\d+/g
+/**
+ * A standalone number this large is a rowid, a page number, or a count — all of
+ * which put a lower bound on how much history exists. `integrity_check` prints
+ * them freely ("row 39204 missing from index"), and that text can be embedded in
+ * a failure message.
+ *
+ * Four digits is the cut so the numbers worth reading survive: shortfalls,
+ * attempt counts, schema versions. A shortfall in the thousands is redacted too,
+ * which loses a little precision on the rarest failures and is the right trade.
+ */
+const LARGE_NUMBER_PATTERN = /\d{4,}/g
+
+const withoutCounts = (text: string): string =>
+  text
+    .replace(COUNT_PAIR_PATTERN, "[counts removed]")
+    .replace(LARGE_NUMBER_PATTERN, "[n]")
 
 export const summarizeMigrationReceipt = (
   receipt: MigrationReceipt | null
 ): DiagnosticStorageMigration | undefined => {
   if (!receipt) return undefined
   const verdict = (value?: string) =>
-    value === undefined ? undefined : value.slice(0, 120)
+    value === undefined ? undefined : withoutCounts(value).slice(0, 120)
   const mismatches = receipt.mismatches
     ?.slice(0, MAX_REPORTED_MISMATCHES)
-    .map((mismatch) => {
-      const delta = mismatch.source - mismatch.imported
-      return delta > 0
-        ? (`${mismatch.table} short by ${delta}` as const)
-        : (`${mismatch.table} over by ${-delta}` as const)
-    })
+    .map(describeMismatch)
   return {
     outcome: receipt.outcome,
     attempts: receipt.attempts,
@@ -164,7 +185,9 @@ export const summarizeMigrationReceipt = (
     importedIntegrity: verdict(receipt.importedIntegrity?.integrityCheck),
     foreignKeyViolations: receipt.importedIntegrity?.foreignKeyViolations,
     ...(mismatches && mismatches.length > 0 ? { mismatches } : {}),
-    failure: receipt.failure ? receipt.failure.slice(0, 200) : undefined
+    failure: receipt.failure
+      ? withoutCounts(receipt.failure).slice(0, 200)
+      : undefined
   }
 }
 

--- a/src/lib/diagnostics/diagnostics-service.ts
+++ b/src/lib/diagnostics/diagnostics-service.ts
@@ -5,7 +5,11 @@ import {
 } from "@/lib/dnr-rules"
 import { vectorDb } from "@/lib/embeddings/db"
 import { getSafeClientEnvironment } from "@/lib/error-report"
-import { readPersistenceBackend } from "@/lib/persistence/backend"
+import {
+  type MigrationReceipt,
+  readMigrationReceipt,
+  readPersistenceBackend
+} from "@/lib/persistence/backend"
 import {
   rpcQuery,
   rpcRun,
@@ -18,6 +22,7 @@ import { ProviderRpcService } from "@/lib/providers/provider-rpc-service"
 import { ProviderId } from "@/lib/providers/types"
 import { countMessages } from "@/lib/repositories/chat-history"
 import type {
+  DiagnosticStorageMigration,
   DiagnosticsGetBundleResult,
   DiagnosticsRunResult,
   DiagnosticTestResult
@@ -118,6 +123,49 @@ const runMigrationTest = async (): Promise<DiagnosticTestResult> => {
     }
   }
   return result
+}
+
+/**
+ * Reduce a migration receipt to the evidence a maintainer needs and nothing
+ * more.
+ *
+ * Row counts stay on the device. `messages: 39204` describes how much someone
+ * has said, and a shortfall is diagnosable without it: `messages short by 5`
+ * says a table lost five rows, which is the actionable half. An absolute pair
+ * would have disclosed history volume out of a support report, which is the one
+ * thing this summary exists to avoid.
+ *
+ * `integrity_check` output can be long on a damaged file, so each verdict is
+ * clamped and the list of shortfalls is capped.
+ */
+const MAX_REPORTED_MISMATCHES = 10
+
+export const summarizeMigrationReceipt = (
+  receipt: MigrationReceipt | null
+): DiagnosticStorageMigration | undefined => {
+  if (!receipt) return undefined
+  const verdict = (value?: string) =>
+    value === undefined ? undefined : value.slice(0, 120)
+  const mismatches = receipt.mismatches
+    ?.slice(0, MAX_REPORTED_MISMATCHES)
+    .map((mismatch) => {
+      const delta = mismatch.source - mismatch.imported
+      return delta > 0
+        ? (`${mismatch.table} short by ${delta}` as const)
+        : (`${mismatch.table} over by ${-delta}` as const)
+    })
+  return {
+    outcome: receipt.outcome,
+    attempts: receipt.attempts,
+    recordedAt: receipt.recordedAt,
+    extensionVersion: receipt.extensionVersion,
+    sourceSchemaVersion: receipt.sourceSchemaVersion,
+    sourceIntegrity: verdict(receipt.sourceIntegrity?.integrityCheck),
+    importedIntegrity: verdict(receipt.importedIntegrity?.integrityCheck),
+    foreignKeyViolations: receipt.importedIntegrity?.foreignKeyViolations,
+    ...(mismatches && mismatches.length > 0 ? { mismatches } : {}),
+    failure: receipt.failure ? receipt.failure.slice(0, 200) : undefined
+  }
 }
 
 /**
@@ -513,6 +561,7 @@ export const DiagnosticsService = {
     ])
     signal?.throwIfAborted()
     const backend = await readPersistenceBackend()
+    const migration = summarizeMigrationReceipt(await readMigrationReceipt())
     const environment = getSafeClientEnvironment()
     return {
       bundle: {
@@ -528,7 +577,12 @@ export const DiagnosticsService = {
           wire: String(provider.type),
           enabled: provider.enabled
         })),
-        storage: { backend, messageCount, vectorCount },
+        storage: {
+          backend,
+          messageCount,
+          vectorCount,
+          ...(migration ? { migration } : {})
+        },
         events: sessionId
           ? events.filter((event) => event.sessionId === sessionId)
           : events,

--- a/src/lib/error-report.ts
+++ b/src/lib/error-report.ts
@@ -172,6 +172,40 @@ export const buildGenericIssueReportUrl = (
 }
 
 /**
+ * Chat-history migration evidence, when this profile has any. Omitted entirely
+ * for a profile that never held a legacy blob, so a normal report does not carry
+ * three lines about a migration that never happened.
+ *
+ * A clean result stays one line. Detail appears only when something went wrong,
+ * because that is the only case a maintainer needs to read.
+ */
+const migrationLines = (
+  migration: NonNullable<DiagnosticBundle>["storage"]["migration"]
+): string[] => {
+  if (!migration) return []
+  const lines = [
+    `- Chat migration: ${clampLine(migration.outcome, 40)} (attempt ${migration.attempts}, from schema v${migration.sourceSchemaVersion ?? "?"}, on ${clampLine(migration.extensionVersion, 20)})`
+  ]
+  if (migration.importedIntegrity && migration.importedIntegrity !== "ok") {
+    lines.push(
+      `- Migration integrity: ${clampLine(migration.importedIntegrity, 120)}`
+    )
+  }
+  if (migration.foreignKeyViolations) {
+    lines.push(`- Migration orphan rows: ${migration.foreignKeyViolations}`)
+  }
+  if (migration.mismatches?.length) {
+    lines.push(
+      `- Migration table mismatches: ${clampLine(migration.mismatches.join(", "), 200)}`
+    )
+  }
+  if (migration.failure) {
+    lines.push(`- Migration failure: ${clampLine(migration.failure, 200)}`)
+  }
+  return lines
+}
+
+/**
  * Draft opened from Settings → Help → Diagnostics & support, where the reporter
  * already has a bundle in hand. Shares the composer above, so this draft carries
  * the same paste block, privacy statement, and length guarantee as a chat-error
@@ -195,6 +229,7 @@ export const buildDiagnosticIssueUrl = (
       `- Browser: ${clampLine(bundle.browserFamily, 100)}`,
       `- OS: ${clampLine(bundle.osFamily, 100)}`,
       `- Storage backend: ${clampLine(bundle.storage.backend, 100)}`,
+      ...migrationLines(bundle.storage.migration),
       ...(failed.length > 0 ? failed : ["- Self-tests: passed"])
     ].join("\n")
   )

--- a/src/lib/error-report.ts
+++ b/src/lib/error-report.ts
@@ -1,4 +1,5 @@
 import { runtime } from "@/lib/browser-api"
+import { getSafeClientEnvironment } from "@/lib/client-environment"
 import { EXTERNAL_URLS } from "@/lib/constants"
 import {
   sanitizeModelIdentifier,
@@ -7,16 +8,7 @@ import {
 import type { DiagnosticsGetBundleResult } from "@/protocol/diagnostics-rpc"
 import type { ChatMessage } from "@/types"
 
-type NavigatorWithBrands = Navigator & {
-  brave?: unknown
-  userAgentData?: {
-    brands?: Array<{ brand: string; version: string }>
-    platform?: string
-  }
-}
-
-const majorVersion = (userAgent: string, pattern: RegExp): string | undefined =>
-  userAgent.match(pattern)?.[1]
+export { getSafeClientEnvironment } from "@/lib/client-environment"
 
 const getExtensionVersion = (): string => {
   try {
@@ -24,56 +16,6 @@ const getExtensionVersion = (): string => {
   } catch {
     return "unknown"
   }
-}
-
-export const getSafeClientEnvironment = (): {
-  browser: string
-  os: string
-} => {
-  if (typeof navigator === "undefined") {
-    return { browser: "unknown", os: "unknown" }
-  }
-
-  const nav = navigator as NavigatorWithBrands
-  const userAgent = nav.userAgent || ""
-  const brands = nav.userAgentData?.brands ?? []
-  const chromiumVersion =
-    brands.find(({ brand }) => /Chromium/i.test(brand))?.version ||
-    majorVersion(userAgent, /(?:Chrome|CriOS)\/(\d+)/i)
-  const isBrave =
-    Boolean(nav.brave) || brands.some(({ brand }) => /Brave/i.test(brand))
-
-  const browser = /Firefox\/(\d+)/i.test(userAgent)
-    ? `Firefox ${majorVersion(userAgent, /Firefox\/(\d+)/i)}`
-    : /Edg(?:e|A|iOS)?\/(\d+)/i.test(userAgent)
-      ? `Edge ${majorVersion(userAgent, /Edg(?:e|A|iOS)?\/(\d+)/i)}`
-      : /OPR\/(\d+)/i.test(userAgent)
-        ? `Opera ${majorVersion(userAgent, /OPR\/(\d+)/i)}`
-        : isBrave
-          ? `Brave${chromiumVersion ? ` (Chromium ${chromiumVersion})` : ""}`
-          : /(?:Chrome|CriOS)\/(\d+)/i.test(userAgent)
-            ? `Chrome/Chromium ${majorVersion(userAgent, /(?:Chrome|CriOS)\/(\d+)/i)}`
-            : /Version\/(\d+).+Safari\//i.test(userAgent)
-              ? `Safari ${majorVersion(userAgent, /Version\/(\d+)/i)}`
-              : "unknown"
-
-  const platform = nav.userAgentData?.platform || nav.platform || ""
-  const osSource = `${userAgent} ${platform}`
-  const os = /Android/i.test(osSource)
-    ? "Android"
-    : /iPhone|iPad|iPod/i.test(osSource)
-      ? "iOS/iPadOS"
-      : /Windows/i.test(osSource)
-        ? "Windows"
-        : /CrOS/i.test(osSource)
-          ? "ChromeOS"
-          : /Mac OS|Macintosh|MacIntel/i.test(osSource)
-            ? "macOS"
-            : /Linux/i.test(osSource)
-              ? "Linux"
-              : "unknown"
-
-  return { browser, os }
 }
 
 /**

--- a/src/lib/persistence/__tests__/durable-tables.test.ts
+++ b/src/lib/persistence/__tests__/durable-tables.test.ts
@@ -5,6 +5,7 @@ import {
   countDurableTables,
   DURABLE_TABLES,
   describeMismatches,
+  findMissingDurableTables,
   findTableCountMismatches,
   isSoundDatabase,
   readIntegrityReport,
@@ -71,9 +72,35 @@ describe("table count verification", () => {
       { table: "messages", source: 9, imported: 8 },
       { table: "prompt_templates", source: 7, imported: 0 }
     ])
+    // Shortfalls, not count pairs: this text reaches the receipt's `failure`,
+    // which a support report can carry.
     expect(describeMismatches(mismatches)).toBe(
-      "messages 8/9, prompt_templates 0/7"
+      "messages short by 1, prompt_templates short by 7"
     )
+    expect(describeMismatches(mismatches)).not.toMatch(/\b9\b/)
+  })
+
+  it("names a durable table the destination does not have at all", () => {
+    // Absent from both sides, so no count can disagree — chunk_feedback reached
+    // the schema in 0.10.0 without a migration, and a database predating it
+    // passed verification while lacking the table.
+    expect(findMissingDurableTables({ sessions: 2, messages: 9 })).toContain(
+      "chunk_feedback"
+    )
+    expect(
+      findMissingDurableTables({
+        sessions: 0,
+        messages: 0,
+        files: 0,
+        kv_store: 0,
+        prompt_templates: 0,
+        tool_loop_runs: 0,
+        turn_runs: 0,
+        ingestion_runs: 0,
+        model_pull_runs: 0,
+        chunk_feedback: 0
+      })
+    ).toEqual([])
   })
 })
 

--- a/src/lib/persistence/__tests__/durable-tables.test.ts
+++ b/src/lib/persistence/__tests__/durable-tables.test.ts
@@ -74,10 +74,13 @@ describe("table count verification", () => {
     ])
     // Shortfalls, not count pairs: this text reaches the receipt's `failure`,
     // which a support report can carry.
+    // Shortfalls for a partial loss; the named state for a table that arrived
+    // with nothing, because there the shortfall equals the source count.
     expect(describeMismatches(mismatches)).toBe(
-      "messages short by 1, prompt_templates short by 7"
+      "messages short by 1, prompt_templates arrived empty"
     )
     expect(describeMismatches(mismatches)).not.toMatch(/\b9\b/)
+    expect(describeMismatches(mismatches)).not.toMatch(/\b7\b/)
   })
 
   it("names a durable table the destination does not have at all", () => {

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -1,17 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { ImportResult } from "../protocol"
+import type { ImportResult, SurveyResult } from "../protocol"
 
 // Migration verification and its receipt. Each test re-imports owner-host,
 // because `ensureMigrated` memoizes the attempt for the life of the module —
 // the same reason a real owner runs it once per host.
 
 const legacyBlob = vi.hoisted(() => ({
-  readLegacyBlobBytes: vi.fn(),
-  countLegacyRows: vi.fn()
+  readLegacyBlobBytes: vi.fn()
 }))
 vi.mock("../legacy-blob-reader", () => legacyBlob)
 
 const importResults: ImportResult[] = []
+/** Queued `surveyDb` answers; falls back to a sound survey of the fixture. */
+const surveyResults: SurveyResult[] = []
 
 class StubWorker {
   onmessage: ((event: { data: unknown }) => void) | null = null
@@ -23,6 +24,16 @@ class StubWorker {
     const { id } = payload
     const op = payload.request?.op
     queueMicrotask(() => {
+      if (op === "surveyDb") {
+        this.onmessage?.({
+          data: {
+            id,
+            ok: true,
+            result: surveyResults.shift() ?? sourceSurvey
+          }
+        })
+        return
+      }
       if (op === "importDb") {
         const result = importResults.shift()
         this.onmessage?.({
@@ -73,12 +84,11 @@ describe("legacy-blob migration verification", () => {
   beforeEach(() => {
     store.clear()
     importResults.length = 0
+    surveyResults.length = 0
     legacyBlob.readLegacyBlobBytes.mockReset()
-    legacyBlob.countLegacyRows.mockReset()
     legacyBlob.readLegacyBlobBytes.mockResolvedValue(
       Uint8Array.from([1, 2, 3, 4])
     )
-    legacyBlob.countLegacyRows.mockResolvedValue(sourceSurvey)
     vi.mocked(chrome.storage.local.get as never as ReturnType<typeof vi.fn>)
       .mockReset()
       .mockImplementation(async (key: string) =>

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -64,10 +64,25 @@ const sourceSurvey = {
   integrity: { integrityCheck: "ok", foreignKeyViolations: 0 }
 }
 
+/** Every durable table, since SCHEMA_SQL creates them all on open. Tables the
+ * source never had arrive empty, which is correct rather than data loss. */
+const importedTables = {
+  sessions: 2,
+  messages: 9,
+  prompt_templates: 7,
+  files: 0,
+  kv_store: 0,
+  tool_loop_runs: 0,
+  turn_runs: 0,
+  ingestion_runs: 0,
+  model_pull_runs: 0,
+  chunk_feedback: 0
+}
+
 const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => ({
   sessions: 2,
   messages: 9,
-  tables: { sessions: 2, messages: 9, prompt_templates: 7, turn_runs: 0 },
+  tables: importedTables,
   integrity: { integrityCheck: "ok", foreignKeyViolations: 0 },
   ...overrides
 })
@@ -132,19 +147,19 @@ describe("legacy-blob migration verification", () => {
     // not see: chats look complete while the user's templates are gone.
     importResults.push(
       importResult({
-        tables: { sessions: 2, messages: 9, prompt_templates: 6 }
+        tables: { ...importedTables, prompt_templates: 6 }
       })
     )
     const { ensureMigrated } = await loadHost()
 
     await expect(ensureMigrated()).rejects.toThrow(
-      "Migration verification failed: prompt_templates 6/7"
+      "Migration verification failed: prompt_templates short by 1"
     )
 
     expect(store.has(BACKEND_KEY)).toBe(false)
     expect(receipt()).toMatchObject({
       outcome: "failed",
-      failure: expect.stringContaining("prompt_templates 6/7"),
+      failure: expect.stringContaining("prompt_templates short by 1"),
       mismatches: [{ table: "prompt_templates", source: 7, imported: 6 }]
     })
   })
@@ -164,7 +179,7 @@ describe("legacy-blob migration verification", () => {
 
   it("counts attempts across boots", async () => {
     importResults.push(
-      importResult({ tables: { sessions: 2, messages: 8 } }),
+      importResult({ tables: { ...importedTables, messages: 8 } }),
       importResult()
     )
 

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -168,8 +168,21 @@ const initializeSchema = (db: Database): void => {
       db,
       "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
     ) > 0
+  // Every statement in SCHEMA_SQL is IF NOT EXISTS, so it runs on every open:
+  // on a fresh database it creates everything, and on an existing one it fills
+  // in whatever is absent.
+  //
+  // It used to run only when `sessions` was missing, which meant a table added
+  // to the schema without a paired migration never reached a profile that
+  // already had `sessions`. chunk_feedback arrived that way in 0.10.0, so
+  // profiles created on 0.6.0-0.9.x have been missing it since — the drift
+  // repair below only knows about tool_loop_runs and prompt_templates.
+  //
+  // The version stamp stays gated: only a database that did not exist a moment
+  // ago is at the latest schema by construction. Stamping an old one would skip
+  // the forward migrations it still needs.
+  db.exec(SCHEMA_SQL)
   if (!hasSessions) {
-    db.exec(SCHEMA_SQL)
     setSchemaVersion(compat, LATEST_SCHEMA_VERSION)
   }
   db.exec("PRAGMA foreign_keys=ON")

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -242,15 +242,23 @@ const verifyImportCandidate = async (
 ): Promise<IntegrityReport> => {
   pool.unlink(PROBE_PATH)
   await ensureFreeSlots(pool, 1)
-  await pool.importDb(PROBE_PATH, new Uint8Array(bytes))
-  const probe = new pool.OpfsSAHPoolDb(PROBE_PATH)
+  // Owns the scratch file's whole lifetime, including the failure paths. The
+  // caller's cleanup ran only after the rollback copy was staged, so a payload
+  // that imported but would not open left the scratch file linked and holding
+  // one of the pool's fixed slots.
   try {
-    // Read before any schema runner sees the file: migrations write, and
-    // writing into a corrupt database turns a rejectable import into a
-    // damaged one.
-    return integrity(probe)
+    await pool.importDb(PROBE_PATH, new Uint8Array(bytes))
+    const probe = new pool.OpfsSAHPoolDb(PROBE_PATH)
+    try {
+      // Read before any schema runner sees the file: migrations write, and
+      // writing into a corrupt database turns a rejectable import into a
+      // damaged one.
+      return integrity(probe)
+    } finally {
+      probe.close()
+    }
   } finally {
-    probe.close()
+    pool.unlink(PROBE_PATH)
   }
 }
 
@@ -360,19 +368,27 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
       // for the next one to trip over.
       pool.unlink(PROBE_PATH)
       await ensureFreeSlots(pool, 1)
-      await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
-      const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+      // The unlink covers the import and the open, not just the survey: a blob
+      // that imports but cannot be opened would otherwise keep the scratch file
+      // linked and hold a pool slot until some later op happened to clear it.
+      // The pool has a fixed capacity, so a leaked slot is a resource the next
+      // import has to grow the pool to replace.
       try {
-        // Nothing writes to this handle — no schema runner, no migrations. A
-        // source blob is evidence, and evidence that has been written to is
-        // no longer the thing that was measured.
-        return {
-          ...counts(source),
-          schemaVersion: queryNumber(source, "PRAGMA user_version"),
-          integrity: integrity(source)
-        } satisfies SurveyResult
+        await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
+        const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+        try {
+          // Nothing writes to this handle — no schema runner, no migrations. A
+          // source blob is evidence, and evidence that has been written to is
+          // no longer the thing that was measured.
+          return {
+            ...counts(source),
+            schemaVersion: queryNumber(source, "PRAGMA user_version"),
+            integrity: integrity(source)
+          } satisfies SurveyResult
+        } finally {
+          source.close()
+        }
       } finally {
-        source.close()
         pool.unlink(PROBE_PATH)
       }
     }
@@ -384,9 +400,10 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
       // whenever the payload turned out to be unusable: a rejected restore
       // reported failure over an already-destroyed database. Nothing touches
       // the live file until the incoming one is known to be sound.
+      // The scratch file is gone by the time this returns, whichever way it
+      // went — verifyImportCandidate owns it end to end.
       const report = await verifyImportCandidate(pool, request.bytes)
       if (!isSoundDatabase(report)) {
-        pool.unlink(PROBE_PATH)
         throw new Error(
           `Imported database failed integrity_check: ${report.integrityCheck}`
         )
@@ -426,8 +443,6 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
           })
         }
         throw error
-      } finally {
-        pool.unlink(PROBE_PATH)
       }
     }
     case "reset": {

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -31,7 +31,8 @@ import type {
   PersistenceOp,
   QueryRow,
   RunResult,
-  SqlValue
+  SqlValue,
+  SurveyResult
 } from "./protocol"
 import { asSqlJsDatabase } from "./sqljs-compat"
 
@@ -351,6 +352,29 @@ const execute = async (request: PersistenceOp): Promise<unknown> => {
         bytes.byteOffset,
         bytes.byteOffset + bytes.byteLength
       )
+    }
+    case "surveyDb": {
+      // Read-only measurement of a candidate database, on the same engine that
+      // will import it. The live database is not touched and the scratch file is
+      // unlinked before returning, so a survey that throws leaves nothing behind
+      // for the next one to trip over.
+      pool.unlink(PROBE_PATH)
+      await ensureFreeSlots(pool, 1)
+      await pool.importDb(PROBE_PATH, new Uint8Array(request.bytes))
+      const source = new pool.OpfsSAHPoolDb(PROBE_PATH)
+      try {
+        // Nothing writes to this handle — no schema runner, no migrations. A
+        // source blob is evidence, and evidence that has been written to is
+        // no longer the thing that was measured.
+        return {
+          ...counts(source),
+          schemaVersion: queryNumber(source, "PRAGMA user_version"),
+          integrity: integrity(source)
+        } satisfies SurveyResult
+      } finally {
+        source.close()
+        pool.unlink(PROBE_PATH)
+      }
     }
     case "importDb": {
       // Backup restore and legacy migration: replace the database wholesale.

--- a/src/lib/persistence/durable-tables.ts
+++ b/src/lib/persistence/durable-tables.ts
@@ -88,13 +88,43 @@ export const findTableCountMismatches = (
   return mismatches
 }
 
+/**
+ * Durable tables the destination is missing after an import.
+ *
+ * Count comparison cannot catch these: a table absent from the source is
+ * skipped, because forward migrations are expected to create it empty. That
+ * expectation is only as good as the migration set — `chunk_feedback` was added
+ * to the schema in 0.10.0 with no migration behind it, so a database that
+ * predates it stayed without the table and verification called that success.
+ *
+ * Checked against the destination's own table list rather than the source's, so
+ * the next table added without a migration fails the migration instead of
+ * shipping a profile that raises "no such table" at the first write.
+ */
+export const findMissingDurableTables = (
+  imported: TableCounts
+): DurableTable[] =>
+  DURABLE_TABLES.filter((table) => imported[table] === undefined)
+
+/**
+ * Describe a failed verification as shortfalls, not as count pairs.
+ *
+ * This text becomes the thrown error, which is stored as the receipt's `failure`
+ * and can be carried into a support report. `messages 39199/39204` would put
+ * history volume in that report; `messages short by 5` diagnoses the same defect
+ * without it. The absolute counts stay in the receipt's structured
+ * `sourceCounts`/`importedCounts`, which never leave the device.
+ */
 export const describeMismatches = (
   mismatches: readonly TableCountMismatch[]
 ): string =>
   mismatches
-    .map(
-      (mismatch) => `${mismatch.table} ${mismatch.imported}/${mismatch.source}`
-    )
+    .map((mismatch) => {
+      const delta = mismatch.source - mismatch.imported
+      return delta > 0
+        ? `${mismatch.table} short by ${delta}`
+        : `${mismatch.table} over by ${-delta}`
+    })
     .join(", ")
 
 export const readIntegrityReport = (read: RowReader): IntegrityReport => {

--- a/src/lib/persistence/durable-tables.ts
+++ b/src/lib/persistence/durable-tables.ts
@@ -115,17 +115,22 @@ export const findMissingDurableTables = (
  * without it. The absolute counts stay in the receipt's structured
  * `sourceCounts`/`importedCounts`, which never leave the device.
  */
+export const describeMismatch = (mismatch: TableCountMismatch): string => {
+  // A table that arrived empty has a shortfall equal to its source count, so
+  // "short by 39204" would be the absolute number this wording exists to avoid.
+  // Naming the state instead says more and discloses less.
+  if (mismatch.imported === 0 && mismatch.source > 0) {
+    return `${mismatch.table} arrived empty`
+  }
+  const delta = mismatch.source - mismatch.imported
+  return delta > 0
+    ? `${mismatch.table} short by ${delta}`
+    : `${mismatch.table} over by ${-delta}`
+}
+
 export const describeMismatches = (
   mismatches: readonly TableCountMismatch[]
-): string =>
-  mismatches
-    .map((mismatch) => {
-      const delta = mismatch.source - mismatch.imported
-      return delta > 0
-        ? `${mismatch.table} short by ${delta}`
-        : `${mismatch.table} over by ${-delta}`
-    })
-    .join(", ")
+): string => mismatches.map(describeMismatch).join(", ")
 
 export const readIntegrityReport = (read: RowReader): IntegrityReport => {
   const integrityRows = read("PRAGMA integrity_check")

--- a/src/lib/persistence/legacy-blob-reader.ts
+++ b/src/lib/persistence/legacy-blob-reader.ts
@@ -1,18 +1,12 @@
-import type { SqlJsStatic } from "sql.js"
-import initSqlJs from "sql.js/dist/sql-wasm.js"
 import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
-import {
-  countDurableTables,
-  type IntegrityReport,
-  readIntegrityReport,
-  type TableCounts,
-  tableExistsSql
-} from "./durable-tables"
 
-// Migration-time compatibility reader for the legacy sql.js IndexedDB blob.
-// Loaded lazily (dynamic import) so sql.js stays out of every startup chunk
-// once a profile has migrated. Also used by old-format backup import, which
-// carries a database.sqlite produced by sql.js.
+// Migration-time reader for the legacy IndexedDB blob. Loaded lazily so it
+// stays out of every startup chunk once a profile has migrated.
+//
+// This module holds no SQLite engine. The blob is a valid SQLite file, so the
+// database owner's worker surveys it through the `surveyDb` op on official
+// sqlite-wasm — the same engine that performs the import. Reading it here with
+// a second engine is what kept sql.js in the package for a read.
 
 export const readLegacyBlobBytes = async (): Promise<Uint8Array | null> =>
   new Promise((resolve, reject) => {
@@ -45,52 +39,3 @@ export const readLegacyBlobBytes = async (): Promise<Uint8Array | null> =>
       }
     }
   })
-
-export interface LegacySourceSurvey {
-  sessions: number
-  messages: number
-  /** Row counts for every durable table the source actually has. */
-  tables: TableCounts
-  /** `PRAGMA user_version` of the source blob — the migration receipt's
-   * record of which schema generation the data came from. */
-  schemaVersion: number
-  integrity: IntegrityReport
-}
-
-/** Open legacy bytes with sql.js and survey the rows that must survive the
- * physical import — the migration's verification source of truth. */
-export const countLegacyRows = async (
-  bytes: Uint8Array
-): Promise<LegacySourceSurvey> => {
-  const wasmUrl = chrome.runtime.getURL("assets/sql-wasm.wasm")
-  const response = await fetch(wasmUrl)
-  const wasmBinary = await response.arrayBuffer()
-  const SQL = await (
-    initSqlJs as unknown as (config: {
-      wasmBinary: Uint8Array
-    }) => Promise<SqlJsStatic>
-  )({ wasmBinary: new Uint8Array(wasmBinary) })
-
-  const db = new SQL.Database(bytes)
-  try {
-    const scalar = (sql: string): number => {
-      const result = db.exec(sql)
-      return Number(result[0]?.values?.[0]?.[0] ?? 0)
-    }
-    const rows = (sql: string): unknown[][] =>
-      (db.exec(sql)[0]?.values as unknown[][] | undefined) ?? []
-    const tables = countDurableTables(
-      scalar,
-      (table) => scalar(tableExistsSql(table)) > 0
-    )
-    return {
-      sessions: tables.sessions ?? 0,
-      messages: tables.messages ?? 0,
-      tables,
-      schemaVersion: scalar("PRAGMA user_version"),
-      integrity: readIntegrityReport(rows)
-    }
-  } finally {
-    db.close()
-  }
-}

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -12,7 +12,7 @@ import {
   isSoundDatabase,
   type TableCountMismatch
 } from "./durable-tables"
-import type { ImportResult } from "./protocol"
+import type { ImportResult, SurveyResult } from "./protocol"
 import {
   decodeBind,
   encodeRows,
@@ -184,9 +184,7 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
   if (backend === "opfs") return
 
   logger.info("Starting legacy-blob → OPFS migration", "Persistence")
-  const { readLegacyBlobBytes, countLegacyRows } = await import(
-    "./legacy-blob-reader"
-  )
+  const { readLegacyBlobBytes } = await import("./legacy-blob-reader")
   const bytes = await readLegacyBlobBytes()
 
   if (!bytes || bytes.byteLength === 0) {
@@ -198,11 +196,24 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
     return
   }
 
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer
+
   // Survey the source BEFORE the physical import — this is the verification
   // target, and it covers every durable table the blob has, not just the two
   // the chat list happens to read. The source blob itself is never modified or
   // deleted; it remains the rollback artifact.
-  const source = await countLegacyRows(bytes)
+  //
+  // Measured by the worker, on the engine that will import it. A separate
+  // reader could disagree with the importer about what the file contains, and
+  // then verification would be comparing two engines rather than checking a
+  // migration. It also means the blob is read by one SQLite, not two.
+  const source = (await callWorker({
+    op: "surveyDb",
+    bytes: buffer
+  })) as SurveyResult
   if (!isSoundDatabase(source.integrity)) {
     logger.warn(
       "Legacy blob failed integrity_check before import",
@@ -212,11 +223,6 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
       }
     )
   }
-  const buffer = bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength
-  ) as ArrayBuffer
-
   let imported: ImportResult | undefined
   let mismatches: TableCountMismatch[] = []
   try {

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -8,6 +8,7 @@ import {
 } from "./backend"
 import {
   describeMismatches,
+  findMissingDurableTables,
   findTableCountMismatches,
   isSoundDatabase,
   type TableCountMismatch
@@ -235,6 +236,17 @@ const migrateLegacyBlobOnce = async (): Promise<void> => {
     if (mismatches.length > 0) {
       throw new Error(
         `Migration verification failed: ${describeMismatches(mismatches)}`
+      )
+    }
+
+    // Row counts only prove that what the source had arrived. They say nothing
+    // about a durable table the destination is supposed to have and does not —
+    // that one is invisible to a comparison, because an absent source table is
+    // skipped on the assumption a forward migration creates it.
+    const missing = findMissingDurableTables(imported.tables)
+    if (missing.length > 0) {
+      throw new Error(
+        `Migration verification failed: imported database is missing ${missing.join(", ")}`
       )
     }
 

--- a/src/lib/persistence/protocol.ts
+++ b/src/lib/persistence/protocol.ts
@@ -23,6 +23,18 @@ export type PersistenceOp =
   | { op: "txRollback"; token: string }
   | { op: "exportDb" }
   | { op: "importDb"; bytes: ArrayBuffer }
+  /**
+   * Survey a candidate database without adopting it: row counts per durable
+   * table, `PRAGMA user_version`, and the integrity verdicts. Read-only, on a
+   * scratch file that is unlinked afterwards, so the live database and the
+   * source bytes are both untouched.
+   *
+   * This is how the legacy blob is measured before migration. It exists so the
+   * survey runs on the same engine as the import — sql.js read the blob for
+   * this, which meant carrying a second SQLite for a read that official
+   * sqlite-wasm performs natively.
+   */
+  | { op: "surveyDb"; bytes: ArrayBuffer }
   | { op: "counts" }
   | { op: "reset" }
   | { op: "ping" }
@@ -43,6 +55,12 @@ export interface CountsResult {
 
 export interface ImportResult extends CountsResult {
   integrity: IntegrityReport
+}
+
+/** What a source database says about itself before anything imports it. */
+export interface SurveyResult extends ImportResult {
+  /** `PRAGMA user_version` — which schema generation the data came from. */
+  schemaVersion: number
 }
 
 export interface PersistenceRpcRequest {

--- a/src/protocol/diagnostics-rpc.ts
+++ b/src/protocol/diagnostics-rpc.ts
@@ -89,7 +89,33 @@ export const DiagnosticsGetBundleResultSchema = z
         storage: z.object({
           backend: z.string(),
           messageCount: z.number().int().nonnegative(),
-          vectorCount: z.number().int().nonnegative()
+          vectorCount: z.number().int().nonnegative(),
+          /**
+           * Chat-history migration evidence, absent on a profile that never had
+           * a legacy blob. Counts and integrity verdicts only — no chat content,
+           * no table contents, nothing user-identifying. This is the only way
+           * receipt evidence leaves a device, and it leaves it because the
+           * reporter chose to send it.
+           */
+          migration: z
+            .object({
+              outcome: z.string(),
+              attempts: z.number().int().nonnegative(),
+              recordedAt: z.number().int().nonnegative(),
+              extensionVersion: z.string(),
+              sourceSchemaVersion: z.number().int().optional(),
+              sourceIntegrity: z.string().optional(),
+              importedIntegrity: z.string().optional(),
+              foreignKeyViolations: z.number().int().nonnegative().optional(),
+              /**
+               * One entry per table that did not arrive intact, as
+               * `table short by N`. A shortfall, never the row counts it was
+               * derived from — those describe how much history a person has.
+               */
+              mismatches: z.array(z.string()).optional(),
+              failure: z.string().optional()
+            })
+            .optional()
         }),
         events: z.array(DiagnosticEventSchema),
         selfTests: z.array(DiagnosticTestResultSchema)
@@ -118,6 +144,10 @@ export type DiagnosticsClearResult = z.infer<
   typeof DiagnosticsClearResultSchema
 >
 export type DiagnosticEvent = z.infer<typeof DiagnosticEventSchema>
+/** Migration evidence as it appears in a bundle — the schema is the contract. */
+export type DiagnosticStorageMigration = NonNullable<
+  DiagnosticsGetBundleResult["bundle"]
+>["storage"]["migration"]
 export type DiagnosticTestResult = z.infer<typeof DiagnosticTestResultSchema>
 
 declare module "./provider-rpc" {


### PR DESCRIPTION
**Stacked on #230** — branched from `persistence/sqlite-wasm-legacy-reader` so the worker changes don't collide. Merge #230 first; this then reduces to the items below.

## Why this exists

#229 landed fixes on the 0.12.6 line that `release/0.13.x` does not have. Checked each against the branch:

| Fix | On `release/0.13.x` before this PR |
|---|---|
| Receipt observability (`summarizeMigrationReceipt`) | missing |
| Schema applied on every open | missing |
| Destination-completeness guard (`findMissingDurableTables`) | missing |
| Shortfalls instead of row counts (`short by`) | missing |

Without this, **0.13.0 would ship the defects 0.12.6 fixed**: `chunk_feedback` still absent on profiles created before 0.10.0, and row counts still leaving the device in support reports. A forward-port gap, not new work — worth stating plainly, because nothing would have surfaced it until a user on 0.13.0 filed a report with their message counts in it.

## The fixes

1. **Receipt observability.** The receipt was device-local with no reader outside `src/lib/persistence`, so a profile that failed verification looked identical in a report to one that never migrated. The diagnostics bundle and issue draft now carry outcome, attempts, source schema version, integrity verdicts, orphan rows, per-table shortfalls, and failure text.
2. **Schema applied on every open.** `SCHEMA_SQL` ran only when `sessions` was absent, so a table added without a paired migration never reached a profile that already had chats — `chunk_feedback` arrived that way in 0.10.0. All 16 statements are `IF NOT EXISTS`, so it now runs unconditionally; the version stamp stays gated on a fresh database. Plus the destination-completeness guard, so the next such table fails the migration instead of shipping a profile that raises "no such table".
3. **Shortfalls instead of row counts.** Both the diagnostics summary and the verification error formatted absolute count pairs, and both reached a submitted report. Now `table short by N`; absolutes stay in the receipt's structured fields, which never leave the device.

## One extra commit, and why it is here

`pnpm bundle:check` failed on the forward-port: background gzip **193009 > 193000**, over by 9 bytes.

The cause was worth fixing rather than papering over. The background imported `getSafeClientEnvironment` from `error-report`, which pulled that entire module — issue templates, URL length budgeting, the privacy tail, every draft builder — into a chunk with a size budget and no use for any of it. Adding the migration summary to the draft was simply what tipped it.

The helper moves to `src/lib/client-environment.ts`; `error-report` re-exports it so existing importers are unchanged. Background gzip **193009 → 192540** — under budget *with* the new code, instead of raising the ceiling to fit it.

## Deliberate differences from the 0.12.6 commits

- **`DURABLE_TABLES` keeps all ten tables**, not the seven on that line. The guard and both fixtures were extended to `turn_runs`, `ingestion_runs`, `model_pull_runs`.
- **The changelog entry stays with 0.12.6**, the release that ships these to users.

## Gates

`typecheck`, `lint:check`, `format:check` ✅ · `test:run` ✅ 304 files, 2512 tests · `package` + `bundle:check` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This forward-port restores migration completeness and privacy safeguards from the 0.12.6 line.
- Applies the idempotent schema on every database open while preserving version-stamp semantics for existing profiles.
- Surveys and verifies legacy imports with sqlite-wasm, checks all durable destination tables, and guarantees scratch-file cleanup.
- Adds sanitized migration receipts to diagnostic bundles and issue drafts without exposing absolute history counts.
- Moves client-environment detection into a lightweight module to keep the background bundle within budget.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported legacy receipt-count disclosure is no longer present: absolute count fields are omitted, count-bearing legacy text is sanitized, and the diagnostics issue draft consumes only the reduced migration summary.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/diagnostics/diagnostics-service.ts | Adds a bounded migration-receipt summary that excludes structured counts and sanitizes legacy count-bearing text. |
| src/lib/error-report.ts | Includes sanitized migration evidence in diagnostic issue drafts and preserves the existing environment-helper export. |
| src/lib/persistence/chat-db-worker.ts | Applies the idempotent schema on every open, adds read-only source surveying, and centralizes scratch-file cleanup. |
| src/lib/persistence/owner-host.ts | Uses worker-based source surveys and rejects imports missing any required durable destination table. |
| src/lib/persistence/durable-tables.ts | Adds destination-completeness checks and privacy-preserving mismatch descriptions. |
| src/lib/persistence/protocol.ts | Extends the worker protocol with the typed read-only database survey operation. |
| src/protocol/diagnostics-rpc.ts | Extends the diagnostics contract with sanitized migration evidence. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Legacy[Legacy SQLite blob] --> Survey[Survey with sqlite-wasm]
  Survey --> Import[Import into OPFS scratch database]
  Import --> Verify[Verify integrity, row shortfalls, and durable tables]
  Verify -->|Pass| Adopt[Adopt OPFS database]
  Verify -->|Fail| Receipt[Persist failure receipt]
  Adopt --> Receipt
  Receipt --> Sanitize[Sanitize diagnostic summary]
  Sanitize --> Bundle[Support bundle and issue draft]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(diagnostics): treat persisted receip..."](https://github.com/shishir435/ollama-client/commit/cb2826b6bb230ac7bc8abfb033ad6f64203505cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48794687)</sub>

<!-- /greptile_comment -->