### PR TITLE
refactor(contracts): extract turn schemas

### DIFF
--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -248,7 +248,8 @@ Remaining package work:
 
 #### P1 — `packages/contracts`
 
-Status: in progress on `feature/contracts-package`, 2026-08-09.
+Status: in progress; first slice merged, turn-schema slice active on
+`feature/contracts-turn-schemas`, 2026-08-09.
 
 Completed in the first extraction slice:
 
@@ -259,14 +260,23 @@ Completed in the first extraction slice:
 - Added package-only Node tests, an independent no-DOM typecheck, and a source
   contract that permits only relative imports and Zod.
 
+Completed in the turn-schema slice:
+
+- Moved shared chat, persisted context, and persisted turn Zod schemas into
+  package subpath exports.
+- Kept normalized application command types behind explicit compatibility
+  adapters because legacy attachment bytes and replay artifacts have broader
+  persisted shapes than runtime `ChatMessage`.
+- Migrated stream and persistence schema consumers to package APIs directly and
+  added clean-Node coverage for nested turn contracts and UTF-8 replay limits.
+
 Remaining in P1:
 
-- Decouple persisted turn/context schemas from app-owned `ChatMessage` and
-  context implementations before moving them.
 - Move stable per-method request/result schemas in small domain slices once
   both callers import the package API directly.
