### PR TITLE
refactor(runtime): extract turn orchestration

### DIFF
--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -240,17 +240,14 @@ Completed:
 
 Remaining package work:
 
-- P1: complete on `feature/contracts-provider-rpc-schemas`; merge the proven
-  contract seams into `release/0.13.x`.
-- P2: complete on `feature/runtime-core-primitives`; merge deterministic
-  runtime helpers and their environment ports into `release/0.13.x`.
-- P3: extract chat runtime only after P1/P2 prove stable; agent runtime remains
-  scheduled for `0.14.x`.
+- P1: complete in `release/0.13.x` via PRs #244–#246.
+- P2: complete in `release/0.13.x` via PR #247.
+- P3: in progress on `feature/chat-runtime-turn-orchestration`; agent runtime
+  remains scheduled for `0.14.x`.
 
 #### P1 — `packages/contracts`
 
-Status: complete on `feature/contracts-provider-rpc-schemas`, pending merge,
-2026-08-09.
+Status: complete in `release/0.13.x` via PRs #244–#246, 2026-08-09.
 
 Completed in the first extraction slice:
 
@@ -302,7 +299,7 @@ Completed in the final P1 slice:
   application normalization adapters; they convert errors or persisted legacy
   shapes and do not re-export package contracts.
 
-Remaining in P1: none after this branch merges.
+Remaining in P1: none.
 
 Candidate ownership:
 
@@ -315,8 +312,7 @@ consume it through its public exports.
 
 #### P2 — `packages/runtime-core`
 
-Status: complete on `feature/runtime-core-primitives`, pending merge,
-2026-08-09.
+Status: complete in `release/0.13.x` via PR #247, 2026-08-09.
 
 Completed:
 
@@ -338,8 +334,8 @@ Completed:
 - Added an architecture contract that permits only relative modules and
   `@ollama-client/contracts` imports from runtime-core.
 
-Remaining in P2: none after this branch merges. Browser transport authorization
-remains extension policy; turn, context, and tool-loop
+Remaining in P2: none. Browser transport authorization remains extension
+policy; turn, context, and tool-loop
 orchestration remain domain-runtime work for P3.
 
 Candidate ownership:
@@ -352,7 +348,21 @@ Exit gate: deterministic tests run without browser globals or extension setup.
 
 #### P3 — domain runtimes
 
-Extract only after P1/P2 prove useful:
+Status: in progress on `feature/chat-runtime-turn-orchestration`, 2026-08-09.
+
+Completed in the first turn-orchestration slice:
+
+- Added the environment-independent `@ollama-client/chat-runtime` workspace
+  package with a clean-Node test project and independent no-DOM typecheck.
+- Moved durable turn submission, context/generation transitions, resume,
+  completion/cancellation, and failure persistence into a port-driven runtime.
+- Kept persisted-shape normalization, context callbacks, failure conversion,
+  SQLite repositories, provider invocation, and browser streaming in extension
+  composition.
+- Added a source contract allowing only relative modules plus contracts and
+  runtime-core dependencies from chat-runtime.
+
+Remaining P3 slices:
 
 - `packages/chat-runtime`: turn orchestration, context contracts, and tool-loop
   coordination behind ports.

--- a/package.json
+++ b/package.json
@@ -79,9 +79,10 @@
     "format:fix": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "pnpm typecheck:packages && tsc6 -p tsconfig.json --noEmit",
-    "typecheck:packages": "pnpm typecheck:contracts && pnpm typecheck:runtime-core",
+    "typecheck:packages": "pnpm typecheck:contracts && pnpm typecheck:runtime-core && pnpm typecheck:chat-runtime",
     "typecheck:contracts": "tsc6 -p packages/contracts/tsconfig.json --noEmit",
     "typecheck:runtime-core": "tsc6 -p packages/runtime-core/tsconfig.json --noEmit",
+    "typecheck:chat-runtime": "tsc6 -p packages/chat-runtime/tsconfig.json --noEmit",
     "check:dead": "knip --no-config-hints",
     "audit": "pnpm audit",
     "clean": "rm -rf build .plasmo .wxt .output node_modules",
