### PR TITLE
refactor(storage): type web search settings

### DIFF
--- a/src/features/web-search/stores/web-search-config-store.ts
+++ b/src/features/web-search/stores/web-search-config-store.ts
@@ -1,19 +1,12 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback } from "react"
-import { STORAGE_KEYS } from "@/lib/constants"
-import { getPlasmoStorageForKey } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 import {
-  DEFAULT_WEB_SEARCH_CONFIG,
   getWebSearchConfig,
   normalizeWebSearchConfig,
   setWebSearchConfig,
   type WebSearchProviderConfig
 } from "@/lib/tools/web-search"
-
-const webSearchStorage = getPlasmoStorageForKey(STORAGE_KEYS.WEB_SEARCH.CONFIG)
-const webSearchActiveStorage = getPlasmoStorageForKey(
-  STORAGE_KEYS.WEB_SEARCH.ACTIVE
-)
 
 /**
  * Per-device "use web search in this chat" flag. Separate from
@@ -21,24 +14,12 @@ const webSearchActiveStorage = getPlasmoStorageForKey(
  * toggle doesn't silently flip the settings switch.
  */
 export const useWebSearchActive = () => {
-  const [active, setActive] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.WEB_SEARCH.ACTIVE,
-      instance: webSearchActiveStorage
-    },
-    true
-  )
-  return { active: active !== false, setActive }
+  const [active, setActive] = useSetting(SETTINGS.WEB_SEARCH_ACTIVE)
+  return { active, setActive }
 }
 
 export const useWebSearchConfig = () => {
-  const [config, setConfig] = useStorage<WebSearchProviderConfig>(
-    {
-      key: STORAGE_KEYS.WEB_SEARCH.CONFIG,
-      instance: webSearchStorage
-    },
-    DEFAULT_WEB_SEARCH_CONFIG
-  )
+  const [config, setConfig] = useSetting(SETTINGS.WEB_SEARCH_CONFIG)
 
   const updateConfig = useCallback(
     (updates: Partial<WebSearchProviderConfig>) => {

--- a/src/lib/storage/__tests__/storage-api-boundary.test.ts
+++ b/src/lib/storage/__tests__/storage-api-boundary.test.ts
@@ -7,7 +7,8 @@ const ROOT = process.cwd()
 const SCOPE_AWARE_UI = [
   "src/features/chat/hooks/use-speech-settings.ts",
   "src/features/model/hooks/use-model-capability-overrides.ts",
-  "src/features/permissions/components/approvals-card.tsx"
+  "src/features/permissions/components/approvals-card.tsx",
+  "src/features/web-search/stores/web-search-config-store.ts"
 ]
 
 describe("storage API boundary", () => {

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -1,7 +1,13 @@
+import { z } from "zod"
 import { STORAGE_KEYS } from "@/lib/constants"
 import type { CapabilityProbeMap } from "@/lib/providers/capability-probe"
 import type { ModelCapabilityOverrideMap } from "@/lib/providers/model-capability-overrides"
 import type { ApprovalGrantMap } from "@/lib/tools/approval/approval-grants"
+import {
+  DEFAULT_WEB_SEARCH_CONFIG,
+  type WebSearchProviderConfig,
+  WebSearchProviderConfigSchema
+} from "@/lib/tools/web-search"
 import { defineSetting } from "./setting-descriptor"
 
 export const SETTINGS = {
@@ -23,5 +29,16 @@ export const SETTINGS = {
   APPROVAL_GRANTS: defineSetting<ApprovalGrantMap>(
     STORAGE_KEYS.TOOLS.APPROVAL_GRANTS,
     { defaultValue: {} }
+  ),
+  WEB_SEARCH_ACTIVE: defineSetting<boolean>(STORAGE_KEYS.WEB_SEARCH.ACTIVE, {
+    defaultValue: true,
+    parser: z.boolean()
+  }),
+  WEB_SEARCH_CONFIG: defineSetting<WebSearchProviderConfig>(
+    STORAGE_KEYS.WEB_SEARCH.CONFIG,
+    {
+      defaultValue: DEFAULT_WEB_SEARCH_CONFIG,
+      parser: WebSearchProviderConfigSchema
+    }
   )
 }

--- a/src/lib/tools/web-search/__tests__/config.test.ts
+++ b/src/lib/tools/web-search/__tests__/config.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const storage = vi.hoisted(() => ({
+  get: vi.fn()
+}))
+
+vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: storage.get,
+  setPlasmoStoredValue: vi.fn()
+}))
+
 import {
   DEFAULT_SEARXNG_ENDPOINT,
+  DEFAULT_WEB_SEARCH_CONFIG,
+  getWebSearchConfig,
   WebSearchProviderConfigSchema
 } from "../config"
 
 describe("WebSearchProviderConfigSchema", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("normalizes partial legacy values", () => {
     expect(
       WebSearchProviderConfigSchema.parse({
@@ -44,6 +60,34 @@ describe("WebSearchProviderConfigSchema", () => {
   it("rejects non-object persisted values", () => {
     expect(WebSearchProviderConfigSchema.safeParse("broken").success).toBe(
       false
+    )
+  })
+
+  it("applies the same parser on the runtime read path", async () => {
+    storage.get.mockResolvedValue({
+      provider: "unknown",
+      apiKey: "secret",
+      count: "many",
+      safeSearch: "unsafe",
+      enabled: true
+    })
+
+    await expect(getWebSearchConfig()).resolves.toEqual(
+      expect.objectContaining({
+        provider: "searxng",
+        apiKey: "secret",
+        count: 5,
+        safeSearch: "moderate",
+        enabled: true
+      })
+    )
+  })
+
+  it("falls back safely when runtime storage is not an object", async () => {
+    storage.get.mockResolvedValue("broken")
+
+    await expect(getWebSearchConfig()).resolves.toEqual(
+      DEFAULT_WEB_SEARCH_CONFIG
     )
   })
 })

--- a/src/lib/tools/web-search/__tests__/config.test.ts
+++ b/src/lib/tools/web-search/__tests__/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_SEARXNG_ENDPOINT,
+  WebSearchProviderConfigSchema
+} from "../config"
+
+describe("WebSearchProviderConfigSchema", () => {
+  it("normalizes partial legacy values", () => {
+    expect(
+      WebSearchProviderConfigSchema.parse({
+        provider: "searxng",
+        endpoint: "",
+        count: 99,
+        searxngPages: 0
+      })
+    ).toEqual(
+      expect.objectContaining({
+        provider: "searxng",
+        endpoint: DEFAULT_SEARXNG_ENDPOINT,
+        count: 10,
+        searxngPages: 1
+      })
+    )
+  })
+
+  it("drops malformed fields while preserving valid secrets", () => {
+    expect(
+      WebSearchProviderConfigSchema.parse({
+        provider: "unknown",
+        apiKey: "secret",
+        count: "many",
+        enabled: "yes"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        provider: "searxng",
+        apiKey: "secret",
+        count: 5,
+        enabled: true
+      })
+    )
+  })
+
+  it("rejects non-object persisted values", () => {
+    expect(WebSearchProviderConfigSchema.safeParse("broken").success).toBe(
+      false
+    )
+  })
+})

--- a/src/lib/tools/web-search/config.ts
+++ b/src/lib/tools/web-search/config.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { STORAGE_KEYS } from "@/lib/constants"
 import {
   getPlasmoStoredValue,
@@ -42,6 +43,28 @@ export const normalizeWebSearchConfig = (
   normalized.searxngPages = clamp(normalized.searxngPages, 1, 3, 1)
   return normalized
 }
+
+const StoredWebSearchProviderConfigSchema = z.object({
+  provider: z.enum(["searxng", "brave", "tavily"]).optional().catch(undefined),
+  endpoint: z.string().optional().catch(undefined),
+  apiKey: z.string().optional().catch(undefined),
+  count: z.number().finite().optional().catch(undefined),
+  searxngPages: z.number().finite().optional().catch(undefined),
+  safeSearch: z.enum(["off", "moderate", "strict"]).optional().catch(undefined),
+  enabled: z.boolean().optional().catch(undefined)
+})
+
+/**
+ * Runtime parser for the persisted UI setting. Older partial objects remain
+ * readable; malformed fields are discarded before defaults and bounds apply.
+ */
+export const WebSearchProviderConfigSchema =
+  StoredWebSearchProviderConfigSchema.transform((stored) => {
+    const validFields = Object.fromEntries(
+      Object.entries(stored).filter(([, value]) => value !== undefined)
+    ) as Partial<WebSearchProviderConfig>
+    return normalizeWebSearchConfig(validFields)
+  })
 
 export const getWebSearchConfig =
   async (): Promise<WebSearchProviderConfig> => {

--- a/src/lib/tools/web-search/config.ts
+++ b/src/lib/tools/web-search/config.ts
@@ -68,10 +68,11 @@ export const WebSearchProviderConfigSchema =
 
 export const getWebSearchConfig =
   async (): Promise<WebSearchProviderConfig> => {
-    const stored = await getPlasmoStoredValue<WebSearchProviderConfig>(
+    const stored = await getPlasmoStoredValue<unknown>(
       STORAGE_KEYS.WEB_SEARCH.CONFIG
     )
-    return normalizeWebSearchConfig(stored)
+    const parsed = WebSearchProviderConfigSchema.safeParse(stored)
+    return parsed.success ? parsed.data : DEFAULT_WEB_SEARCH_CONFIG
   }
 
 export const setWebSearchConfig = async (


### PR DESCRIPTION
## Summary

- move web-search UI state from raw Plasmo storage hooks to scope-aware setting descriptors
- runtime-validate and normalize persisted web-search configuration
- preserve valid fields while recovering malformed legacy fields to safe defaults
- enforce the migrated storage boundary with a source-contract test

## Why

The settings audit found structured UI values entering typed state without runtime validation. Web-search configuration is device-local and may include credentials, provider selection, endpoints, and bounded result controls, making it a high-risk first incremental migration.

## Impact

Existing partial configurations remain readable. Invalid individual fields fall back safely without discarding valid fields such as an API key. Non-object persisted values use the descriptor default.

## Validation

- pre-commit lint-staged checks
- Biome format and lint
- TypeScript typecheck
- 307 test files, 2,574 tests passed
- Chrome production package
- bundle-budget checks
- docs production build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates device-local web-search state to scope-aware setting descriptors and applies the same runtime schema to UI and tool-execution reads.
- Adds field-level recovery and normalization for malformed legacy web-search configuration.
- Routes the active flag and provider configuration through typed setting descriptors.
- Adds runtime-read and storage-boundary regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; current tool registration and execution both read configuration through the newly validated runtime path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tools/web-search/config.ts | Adds a shared schema that validates and normalizes persisted configuration on the runtime path, resolving the previously reported validation bypass. |
| src/lib/storage/settings.ts | Defines device-local web-search descriptors using the shared configuration parser and a boolean parser for the active flag. |
| src/features/web-search/stores/web-search-config-store.ts | Migrates UI storage hooks to the scope-aware descriptors while retaining normalized updates. |
| src/lib/tools/web-search/__tests__/config.test.ts | Covers malformed fields, preserved valid credentials, non-object fallback, and runtime parser parity. |
| src/lib/storage/__tests__/storage-api-boundary.test.ts | Extends the source-contract test to prevent the web-search store from returning to raw storage hooks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(storage): validate runtime web confi..."](https://github.com/shishir435/ollama-client/commit/991c9770f670b5ef630c9c577dfc4ee81f82acb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51492374)</sub>

**Context used:**

- Knowledge Base — [Web Search](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/web-search.md)

<!-- /greptile_comment -->