### PR TITLE
Fix/provider health request storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - A provider running on model IDs you declared is labelled as such rather than
   reported as a failed connection.
 - Editing a provider's base URL no longer runs a connection test on every
-  keystroke. Typing one URL fired one test per character, each against the
-  half-typed value — on a hosted provider, a real API call per keypress. Edits
-  now settle first, and a re-render that changes nothing about where a provider
-  points costs nothing at all.
+  keystroke. Typing one URL fired one test per character — on a hosted
+  provider, a real API call per keypress — and none of them told you anything,
+  because the check reads saved configuration and you were still typing. The
+  check now runs when a change is saved, and the status you see after saving
+  describes the endpoint you just saved rather than the one before it.
 - A support report from a provider that publishes no model list no longer says
   "Provider reachable: no". It is reachable; it just has nothing to discover,
   and the old wording sent whoever read the report after the wrong thing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   provider still re-checks it immediately.
 - A provider running on model IDs you declared is labelled as such rather than
   reported as a failed connection.
+- Editing a provider's base URL no longer runs a connection test on every
+  keystroke. Typing one URL fired one test per character, each against the
+  half-typed value — on a hosted provider, a real API call per keypress. Edits
+  now settle first, and a re-render that changes nothing about where a provider
+  points costs nothing at all.
+- A support report from a provider that publishes no model list no longer says
+  "Provider reachable: no". It is reachable; it just has nothing to discover,
+  and the old wording sent whoever read the report after the wrong thing.
 
 ## [0.12.7]
 

--- a/src/features/chat/components/chat-error-report-action.tsx
+++ b/src/features/chat/components/chat-error-report-action.tsx
@@ -19,6 +19,7 @@ import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 import type { DiagnosticsGetBundleResult } from "@/protocol/diagnostics-rpc"
 import { extensionRpcClient } from "@/protocol/extension-client"
+import { MODEL_DISCOVERY_FAILURE } from "@/protocol/provider-rpc"
 import { RpcMethod } from "@/protocol/rpc"
 import type { ChatMessage } from "@/types"
 
@@ -170,7 +171,14 @@ export const ChatErrorReportAction = ({
             }
           )
           checks.latencyMs = Math.max(0, performance.now() - startedAt)