-- Remove temporary `src/protocol` compatibility re-exports after callers have
-  migrated.
+- Remove temporary `src/protocol`, `src/types`, and `src/application` contract
+  compatibility re-exports/adapters after callers have migrated and persisted
+  data is normalized at each boundary.
 
 Candidate ownership:
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -6,8 +6,11 @@
   "exports": {
     ".": "./src/index.ts",
     "./app-failure": "./src/app-failure.ts",
+    "./chat": "./src/chat.ts",
+    "./context": "./src/context.ts",
     "./rpc": "./src/rpc.ts",
-    "./streams": "./src/streams.ts"
+    "./streams": "./src/streams.ts",
+    "./turns": "./src/turns.ts"
   },
   "dependencies": {
     "zod": "^4.4.3"

--- a/packages/contracts/src/chat.ts
+++ b/packages/contracts/src/chat.ts
@@ -1,0 +1,338 @@
+import { z } from "zod"
+import { AppFailureSchema } from "./app-failure"
+
+const optionalString = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.string().optional()
+)
+
+const optionalNumber = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.number().optional()
+)
+
+const optionalBoolean = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.boolean().optional()
+)
+
+// ---- Metrics (used inside messages and for SQLite parseMetrics) ----
+
+const RagSourceSchema = z.object({
+  id: z.union([z.number(), z.string()]),
+  title: z.string(),
+  content: z.string(),
+  score: z.number(),
+  source: z.string().optional(),
+  chunkIndex: z.number().optional(),
+  fileId: z.string().optional(),
+  type: z.string().optional()
+})
+
+export const UsedContextChunkSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  title: z.string(),
+  titleKey: z.string().optional(),
+  excerpt: z.string(),
+  score: z.number(),
+  sectionPath: z.string().optional(),
+  source: z.string().optional(),
+  chunkIndex: z.number().optional()
+})
+
+export const ToolRunSchema = z.object({
+  toolId: z.string(),
+  label: z.string(),
+  displayNameKey: z.string().optional(),
+  iconKey: z.string().optional(),
+  category: z
+    .enum([
+      "browser",
+      "knowledge",
+      "files",
+      "selection",
+      "web",
+      "system",
+      "external"
+    ])
+    .optional(),
+  risk: z.enum(["low", "medium", "high", "critical"]).optional(),
+  taintGeneration: z.number().int().nonnegative().optional(),
+  origin: z.string().optional(),
+  status: z.enum([
+    "pending",
+    "running",
+    "done",
+    "error",
+    "awaiting-confirmation"
+  ]),
+  callId: z.string().optional(),
+  startedAt: z.number(),
+  completedAt: z.number().optional(),
+  sources: z
+    .array(
+      z.object({
+        id: z.union([z.string(), z.number()]).optional(),
+        title: z.string(),
+        url: optionalString,
+        excerpt: optionalString,
+        publishedAt: optionalString,
+        source: optionalString,
+        score: optionalNumber,
+        category: optionalString,
+        used: optionalBoolean
+      })
+    )
+    .optional(),
+  error: z.string().optional(),
+  truncated: z.boolean().optional(),
+  args: z.record(z.string(), z.unknown()).optional(),
+  resultPreview: z.string().optional()
+})
+
+export const ActivityTextSchema = z.object({
+  text: z.string(),
+  textKey: z.string().optional()
+})
+
+export const ActivityEventSchema = z.object({
+  id: z.string(),
+  kind: z.enum([
+    "preparing_context",
+    "query_rewrite",
+    "searching_memory",
+    "searching_files",
+    "reading_page",
+    "calling_tool",
+    "generating_answer"
+  ]),
+  label: z.string(),
+  labelKey: z.string().optional(),
+  status: z.enum(["running", "done", "error"]),
+  startedAt: z.number(),
+  finishedAt: z.number().optional(),
+  inputPreview: z.string().optional(),
+  outputPreview: z.union([z.string(), ActivityTextSchema]).optional(),
+  resultCount: z.number().optional(),
+  sourceTitles: z.array(z.union([z.string(), ActivityTextSchema])).optional(),
+  error: z.string().optional()
+})
+
+export const ToolCallSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  arguments: z.record(z.string(), z.unknown())
+})
+
+const MAX_REPLAY_ARTIFACT_BYTES = 1024 * 1024
+const MAX_REPLAY_BLOCKS = 256
+
+const AnthropicReplayBlockSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("thinking"),
+      thinking: z.string(),
+      signature: z.string()
+    })
+    .passthrough(),
+  z
+    .object({
+      type: z.literal("redacted_thinking"),
+      data: z.string()
+    })
+    .passthrough(),
+  z.object({ type: z.literal("text"), text: z.string() }).passthrough(),
+  z
+    .object({
+      type: z.literal("tool_use"),
+      id: z.string(),
+      name: z.string(),
+      input: z.record(z.string(), z.unknown())
+    })
+    .passthrough()
+])
+
+const OpenAIReasoningCommonSchema = z.object({
+  id: z.string().nullish(),
+  format: z.string().nullish(),
+  index: z.number().int().nonnegative().optional()
+})
+
+const OpenAIReplayBlockSchema = z.discriminatedUnion("type", [
+  OpenAIReasoningCommonSchema.extend({
+    type: z.literal("reasoning.summary"),
+    summary: z.string()
+  }).passthrough(),
+  OpenAIReasoningCommonSchema.extend({
+    type: z.literal("reasoning.encrypted"),
+    data: z.string()
+  }).passthrough(),
+  OpenAIReasoningCommonSchema.extend({
+    type: z.literal("reasoning.text"),
+    text: z.string(),
+    signature: z.string().nullish()
+  }).passthrough()
+])
+
+const utf8ByteLength = (value: string): number => {
+  let bytes = 0
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0
+    bytes +=
+      codePoint <= 0x7f
+        ? 1
+        : codePoint <= 0x7ff
+          ? 2
+          : codePoint <= 0xffff
+            ? 3
+            : 4
+  }
+  return bytes
+}
+
+const replayArtifactSize = (value: unknown): number => {
+  try {
+    const serialized = JSON.stringify(value)
+    return typeof serialized === "string"
+      ? utf8ByteLength(serialized)
+      : Number.POSITIVE_INFINITY
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}
+
+export const ProviderReplayArtifactSchema = z
+  .discriminatedUnion("wire", [
+    z.object({
+      version: z.literal(1),
+      wire: z.literal("anthropic"),
+      providerId: z.string().min(1),
+      model: z.string().min(1),
+      blocks: z.array(AnthropicReplayBlockSchema).min(1).max(MAX_REPLAY_BLOCKS)
+    }),
+    z.object({
+      version: z.literal(1),
+      wire: z.literal("openai"),
+      providerId: z.string().min(1),
+      model: z.string().min(1),
+      blocks: z.array(OpenAIReplayBlockSchema).min(1).max(MAX_REPLAY_BLOCKS)
+    })
+  ])
+  .refine(
+    (artifact) => replayArtifactSize(artifact) <= MAX_REPLAY_ARTIFACT_BYTES,
+    "Provider replay artifact exceeds the storage limit"
+  )
+
+export const ChatMessageMetricsSchema = z.object({
+  total_duration: z.number().optional(),
+  load_duration: z.number().optional(),
+  prompt_eval_count: z.number().optional(),
+  prompt_eval_duration: z.number().optional(),
+  eval_count: z.number().optional(),
+  eval_duration: z.number().optional(),
+  ragQuery: z.string().optional(),
+  ragSources: z.array(RagSourceSchema).optional(),
+  usedContextChunks: z.array(UsedContextChunkSchema).optional(),
+  activityEvents: z.array(ActivityEventSchema).optional(),
+  toolRuns: z.array(ToolRunSchema).optional(),
+  groundedOnlyMode: z.boolean().optional(),
+  insufficientContext: z.boolean().optional(),
+  promptInputLength: z.number().optional(),
+  promptAugmentedLength: z.number().optional(),
+  tabContextLength: z.number().optional(),
+  ragContextLength: z.number().optional(),
+  tabContextTruncated: z.boolean().optional(),
+  contextBuildFailed: z.boolean().optional(),
+  thinkingOnlyResponse: z.boolean().optional(),
+  emptyResponse: z.boolean().optional(),
+  interrupted: z.boolean().optional()
+})
+
+// ---- FileAttachment ----
+
+export const FileAttachmentSchema = z.object({
+  id: z.number().optional(),
+  fileId: z.string(),
+  fileName: z.string(),
+  fileType: z.string(),
+  fileSize: z.number(),
+  textPreview: z.string().optional(),
+  processedAt: z.number(),
+  sessionId: z.string().optional(),
+  messageId: z.number().optional(),
+  // Bytes export as a JSON array, but a Uint8Array that slips through
+  // JSON.stringify serializes to an index-keyed object ({"0":..,"1":..}).
+  // Accept both so one stray byte field can't fail validation and silently
+  // skip the whole session on import.
+  data: z
+    .union([
+      z.instanceof(Uint8Array),
+      z.array(z.number()),
+      z.record(z.string(), z.number())
+    ])
+    .optional()
+})
+
+export type FileAttachmentParsed = z.infer<typeof FileAttachmentSchema>
+
+const ImageAttachmentSchema = z.object({
+  id: z.number().optional(),
+  imageId: z.string(),
+  fileName: z.string(),
+  mimeType: z.string(),
+  size: z.number(),
+  base64: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  sessionId: z.string().optional(),
+  messageId: z.number().optional()
+})
+
+// ---- ChatMessage ----
+
+export const ChatMessageErrorSchema = AppFailureSchema.partial()
+
+export const ChatMessageSchema = z.object({
+  id: z.union([z.number(), z.string()]).optional(),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string(),
+  thinking: z.string().optional(),
+  replayArtifact: ProviderReplayArtifactSchema.optional(),
+  done: z.boolean().optional(),
+  model: z.string().optional(),
+  attachments: z.array(FileAttachmentSchema).optional(),
+  images: z.array(ImageAttachmentSchema).optional(),
+  toolCalls: z.array(ToolCallSchema).optional(),
+  toolName: z.string().optional(),
+  toolCallId: z.string().optional(),
+  toolIsError: z.boolean().optional(),
+  error: ChatMessageErrorSchema.optional(),
+  timestamp: z.number().optional(),
+  metrics: ChatMessageMetricsSchema.optional(),
+  parentId: z.union([z.number(), z.string()]).optional(),
+  childrenIds: z.array(z.union([z.number(), z.string()])).optional(),
+  siblingIds: z.array(z.union([z.number(), z.string()])).optional()
+})
+
+// ---- ChatSession ----
+
+export const ChatSessionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  modelId: z.string().optional(),
+  currentLeafId: z.union([z.number(), z.string()]).optional(),
+  messages: z.array(ChatMessageSchema).optional()
+})
+
+/** Strict variant for import — messages are required. */
+export const ChatSessionImportSchema = ChatSessionSchema.extend({
+  messages: z.array(ChatMessageSchema)
+})
+
+// -- Output type aliases for consumers that need typed results --
+
+export type ChatMessageParsed = z.infer<typeof ChatMessageSchema>
+export type ChatSessionParsed = z.infer<typeof ChatSessionSchema>
+export type ChatSessionImportParsed = z.infer<typeof ChatSessionImportSchema>

