### PR TITLE
fix(architecture): freeze prepackage boundaries

### DIFF
--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -212,7 +212,8 @@ import background implementation.
 
 #### P0 — freeze dependency rules
 
-Status: complete on `feature/prepackage-boundary-gates`, 2026-08-09.
+Status: implemented on `feature/prepackage-boundary-gates`; pending review and
+merge in PR #243, 2026-08-09.
 
 - Stored provider arrays validate required identity fields before runtime use,
   recover malformed optional fields independently, and preserve unknown fields
@@ -223,12 +224,33 @@ Status: complete on `feature/prepackage-boundary-gates`, 2026-08-09.
 - Source contracts keep chat and the future agent mutually independent and
   keep current contract/runtime candidates free of UI, browser, persistence,
   background, and concrete-provider adapters.
+- Forward-compatible provider fields remain preserved in storage while the
+  provider RPC boundary explicitly projects known public fields, so newer
+  fields cannot invalidate list responses or expose future credential fields.
+- Boundary matching covers bound imports, type imports, side-effect imports,
+  dynamic imports, and re-exports.
 
-- Extend architecture contract tests before moving files.
+Completed:
+
+- Architecture contracts are in place before files move.
 - `chat` cannot import `agent`; `agent` cannot import `chat`.
-- Contracts and runtime packages cannot import React, WXT, Chrome APIs, DOM,
-  SQLite/OPFS, feature UI, or concrete providers.
-- Composition happens in extension/background roots.
+- Current contract/runtime candidates cannot import React, WXT, browser and
+  persistence adapters, feature UI, background composition, or concrete
+  providers.
+- Current composition remains in extension/background roots.
+
+Remaining before P1:
+
+- Merge PR #243 after review and CI.
+- No additional P0 implementation is known.
+
+Remaining package work:
+
+- P1: create `packages/contracts` and move only the proven contract seams.
+- P2: create `packages/runtime-core` and inject environment dependencies behind
+  ports before moving deterministic runtime helpers.
+- P3: extract chat runtime only after P1/P2 prove stable; agent runtime remains
+  scheduled for `0.14.x`.
 
 #### P1 — `packages/contracts`
 

--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -212,6 +212,18 @@ import background implementation.
 
 #### P0 — freeze dependency rules
 
+Status: complete on `feature/prepackage-boundary-gates`, 2026-08-09.
+
+- Stored provider arrays validate required identity fields before runtime use,
+  recover malformed optional fields independently, and preserve unknown fields
+  across downgrade/upgrade cycles.
+- Provider writes validate before journaling. Secret maps and both persistence
+  and reset journals validate on recovery; malformed journals are discarded
+  without applying partial cleanup or exposing stored values.
+- Source contracts keep chat and the future agent mutually independent and
+  keep current contract/runtime candidates free of UI, browser, persistence,
+  background, and concrete-provider adapters.
+
 - Extend architecture contract tests before moving files.
 - `chat` cannot import `agent`; `agent` cannot import `chat`.
 - Contracts and runtime packages cannot import React, WXT, Chrome APIs, DOM,

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 
+import ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 const sourceRoot = join(process.cwd(), "src")
@@ -18,10 +19,42 @@ const productionSources = walk(sourceRoot)
   .filter((path) => !path.includes("__tests__/"))
   .filter((path) => !path.startsWith("test/"))
 