@@ -92,6 +93,7 @@
     "check:compatibility": "node tools/check-compatibility-ledger.mjs"
   },
   "dependencies": {
+    "@ollama-client/chat-runtime": "workspace:*",
     "@ollama-client/contracts": "workspace:*",
     "@ollama-client/runtime-core": "workspace:*",
     "@base-ui/react": "^1.5.0",

--- a/packages/chat-runtime/package.json
+++ b/packages/chat-runtime/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ollama-client/chat-runtime",
+  "version": "0.13.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./turn-runtime": "./src/turn-runtime.ts"
+  },
+  "dependencies": {
+    "@ollama-client/contracts": "workspace:*"
+  }
+}

--- a/packages/chat-runtime/src/__tests__/turn-runtime.test.ts
+++ b/packages/chat-runtime/src/__tests__/turn-runtime.test.ts
@@ -5,7 +5,7 @@ import {
   type TurnGenerationOwner,
   type TurnRunStore,
   TurnRuntime
-} from "./turn-runtime"
+} from "../turn-runtime"
 
 type TestContext = { rawInput: string }
 type TestMessage = { role: "user"; content: string }

--- a/packages/chat-runtime/src/index.ts
+++ b/packages/chat-runtime/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./turn-runtime"

--- a/packages/chat-runtime/src/turn-runtime.test.ts
+++ b/packages/chat-runtime/src/turn-runtime.test.ts
@@ -1,0 +1,171 @@
+import type { ContextReceipt } from "@ollama-client/contracts/turns"
+import { describe, expect, it, vi } from "vitest"
+import {
+  type TurnContextOwner,
+  type TurnGenerationOwner,
+  type TurnRunStore,
+  TurnRuntime
+} from "./turn-runtime"
+
+type TestContext = { rawInput: string }
+type TestMessage = { role: "user"; content: string }
+type TestOutput = { prompt: string }
+
+const receipt: ContextReceipt = {
+  version: 1,
+  turnId: "turn-1",
+  mode: "new",
+  createdAt: 11,
+  query: "hello",
+  model: { id: "llama3" },
+  prompt: {
+    inputLength: 5,
+    augmentedLength: 5,
+    tabContextLength: 0,
+    ragContextLength: 0,
+    tabContextTruncated: false,
+    groundedOnlyMode: false,
+    insufficientContext: false
+  },
+  sources: []
+}
+
+const command = {
+  id: "turn-1",
+  sessionId: "session-1",
+  mode: "new" as const,
+  model: "llama3",
+  persistedContext: { rawInput: "hello" },
+  contextOptions: { rawInput: "hello" },
+  userMessage: { role: "user" as const, content: "hello" }
+}
+
+const makeRuntime = (
+  store: TurnRunStore<TestContext, TestMessage>,
+  context: TurnContextOwner<TestContext, TestOutput>,
+  generation: TurnGenerationOwner<TestContext, TestMessage, TestOutput>
+) =>
+  new TurnRuntime<TestContext, TestMessage, TestContext, TestOutput>(
+    store,
+    context,
+    generation,
+    {
+      toFailure: (error) => ({
+        status: 0,
+        message: error instanceof Error ? error.message : "Turn failed"
+      })
+    },
+    { now: () => 10 }
+  )
+
+describe("TurnRuntime", () => {
+  it("owns the durable lifecycle in order", async () => {
+    const order: string[] = []
+    const store: TurnRunStore<TestContext, TestMessage> = {
+      create: vi.fn(async () => {
+        order.push("create")
+      }),
+      update: vi.fn(async (_id, update) => {
+        order.push(`update:${update.status}`)
+      })
+    }
+    const context: TurnContextOwner<TestContext, TestOutput> = {
+      build: vi.fn(async () => {
+        order.push("context")
+        return { prompt: "hello", receipt }
+      })
+    }
+    const generation: TurnGenerationOwner<
+      TestContext,
+      TestMessage,
+      TestOutput
+    > = {
+      start: vi.fn(async () => {
+        order.push("generation")
+        return { userMessageId: 1, assistantMessageId: 2 }
+      })
+    }
+
+    await makeRuntime(store, context, generation).start(command)
+
+    expect(order).toEqual([
+      "create",
+      "update:building-context",
+      "context",
+      "update:generating",
+      "generation",
+      "update:completed"
+    ])
+    expect(store.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdAt: 10,
+        request: {
+          version: 1,
+          context: command.persistedContext,
+          userMessage: command.userMessage
+        }
+      })
+    )
+  })
+
+  it("maps and persists failures before rethrowing", async () => {
+    const store: TurnRunStore<TestContext, TestMessage> = {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined)
+    }
+    const context: TurnContextOwner<TestContext, TestOutput> = {
+      build: vi.fn().mockRejectedValue(new Error("context unavailable"))
+    }
+    const generation: TurnGenerationOwner<
+      TestContext,
+      TestMessage,
+      TestOutput
+    > = { start: vi.fn() }
+
+    await expect(
+      makeRuntime(store, context, generation).start(command)
+    ).rejects.toThrow("context unavailable")
+    expect(store.update).toHaveBeenLastCalledWith("turn-1", {
+      status: "failed",
+      failure: { status: 0, message: "context unavailable" }
+    })
+    expect(generation.start).not.toHaveBeenCalled()
+  })
+
+  it("resumes without creating a second durable intent", async () => {
+    const store: TurnRunStore<TestContext, TestMessage> = {
+      create: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined)
+    }
+    const context: TurnContextOwner<TestContext, TestOutput> = {
+      build: vi.fn().mockResolvedValue({ prompt: "hello", receipt })
+    }
+    const generation: TurnGenerationOwner<
+      TestContext,
+      TestMessage,
+      TestOutput
+    > = { start: vi.fn().mockResolvedValue({ outcome: "cancelled" }) }
+    const runtime = makeRuntime(store, context, generation)
+
+    await runtime.resume({
+      turn: {
+        ...command,
+        request: {
+          version: 1,
+          context: command.persistedContext,
+          userMessage: command.userMessage
+        },
+        createdAt: 10,
+        updatedAt: 12,
+        status: "generating"
+      },
+      contextOptions: command.contextOptions
+    })
+
+    expect(store.create).not.toHaveBeenCalled()
+    expect(store.update).toHaveBeenLastCalledWith("turn-1", {
+      status: "cancelled",
+      failure: null
+    })
+  })
+})