--- a/packages/contracts/src/context.ts
+++ b/packages/contracts/src/context.ts
@@ -1,0 +1,48 @@
+import { z } from "zod"
+import { ChatMessageSchema } from "./chat"
+
+export const ContextFileInputSchema = z.object({
+  text: z.string(),
+  metadata: z.object({
+    fileName: z.string(),
+    fileId: z.string().optional()
+  })
+})
+
+export type ContextFileInput = z.infer<typeof ContextFileInputSchema>
+
+export const DurableContextOptionsSchema = z.object({
+  rawInput: z.string(),
+  files: z.array(ContextFileInputSchema).optional(),
+  messages: z.array(ChatMessageSchema),
+  hasTabContext: z.boolean(),
+  contextText: z.string(),
+  tabDocuments: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      content: z.string()
+    })
+  ),
+  memoryEnabled: z.boolean(),
+  maxTabContextChars: z.number(),
+  maxRagContextChars: z.number(),
+  groundedOnlyMode: z.boolean(),
+  retrievalToolsActive: z.boolean().optional(),
+  selectedModel: z.string(),
+  selectedModelRef: z
+    .object({
+      providerId: z.string(),
+      modelId: z.string()
+    })
+    .nullable(),
+  customModel: z.string().optional()
+})
+
+export type DurableContextOptionsParsed = z.infer<
+  typeof DurableContextOptionsSchema
+>
+
+export const parseDurableContextOptions = (
+  value: unknown
+): DurableContextOptionsParsed => DurableContextOptionsSchema.parse(value)