-const importsModule = (source: string, modulePath: RegExp): boolean =>
-  new RegExp(
-    String.raw`(?:\bimport\s*\(\s*|\bimport\s+(?:type\s+)?(?:[^"'();]*?\s+from\s*)?|\bexport\s+(?:type\s+)?[^"'();]*?\s+from\s*)["']${modulePath.source}["']`
-  ).test(source)
+const referencedModules = (source: string): string[] => {
+  const sourceFile = ts.createSourceFile(
+    "architecture-boundary.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const modules: string[] = []
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      modules.push(node.moduleSpecifier.text)
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      modules.push(node.arguments[0].text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return modules
+}
+
+const importsModule = (source: string, modulePath: RegExp): boolean => {
+  const exactModulePath = new RegExp(`^(?:${modulePath.source})$`)
+  return referencedModules(source).some((module) =>
+    exactModulePath.test(module)
+  )
+}
 
 /**
  * Value imports only. `import type { Database } from "sql.js"` is erased at
@@ -42,6 +75,12 @@ describe("architecture import boundaries", () => {
       'import type { Agent } from "@/features/agent/types"',
       'export { run } from "@/features/agent/runtime"',
       'export * from "@/features/agent/public"',
+      `import {
+        run
+      } from "@/features/agent/runtime"`,
+      `export {
+        run
+      } from "@/features/agent/runtime"`,
       'const runtime = import("@/features/agent/runtime")'
     ]
 

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -20,7 +20,7 @@ const productionSources = walk(sourceRoot)
 
 const importsModule = (source: string, modulePath: RegExp): boolean =>
   new RegExp(
-    String.raw`(?:from\s+|import\s*\()\s*["']${modulePath.source}["']`
+    String.raw`(?:\bimport\s*\(\s*|\bimport\s+(?:type\s+)?(?:[^"'();]*?\s+from\s*)?|\bexport\s+(?:type\s+)?[^"'();]*?\s+from\s*)["']${modulePath.source}["']`
   ).test(source)
 
 /**
@@ -34,6 +34,22 @@ const importsAtRuntime = (source: string, modulePath: RegExp): boolean =>
   ).test(source)
 
 describe("architecture import boundaries", () => {
+  it("recognizes every module dependency form used by source contracts", () => {
+    const forbidden = /@\/features\/agent\/[^"']+/
+    const references = [
+      'import "@/features/agent/register"',
+      'import { run } from "@/features/agent/runtime"',
+      'import type { Agent } from "@/features/agent/types"',
+      'export { run } from "@/features/agent/runtime"',
+      'export * from "@/features/agent/public"',
+      'const runtime = import("@/features/agent/runtime")'
+    ]
+
+    expect(references.every((source) => importsModule(source, forbidden))).toBe(
+      true
+    )
+  })
+
   it("routes chat-history callers through the public repository facade", () => {
     const allowed = new Set([
       "entrypoints/persistence-verify/main.ts",

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -135,4 +135,45 @@ describe("architecture import boundaries", () => {
 
     expect(offenders).toEqual([])
   })
+
+  it("keeps chat and future agent domains mutually independent", () => {
+    const chatRoots = ["application/turns/", "features/chat/"]
+    const agentRoots = ["application/agent/", "features/agent/"]
+    const offenders = productionSources.filter((file) => {
+      const source = readFileSync(join(sourceRoot, file), "utf8")
+      if (chatRoots.some((root) => file.startsWith(root))) {
+        return importsModule(
+          source,
+          /@\/(?:application|features)\/agent\/[^"']+/
+        )
+      }
+      if (agentRoots.some((root) => file.startsWith(root))) {
+        return importsModule(
+          source,
+          /@\/(?:application\/turns|features\/chat)\/[^"']+/
+        )
+      }
+      return false
+    })
+
+    expect(offenders).toEqual([])
+  })
+
+  it("keeps package candidates free of environment and UI adapters", () => {
+    const candidateFiles = productionSources.filter(
+      (file) =>
+        (file.startsWith("protocol/") &&
+          file !== "protocol/extension-client.ts") ||
+        file === "application/turns/chat-stream-reducer.ts" ||
+        file === "application/turns/turn-contract.ts"
+    )
+    const forbidden =
+      /(?:react(?:\/[^"']+)?|wxt(?:\/[^"']+)?|@\/background\/[^"']+|@\/features\/[^"']+|@\/lib\/(?:browser-api|sqlite\/[^"']+)|@\/lib\/providers\/(?:anthropic|factory|llama-cpp|lm-studio|ollama|openai-compatible))/
+    const offenders = candidateFiles.filter((file) => {
+      const source = readFileSync(join(sourceRoot, file), "utf8")
+      return importsModule(source, forbidden)
+    })
+
+    expect(offenders).toEqual([])
+  })
 })

--- a/src/lib/providers/__tests__/manager.test.ts
+++ b/src/lib/providers/__tests__/manager.test.ts
@@ -72,6 +72,77 @@ describe("ProviderManager", () => {
     ])
   })
 
+  it("drops malformed stored providers before runtime use", async () => {
+    const valid = {
+      id: "custom:openai:valid",
+      type: ProviderType.OPENAI,
+      name: "Valid",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [
+      valid,
+      { ...valid, id: "", enabled: "yes" }
+    ])
+
+    const providers = await ProviderManager.getProviders()
+
+    expect(providers).toContainEqual(valid)
+    expect(providers.filter((entry) => entry.id === "")).toEqual([])
+    expect(syncBacking.get(ProviderStorageKey.CONFIG)).not.toContainEqual(
+      expect.objectContaining({ id: "" })
+    )
+  })
+
+  it("discards malformed provider recovery journals safely", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, DEFAULT_PROVIDERS)
+    localBacking.set(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL, {
+      version: 1,
+      previousSecrets: "broken",
+      nextSecrets: {},
+      nextPublicConfigs: DEFAULT_PROVIDERS
+    })
+
+    await expect(ProviderManager.getProviders()).resolves.toEqual(
+      DEFAULT_PROVIDERS
+    )
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)).toBe(
+      false
+    )
+  })
+
+  it("discards malformed provider reset journals safely", async () => {
+    syncBacking.set(ProviderStorageKey.CONFIG, DEFAULT_PROVIDERS)
+    localBacking.set(STORAGE_KEYS.PROVIDER.RESET_JOURNAL, {
+      version: 1,
+      keys: [42]
+    })
+
+    await expect(ProviderManager.getProviders()).resolves.toEqual(
+      DEFAULT_PROVIDERS
+    )
+    expect(localBacking.has(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)).toBe(false)
+  })
+
+  it("ignores malformed secrets without losing valid credentials", async () => {
+    const provider = {
+      id: "custom:openai:secrets",
+      type: ProviderType.OPENAI,
+      name: "Secrets",
+      enabled: true,
+      baseUrl: "https://example.com/v1"
+    }
+    syncBacking.set(ProviderStorageKey.CONFIG, [...DEFAULT_PROVIDERS, provider])
+    localBacking.set(STORAGE_KEYS.PROVIDER.SECRETS, {
+      [provider.id]: "sk-valid",
+      broken: 42
+    })
+
+    await expect(
+      ProviderManager.getProviderConfig(provider.id)
+    ).resolves.toEqual({ ...provider, apiKey: "sk-valid" })
+  })
+
   it("stores provider API keys locally and keeps sync config secret-free", async () => {
     const providers = [
       ...DEFAULT_PROVIDERS,

--- a/src/lib/providers/__tests__/provider-config-schema.test.ts
+++ b/src/lib/providers/__tests__/provider-config-schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import {
+  parseStoredProviderConfigs,
+  validateProviderConfigs
+} from "../provider-config-schema"
+import { ProviderType } from "../types"
+
+const provider = {
+  id: "custom:openai:test",
+  type: ProviderType.OPENAI,
+  enabled: true,
+  name: "Test provider"
+}
+
+describe("provider config storage schemas", () => {
+  it("recovers optional fields and preserves future fields", () => {
+    const result = parseStoredProviderConfigs([
+      {
+        ...provider,
+        baseUrl: 42,
+        customModels: "model",
+        futureOption: { enabled: true }
+      }
+    ])
+
+    expect(result).toMatchObject({ rejected: 0, normalized: true })
+    expect(result.providers).toEqual([
+      {
+        ...provider,
+        futureOption: { enabled: true }
+      }
+    ])
+  })
+
+  it("rejects entries with invalid identity fields", () => {
+    const result = parseStoredProviderConfigs([
+      provider,
+      { ...provider, id: "", name: 42 },
+      null
+    ])
+
+    expect(result.providers).toEqual([provider])
+    expect(result.rejected).toBe(2)
+  })
+
+  it("rejects malformed provider writes", () => {
+    expect(() =>
+      validateProviderConfigs([{ ...provider, enabled: "yes" }])
+    ).toThrow(/Provider configuration is invalid/)
+  })
+})

--- a/src/lib/providers/__tests__/provider-rpc-service.test.ts
+++ b/src/lib/providers/__tests__/provider-rpc-service.test.ts
@@ -51,6 +51,7 @@ vi.mock("../factory", () => ({
 }))
 
 import { createAppError } from "@/lib/error-utils"
+import { ProvidersListResultSchema } from "@/protocol/provider-rpc"
 import {
   clearModelCatalogSupport,
   getModelCatalogSupport
@@ -141,6 +142,31 @@ describe("ProviderRpcService", () => {
     })
     expect(result.providers[0]).not.toHaveProperty("apiKey")
     expect(JSON.stringify(result)).not.toContain("private-key")
+  })
+
+  it("keeps future stored fields from invalidating public provider results", async () => {
+    mocks.getProviders.mockResolvedValue([
+      {
+        ...configs[0],
+        futureProviderField: "preserved-in-storage",
+        compatibility: {
+          maxTokensField: "max_tokens",
+          futureCompatibilityField: "preserved-in-storage"
+        }
+      }
+    ])
+
+    const result = await ProviderRpcService.list()
+
+    expect(() => ProvidersListResultSchema.parse(result)).not.toThrow()
+    expect(result.providers[0]).toMatchObject({
+      compatibility: { maxTokensField: "max_tokens" },
+      hasApiKey: true
+    })
+    expect(result.providers[0]).not.toHaveProperty("futureProviderField")
+    expect(result.providers[0].compatibility).not.toHaveProperty(
+      "futureCompatibilityField"
+    )
   })
 
   it("tests an unsaved draft without returning its credential", async () => {

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -5,6 +5,7 @@ import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { clearCapabilityProbesForProvider } from "./capability-probe"
 import { clearModelCapabilityOverridesForProvider } from "./model-capability-overrides"
 import { clearModelCatalogSupport } from "./model-catalog-support"
+import { parseStoredProviderConfigs } from "./provider-config-schema"
 import {
   containsLegacySyncedSecrets,
   hydrateProviderSecrets,
@@ -285,10 +286,12 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
 const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
   await recoverProviderResetUnlocked()
   await recoverProviderPersistenceUnlocked()
-  let stored = await plasmoGlobalStorage.get<ProviderConfig[]>(
+  const rawStored = await plasmoGlobalStorage.get<unknown>(
     ProviderStorageKey.CONFIG
   )
-  if (!stored || stored.length === 0) {
+  const parsedStored = parseStoredProviderConfigs(rawStored)
+  let stored = parsedStored.providers
+  if (stored.length === 0) {
     stored = [...DEFAULT_PROVIDERS]
     await persistProviderConfigsUnlocked(stored)
   }
@@ -306,6 +309,7 @@ const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
   // on some *other* anomaly being present in the same read, which meant the
   // surviving entry depended on an unrelated condition.
   const sanitizationChanged =
+    parsedStored.normalized ||
     sanitized.removed.length > 0 ||
     sanitized.migrated.length > 0 ||
     sanitized.duplicates.length > 0
@@ -318,7 +322,8 @@ const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
         migrated: sanitized.migrated,
         // Ids only. A duplicate is a config the user cannot see collapsing, so
         // it has to leave a trace, but provider names are user text.
-        duplicates: sanitized.duplicates
+        duplicates: sanitized.duplicates,
+        rejectedMalformedEntries: parsedStored.rejected
       }
     )
     stored = sanitized.providers

--- a/src/lib/providers/provider-config-schema.ts
+++ b/src/lib/providers/provider-config-schema.ts
@@ -1,0 +1,96 @@
+import { z } from "zod"
+import { createAppError } from "@/lib/error-utils"
+import {
+  type ProviderConfig,
+  ProviderServiceProfile,
+  ProviderType
+} from "./types"
+
+const OptionalStringSchema = z.string().optional().catch(undefined)
+
+const OpenAICompatibilityOptionsSchema = z
+  .object({
+    maxTokensField: z
+      .enum(["max_tokens", "max_completion_tokens"])
+      .optional()
+      .catch(undefined),
+    sendStreamOptions: z.enum(["always", "never"]).optional().catch(undefined)
+  })
+  .passthrough()
+
+/**
+ * Required identity fields reject the entry. Optional legacy fields recover
+ * independently so one stale preference does not discard a usable provider.
+ * Unknown fields survive downgrade/upgrade cycles.
+ */
+export const ProviderConfigSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.enum([
+      ProviderType.OLLAMA,
+      ProviderType.OPENAI,
+      ProviderType.ANTHROPIC,
+      ProviderType.CUSTOM
+    ]),
+    enabled: z.boolean(),
+    baseUrl: OptionalStringSchema,
+    apiKey: OptionalStringSchema,
+    modelId: OptionalStringSchema,
+    name: z.string().min(1),
+    customModels: z.array(z.string()).optional().catch(undefined),
+    serviceProfile: z
+      .enum([
+        ProviderServiceProfile.GENERIC,
+        ProviderServiceProfile.OPENAI,
+        ProviderServiceProfile.ANTHROPIC,
+        ProviderServiceProfile.OPENROUTER
+      ])
+      .optional()
+      .catch(undefined),
+    compatibility: OpenAICompatibilityOptionsSchema.optional().catch(undefined)
+  })
+  .passthrough()
+
+export interface StoredProviderConfigParseResult {
+  providers: ProviderConfig[]
+  rejected: number
+  normalized: boolean
+}
+
+export const parseStoredProviderConfigs = (
+  value: unknown
+): StoredProviderConfigParseResult => {
+  if (!Array.isArray(value)) {
+    return {
+      providers: [],
+      rejected: value === undefined || value === null ? 0 : 1,
+      normalized: value !== undefined && value !== null
+    }
+  }
+
+  const providers: ProviderConfig[] = []
+  let rejected = 0
+  for (const entry of value) {
+    const parsed = ProviderConfigSchema.safeParse(entry)
+    if (parsed.success) providers.push(parsed.data)
+    else rejected += 1
+  }
+
+  return {
+    providers,
+    rejected,
+    normalized:
+      rejected > 0 || JSON.stringify(providers) !== JSON.stringify(value)
+  }
+}
+
+export const validateProviderConfigs = (value: unknown): ProviderConfig[] => {
+  const parsed = z.array(ProviderConfigSchema).safeParse(value)
+  if (!parsed.success) {
+    throw createAppError("Provider configuration is invalid", {
+      kind: "validation",
+      phase: "configuration"
+    })
+  }
+  return parsed.data
+}

