### PR TITLE
Correct the RAG path and the sql.js removal target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ Each feature owns its UI, hooks, and — if needed — its Zustand store.
 
 ### RAG / embeddings
 
-- Pipeline: `src/features/chat/rag/` (`rag-pipeline.ts`, `rag-retriever.ts`, `rag-prompt-builder.ts`, `query-classifier.ts`).
+- Pipeline: `src/application/context/rag/` (`rag-pipeline.ts`, `rag-retriever.ts`, `rag-prompt-builder.ts`, `query-classifier.ts`), driven by `src/application/context/build-context.ts`. It moved out of `src/features/chat/` when context building went to the background — a feature directory cannot own work the background performs.
 - **All** file, memory, and live-page splitting goes through `src/lib/embeddings/chunker.ts`. Do not build a parallel text splitter.
 - Plumbing: `src/lib/embeddings/` (`embedding-strategy.ts`, `embedder-factory.ts`, `hnsw-index.ts`, `keyword-index.ts`, `storage.ts`, `chunker.ts`, `search.ts`).
 - Embedding strategy chain: provider-native → shared model → Ollama fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,24 @@ Chat history is **SQLite-only** (SQLite-in-WASM). The Dexie chat-history fallbac
 - **Reasoning replay** — signed Anthropic thinking/redacted blocks and OpenRouter `reasoning_details` live in the versioned, size-capped `ChatMessage.replayArtifact`, separate from display-only `thinking`. Preserve block order and opaque values through SQLite and checkpoints, validate provider/model ownership before replay, and never render or log opaque contents.
 - **Sync vs local** — sync-safe settings use `chrome.storage.sync`; device-local keys are routed to `chrome.storage.local` by the wrapper.
 
+#### State ownership
+
+Four state systems hold live values. Each value has exactly one owner; the rest read it. Picking the wrong owner is how a value ends up written from two places with no rule for which wins.
+
+| System | Owns | Never holds |
+|---|---|---|
+| **SQLite** (`chat-history.ts` facade) | chats, sessions, messages, attachments, prompt templates, tool-loop checkpoints, durable job runs | anything a UI needs synchronously on first paint |
+| **Dexie / IndexedDB** (`lib/embeddings/`, `lib/knowledge/`) | vectors, HNSW and keyword indexes, knowledge sets, chunk feedback | anything SQLite already owns — chat rows never live in both |
+| **`chrome.storage`** via `plasmoGlobalStorage` | settings, provider config and mappings, capability overrides, approval grants, handoff flags, persistence markers and the migration receipt | bulk data, and anything large enough to matter against the sync quota |
+| **Zustand stores** | ephemeral UI state: selected tabs, input draft, stream progress, speech, search dialog | durable values, unless the store explicitly reads and writes through one of the systems above |
+
+Rules that follow from it:
+
+- **Every `chrome.storage` key needs a descriptor** in `src/lib/storage/storage-key-registry.ts` with its sync scope and a `reason`. `storage-key-registry.test.ts` asserts the registry and `STORAGE_KEYS` match exactly, so adding a key without one fails.
+- **Two stores are durable-backed and say so:** `stores/theme.ts` and `stores/shortcut-store.ts` read and write `plasmoGlobalStorage`. Every other store is ephemeral and its contents die with the page — do not add a durable value to one of them.
+- **`MESSAGE_KEYS` are not storage keys.** They name runtime ports and one-way events, hold nothing, and do not belong in the storage registry.
+- The background/application layer owns durable workflows; the UI submits intent. A durable value written directly from a component is a boundary violation even when it works.
+
 The persistence host (Chromium offscreen document / Firefox MV2 background page) owns the only chat-db worker. It reports worker `error` and `messageerror` events with their cause — keep it that way; a bare "worker crashed" hides the actual failure. Note that in dev the worker loads from the Vite dev server, which is why `worker-src` allows that origin during `serve` only (`config/__tests__/manifest-csp.test.ts` guards both halves).
 
 ### Feature modules (`src/features/`)