--- a/packages/chat-runtime/src/turn-runtime.ts
+++ b/packages/chat-runtime/src/turn-runtime.ts
@@ -1,0 +1,219 @@
+import type { AppFailure } from "@ollama-client/contracts/app-failure"
+import type {
+  ContextReceipt,
+  TurnMode,
+  TurnStatus
+} from "@ollama-client/contracts/turns"
+
+export interface PersistedTurnRequest<TContext, TMessage> {
+  version: 1
+  context: TContext
+  userMessage: TMessage
+}
+
+export interface TurnSubmission<TContext, TMessage> {
+  id: string
+  sessionId: string
+  mode: TurnMode
+  model: string
+  providerId?: string
+  request: PersistedTurnRequest<TContext, TMessage>
+  createdAt: number
+}
+
+export interface DurableTurnRun<TContext, TMessage>
+  extends TurnSubmission<TContext, TMessage> {
+  status: TurnStatus
+  contextReceipt?: ContextReceipt
+  userMessageId?: number
+  assistantMessageId?: number
+  failure?: AppFailure
+  updatedAt: number
+}
+
+export type TurnRunUpdate = {
+  status?: TurnStatus
+  contextReceipt?: ContextReceipt
+  userMessageId?: number
+  assistantMessageId?: number
+  failure?: AppFailure | null
+}
+
+export interface TurnRunStore<TContext, TMessage> {
+  create: (submission: TurnSubmission<TContext, TMessage>) => Promise<void>
+  update: (id: string, updates: TurnRunUpdate) => Promise<void>
+}
+
+export interface TurnContextCommand<TContextOptions> {
+  turnId: string
+  mode: TurnMode
+  model: string
+  providerId?: string
+  options: TContextOptions
+}
+
+export interface TurnContextOwner<TContextOptions, TContextOutput> {
+  build: (
+    command: TurnContextCommand<TContextOptions>
+  ) => Promise<TContextOutput & { receipt: ContextReceipt }>
+}
+
+export interface TurnGenerationInput<TContext, TMessage, TContextOutput> {
+  submission: TurnSubmission<TContext, TMessage>
+  context: TContextOutput & { receipt: ContextReceipt }
+  userMessageId?: number
+  assistantMessageId?: number
+}
+
+export interface TurnGenerationOwner<TContext, TMessage, TContextOutput> {
+  start: (
+    input: TurnGenerationInput<TContext, TMessage, TContextOutput>
+  ) => Promise<{
+    outcome?: "completed" | "cancelled"
+    userMessageId?: number
+    assistantMessageId?: number
+  }>
+}
+
+export interface TurnFailureMapper {
+  toFailure: (error: unknown) => AppFailure
+}
+
+export interface TurnClock {
+  now: () => number
+}
+
+export interface StartTurnCommand<TContext, TMessage, TContextOptions> {
+  id: string
+  sessionId: string
+  mode: TurnMode
+  model: string
+  providerId?: string
+  persistedContext: TContext
+  contextOptions: TContextOptions
+  userMessage: TMessage
+  userMessageId?: number
+  assistantMessageId?: number
+  prepareContextOptions?: (options: TContextOptions) => Promise<TContextOptions>
+  createdAt?: number
+}
+
+export interface ResumeTurnCommand<TContext, TMessage, TContextOptions> {
+  turn: DurableTurnRun<TContext, TMessage>
+  contextOptions: TContextOptions
+  prepareContextOptions?: (options: TContextOptions) => Promise<TContextOptions>
+}
+
+/**
+ * Environment-independent owner of the durable turn lifecycle.
+ *
+ * Intent is persisted before context or generation work. Browser transport,
+ * provider invocation, context construction, persistence, and failure mapping
+ * enter only through ports supplied by the extension composition root.
+ */
+export class TurnRuntime<TContext, TMessage, TContextOptions, TContextOutput> {
+  constructor(
+    private readonly store: TurnRunStore<TContext, TMessage>,
+    private readonly context: TurnContextOwner<TContextOptions, TContextOutput>,
+    private readonly generation: TurnGenerationOwner<
+      TContext,
+      TMessage,
+      TContextOutput
+    >,
+    private readonly failures: TurnFailureMapper,
+    private readonly clock: TurnClock
+  ) {}
+
+  async start(
+    command: StartTurnCommand<TContext, TMessage, TContextOptions>
+  ): Promise<void> {
+    const submission: TurnSubmission<TContext, TMessage> = {
+      id: command.id,
+      sessionId: command.sessionId,
+      mode: command.mode,
+      model: command.model,
+      providerId: command.providerId,
+      request: {
+        version: 1,
+        context: command.persistedContext,
+        userMessage: command.userMessage
+      },
+      createdAt: command.createdAt ?? this.clock.now()
+    }
+
+    await this.store.create(submission)
+    await this.run(
+      submission,
+      command.contextOptions,
+      command.userMessageId,
+      command.assistantMessageId,
+      command.prepareContextOptions
+    )
+  }
+
+  async resume(
+    command: ResumeTurnCommand<TContext, TMessage, TContextOptions>
+  ): Promise<void> {
+    await this.run(
+      command.turn,
+      command.contextOptions,
+      command.turn.userMessageId,
+      command.turn.assistantMessageId,
+      command.prepareContextOptions
+    )
+  }
+
+  private async run(
+    submission: TurnSubmission<TContext, TMessage>,
+    contextOptions: TContextOptions,
+    userMessageId?: number,
+    assistantMessageId?: number,
+    prepareContextOptions?: (
+      options: TContextOptions
+    ) => Promise<TContextOptions>
+  ): Promise<void> {
+    try {
+      await this.store.update(submission.id, {
+        status: "building-context",
+        ...(userMessageId !== undefined ? { userMessageId } : {}),
+        ...(assistantMessageId !== undefined ? { assistantMessageId } : {})
+      })
+      const preparedOptions = prepareContextOptions
+        ? await prepareContextOptions(contextOptions)
+        : contextOptions
+      const context = await this.context.build({
+        turnId: submission.id,
+        mode: submission.mode,
+        model: submission.model,
+        providerId: submission.providerId,
+        options: preparedOptions
+      })
+      await this.store.update(submission.id, {
+        status: "generating",
+        contextReceipt: context.receipt
+      })
+      const result = await this.generation.start({
+        submission,
+        context,
+        userMessageId,
+        assistantMessageId
+      })
+      await this.store.update(submission.id, {
+        status: result.outcome === "cancelled" ? "cancelled" : "completed",
+        ...(result.outcome === "cancelled" ? { failure: null } : {}),
+        ...(result.userMessageId !== undefined
+          ? { userMessageId: result.userMessageId }
+          : {}),
+        ...(result.assistantMessageId !== undefined
+          ? { assistantMessageId: result.assistantMessageId }
+          : {})
+      })
+    } catch (error) {
+      await this.store.update(submission.id, {
+        status: "failed",
+        failure: this.failures.toFailure(error)
+      })
+      throw error
+    }
+  }
+}