--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { AppFailureSchema } from "./app-failure"
+import { ChatMessageSchema } from "./chat"
+import { DurableContextOptionsSchema } from "./context"
 import {
   createRpcResponseEnvelopeSchema,
   RPC_PROTOCOL_VERSION,
@@ -14,6 +16,7 @@ import {
   MODEL_PULL_EVENT_TYPES,
   STREAM_PROTOCOL_VERSION
 } from "./streams"
+import { PersistedTurnRequestSchema } from "./turns"
 
 describe("contracts package", () => {
   it("runs without application or browser test shims", () => {
@@ -55,5 +58,51 @@ describe("contracts package", () => {
     expect(STREAM_PROTOCOL_VERSION).toBe(1)
     expect(CHAT_STREAM_EVENT_TYPES.CHUNK).toBe("chat_chunk")
     expect(MODEL_PULL_EVENT_TYPES.COMPLETE).toBe("model_pull_complete")
+  })
+
+  it("validates persisted turn and context contracts in clean Node", () => {
+    const context = {
+      rawInput: "hello",
+      messages: [{ role: "user", content: "hello" }],
+      hasTabContext: false,
+      contextText: "",
+      tabDocuments: [],
+      memoryEnabled: false,
+      maxTabContextChars: 10_000,
+      maxRagContextChars: 10_000,
+      groundedOnlyMode: false,
+      selectedModel: "llama3",
+      selectedModelRef: { providerId: "ollama", modelId: "llama3" }
+    }
+
+    expect(DurableContextOptionsSchema.parse(context)).toMatchObject(context)
+    expect(
+      PersistedTurnRequestSchema.parse({
+        version: 1,
+        context,
+        userMessage: { role: "user", content: "hello" }
+      })
+    ).toMatchObject({ version: 1, context })
+  })
+
+  it("measures replay limits as UTF-8 without browser globals", () => {
+    const oversized = ChatMessageSchema.safeParse({
+      role: "assistant",
+      content: "response",
+      replayArtifact: {
+        version: 1,
+        wire: "openai",
+        providerId: "openrouter",
+        model: "remote-model",
+        blocks: [
+          {
+            type: "reasoning.encrypted",
+            data: "😀".repeat(270_000)
+          }
+        ]
+      }
+    })
+
+    expect(oversized.success).toBe(false)
   })
 })

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,6 @@
 export * from "./app-failure"
+export * from "./chat"
+export * from "./context"
 export * from "./rpc"
 export * from "./streams"
+export * from "./turns"

--- a/packages/contracts/src/turns.ts
+++ b/packages/contracts/src/turns.ts
@@ -1,0 +1,81 @@
+import { z } from "zod"
+import { ChatMessageSchema } from "./chat"
+import { DurableContextOptionsSchema } from "./context"
+
+export const TURN_MODES = [
+  "new",
+  "retry",
+  "regenerate",
+  "fork",
+  "selection"
+] as const
+
+export const TurnModeSchema = z.enum(TURN_MODES)
+export type TurnMode = z.infer<typeof TurnModeSchema>
+
+export const TURN_STATUSES = [
+  "submitted",
+  "building-context",
+  "generating",
+  "completed",
+  "failed",
+  "cancelled"
+] as const
+
+export const TurnStatusSchema = z.enum(TURN_STATUSES)
+export type TurnStatus = z.infer<typeof TurnStatusSchema>
+
+export type TurnToast = {
+  variant?: "default" | "destructive"
+  titleKey: string
+  descriptionKey?: string
+  descriptionValues?: Record<string, string>
+}
+
+export const ContextReceiptSchema = z.object({
+  version: z.literal(1),
+  turnId: z.string().min(1),
+  mode: TurnModeSchema,
+  createdAt: z.number().int().nonnegative(),
+  query: z.string(),
+  model: z.object({
+    id: z.string().min(1),
+    providerId: z.string().min(1).optional()
+  }),
+  prompt: z.object({
+    inputLength: z.number().int().nonnegative(),
+    augmentedLength: z.number().int().nonnegative(),
+    tabContextLength: z.number().int().nonnegative(),
+    ragContextLength: z.number().int().nonnegative(),
+    tabContextTruncated: z.boolean(),
+    groundedOnlyMode: z.boolean(),
+    insufficientContext: z.boolean()
+  }),
+  sources: z.array(
+    z.object({
+      id: z.union([z.string(), z.number()]),
+      title: z.string(),
+      excerpt: z.string(),
+      score: z.number(),
+      sectionPath: z.string().optional(),
+      source: z.enum(["file", "memory", "tab", "unknown"]),
+      chunkIndex: z.number().int().optional()
+    })
+  )
+})
+
+export type ContextReceipt = z.infer<typeof ContextReceiptSchema>
+
+export const PersistedTurnRequestSchema = z.object({
+  version: z.literal(1),
+  context: DurableContextOptionsSchema,
+  userMessage: ChatMessageSchema
+})
+
+export type PersistedTurnRequestParsed = z.infer<
+  typeof PersistedTurnRequestSchema
+>
+
+export const parsePersistedTurnRequest = (
+  value: unknown
+): PersistedTurnRequestParsed => PersistedTurnRequestSchema.parse(value)

--- a/src/application/context/context-contract.ts
+++ b/src/application/context/context-contract.ts
@@ -1,45 +1,13 @@
-import { z } from "zod"
+import {
+  type ContextFileInput,
+  DurableContextOptionsSchema
+} from "@ollama-client/contracts/context"
 import type { ChatMessage, SelectedModelRef } from "@/types"
-import { ChatMessageSchema } from "@/types/chat.schemas"
+import { toRuntimeChatMessage } from "@/types/chat.schemas"
 
-export const ContextFileInputSchema = z.object({
-  text: z.string(),
-  metadata: z.object({
-    fileName: z.string(),
-    fileId: z.string().optional()
-  })
-})
+export * from "@ollama-client/contracts/context"
 
-export type ContextFileInput = z.infer<typeof ContextFileInputSchema>
-
-export const DurableContextOptionsSchema = z.object({
-  rawInput: z.string(),
-  files: z.array(ContextFileInputSchema).optional(),
-  messages: z.array(ChatMessageSchema),
-  hasTabContext: z.boolean(),
-  contextText: z.string(),
-  tabDocuments: z.array(
-    z.object({
-      id: z.string(),
-      title: z.string(),
-      content: z.string()
-    })
-  ),
-  memoryEnabled: z.boolean(),
-  maxTabContextChars: z.number(),
-  maxRagContextChars: z.number(),
-  groundedOnlyMode: z.boolean(),
-  retrievalToolsActive: z.boolean().optional(),
-  selectedModel: z.string(),
-  selectedModelRef: z
-    .object({
-      providerId: z.string(),
-      modelId: z.string()
-    })
-    .nullable(),
-  customModel: z.string().optional()
-})
-
+/** Runtime-normalized context command used inside the application. */
 export interface DurableContextOptions {
   rawInput: string
   files?: ContextFileInput[]
@@ -59,5 +27,10 @@ export interface DurableContextOptions {
 
 export const parseDurableContextOptions = (
   value: unknown
-): DurableContextOptions =>
-  DurableContextOptionsSchema.parse(value) as DurableContextOptions
+): DurableContextOptions => {
+  const parsed = DurableContextOptionsSchema.parse(value)
+  return {
+    ...parsed,
+    messages: parsed.messages.map(toRuntimeChatMessage)
+  }
+}

--- a/src/application/turns/turn-contract.ts
+++ b/src/application/turns/turn-contract.ts
@@ -1,82 +1,20 @@
 import type { AppFailure } from "@ollama-client/contracts/app-failure"
-import { z } from "zod"
+import {
+  type ContextReceipt,
+  PersistedTurnRequestSchema,
+  type TurnMode,
+  type TurnStatus
+} from "@ollama-client/contracts/turns"
 import {
   type DurableContextOptions,
-  DurableContextOptionsSchema
+  parseDurableContextOptions
 } from "@/application/context/context-contract"
 import type { ChatMessage } from "@/types"
-import { ChatMessageSchema } from "@/types/chat.schemas"
+import { toRuntimeChatMessage } from "@/types/chat.schemas"
 
-export const TURN_MODES = [
-  "new",
-  "retry",
-  "regenerate",
-  "fork",
-  "selection"
-] as const
+export * from "@ollama-client/contracts/turns"
 
-export const TurnModeSchema = z.enum(TURN_MODES)
-export type TurnMode = z.infer<typeof TurnModeSchema>
-
-export const TURN_STATUSES = [
-  "submitted",
-  "building-context",
-  "generating",
-  "completed",
-  "failed",
-  "cancelled"
-] as const
-
-export const TurnStatusSchema = z.enum(TURN_STATUSES)
-export type TurnStatus = z.infer<typeof TurnStatusSchema>
-
-export type TurnToast = {
-  variant?: "default" | "destructive"
-  titleKey: string
-  descriptionKey?: string
-  descriptionValues?: Record<string, string>
-}
-
-export const ContextReceiptSchema = z.object({
-  version: z.literal(1),
-  turnId: z.string().min(1),
-  mode: TurnModeSchema,
-  createdAt: z.number().int().nonnegative(),
-  query: z.string(),
-  model: z.object({
-    id: z.string().min(1),
-    providerId: z.string().min(1).optional()
-  }),
-  prompt: z.object({
-    inputLength: z.number().int().nonnegative(),
-    augmentedLength: z.number().int().nonnegative(),
-    tabContextLength: z.number().int().nonnegative(),
-    ragContextLength: z.number().int().nonnegative(),
-    tabContextTruncated: z.boolean(),
-    groundedOnlyMode: z.boolean(),
-    insufficientContext: z.boolean()
-  }),
-  sources: z.array(
-    z.object({
-      id: z.union([z.string(), z.number()]),
-      title: z.string(),
-      excerpt: z.string(),
-      score: z.number(),
-      sectionPath: z.string().optional(),
-      source: z.enum(["file", "memory", "tab", "unknown"]),
-      chunkIndex: z.number().int().optional()
-    })
-  )
-})
-
-export type ContextReceipt = z.infer<typeof ContextReceiptSchema>
-
-export const PersistedTurnRequestSchema = z.object({
-  version: z.literal(1),
-  context: DurableContextOptionsSchema,
-  userMessage: ChatMessageSchema
-})
-
+/** Runtime-normalized request used after the persisted contract is decoded. */
 export interface PersistedTurnRequest {
   version: 1
   context: DurableContextOptions
@@ -85,8 +23,14 @@ export interface PersistedTurnRequest {
 
 export const parsePersistedTurnRequest = (
   value: unknown
-): PersistedTurnRequest =>
-  PersistedTurnRequestSchema.parse(value) as PersistedTurnRequest
+): PersistedTurnRequest => {
+  const parsed = PersistedTurnRequestSchema.parse(value)
+  return {
+    version: parsed.version,
+    context: parseDurableContextOptions(parsed.context),
+    userMessage: toRuntimeChatMessage(parsed.userMessage)
+  }
+}
 
 export interface TurnSubmission {
   id: string

--- a/src/lib/repositories/tool-loop-runs.ts
+++ b/src/lib/repositories/tool-loop-runs.ts
@@ -1,14 +1,14 @@
-import { z } from "zod"
-import { createAppError } from "@/lib/error-utils"
-import { flushSave, query, run } from "@/lib/sqlite/db"
-import type { ToolCall } from "@/lib/tools"
-import type { ChatMessage, ToolRun } from "@/types"
 import {
   ChatMessageMetricsSchema,
   ChatMessageSchema,
   ToolCallSchema,
   ToolRunSchema
-} from "@/types/chat.schemas"
+} from "@ollama-client/contracts/chat"
+import { z } from "zod"
+import { createAppError } from "@/lib/error-utils"
+import { flushSave, query, run } from "@/lib/sqlite/db"
+import type { ToolCall } from "@/lib/tools"
+import type { ChatMessage, ToolRun } from "@/types"
 
 export type ToolLoopMode = "native" | "native-user-results" | "non-native"
 export type ToolLoopRunStatus = "running" | "awaiting-confirmation"

--- a/src/lib/repositories/turn-runs.ts
+++ b/src/lib/repositories/turn-runs.ts
@@ -1,10 +1,12 @@
 import {
   ContextReceiptSchema,
+  TurnModeSchema,
+  TurnStatusSchema
+} from "@ollama-client/contracts/turns"
+import {
   type DurableTurnRun,
   parsePersistedTurnRequest,
-  TurnModeSchema,
   type TurnStatus,
-  TurnStatusSchema,
   type TurnSubmission
 } from "@/application/turns/turn-contract"
 import { flushSave, query, run } from "@/lib/sqlite/db"

--- a/src/protocol/streams/chat-stream.ts
+++ b/src/protocol/streams/chat-stream.ts
@@ -1,24 +1,25 @@
 import { AppFailureSchema } from "@ollama-client/contracts/app-failure"
 import {
-  CHAT_STREAM_EVENT_TYPES,
-  STREAM_PROTOCOL_VERSION
-} from "@ollama-client/contracts/streams"
-import { z } from "zod"
-import {
-  ContextReceiptSchema,
-  type PersistedTurnRequest,
-  PersistedTurnRequestSchema,
-  TurnModeSchema
-} from "@/application/turns/turn-contract"
-import { MESSAGE_KEYS } from "@/lib/constants"
-import type { ChatMessage, ProviderReplayArtifact, ToolRun } from "@/types"
-import {
   ActivityEventSchema,
   ChatMessageSchema,
   ProviderReplayArtifactSchema,
   ToolRunSchema,
   UsedContextChunkSchema
-} from "@/types/chat.schemas"
+} from "@ollama-client/contracts/chat"
+import {
+  CHAT_STREAM_EVENT_TYPES,
+  STREAM_PROTOCOL_VERSION
+} from "@ollama-client/contracts/streams"
+import {
+  ContextReceiptSchema,
+  PersistedTurnRequestSchema,
+  TurnModeSchema
+} from "@ollama-client/contracts/turns"
+import { z } from "zod"
+import type { PersistedTurnRequest } from "@/application/turns/turn-contract"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import type { ProviderReplayArtifact, ToolRun } from "@/types"
+import { toRuntimeChatMessage } from "@/types/chat.schemas"
 import {
   SelectionStreamClientEventSchemas,
   SelectionStreamServerEventSchemas
@@ -38,35 +39,6 @@ const ContextFileSchema = z.object({
     fileId: z.string().optional()
   })
 })
-
-const toRuntimeChatMessage = (
-  message: z.infer<typeof ChatMessageSchema>
-): ChatMessage => {
-  const { attachments, ...rest } = message
-  return {
-    ...rest,
-    ...(attachments
-      ? {
-          attachments: attachments.map((attachment) => {
-            const { data, ...attachmentRest } = attachment
-            return {
-              ...attachmentRest,
-              ...(data
-                ? {
-                    data:
-                      data instanceof Uint8Array
-                        ? data
-                        : Uint8Array.from(
-                            Array.isArray(data) ? data : Object.values(data)
-                          )
-                  }
-                : {})
-            }
-          })
-        }
-      : {})
-  }
-}
 
 const RuntimeChatMessageSchema =
   ChatMessageSchema.transform(toRuntimeChatMessage)

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -3,7 +3,8 @@ import {
   ChatMessageMetricsSchema,
   ChatMessageSchema,
   ChatSessionImportSchema,
-  ChatSessionSchema
+  ChatSessionSchema,
+  toRuntimeChatMessage
 } from "../chat.schemas"
 import { PromptTemplateSchema, ThemeSchema } from "../ui-state.schemas"
 
@@ -14,6 +15,27 @@ describe("ChatMessageSchema", () => {
       content: "hello"
     })
     expect(result.success).toBe(true)
+  })
+
+  it("normalizes legacy attachment bytes at the application boundary", () => {
+    const parsed = ChatMessageSchema.parse({
+      role: "user",
+      content: "hello",
+      attachments: [
+        {
+          fileId: "file-1",
+          fileName: "notes.txt",
+          fileType: "text/plain",
+          fileSize: 2,
+          processedAt: 1,
+          data: { 0: 65, 1: 66 }
+        }
+      ]
+    })
+
+    expect(toRuntimeChatMessage(parsed).attachments?.[0].data).toEqual(
+      Uint8Array.from([65, 66])
+    )
   })
 
   it("accepts a full message with all optional fields", () => {

--- a/src/types/chat.schemas.ts
+++ b/src/types/chat.schemas.ts
@@ -1,319 +1,34 @@
-import { AppFailureSchema } from "@ollama-client/contracts/app-failure"
-import { z } from "zod"
+import type { ChatMessageParsed } from "@ollama-client/contracts/chat"
+import type { ChatMessage } from "./chat"
 
-const optionalString = z.preprocess(
-  (value) => (value === null ? undefined : value),
-  z.string().optional()
-)
+export * from "@ollama-client/contracts/chat"
 
-const optionalNumber = z.preprocess(
-  (value) => (value === null ? undefined : value),
-  z.number().optional()
-)
-
-const optionalBoolean = z.preprocess(
-  (value) => (value === null ? undefined : value),
-  z.boolean().optional()
-)
-
-// ---- Metrics (used inside messages and for SQLite parseMetrics) ----
-
-const RagSourceSchema = z.object({
-  id: z.union([z.number(), z.string()]),
-  title: z.string(),
-  content: z.string(),
-  score: z.number(),
-  source: z.string().optional(),
-  chunkIndex: z.number().optional(),
-  fileId: z.string().optional(),
-  type: z.string().optional()
-})
-
-export const UsedContextChunkSchema = z.object({
-  id: z.union([z.string(), z.number()]),
-  title: z.string(),
-  titleKey: z.string().optional(),
-  excerpt: z.string(),
-  score: z.number(),
-  sectionPath: z.string().optional(),
-  source: z.string().optional(),
-  chunkIndex: z.number().optional()
-})
-
-export const ToolRunSchema = z.object({
-  toolId: z.string(),
-  label: z.string(),
-  displayNameKey: z.string().optional(),
-  iconKey: z.string().optional(),
-  category: z
-    .enum([
-      "browser",
-      "knowledge",
-      "files",
-      "selection",
-      "web",
-      "system",
-      "external"
-    ])
-    .optional(),
-  risk: z.enum(["low", "medium", "high", "critical"]).optional(),
-  taintGeneration: z.number().int().nonnegative().optional(),
-  origin: z.string().optional(),
-  status: z.enum([
-    "pending",
-    "running",
-    "done",
-    "error",
-    "awaiting-confirmation"
-  ]),
-  callId: z.string().optional(),
-  startedAt: z.number(),
-  completedAt: z.number().optional(),
-  sources: z
-    .array(
-      z.object({
-        id: z.union([z.string(), z.number()]).optional(),
-        title: z.string(),
-        url: optionalString,
-        excerpt: optionalString,
-        publishedAt: optionalString,
-        source: optionalString,
-        score: optionalNumber,
-        category: optionalString,
-        used: optionalBoolean
-      })
-    )
-    .optional(),
-  error: z.string().optional(),
-  truncated: z.boolean().optional(),
-  args: z.record(z.string(), z.unknown()).optional(),
-  resultPreview: z.string().optional()
-})
-
-export const ActivityTextSchema = z.object({
-  text: z.string(),
-  textKey: z.string().optional()
-})
-
-export const ActivityEventSchema = z.object({
-  id: z.string(),
-  kind: z.enum([
-    "preparing_context",
-    "query_rewrite",
-    "searching_memory",
-    "searching_files",
-    "reading_page",
-    "calling_tool",
-    "generating_answer"
-  ]),
-  label: z.string(),
-  labelKey: z.string().optional(),
-  status: z.enum(["running", "done", "error"]),
-  startedAt: z.number(),
-  finishedAt: z.number().optional(),
-  inputPreview: z.string().optional(),
-  outputPreview: z.union([z.string(), ActivityTextSchema]).optional(),
-  resultCount: z.number().optional(),
-  sourceTitles: z.array(z.union([z.string(), ActivityTextSchema])).optional(),
-  error: z.string().optional()
-})
-
-export const ToolCallSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  arguments: z.record(z.string(), z.unknown())
-})
-
-const MAX_REPLAY_ARTIFACT_BYTES = 1024 * 1024
-const MAX_REPLAY_BLOCKS = 256
-
-const AnthropicReplayBlockSchema = z.discriminatedUnion("type", [
-  z
-    .object({
-      type: z.literal("thinking"),
-      thinking: z.string(),
-      signature: z.string()
-    })
-    .passthrough(),
-  z
-    .object({
-      type: z.literal("redacted_thinking"),
-      data: z.string()
-    })
-    .passthrough(),
-  z.object({ type: z.literal("text"), text: z.string() }).passthrough(),
-  z
-    .object({
-      type: z.literal("tool_use"),
-      id: z.string(),
-      name: z.string(),
-      input: z.record(z.string(), z.unknown())
-    })
-    .passthrough()
-])
-
-const OpenAIReasoningCommonSchema = z.object({
-  id: z.string().nullish(),
-  format: z.string().nullish(),
-  index: z.number().int().nonnegative().optional()
-})
-
-const OpenAIReplayBlockSchema = z.discriminatedUnion("type", [
-  OpenAIReasoningCommonSchema.extend({
-    type: z.literal("reasoning.summary"),
-    summary: z.string()
-  }).passthrough(),
-  OpenAIReasoningCommonSchema.extend({
-    type: z.literal("reasoning.encrypted"),
-    data: z.string()
-  }).passthrough(),
-  OpenAIReasoningCommonSchema.extend({
-    type: z.literal("reasoning.text"),
-    text: z.string(),
-    signature: z.string().nullish()
-  }).passthrough()
-])
-
-const replayArtifactSize = (value: unknown): number => {
-  try {
-    return new TextEncoder().encode(JSON.stringify(value)).byteLength
-  } catch {
-    return Number.POSITIVE_INFINITY
+/** Convert persisted compatibility byte shapes into the app's runtime form. */
+export const toRuntimeChatMessage = (
+  message: ChatMessageParsed
+): ChatMessage => {
+  const { attachments, ...rest } = message
+  return {
+    ...rest,
+    ...(attachments
+      ? {
+          attachments: attachments.map((attachment) => {
+            const { data, ...attachmentRest } = attachment
+            return {
+              ...attachmentRest,
+              ...(data !== undefined
+                ? {
+                    data:
+                      data instanceof Uint8Array
+                        ? data
+                        : Uint8Array.from(
+                            Array.isArray(data) ? data : Object.values(data)
+                          )
+                  }
+                : {})
+            }
+          })
+        }
+      : {})
   }
 }
-
-export const ProviderReplayArtifactSchema = z
-  .discriminatedUnion("wire", [
-    z.object({
-      version: z.literal(1),
-      wire: z.literal("anthropic"),
-      providerId: z.string().min(1),
-      model: z.string().min(1),
-      blocks: z.array(AnthropicReplayBlockSchema).min(1).max(MAX_REPLAY_BLOCKS)
-    }),
-    z.object({
-      version: z.literal(1),
-      wire: z.literal("openai"),
-      providerId: z.string().min(1),
-      model: z.string().min(1),
-      blocks: z.array(OpenAIReplayBlockSchema).min(1).max(MAX_REPLAY_BLOCKS)
-    })
-  ])
-  .refine(
-    (artifact) => replayArtifactSize(artifact) <= MAX_REPLAY_ARTIFACT_BYTES,
-    "Provider replay artifact exceeds the storage limit"
-  )
-
-export const ChatMessageMetricsSchema = z.object({
-  total_duration: z.number().optional(),
-  load_duration: z.number().optional(),
-  prompt_eval_count: z.number().optional(),
-  prompt_eval_duration: z.number().optional(),
-  eval_count: z.number().optional(),
-  eval_duration: z.number().optional(),
-  ragQuery: z.string().optional(),
-  ragSources: z.array(RagSourceSchema).optional(),
-  usedContextChunks: z.array(UsedContextChunkSchema).optional(),
-  activityEvents: z.array(ActivityEventSchema).optional(),
-  toolRuns: z.array(ToolRunSchema).optional(),
-  groundedOnlyMode: z.boolean().optional(),
-  insufficientContext: z.boolean().optional(),
-  promptInputLength: z.number().optional(),
-  promptAugmentedLength: z.number().optional(),
-  tabContextLength: z.number().optional(),
-  ragContextLength: z.number().optional(),
-  tabContextTruncated: z.boolean().optional(),
-  contextBuildFailed: z.boolean().optional(),
-  thinkingOnlyResponse: z.boolean().optional(),
-  emptyResponse: z.boolean().optional(),
-  interrupted: z.boolean().optional()
-})
-
-// ---- FileAttachment ----
-
-export const FileAttachmentSchema = z.object({
-  id: z.number().optional(),
-  fileId: z.string(),
-  fileName: z.string(),
-  fileType: z.string(),
-  fileSize: z.number(),
-  textPreview: z.string().optional(),
-  processedAt: z.number(),
-  sessionId: z.string().optional(),
-  messageId: z.number().optional(),
-  // Bytes export as a JSON array, but a Uint8Array that slips through
-  // JSON.stringify serializes to an index-keyed object ({"0":..,"1":..}).
-  // Accept both so one stray byte field can't fail validation and silently
-  // skip the whole session on import.
-  data: z
-    .union([
-      z.instanceof(Uint8Array),
-      z.array(z.number()),
-      z.record(z.string(), z.number())
-    ])
-    .optional()
-})
-
-export type FileAttachmentParsed = z.infer<typeof FileAttachmentSchema>
-
-const ImageAttachmentSchema = z.object({
-  id: z.number().optional(),
-  imageId: z.string(),
-  fileName: z.string(),
-  mimeType: z.string(),
-  size: z.number(),
-  base64: z.string(),
-  width: z.number().optional(),
-  height: z.number().optional(),
-  sessionId: z.string().optional(),
-  messageId: z.number().optional()
-})
-
-// ---- ChatMessage ----
-
-export const ChatMessageErrorSchema = AppFailureSchema.partial()
-
-export const ChatMessageSchema = z.object({
-  id: z.union([z.number(), z.string()]).optional(),
-  role: z.enum(["user", "assistant", "system", "tool"]),
-  content: z.string(),
-  thinking: z.string().optional(),
-  replayArtifact: ProviderReplayArtifactSchema.optional(),
-  done: z.boolean().optional(),
-  model: z.string().optional(),
-  attachments: z.array(FileAttachmentSchema).optional(),
-  images: z.array(ImageAttachmentSchema).optional(),
-  toolCalls: z.array(ToolCallSchema).optional(),
-  toolName: z.string().optional(),
-  toolCallId: z.string().optional(),
-  toolIsError: z.boolean().optional(),
-  error: ChatMessageErrorSchema.optional(),
-  timestamp: z.number().optional(),
-  metrics: ChatMessageMetricsSchema.optional(),
-  parentId: z.union([z.number(), z.string()]).optional(),
-  childrenIds: z.array(z.union([z.number(), z.string()])).optional(),
-  siblingIds: z.array(z.union([z.number(), z.string()])).optional()
-})
-
-// ---- ChatSession ----
-
-export const ChatSessionSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
-  modelId: z.string().optional(),
-  currentLeafId: z.union([z.number(), z.string()]).optional(),
-  messages: z.array(ChatMessageSchema).optional()
-})
-
-/** Strict variant for import — messages are required. */
-export const ChatSessionImportSchema = ChatSessionSchema.extend({
-  messages: z.array(ChatMessageSchema)
-})
-
-// -- Output type aliases for consumers that need typed results --
-
-export type ChatMessageParsed = z.infer<typeof ChatMessageSchema>
-export type ChatSessionParsed = z.infer<typeof ChatSessionSchema>
-export type ChatSessionImportParsed = z.infer<typeof ChatSessionImportSchema>


### PR DESCRIPTION
## Summary

- move shared chat, persisted context, and persisted turn schemas into `@ollama-client/contracts`
- retain explicit application adapters for normalized runtime messages and legacy attachment bytes
- migrate stream and persistence schema consumers to package subpath imports
- update the release roadmap with completed and remaining P1 work

## Why

Persisted compatibility shapes are broader than the application-owned `ChatMessage` runtime type. Separating package validation contracts from normalization adapters keeps the contracts package environment-independent without weakening application types.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 309 files, 2,594 tests
- Chrome production package and bundle budgets
- documentation build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts shared chat, context, and turn schemas into the environment-independent contracts package while retaining application adapters for runtime attachment bytes.
- Adds public `chat`, `context`, and `turns` contract subpaths.
- Migrates stream and persistence consumers to package-owned schemas.
- Normalizes legacy attachment representations when persisted context and turn requests enter the application.
- Adds clean-Node coverage for nested contracts and UTF-8 replay limits.
- Updates the release roadmap to reflect the completed extraction slice.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with schema behavior preserved and legacy attachment normalization applied at explicit application boundaries.

The extracted contracts remain environment-independent, current build targets resolve the new package subpaths, and no reachable validation, persistence, stream, or attachment-byte regression was established.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/contracts/src/chat.ts | Extracts chat, attachment, metrics, and replay-artifact schemas while replacing the DOM-dependent byte counter with an equivalent ES-only implementation. |
| packages/contracts/src/context.ts | Defines the package-owned durable context contract without application or browser dependencies. |
| packages/contracts/src/turns.ts | Defines shared turn modes, statuses, receipts, and persisted request validation using package-local schemas. |
| src/types/chat.schemas.ts | Becomes a compatibility re-export plus an explicit adapter that converts persisted attachment byte shapes into runtime Uint8Arrays. |
| src/application/context/context-contract.ts | Preserves the application-owned normalized context type and converts every parsed message at the boundary. |
| src/application/turns/turn-contract.ts | Preserves the application-owned turn request type while normalizing nested context messages and the user message after validation. |
| src/protocol/streams/chat-stream.ts | Migrates stream validation to package contracts while retaining runtime message transformation. |
| src/lib/repositories/tool-loop-runs.ts | Switches persisted tool-loop checkpoint validation to the equivalent package-owned chat schemas. |
| src/lib/repositories/turn-runs.ts | Uses package-owned turn schemas while retaining application parsing for normalized persisted requests. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Persisted["Persisted turn/context data"] --> Contracts["Contracts package schemas"]
  Stream["Cross-context stream events"] --> Contracts
  Contracts --> Adapter["Application normalization adapter"]
  Adapter --> Runtime["Runtime ChatMessage with Uint8Array attachments"]
  Contracts --> Repositories["Turn and tool-loop repositories"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(contracts): extract turn schema..."](https://github.com/shishir435/ollama-client/commit/9ee20249692bef6dc6d23b56cb92c35b87570907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51558231)</sub>

**Context used:**

- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)

<!-- /greptile_comment -->