-          checks.providerReachable = result.failures.length === 0
+          // An endpoint that publishes no model list is reachable — it just has
+          // nothing to discover. Counting that as unreachable puts "Provider
+          // reachable: no" in a report from a provider that answers chat fine,
+          // which sends whoever reads it after the wrong thing.
+          checks.providerReachable = result.failures.every(
+            ({ code }) =>
+              code === MODEL_DISCOVERY_FAILURE.MODEL_LIST_UNSUPPORTED
+          )
           if (msg.error?.model) {
             checks.selectedModelFound = result.models.some(
               (model) =>

--- a/src/features/model/hooks/__tests__/use-provider-health.test.ts
+++ b/src/features/model/hooks/__tests__/use-provider-health.test.ts
@@ -86,6 +86,28 @@ describe("useProviderHealth — initial check (real timers)", () => {
     expect(result.current[ProviderId.OLLAMA].success).toBe(false)
   })
 
+  it("does not re-check when a render changes nothing it depends on", async () => {
+    mockedCall.mockResolvedValue({ modelCount: 1 } as never)
+    const provider = mkProvider(ProviderId.OLLAMA, true)
+    const { rerender, result } = renderHook(
+      // A fresh array every render, which is exactly what the settings screen
+      // produces: `updateConfig` maps over state on each keystroke.
+      ({ name }) => useProviderHealth([{ ...provider, name }]),
+      { initialProps: { name: "Ollama" } }
+    )
+    await waitFor(() => expect(result.current[ProviderId.OLLAMA]).toBeDefined())
+    const afterMount = mockedCall.mock.calls.length
+
+    for (const name of ["O", "Ol", "Oll", "Olla", "Ollam", "Ollama!"]) {
+      rerender({ name })
+    }
+
+    // Renaming a provider cannot change whether it is reachable, and neither
+    // can a re-render on its own. Typing one base URL used to fire one
+    // connection test per character.
+    expect(mockedCall.mock.calls.length).toBe(afterMount)
+  })
+
   it("carries whether the provider publishes a catalog", async () => {
     mockedCall.mockResolvedValue({
       modelCount: 2,
@@ -183,6 +205,29 @@ describe("useProviderHealth — interval + cleanup (fake timers)", () => {
 
     await vi.advanceTimersByTimeAsync(30_000)
     expect(mockedCall.mock.calls.length).toBeGreaterThan(initialCalls)
+  })
+
+  it("collapses a burst of base-URL edits into one check", async () => {
+    mockedCall.mockResolvedValue({ modelCount: 1 } as never)
+    const provider = mkProvider(ProviderId.OLLAMA, true)
+    const { rerender } = renderHook(
+      ({ baseUrl }) => useProviderHealth([{ ...provider, baseUrl }]),
+      { initialProps: { baseUrl: "https" } }
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    const afterMount = mockedCall.mock.calls.length
+
+    const url = "https://api.example.test/v1"
+    for (let end = 6; end <= url.length; end += 1) {
+      rerender({ baseUrl: url.slice(0, end) })
+      await vi.advanceTimersByTimeAsync(40)
+    }
+    // Mid-typing: every keystroke restarted the settle window, so nothing has
+    // been spent yet.
+    expect(mockedCall.mock.calls.length).toBe(afterMount)
+
+    await vi.advanceTimersByTimeAsync(700)
+    expect(mockedCall.mock.calls.length).toBe(afterMount + 1)
   })
 
   it("clears the interval on unmount", async () => {

--- a/src/features/model/hooks/__tests__/use-provider-health.test.ts
+++ b/src/features/model/hooks/__tests__/use-provider-health.test.ts
@@ -86,26 +86,46 @@ describe("useProviderHealth — initial check (real timers)", () => {
     expect(result.current[ProviderId.OLLAMA].success).toBe(false)
   })
 
-  it("does not re-check when a render changes nothing it depends on", async () => {
+  it("spends nothing while a provider's endpoint is being typed", async () => {
     mockedCall.mockResolvedValue({ modelCount: 1 } as never)
     const provider = mkProvider(ProviderId.OLLAMA, true)
     const { rerender, result } = renderHook(
       // A fresh array every render, which is exactly what the settings screen
       // produces: `updateConfig` maps over state on each keystroke.
-      ({ name }) => useProviderHealth([{ ...provider, name }]),
-      { initialProps: { name: "Ollama" } }
+      ({ baseUrl }) => useProviderHealth([{ ...provider, baseUrl }], 0),
+      { initialProps: { baseUrl: "h" } }
     )
     await waitFor(() => expect(result.current[ProviderId.OLLAMA]).toBeDefined())
     const afterMount = mockedCall.mock.calls.length
 
-    for (const name of ["O", "Ol", "Oll", "Olla", "Ollam", "Ollama!"]) {
-      rerender({ name })
+    const url = "https://api.example.test/v1"
+    for (let end = 1; end <= url.length; end += 1) {
+      rerender({ baseUrl: url.slice(0, end) })
     }
 
-    // Renaming a provider cannot change whether it is reachable, and neither
-    // can a re-render on its own. Typing one base URL used to fire one
-    // connection test per character.
+    // A draft URL is not the one this check contacts — it tests stored config —
+    // so typing describes an endpoint it would not reach either way. Every one
+    // of these keystrokes used to cost a connection test.
     expect(mockedCall.mock.calls.length).toBe(afterMount)
+  })
+
+  it("re-checks as soon as the edited endpoint is saved", async () => {
+    mockedCall.mockResolvedValue({ modelCount: 1 } as never)
+    const providers = [mkProvider(ProviderId.OLLAMA, true)]
+    const { rerender, result } = renderHook(
+      ({ revision }) => useProviderHealth(providers, revision),
+      { initialProps: { revision: 0 } }
+    )
+    await waitFor(() => expect(result.current[ProviderId.OLLAMA]).toBeDefined())
+    const afterMount = mockedCall.mock.calls.length
+
+    // The save landed: whatever the previous answer described, it is not this
+    // endpoint any more.
+    rerender({ revision: 1 })
+
+    await waitFor(() =>
+      expect(mockedCall.mock.calls.length).toBe(afterMount + 1)
+    )
   })
 
   it("carries whether the provider publishes a catalog", async () => {
@@ -205,29 +225,6 @@ describe("useProviderHealth — interval + cleanup (fake timers)", () => {
 
     await vi.advanceTimersByTimeAsync(30_000)
     expect(mockedCall.mock.calls.length).toBeGreaterThan(initialCalls)
-  })
-
-  it("collapses a burst of base-URL edits into one check", async () => {
-    mockedCall.mockResolvedValue({ modelCount: 1 } as never)
-    const provider = mkProvider(ProviderId.OLLAMA, true)
-    const { rerender } = renderHook(
-      ({ baseUrl }) => useProviderHealth([{ ...provider, baseUrl }]),
-      { initialProps: { baseUrl: "https" } }
-    )
-    await vi.advanceTimersByTimeAsync(0)
-    const afterMount = mockedCall.mock.calls.length
-
-    const url = "https://api.example.test/v1"
-    for (let end = 6; end <= url.length; end += 1) {
-      rerender({ baseUrl: url.slice(0, end) })
-      await vi.advanceTimersByTimeAsync(40)
-    }
-    // Mid-typing: every keystroke restarted the settle window, so nothing has
-    // been spent yet.
-    expect(mockedCall.mock.calls.length).toBe(afterMount)
-
-    await vi.advanceTimersByTimeAsync(700)
-    expect(mockedCall.mock.calls.length).toBe(afterMount + 1)
   })
 
   it("clears the interval on unmount", async () => {

--- a/src/features/model/hooks/use-provider-health.ts
+++ b/src/features/model/hooks/use-provider-health.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import type { ProviderConfig } from "@/lib/providers/types"
 import { extensionRpcClient } from "@/protocol/extension-client"
@@ -23,11 +23,47 @@ export type ProviderHealthMap = Record<string, ProviderHealthEntry>
  * This runs against every enabled provider for as long as the settings screen
  * is open, and half of them are somebody's metered hosted endpoint. Ten seconds
  * bought a freshness nobody asked for at six requests a minute per provider,
- * forever. Config edits re-run the check immediately anyway — the effect
- * depends on `providers` — and the Test button covers deliberate checks, so the
- * heartbeat only has to catch a provider that dies while you watch.
+ * forever. A saved config change still re-checks straight away, and the Test
+ * button covers deliberate checks, so the heartbeat only has to catch a
+ * provider that dies while you watch.
  */
 const HEALTH_CHECK_INTERVAL_MS = 60_000
+
+/*
+ * How long a config change is left to settle before it is checked.
+ *
+ * Every keystroke in the base-URL field produces a new `providers` array, and
+ * this effect used to key on that array's identity — so typing one URL fired
+ * one connection test per character, each against whatever partial value was
+ * in the box. On a hosted provider that is a real API call per keypress.
+ */
+const CONFIG_SETTLE_MS = 700
+
+/**
+ * Field separator inside a signature row. Deliberately a character no provider
+ * id, URL, wire, or profile can contain, so splitting a row back apart cannot
+ * be confused by a value that happens to hold the separator.
+ */
+const FIELD = "\u001f"
+
+/**
+ * What actually decides the answer: which providers exist, which are on, and
+ * where they point. Everything else about a provider — its name, its declared
+ * model ids, an API key being retyped — cannot change whether it is reachable,
+ * so it must not cost a request.
+ */
+const healthSignature = (providers: ProviderConfig[]): string =>
+  providers
+    .filter((provider) => provider.enabled)
+    .map((provider) =>
+      [
+        String(provider.id),
+        provider.baseUrl ?? "",
+        String(provider.type),
+        provider.serviceProfile ?? ""
+      ].join(FIELD)
+    )
+    .join("\n")
 
 /**
  * Poll every enabled provider through the provider connection RPC. A provider
@@ -42,20 +78,34 @@ export const useProviderHealth = (
   providers: ProviderConfig[]
 ): ProviderHealthMap => {
   const [health, setHealth] = useState<ProviderHealthMap>({})
+  const signature = healthSignature(providers)
+  // A stable list for as long as the signature is: the string is rebuilt on
+  // every render but is equal across renders that changed nothing this hook
+  // cares about, so the effect below does not restart on each keystroke.
+  const targets = useMemo(
+    () =>
+      signature
+        ? signature.split("\n").map((row) => row.split(FIELD)[0])
+        : ([] as string[]),
+    [signature]
+  )
+  // The first run is the settings screen opening and should not sit behind the
+  // settle delay; later runs are edits, and those should.
+  const hasRun = useRef(false)
 
   useEffect(() => {
     let cancelled = false
 
-    const checkOne = async (provider: ProviderConfig) => {
+    const checkOne = async (providerId: string) => {
       try {
         const result = await extensionRpcClient.call(
           RpcMethod.ProvidersTestConnection,
-          { target: "stored", providerId: String(provider.id) }
+          { target: "stored", providerId }
         )
         if (cancelled) return
         setHealth((prev) => ({
           ...prev,
-          [provider.id]: {
+          [providerId]: {
             success: result.modelCount > 0,
             modelListSupported: result.modelListSupported,
             lastChecked: Date.now()
@@ -65,7 +115,7 @@ export const useProviderHealth = (
         if (cancelled) return
         setHealth((prev) => ({
           ...prev,
-          [provider.id]: {
+          [providerId]: {
             success: false,
             modelListSupported: true,
             lastChecked: Date.now()
@@ -76,13 +126,13 @@ export const useProviderHealth = (
 
     const checkAll = async () => {
       if (typeof document !== "undefined" && document.hidden) return
-      for (const provider of providers) {
-        if (!provider.enabled) continue
-        await checkOne(provider)
+      for (const providerId of targets) {
+        await checkOne(providerId)
       }
     }
 
-    checkAll()
+    const settle = setTimeout(checkAll, hasRun.current ? CONFIG_SETTLE_MS : 0)
+    hasRun.current = true
     const interval = setInterval(checkAll, HEALTH_CHECK_INTERVAL_MS)
     const onVisibilityChange = () => {
       if (!document.hidden) checkAll()
@@ -91,10 +141,11 @@ export const useProviderHealth = (
 
     return () => {
       cancelled = true
+      clearTimeout(settle)
       clearInterval(interval)
       document.removeEventListener("visibilitychange", onVisibilityChange)
     }
-  }, [providers])
+  }, [targets])
 
   return health
 }

--- a/src/features/model/hooks/use-provider-health.ts
+++ b/src/features/model/hooks/use-provider-health.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import type { ProviderConfig } from "@/lib/providers/types"
 import { extensionRpcClient } from "@/protocol/extension-client"
@@ -29,41 +29,30 @@ export type ProviderHealthMap = Record<string, ProviderHealthEntry>
  */
 const HEALTH_CHECK_INTERVAL_MS = 60_000
 
-/*
- * How long a config change is left to settle before it is checked.
+/**
+ * Which providers this check has anything to say about.
  *
- * Every keystroke in the base-URL field produces a new `providers` array, and
- * this effect used to key on that array's identity — so typing one URL fired
- * one connection test per character, each against whatever partial value was
- * in the box. On a hosted provider that is a real API call per keypress.
+ * Not where they point: the check tests *stored* config, so a base URL the
+ * user is still typing describes an endpoint it will not contact. Keying on
+ * the draft is what made typing one URL fire one connection test per
+ * character — and a debounce only hid that, because the check still ran
+ * against the old stored value and then never re-ran once the save landed.
+ * `savedRevision` is the signal for "the stored endpoint changed"; this is the
+ * signal for "the set of providers changed".
  */
-const CONFIG_SETTLE_MS = 700
-
-/**
- * Field separator inside a signature row. Deliberately a character no provider
- * id, URL, wire, or profile can contain, so splitting a row back apart cannot
- * be confused by a value that happens to hold the separator.
- */
-const FIELD = "\u001f"
-
-/**
- * What actually decides the answer: which providers exist, which are on, and
- * where they point. Everything else about a provider — its name, its declared
- * model ids, an API key being retyped — cannot change whether it is reachable,
- * so it must not cost a request.
- */
-const healthSignature = (providers: ProviderConfig[]): string =>
-  providers
-    .filter((provider) => provider.enabled)
-    .map((provider) =>
-      [
-        String(provider.id),
-        provider.baseUrl ?? "",
-        String(provider.type),
-        provider.serviceProfile ?? ""
-      ].join(FIELD)
-    )
-    .join("\n")
+const healthSignature = (
+  providers: ProviderConfig[],
+  savedRevision: number
+): string =>
+  [
+    // The revision rides along as the first row so a save rebuilds the list:
+    // the same providers now point somewhere else, and the answers already on
+    // screen describe the endpoint they used to have.
+    String(savedRevision),
+    ...providers
+      .filter((provider) => provider.enabled)
+      .map((provider) => String(provider.id))
+  ].join("\n")
 
 /**
  * Poll every enabled provider through the provider connection RPC. A provider
@@ -75,23 +64,15 @@ const healthSignature = (providers: ProviderConfig[]): string =>
  * a settings tab left open in a window nobody is looking at costs nothing.
  */
 export const useProviderHealth = (
-  providers: ProviderConfig[]
+  providers: ProviderConfig[],
+  savedRevision = 0
 ): ProviderHealthMap => {
   const [health, setHealth] = useState<ProviderHealthMap>({})
-  const signature = healthSignature(providers)
+  const signature = healthSignature(providers, savedRevision)
   // A stable list for as long as the signature is: the string is rebuilt on
   // every render but is equal across renders that changed nothing this hook
   // cares about, so the effect below does not restart on each keystroke.
-  const targets = useMemo(
-    () =>
-      signature
-        ? signature.split("\n").map((row) => row.split(FIELD)[0])
-        : ([] as string[]),
-    [signature]
-  )
-  // The first run is the settings screen opening and should not sit behind the
-  // settle delay; later runs are edits, and those should.
-  const hasRun = useRef(false)
+  const targets = useMemo(() => signature.split("\n").slice(1), [signature])
 
   useEffect(() => {
     let cancelled = false
@@ -124,15 +105,23 @@ export const useProviderHealth = (
       }
     }
 
+    // Returning to a visible page and the interval can land together; without
+    // this the same sweep runs twice, concurrently, against every provider.
+    let running = false
     const checkAll = async () => {
+      if (running) return
       if (typeof document !== "undefined" && document.hidden) return
-      for (const providerId of targets) {
-        await checkOne(providerId)
+      running = true
+      try {
+        for (const providerId of targets) {
+          await checkOne(providerId)
+        }
+      } finally {
+        running = false
       }
     }
 
-    const settle = setTimeout(checkAll, hasRun.current ? CONFIG_SETTLE_MS : 0)
-    hasRun.current = true
+    checkAll()
     const interval = setInterval(checkAll, HEALTH_CHECK_INTERVAL_MS)
     const onVisibilityChange = () => {
       if (!document.hidden) checkAll()
@@ -141,7 +130,6 @@ export const useProviderHealth = (
 
     return () => {
       cancelled = true
-      clearTimeout(settle)
       clearInterval(interval)
       document.removeEventListener("visibilitychange", onVisibilityChange)
     }

--- a/src/features/model/hooks/use-provider-models.ts
+++ b/src/features/model/hooks/use-provider-models.ts
@@ -24,7 +24,10 @@ import {
 } from "@/lib/providers/types"
 import { queryKeys } from "@/lib/query-keys"
 import { extensionRpcClient } from "@/protocol/extension-client"
-import type { ProvidersListModelsResult } from "@/protocol/provider-rpc"
+import {
+  MODEL_DISCOVERY_FAILURE,
+  type ProvidersListModelsResult
+} from "@/protocol/provider-rpc"
 import { RpcMethod } from "@/protocol/rpc"
 import type { SelectedModelRef } from "@/types"
 import { isEmbeddingModel } from "../lib/model-utils"
@@ -143,7 +146,7 @@ export const useProviderModels = () => {
    * given.
    */
   const unavailableProviders = (modelList?.failures ?? EMPTY_FAILURES).filter(
-    (failure) => failure.code !== "discovery_unavailable"
+    (failure) => failure.code !== MODEL_DISCOVERY_FAILURE.DISCOVERY_UNAVAILABLE
   )
 
   const selectedModelData = models.find((m) => m.name === selectedModel)

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -82,8 +82,16 @@ export const useProviderSettingsState = () => {
   // Incremented synchronously for every local edit. An RPC response may update
   // local state only when the provider still has the revision it started with.
   const configRevisions = useRef(new Map<string, number>())
+  /*
+   * Bumped whenever stored provider config actually changes. The health check
+   * tests what is *stored*, so a draft the user is still typing tells it
+   * nothing — but the moment a save lands, the endpoint it would reach is a
+   * different one and the previous answer is about somewhere else.
+   */
+  const [savedRevision, setSavedRevision] = useState(0)
+  const markSaved = useCallback(() => setSavedRevision((n) => n + 1), [])
 
-  const providerHealth = useProviderHealth(providers)
+  const providerHealth = useProviderHealth(providers, savedRevision)
 
   const loadProviders = useCallback(async () => {
     setLoading(true)
@@ -314,6 +322,9 @@ export const useProviderSettingsState = () => {
           return next
         })
         setHasUnsavedChanges(false)
+        // The stored endpoint may now be somewhere else, so the health entry
+        // describing the previous one is out of date as of this line.
+        markSaved()
         if (showSuccessToast) {
           toast({
             title: t("settings.saved"),
@@ -339,7 +350,7 @@ export const useProviderSettingsState = () => {
         return false
       }
     },
-    [configForRpc, t]
+    [configForRpc, markSaved, t]
   )
 
   const setSelectedId = useCallback(
@@ -389,6 +400,7 @@ export const useProviderSettingsState = () => {
         toSettingsConfig(config)
       ])
       setSelectedIdState(String(config.id))
+      markSaved()
       toast({
         title: t("settings.providers.add.added_title"),
         description: t("settings.providers.add.added_description", {
@@ -425,6 +437,7 @@ export const useProviderSettingsState = () => {
         current.filter((provider) => String(provider.id) !== id)
       )
       if (selectedId === id) setSelectedIdState(DEFAULT_PROVIDER_ID)
+      markSaved()
       toast({
         title: t("settings.providers.add.removed_title"),
         description: t("settings.providers.add.removed_description", {
@@ -482,6 +495,7 @@ export const useProviderSettingsState = () => {
         target: "existing",
         config: configForRpc(updated)
       })
+      markSaved()
     } catch (error) {
       logger.error("Failed to auto-save toggle", "ProviderSettings", { error })
     }

--- a/src/lib/providers/provider-rpc-service.ts
+++ b/src/lib/providers/provider-rpc-service.ts
@@ -1,19 +1,20 @@
 import { createAppError, isAbortError, isAppError } from "@/lib/error-utils"
-import type {
-  ProvidersListModelsRequest,
-  ProvidersListModelsResult,
-  ProvidersListResult,
-  ProvidersProbeModelCapabilitiesRequest,
-  ProvidersProbeModelCapabilitiesResult,
-  ProvidersRemoveRequest,
-  ProvidersRemoveResult,
-  ProvidersSetEnabledRequest,
-  ProvidersSetEnabledResult,
-  ProvidersUpsertRequest,
-  ProvidersUpsertResult,
-  ProviderTestConnectionRequest,
-  ProviderTestConnectionResult,
-  PublicProviderConfig
+import {
+  MODEL_DISCOVERY_FAILURE,
+  type ProvidersListModelsRequest,
+  type ProvidersListModelsResult,
+  type ProvidersListResult,
+  type ProvidersProbeModelCapabilitiesRequest,
+  type ProvidersProbeModelCapabilitiesResult,
+  type ProvidersRemoveRequest,
+  type ProvidersRemoveResult,
+  type ProvidersSetEnabledRequest,
+  type ProvidersSetEnabledResult,
+  type ProvidersUpsertRequest,
+  type ProvidersUpsertResult,
+  type ProviderTestConnectionRequest,
+  type ProviderTestConnectionResult,
+  type PublicProviderConfig
 } from "@/protocol/provider-rpc"
 import type { ProviderModel } from "@/types/model"
 
@@ -421,14 +422,18 @@ export const ProviderRpcService = {
             code
           })
         if (catalog === "failed") {
-          report(merged.length > 0 ? "discovery_unavailable" : "request_failed")
+          report(
+            merged.length > 0
+              ? MODEL_DISCOVERY_FAILURE.DISCOVERY_UNAVAILABLE
+              : MODEL_DISCOVERY_FAILURE.REQUEST_FAILED
+          )
           return
         }
         // A catalog-less provider carrying its own declared ids is a normal,
         // working setup. It is only worth reporting when it has none, because
         // then it contributes nothing and the user has to add some.
         if (catalog === "absent" && merged.length === 0) {
-          report("model_list_unsupported")
+          report(MODEL_DISCOVERY_FAILURE.MODEL_LIST_UNSUPPORTED)
         }
       })
     )
@@ -440,7 +445,7 @@ export const ProviderRpcService = {
      * network error, which is neither true nor actionable.
      */
     const hardFailures = failures.filter(
-      ({ code }) => code !== "model_list_unsupported"
+      ({ code }) => code !== MODEL_DISCOVERY_FAILURE.MODEL_LIST_UNSUPPORTED
     )
     if (
       models.length === 0 &&

--- a/src/protocol/provider-rpc.ts
+++ b/src/protocol/provider-rpc.ts
@@ -212,6 +212,26 @@ export const ProviderTestConnectionResultSchema = z
   })
   .strict()
 
+/**
+ * Why a provider contributed nothing to a model list. Three different things,
+ * and callers act on the difference: only the first two mean something went
+ * wrong, and only the first means the provider has no usable models at all.
+ *
+ * Named here rather than spelled out at each call site — they cross the RPC
+ * boundary, so a typo on one side is a silent behaviour change on the other.
+ */
+export const MODEL_DISCOVERY_FAILURE = {
+  /** Discovery failed and nothing covered for it. */
+  REQUEST_FAILED: "request_failed",
+  /** Discovery failed, but the provider's declared model ids carried the list. */
+  DISCOVERY_UNAVAILABLE: "discovery_unavailable",
+  /** The endpoint publishes no catalog and no model ids were declared. */
+  MODEL_LIST_UNSUPPORTED: "model_list_unsupported"
+} as const
+
+export type ModelDiscoveryFailureCode =
+  (typeof MODEL_DISCOVERY_FAILURE)[keyof typeof MODEL_DISCOVERY_FAILURE]
+
 export const ProvidersListModelsRequestSchema = z
   .object({
     providerId: z.string().min(1).max(200).optional(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents provider health requests from restarting on every draft edit and explicitly refreshes health after persisted configuration changes.
- Keys health polling to enabled provider IDs and a saved-configuration revision.
- Prevents concurrent interval and visibility-triggered health sweeps.
- Centralizes model-discovery failure codes across the RPC boundary.
- Correctly distinguishes catalog-less providers from unreachable providers in support reports.
- Adds regression coverage for draft editing and post-save health checks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defects identified.

The saved-revision signal refreshes health only after persistence, old effect instances reject late state writes, and the updated diagnostic reachability classification matches the provider RPC result semantics.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/model/hooks/use-provider-health.ts | Replaces provider-array identity triggering with a stable enabled-provider signature and saved revision, while serializing health sweeps. |
| src/features/model/hooks/use-provider-settings-state.ts | Tracks successful provider persistence operations and uses that revision to refresh stored-config health. |
| src/features/chat/components/chat-error-report-action.tsx | Treats a provider that explicitly lacks model-list support as reachable in generated support diagnostics. |
| src/lib/providers/provider-rpc-service.ts | Replaces repeated model-discovery failure literals with the shared protocol constants without changing service behavior. |
| src/protocol/provider-rpc.ts | Defines shared model-discovery failure constants and derives their TypeScript union. |
| src/features/model/hooks/__tests__/use-provider-health.test.ts | Adds regression tests proving draft edits do not trigger checks and successful saves do. |
| src/features/model/hooks/use-provider-models.ts | Uses the centralized discovery-unavailable constant when filtering provider failures. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant S as Provider settings
  participant H as Health hook
  participant RPC as Background provider RPC
  participant P as Stored provider endpoint

  U->>S: Edit draft base URL
  S->>H: Render with unchanged savedRevision
  Note over H: No new health sweep

  U->>S: Save configuration
  S->>RPC: providers.upsert
  RPC-->>S: Persisted configuration
  S->>H: Increment savedRevision
  H->>RPC: "providers.testConnection(target=stored)"
  RPC->>P: Test saved endpoint
  P-->>RPC: Discovery result
  RPC-->>H: Health result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(providers): check health when a save..."](https://github.com/shishir435/ollama-client/commit/d6ad907ed3e31f1ad1fc5c8d8966654030210294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51430608)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)
- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [Diagnostics and Error Reporting](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/diagnostics-error-reporting.md)
</details>

<!-- /greptile_comment -->