--- a/packages/chat-runtime/tsconfig.json
+++ b/packages/chat-runtime/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      '@ollama-client/chat-runtime':
+        specifier: workspace:*
+        version: link:packages/chat-runtime
       '@ollama-client/contracts':
         specifier: workspace:*
         version: link:packages/contracts
@@ -346,6 +349,12 @@ importers:
       typescript:
         specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
+
+  packages/chat-runtime:
+    dependencies:
+      '@ollama-client/contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/contracts:
     dependencies:

--- a/src/application/turns/turn-contract.ts
+++ b/src/application/turns/turn-contract.ts
@@ -1,10 +1,8 @@
-import type { AppFailure } from "@ollama-client/contracts/app-failure"
-import {
-  type ContextReceipt,
-  PersistedTurnRequestSchema,
-  type TurnMode,
-  type TurnStatus
-} from "@ollama-client/contracts/turns"
+import type {
+  DurableTurnRun as RuntimeDurableTurnRun,
+  TurnSubmission as RuntimeTurnSubmission
+} from "@ollama-client/chat-runtime/turn-runtime"
+import { PersistedTurnRequestSchema } from "@ollama-client/contracts/turns"
 import {
   type DurableContextOptions,
   parseDurableContextOptions
@@ -30,26 +28,17 @@ export const parsePersistedTurnRequest = (
   }
 }
 