--- a/src/lib/providers/provider-rpc-service.ts
+++ b/src/lib/providers/provider-rpc-service.ts
@@ -36,10 +36,30 @@ import {
 import type { LLMProvider, ProviderConfig } from "./types"
 
 const toPublicConfig = (config: ProviderConfig): PublicProviderConfig => {
-  const { apiKey, ...publicConfig } = config
   return {
-    ...publicConfig,
-    hasApiKey: Boolean(apiKey?.trim())
+    id: String(config.id),
+    type: config.type,
+    enabled: config.enabled,
+    ...(config.baseUrl !== undefined && { baseUrl: config.baseUrl }),
+    ...(config.modelId !== undefined && { modelId: config.modelId }),
+    name: config.name,
+    ...(config.customModels !== undefined && {
+      customModels: config.customModels
+    }),
+    ...(config.serviceProfile !== undefined && {
+      serviceProfile: config.serviceProfile
+    }),
+    ...(config.compatibility !== undefined && {
+      compatibility: {
+        ...(config.compatibility.maxTokensField !== undefined && {
+          maxTokensField: config.compatibility.maxTokensField
+        }),
+        ...(config.compatibility.sendStreamOptions !== undefined && {
+          sendStreamOptions: config.compatibility.sendStreamOptions
+        })
+      }
+    }),
+    hasApiKey: Boolean(config.apiKey?.trim())
   }
 }
 

--- a/src/lib/providers/provider-secret-store.ts
+++ b/src/lib/providers/provider-secret-store.ts
@@ -1,4 +1,6 @@
+import { z } from "zod"
 import { STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
 import {
   plasmoDeviceStorage,
   plasmoGlobalStorage,
@@ -6,6 +8,10 @@ import {
 } from "@/lib/plasmo-global-storage"
 import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
 import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
+import {
+  ProviderConfigSchema,
+  validateProviderConfigs
+} from "./provider-config-schema"
 
 type ProviderSecretMap = Record<string, string>
 type ProviderPersistenceSnapshot = {
@@ -23,12 +29,37 @@ type ProviderResetJournal = {
   keys: string[]
 }
 
+const ProviderSecretMapSchema = z
+  .record(z.string(), z.unknown())
+  .transform((stored): ProviderSecretMap => {
+    const secrets: ProviderSecretMap = {}
+    for (const [providerId, value] of Object.entries(stored)) {
+      if (typeof value === "string" && value.trim()) secrets[providerId] = value
+    }
+    return secrets
+  })
+
+const ProviderPersistenceJournalSchema = z.object({
+  version: z.literal(1),
+  previousSecrets: ProviderSecretMapSchema,
+  nextSecrets: ProviderSecretMapSchema,
+  nextPublicConfigs: z.array(ProviderConfigSchema)
+})
+
+const ProviderResetJournalSchema = z.object({
+  version: z.literal(1),
+  keys: z.array(z.string())
+})
+
 const PROVIDER_PERSISTENCE_LOCK = "ollama-client:provider-persistence"
 
-const configsMatch = (
-  left: ProviderConfig[] | undefined,
-  right: ProviderConfig[]
-): boolean => JSON.stringify(left) === JSON.stringify(right)
+const configsMatch = (left: unknown, right: ProviderConfig[]): boolean =>
+  JSON.stringify(left) === JSON.stringify(right)
+
+const parseSecretMap = (value: unknown): ProviderSecretMap => {
+  const parsed = ProviderSecretMapSchema.safeParse(value)
+  return parsed.success ? parsed.data : {}
+}
 
 const hasOwnApiKey = (provider: ProviderConfig): boolean =>
   Object.hasOwn(provider, "apiKey")
@@ -54,10 +85,9 @@ export const withProviderPersistenceLock = <T>(
 export const hydrateProviderSecrets = async (
   providers: ProviderConfig[]
 ): Promise<ProviderConfig[]> => {
-  const secrets =
-    (await plasmoDeviceStorage.get<ProviderSecretMap>(
-      STORAGE_KEYS.PROVIDER.SECRETS
-    )) ?? {}
+  const secrets = parseSecretMap(
+    await plasmoDeviceStorage.get<unknown>(STORAGE_KEYS.PROVIDER.SECRETS)
+  )
 
   return providers.map((provider) => {
     // During migration, legacy sync value wins. This also preserves an explicit
@@ -74,10 +104,20 @@ export const containsLegacySyncedSecrets = (
 
 /** Caller must hold the provider-persistence lock. */
 export const recoverProviderResetUnlocked = async (): Promise<void> => {
-  const journal = await plasmoDeviceStorage.get<ProviderResetJournal>(
+  const stored = await plasmoDeviceStorage.get<unknown>(
     STORAGE_KEYS.PROVIDER.RESET_JOURNAL
   )
-  if (!journal) return
+  if (!stored) return
+  const parsed = ProviderResetJournalSchema.safeParse(stored)
+  if (!parsed.success) {
+    logger.warn(
+      "Discarded invalid provider reset journal",
+      "ProviderSecretStore"
+    )
+    await plasmoDeviceStorage.remove(STORAGE_KEYS.PROVIDER.RESET_JOURNAL)
+    return
+  }
+  const journal: ProviderResetJournal = parsed.data
 
   for (const key of journal.keys) {
     await removePlasmoStoredValue(key)
@@ -112,12 +152,22 @@ export const resetProviderStorageUnlocked = async (
 
 /** Caller must hold the provider-persistence lock. */
 export const recoverProviderPersistenceUnlocked = async (): Promise<void> => {
-  const journal = await plasmoDeviceStorage.get<ProviderPersistenceJournal>(
+  const stored = await plasmoDeviceStorage.get<unknown>(
     STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL
   )
-  if (!journal) return
+  if (!stored) return
+  const parsed = ProviderPersistenceJournalSchema.safeParse(stored)
+  if (!parsed.success) {
+    logger.warn(
+      "Discarded invalid provider persistence journal",
+      "ProviderSecretStore"
+    )
+    await plasmoDeviceStorage.remove(STORAGE_KEYS.PROVIDER.PERSISTENCE_JOURNAL)
+    return
+  }
+  const journal: ProviderPersistenceJournal = parsed.data
 
-  const syncedConfig = await plasmoGlobalStorage.get<ProviderConfig[]>(
+  const syncedConfig = await plasmoGlobalStorage.get<unknown>(
     ProviderStorageKey.CONFIG
   )
   const recoveredSecrets = configsMatch(syncedConfig, journal.nextPublicConfigs)
@@ -135,14 +185,14 @@ export const recoverProviderPersistenceUnlocked = async (): Promise<void> => {
 export const persistProviderConfigsUnlocked = async (
   providers: ProviderConfig[]
 ): Promise<void> => {
+  providers = validateProviderConfigs(providers)
   const snapshot: ProviderPersistenceSnapshot = {
     secrets: extractSecrets(providers),
     publicConfigs: providers.map(stripSecrets)
   }
-  const previousSecrets =
-    (await plasmoDeviceStorage.get<ProviderSecretMap>(
-      STORAGE_KEYS.PROVIDER.SECRETS
-    )) ?? {}
+  const previousSecrets = parseSecretMap(
+    await plasmoDeviceStorage.get<unknown>(STORAGE_KEYS.PROVIDER.SECRETS)
+  )
   const journal: ProviderPersistenceJournal = {
     version: 1,
     previousSecrets,


### PR DESCRIPTION
## Summary

- runtime-validate stored provider configuration before manager and factory use
- preserve unknown forward-compatible fields while recovering malformed optional fields
- validate provider writes, secret maps, persistence journals, and reset journals
- discard malformed journals without applying partial recovery operations
- add source contracts for chat/agent isolation and environment-free package candidates
- record the completed P0 boundary freeze in the release roadmap

## Why

Package extraction needs proven dependency direction and trustworthy persisted inputs. Provider arrays and recovery journals previously relied on TypeScript generics, allowing malformed sync or device-local values to fail later inside CRUD, credential hydration, or recovery.

## Impact

Malformed provider identities are rejected before runtime use. Valid providers and credentials survive neighboring malformed values. Unknown future fields remain intact across version changes. Corrupt journals cannot trigger partial cleanup.

## Validation

- pnpm verify
- 308 test files, 2,585 tests passed
- TypeScript, Biome, dead-code and i18n checks
- generated-resource and compatibility-ledger checks
- Chrome production package
- bundle-budget checks
- docs production build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens provider persistence and RPC boundaries while replacing source dependency regex matching with TypeScript AST traversal.
- Runtime-validates stored provider configurations, secret maps, and recovery journals.
- Preserves forward-compatible stored fields while projecting only known public fields through provider RPC.
- Adds architecture contracts for domain isolation and environment-free package candidates.
- Updates tests and the release roadmap to record the completed boundary freeze.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/providers/provider-config-schema.ts | Adds runtime schemas that reject malformed provider identities, normalize optional fields, and preserve unknown stored fields. |
| src/lib/providers/provider-secret-store.ts | Validates secret maps, writes, and recovery journals before applying persistence operations. |
| src/lib/providers/manager.ts | Parses and normalizes stored provider arrays before sanitization, hydration, and runtime use. |
| src/lib/providers/provider-rpc-service.ts | Explicitly projects every current public provider field while excluding credentials and unknown forward-compatible fields. |
| src/lib/__tests__/architecture-boundaries.test.ts | Replaces dependency regex matching with TypeScript AST traversal and adds package and domain isolation contracts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Storage[Browser storage] --> Validation[Runtime schema validation]
  Validation --> Manager[Provider manager]
  Manager --> Secrets[Secret hydration]
  Secrets --> Projection[Known-field RPC projection]
  Projection --> Clients[Extension clients]
  Journals[Recovery journals] --> Validation
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(architecture): parse dependency synt..."](https://github.com/shishir435/ollama-client/commit/4f431d80b98011c74c18c24980e67e7c2bfe393f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51495272)</sub>

**Context used:**

- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)

<!-- /greptile_comment -->