@@ -165,7 +183,7 @@ Each feature owns its UI, hooks, and — if needed — its Zustand store.
 
 | Feature | Contents |
 |---|---|
-| `chat/` | chat UI, `use-chat.ts`, RAG pipeline (`rag/`), speech store |
+| `chat/` | chat UI, `use-chat.ts`, speech store. **No `rag/`** — retrieval lives in `src/application/context/rag/` |
 | `sessions/` | session list + repository, `chat-session-store.ts` |
 | `model/` | model management UI, provider/embedding settings |
 | `file-upload/` | ingestion for RAG, per-format `processors/` |

--- a/compatibility-ledger.json
+++ b/compatibility-ledger.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-07-29",
+  "lastReviewed": "2026-07-31",
   "entries": [
     {
       "id": "legacy-sqljs-live-fallback",
@@ -10,8 +10,8 @@
         "0.6.0-0.12.2 sql.js profiles",
         "unmarked sql.js profiles"
       ],
-      "removalGate": "Migration fixtures pass in packaged Chrome and Firefox with per-table verification, integrity checks, and host loss during migration; a migration receipt and the operator rollback switch exist (both shipped); CI retains the evidence; and the fallback has completed its evidence window.",
-      "targetRelease": "0.13.x",
+      "removalGate": "Migration fixtures pass in packaged Chrome and Firefox with per-table verification, integrity checks, destination-completeness, and host loss during migration; a migration receipt, its diagnostics summary, and the operator rollback switch exist (all shipped in 0.12.6); CI retains the evidence; and the fallback has completed its evidence window, which opened 2026-07-31 and runs 2-3 months.",
+      "targetRelease": "0.14.x",
       "recoveryPath": "Keep a lazy migration-only reader and the untouched source blob so supported skipped upgrades from 0.6.0 onward remain recoverable, plus the persistence_legacy_override_v1 switch to serve history from the blob again. Pre-0.6.0 Dexie-only chat history is outside the direct-upgrade contract."
     },
     {
@@ -20,7 +20,7 @@
       "introducedIn": "0.12.3",
       "sourceVersions": ["0.12.3+"],
       "removalGate": "Remove with legacy-sqljs-live-fallback; no production writer may retain the old import-generation concept.",
-      "targetRelease": "0.13.x",
+      "targetRelease": "0.14.x",
       "recoveryPath": "Migration receipts and the single OPFS owner replace the guard."
     },
     {


### PR DESCRIPTION
Two documented statements that are now false. Small, but both are the kind a future reader would act on.

**`AGENTS.md` pointed the RAG pipeline at `src/features/chat/rag/`.** It lives at `src/application/context/rag/` — it moved when context building went to the background, because a feature directory cannot own work the background performs. Noticed while working on #228, when the documented path did not exist.

**`compatibility-ledger.json` targeted `0.13.x` for retiring the live sql.js fallback.** That target predates the evidence window having a start date. The window opened when 0.12.6 shipped today and runs 2–3 months, so it cannot close inside 0.13.x. Both sql.js entries now target `0.14.x`.

The removal gate text also now names what actually shipped — destination-completeness verification, and the diagnostics summary that makes receipts readable — plus the window's start date, so nobody has to reconstruct when the clock started.

No code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects repository guidance and compatibility-planning metadata.
- Updates `AGENTS.md` to consistently locate and assign ownership of the RAG pipeline under `src/application/context/rag/`.
- Moves both sql.js retirement targets to `0.14.x` and clarifies the evidence-window and removal-gate criteria.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Corrects the RAG pipeline path and resolves the previously reported contradictory ownership guidance. |
| compatibility-ledger.json | Defers both related sql.js removal targets and expands the documented removal gate and evidence window. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: name the state owner for every dur..."](https://github.com/shishir435/ollama-client/commit/001cc514c67184fd376e4a60af1259cedc08aadf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48809892)</sub>

<!-- /greptile_comment -->