-export interface TurnSubmission {
-  id: string
-  sessionId: string
-  mode: TurnMode
-  model: string
-  providerId?: string
-  request: PersistedTurnRequest
-  createdAt: number
-}
+export type TurnSubmission = RuntimeTurnSubmission<
+  DurableContextOptions,
+  ChatMessage
+>
 
 export interface DurableTurnStart {
   submission: TurnSubmission
   userMessageId: number
 }
 
-export interface DurableTurnRun extends TurnSubmission {
-  status: TurnStatus
-  contextReceipt?: ContextReceipt
-  userMessageId?: number
-  assistantMessageId?: number
-  failure?: AppFailure
-  updatedAt: number
-}
+export type DurableTurnRun = RuntimeDurableTurnRun<
+  DurableContextOptions,
+  ChatMessage
+>

--- a/src/application/turns/turn-service.ts
+++ b/src/application/turns/turn-service.ts
@@ -1,48 +1,39 @@
+import {
+  type TurnGenerationInput as RuntimeTurnGenerationInput,
+  type TurnGenerationOwner as RuntimeTurnGenerationOwner,
+  type TurnRunStore as RuntimeTurnRunStore,
+  TurnRuntime
+} from "@ollama-client/chat-runtime/turn-runtime"
 import type { TurnMode } from "@ollama-client/contracts/turns"
 import type { BuildRagContextOptions } from "@/application/context/build-context"
-import { parseDurableContextOptions } from "@/application/context/context-contract"
+import {
+  type DurableContextOptions,
+  parseDurableContextOptions
+} from "@/application/context/context-contract"
 import type {
   ContextBuildOutput,
   ContextService
 } from "@/application/context/context-service"
 import { toAppFailure } from "@/protocol/app-failure"
 import type { ChatMessage } from "@/types"
-import type { DurableTurnRun, TurnSubmission } from "./turn-contract"
+import type { DurableTurnRun } from "./turn-contract"
 
-export interface TurnRunStore {
-  create: (submission: TurnSubmission) => Promise<void>
-  update: (
-    id: string,
-    updates: Omit<
-      Partial<
-        Pick<
-          DurableTurnRun,
-          | "status"
-          | "contextReceipt"
-          | "userMessageId"
-          | "assistantMessageId"
-          | "failure"
-        >
-      >,
-      "failure"
-    > & { failure?: DurableTurnRun["failure"] | null }
-  ) => Promise<void>
-}
+export type TurnRunStore = RuntimeTurnRunStore<
+  DurableContextOptions,
+  ChatMessage
+>
 
-export interface TurnGenerationInput {
-  submission: TurnSubmission
-  context: ContextBuildOutput
-  userMessageId?: number
-  assistantMessageId?: number
-}
+export type TurnGenerationInput = RuntimeTurnGenerationInput<
+  DurableContextOptions,
+  ChatMessage,
+  ContextBuildOutput
+>
 
-export interface TurnGenerationOwner {
-  start: (input: TurnGenerationInput) => Promise<{
-    outcome?: "completed" | "cancelled"
-    userMessageId?: number
-    assistantMessageId?: number
-  }>
-}
+export type TurnGenerationOwner = RuntimeTurnGenerationOwner<
+  DurableContextOptions,
+  ChatMessage,
+  ContextBuildOutput
+>
 
 export interface StartTurnCommand {
   id: string
@@ -67,11 +58,32 @@ export interface StartTurnCommand {
  * closure can only hide progress; it cannot erase ownership of the turn.
  */
 export class TurnService {
+  private readonly runtime: TurnRuntime<
+    DurableContextOptions,
+    ChatMessage,
+    BuildRagContextOptions,
+    ContextBuildOutput
+  >
+
   constructor(
-    private readonly store: TurnRunStore,
-    private readonly contextService: ContextService,
-    private readonly generation: TurnGenerationOwner
-  ) {}
+    store: TurnRunStore,
+    contextService: ContextService,
+    generation: TurnGenerationOwner
+  ) {
+    this.runtime = new TurnRuntime(
+      store,
+      contextService,
+      generation,
+      {
+        toFailure: (error) =>
+          toAppFailure(error, {
+            fallbackMessage: "Turn failed",
+            context: "turn-run"
+          })
+      },
+      { now: Date.now }
+    )
+  }
 
   async start(command: StartTurnCommand): Promise<void> {
     const {
@@ -79,28 +91,20 @@ export class TurnService {
       toast: _toast,
       ...context
     } = command.contextOptions
-    const submission: TurnSubmission = {
+    await this.runtime.start({
       id: command.id,
       sessionId: command.sessionId,
       mode: command.mode,
       model: command.model,
       providerId: command.providerId,
-      request: {
-        version: 1,
-        context: parseDurableContextOptions(context),
-        userMessage: command.userMessage
-      },
-      createdAt: command.createdAt ?? Date.now()
-    }
-
-    await this.store.create(submission)
-    await this.run(
-      submission,
-      command.contextOptions,
-      command.userMessageId,
-      command.assistantMessageId,
-      command.prepareContextOptions
-    )
+      persistedContext: parseDurableContextOptions(context),
+      contextOptions: command.contextOptions,
+      userMessage: command.userMessage,
+      userMessageId: command.userMessageId,
+      assistantMessageId: command.assistantMessageId,
+      prepareContextOptions: command.prepareContextOptions,
+      createdAt: command.createdAt
+    })
   }
 
   async resume(
@@ -113,69 +117,10 @@ export class TurnService {
       ...turn.request.context,
       toast: () => undefined
     }
-    await this.run(
+    await this.runtime.resume({
       turn,
-      baseOptions,
-      turn.userMessageId,
-      turn.assistantMessageId,
+      contextOptions: baseOptions,
       prepareContextOptions
-    )
-  }
-
-  private async run(
-    submission: TurnSubmission,
-    contextOptions: BuildRagContextOptions,
-    userMessageId?: number,
-    assistantMessageId?: number,
-    prepareContextOptions?: (
-      options: BuildRagContextOptions
-    ) => Promise<BuildRagContextOptions>
-  ): Promise<void> {
-    try {
-      await this.store.update(submission.id, {
-        status: "building-context",
-        ...(userMessageId !== undefined ? { userMessageId } : {}),
-        ...(assistantMessageId !== undefined ? { assistantMessageId } : {})
-      })
-      const preparedContextOptions = prepareContextOptions
-        ? await prepareContextOptions(contextOptions)
-        : contextOptions
-      const context = await this.contextService.build({
-        turnId: submission.id,
-        mode: submission.mode,
-        model: submission.model,
-        providerId: submission.providerId,
-        options: preparedContextOptions
-      })
-      await this.store.update(submission.id, {
-        status: "generating",
-        contextReceipt: context.receipt
-      })
-      const result = await this.generation.start({
-        submission,
-        context,
-        userMessageId,
-        assistantMessageId
-      })
-      await this.store.update(submission.id, {
-        status: result.outcome === "cancelled" ? "cancelled" : "completed",
-        ...(result.outcome === "cancelled" ? { failure: null } : {}),
-        ...(result.userMessageId !== undefined
-          ? { userMessageId: result.userMessageId }
-          : {}),
-        ...(result.assistantMessageId !== undefined
-          ? { assistantMessageId: result.assistantMessageId }
-          : {})
-      })
-    } catch (error) {
-      await this.store.update(submission.id, {
-        status: "failed",
-        failure: toAppFailure(error, {
-          fallbackMessage: "Turn failed",
-          context: "turn-run"
-        })
-      })
-      throw error
-    }
+    })
   }
 }

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -5,6 +5,7 @@ import ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 const sourceRoot = join(process.cwd(), "src")
+const chatRuntimeRoot = join(process.cwd(), "packages/chat-runtime/src")
 const contractsRoot = join(process.cwd(), "packages/contracts/src")
 const runtimeCoreRoot = join(process.cwd(), "packages/runtime-core/src")
 
@@ -265,6 +266,28 @@ describe("architecture import boundaries", () => {
         )
         .map((module) => ({
           file: relative(runtimeCoreRoot, file).replaceAll("\\", "/"),
+          module
+        }))
+    })
+
+    expect(offenders).toEqual([])
+  })
+
+  it("keeps chat-runtime behind contracts and relative ports", () => {
+    const runtimeSources = walk(chatRuntimeRoot)
+      .filter((file) => /\.ts$/.test(file))
+      .filter((file) => !file.endsWith(".test.ts"))
+    const offenders = runtimeSources.flatMap((file) => {
+      const source = readFileSync(file, "utf8")
+      return referencedModules(source)
+        .filter(
+          (module) =>
+            !module.startsWith(".") &&
+            !module.startsWith("@ollama-client/contracts") &&
+            !module.startsWith("@ollama-client/runtime-core")
+        )
+        .map((module) => ({
+          file: relative(chatRuntimeRoot, file).replaceAll("\\", "/"),
           module
         }))
     })


### PR DESCRIPTION
## Summary

- add the environment-independent `@ollama-client/chat-runtime` workspace package
- move durable turn submission, context/generation transitions, resume, completion/cancellation, and failure persistence behind ports
- retain extension-specific normalization, callbacks, persistence, provider invocation, and streaming in `src/`
- update the release roadmap to record PR #247 and start P3

## Why

P1 and P2 established stable contracts and runtime primitives. This is the first bounded P3 slice: it gives durable chat turns a domain-owned lifecycle without moving browser, storage, provider, or UI adapters into the package.

## Impact

No user-facing behavior changes. Existing durable-turn restart, reconnect, cancellation, and completion behavior remains behind the same extension adapter.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm check:dead`
- `pnpm test:run` (318 files, 2,617 tests)
- pre-push production package/build and bundle budget checks
- pre-push i18n and docs builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts durable chat-turn orchestration into the environment-independent `@ollama-client/chat-runtime` workspace package while retaining extension-specific adapters in `src/`.
- Adds port-driven turn submission, context construction, generation, resume, completion, cancellation, and failure persistence.
- Replaces the extension’s inline lifecycle implementation with a `TurnRuntime` adapter.
- Adds package-level tests, type checking, dependency wiring, and architecture-boundary enforcement.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-runtime/src/turn-runtime.ts | Introduces the environment-independent runtime that coordinates durable turn lifecycle transitions through injected ports. |
| src/application/turns/turn-service.ts | Adapts extension-specific context, generation, persistence, clock, and error handling to the extracted runtime. |
| src/application/turns/turn-contract.ts | Reuses generic runtime turn contracts with extension-specific context and message types. |
| packages/chat-runtime/src/__tests__/turn-runtime.test.ts | Covers ordered lifecycle execution, failure persistence, and resume behavior from the repository-compliant test directory. |
| src/lib/__tests__/architecture-boundaries.test.ts | Enforces that chat-runtime source imports remain limited to relative modules and approved workspace packages. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Service[TurnService extension adapter] --> Runtime[TurnRuntime]
  Runtime --> Store[TurnRunStore port]
  Runtime --> Context[TurnContextOwner port]
  Runtime --> Generation[TurnGenerationOwner port]
  Runtime --> Failure[TurnFailureMapper port]
  Runtime --> Clock[TurnClock port]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(runtime): follow package test layou..."](https://github.com/shishir435/ollama-client/commit/9d4811d0795735064c0c4de1fab8fedbf84c12a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51567415)</sub>

<!-- /greptile_comment -->