### PR TITLE
refactor(runtime): extract context orchestration

### DIFF
--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -242,8 +242,8 @@ Remaining package work:
 
 - P1: complete in `release/0.13.x` via PRs #244–#246.
 - P2: complete in `release/0.13.x` via PR #247.
-- P3: in progress on `feature/chat-runtime-turn-orchestration`; agent runtime
-  remains scheduled for `0.14.x`.
+- P3: in progress on `feature/chat-runtime-context-orchestration`; agent
+  runtime remains scheduled for `0.14.x`.
 
 #### P1 — `packages/contracts`
 
@@ -348,7 +348,8 @@ Exit gate: deterministic tests run without browser globals or extension setup.
 
 #### P3 — domain runtimes
 
-Status: in progress on `feature/chat-runtime-turn-orchestration`, 2026-08-09.
+Status: in progress on `feature/chat-runtime-context-orchestration`,
+2026-08-09.
 
 Completed in the first turn-orchestration slice:
 
@@ -362,10 +363,23 @@ Completed in the first turn-orchestration slice:
 - Added a source contract allowing only relative modules plus contracts and
   runtime-core dependencies from chat-runtime.
 
+Merged in `release/0.13.x` via PR #248.
+
+Completed in the context-orchestration slice:
+
+- Moved context build command/output contracts, injected builder coordination,
+  clock ownership, receipt projection, and source normalization into
+  `@ollama-client/chat-runtime`.
+- Kept RAG retrieval, provider and storage access, browser-derived inputs,
+  activity callbacks, warnings, and prompt construction in the extension
+  adapter.
+- Added clean-Node tests for deterministic evidence, provider attribution,
+  forward-compatible source normalization, and failed builds that mint no
+  receipt.
+
 Remaining P3 slices:
 
-- `packages/chat-runtime`: turn orchestration, context contracts, and tool-loop
-  coordination behind ports.
+- `packages/chat-runtime`: tool-loop coordination behind ports.
 - `packages/agent-runtime`: added in `0.14.x`; task compiler, policy, approval,
   controller, verification, and recovery.
 

--- a/packages/chat-runtime/package.json
+++ b/packages/chat-runtime/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./context-runtime": "./src/context-runtime.ts",
     "./turn-runtime": "./src/turn-runtime.ts"
   },
   "dependencies": {

--- a/packages/chat-runtime/src/__tests__/context-runtime.test.ts
+++ b/packages/chat-runtime/src/__tests__/context-runtime.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest"
+import { type ContextResultEvidence, ContextRuntime } from "../context-runtime"
+
+interface TestResult extends ContextResultEvidence {
+  content: string
+}
+
+const result: TestResult = {
+  content: "grounded answer",
+  promptContextStats: {
+    promptInputLength: 5,
+    promptAugmentedLength: 20,
+    tabContextLength: 4,
+    ragContextLength: 11,
+    tabContextTruncated: true,
+    groundedOnlyMode: true,
+    insufficientContext: false,
+    usedContextChunks: [
+      {
+        id: "file-1",
+        title: "Notes",
+        excerpt: "Relevant notes",
+        score: 0.9,
+        source: "file",
+        chunkIndex: 2
+      },
+      {
+        id: "external-1",
+        title: "External",
+        titleKey: "chat.sources.external",
+        excerpt: "External context",
+        score: 0.7,
+        source: "future-source"
+      }
+    ]
+  }
+}
+
+const command = {
+  turnId: "turn-1",
+  mode: "new" as const,
+  model: "llama3",
+  providerId: "ollama",
+  options: { rawInput: "hello" }
+}
+
+describe("ContextRuntime", () => {
+  it("builds context and durable evidence as one operation", async () => {
+    const builder = { build: vi.fn().mockResolvedValue(result) }
+    const runtime = new ContextRuntime(builder, { now: () => 42 })
+
+    const output = await runtime.build(command)
+
+    expect(builder.build).toHaveBeenCalledWith(command.options)
+    expect(output.result).toBe(result)
+    expect(output.receipt).toEqual({
+      version: 1,
+      turnId: "turn-1",
+      mode: "new",
+      createdAt: 42,
+      query: "hello",
+      model: { id: "llama3", providerId: "ollama" },
+      prompt: {
+        inputLength: 5,
+        augmentedLength: 20,
+        tabContextLength: 4,
+        ragContextLength: 11,
+        tabContextTruncated: true,
+        groundedOnlyMode: true,
+        insufficientContext: false
+      },
+      sources: [
+        {
+          id: "file-1",
+          title: "Notes",
+          excerpt: "Relevant notes",
+          score: 0.9,
+          source: "file",
+          chunkIndex: 2
+        },
+        {
+          id: "external-1",
+          title: "External",
+          titleKey: "chat.sources.external",
+          excerpt: "External context",
+          score: 0.7,
+          source: "unknown"
+        }
+      ]
+    })
+  })
+
+  it("omits an absent provider id", async () => {
+    const runtime = new ContextRuntime(
+      { build: vi.fn().mockResolvedValue(result) },
+      { now: () => 42 }
+    )
+
+    const output = await runtime.build({ ...command, providerId: undefined })
+
+    expect(output.receipt.model).toEqual({ id: "llama3" })
+  })
+
+  it("does not mint evidence when context building fails", async () => {
+    const error = new Error("retrieval failed")
+    const clock = { now: vi.fn(() => 42) }
+    const runtime = new ContextRuntime(
+      { build: vi.fn().mockRejectedValue(error) },
+      clock
+    )
+
+    await expect(runtime.build(command)).rejects.toBe(error)
+    expect(clock.now).not.toHaveBeenCalled()
+  })
+})

--- a/packages/chat-runtime/src/context-runtime.ts
+++ b/packages/chat-runtime/src/context-runtime.ts
@@ -1,0 +1,107 @@
+import type { ContextReceipt, TurnMode } from "@ollama-client/contracts/turns"
+
+export interface ContextClock {
+  now: () => number
+}
+
+export interface ContextEvidenceSource {
+  id: string | number
+  title: string
+  titleKey?: string
+  excerpt: string
+  score: number
+  sectionPath?: string
+  source?: string
+  chunkIndex?: number
+}
+
+export interface ContextPromptStats {
+  promptInputLength: number
+  promptAugmentedLength: number
+  tabContextLength: number
+  ragContextLength: number
+  tabContextTruncated: boolean
+  groundedOnlyMode: boolean
+  insufficientContext: boolean
+  usedContextChunks: ContextEvidenceSource[]
+}
+
+export interface ContextResultEvidence {
+  promptContextStats: ContextPromptStats
+}
+
+export interface ContextBuildCommand<TOptions> {
+  turnId: string
+  mode: TurnMode
+  model: string
+  providerId?: string
+  options: TOptions
+}
+
+export interface ContextBuildOutput<TResult> {
+  result: TResult
+  receipt: ContextReceipt
+}
+
+export interface ContextBuilder<TOptions, TResult> {
+  build: (options: TOptions) => Promise<TResult>
+}
+
+const normalizeSource = (
+  source: string | undefined
+): "file" | "memory" | "tab" | "unknown" =>
+  source === "file" || source === "memory" || source === "tab"
+    ? source
+    : "unknown"
+
+/**
+ * Couples environment-owned context construction with its durable evidence.
+ *
+ * The builder performs provider, retrieval, storage, and browser work through
+ * the extension adapter. This runtime owns only the environment-independent
+ * command, clock, and receipt projection used by durable turns.
+ */
+export class ContextRuntime<
+  TOptions extends { rawInput: string },
+  TResult extends ContextResultEvidence
+> {
+  constructor(
+    private readonly builder: ContextBuilder<TOptions, TResult>,
+    private readonly clock: ContextClock
+  ) {}
+
+  async build(
+    command: ContextBuildCommand<TOptions>
+  ): Promise<ContextBuildOutput<TResult>> {
+    const result = await this.builder.build(command.options)
+    const stats = result.promptContextStats
+
+    return {
+      result,
+      receipt: {
+        version: 1,
+        turnId: command.turnId,
+        mode: command.mode,
+        createdAt: this.clock.now(),
+        query: command.options.rawInput,
+        model: {
+          id: command.model,
+          ...(command.providerId ? { providerId: command.providerId } : {})
+        },
+        prompt: {
+          inputLength: stats.promptInputLength,
+          augmentedLength: stats.promptAugmentedLength,
+          tabContextLength: stats.tabContextLength,
+          ragContextLength: stats.ragContextLength,
+          tabContextTruncated: stats.tabContextTruncated,
+          groundedOnlyMode: stats.groundedOnlyMode,
+          insufficientContext: stats.insufficientContext
+        },
+        sources: stats.usedContextChunks.map((source) => ({
+          ...source,
+          source: normalizeSource(source.source)
+        }))
+      }
+    }
+  }
+}

--- a/packages/chat-runtime/src/index.ts
+++ b/packages/chat-runtime/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./context-runtime"
 export * from "./turn-runtime"

--- a/packages/chat-runtime/src/turn-runtime.ts
+++ b/packages/chat-runtime/src/turn-runtime.ts
@@ -4,6 +4,7 @@ import type {
   TurnMode,
   TurnStatus
 } from "@ollama-client/contracts/turns"
+import type { ContextBuildCommand } from "./context-runtime"
 
 export interface PersistedTurnRequest<TContext, TMessage> {
   version: 1
@@ -44,17 +45,9 @@ export interface TurnRunStore<TContext, TMessage> {
   update: (id: string, updates: TurnRunUpdate) => Promise<void>
 }
 
-export interface TurnContextCommand<TContextOptions> {
-  turnId: string
-  mode: TurnMode
-  model: string
-  providerId?: string
-  options: TContextOptions
-}
-
 export interface TurnContextOwner<TContextOptions, TContextOutput> {
   build: (
-    command: TurnContextCommand<TContextOptions>
+    command: ContextBuildCommand<TContextOptions>
   ) => Promise<TContextOutput & { receipt: ContextReceipt }>
 }
 

--- a/src/application/context/context-service.ts
+++ b/src/application/context/context-service.ts
@@ -1,64 +1,31 @@
-import type { ContextReceipt, TurnMode } from "@ollama-client/contracts/turns"
+import {
+  ContextRuntime,
+  type ContextBuildCommand as RuntimeContextBuildCommand,
+  type ContextBuildOutput as RuntimeContextBuildOutput
+} from "@ollama-client/chat-runtime/context-runtime"
 import {
   type BuildRagContextOptions,
   type BuildRagContextResult,
   buildRagContext
 } from "./build-context"
 
-export interface ContextBuildCommand {
-  turnId: string
-  mode: TurnMode
-  model: string
-  providerId?: string
-  options: BuildRagContextOptions
-}
+export type ContextBuildCommand =
+  RuntimeContextBuildCommand<BuildRagContextOptions>
 
-export interface ContextBuildOutput {
-  result: BuildRagContextResult
-  receipt: ContextReceipt
-}
+export type ContextBuildOutput =
+  RuntimeContextBuildOutput<BuildRagContextResult>
 
 /**
- * Sole application owner of prompt augmentation and its durable attribution.
- * Prompt and receipt are produced together so presentation never reconstructs
- * sources from a later, mutated prompt.
+ * Extension adapter for environment-owned prompt augmentation.
+ * ContextRuntime pairs the result with durable attribution before returning.
  */
 export class ContextService {
-  async build(command: ContextBuildCommand): Promise<ContextBuildOutput> {
-    const result = await buildRagContext(command.options)
-    const stats = result.promptContextStats
+  private readonly runtime = new ContextRuntime(
+    { build: buildRagContext },
+    { now: Date.now }
+  )
 
-    return {
-      result,
-      receipt: {
-        version: 1,
-        turnId: command.turnId,
-        mode: command.mode,
-        createdAt: Date.now(),
-        query: command.options.rawInput,
-        model: {
-          id: command.model,
-          ...(command.providerId ? { providerId: command.providerId } : {})
-        },
-        prompt: {
-          inputLength: stats.promptInputLength,
-          augmentedLength: stats.promptAugmentedLength,
-          tabContextLength: stats.tabContextLength,
-          ragContextLength: stats.ragContextLength,
-          tabContextTruncated: stats.tabContextTruncated,
-          groundedOnlyMode: stats.groundedOnlyMode,
-          insufficientContext: stats.insufficientContext
-        },
-        sources: stats.usedContextChunks.map((chunk) => ({
-          ...chunk,
-          source:
-            chunk.source === "file" ||
-            chunk.source === "memory" ||
-            chunk.source === "tab"
-              ? chunk.source
-              : "unknown"
-        }))
-      }
-    }
+  async build(command: ContextBuildCommand): Promise<ContextBuildOutput> {
+    return this.runtime.build(command)
   }
 }


### PR DESCRIPTION
## Summary

- add a port-driven context runtime to `@ollama-client/chat-runtime`
- move context command/output contracts, clock ownership, durable receipt projection, and source normalization into the package
- keep RAG retrieval, provider/storage access, browser inputs, callbacks, warnings, and prompt construction in the extension adapter
- update the P3 roadmap to record PR #248 and leave tool-loop coordination as the remaining chat-runtime slice

## Why

PR #248 established the durable turn lifecycle boundary. Context building still paired environment work with durable evidence inside `src/`; this slice moves only that deterministic orchestration into the domain runtime while retaining all environment-dependent behavior in the extension.

## Impact

No user-facing behavior changes. Context results and receipts are still produced together, with the same source normalization and attribution fields.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm check:dead`
- `pnpm test:run` (319 files, 2,620 tests)
- focused context/runtime and architecture-boundary tests
- pre-push production package/build and bundle budget checks
- pre-push i18n and docs builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts deterministic context orchestration and durable receipt projection into `@ollama-client/chat-runtime` while retaining environment-dependent context building in the extension adapter.
- Adds generic context command, builder, output, clock, evidence, and receipt-projection contracts.
- Delegates `ContextService` to the new runtime without changing its public result shape.
- Reuses the shared context command contract in turn orchestration.
- Adds focused tests for receipt projection, source normalization, optional provider attribution, and failed builds.
- Updates package exports and the release roadmap.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, packaging, or architecture-boundary issues identified.

The extracted runtime preserves the existing context result and receipt behavior, remains structurally compatible with turn orchestration, and is exposed through a valid package subpath.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-runtime/src/context-runtime.ts | Introduces deterministic context orchestration and preserves the prior receipt projection, timestamp ordering, and source normalization behavior. |
| src/application/context/context-service.ts | Replaces inline receipt construction with delegation to ContextRuntime while preserving the service contract. |
| packages/chat-runtime/src/turn-runtime.ts | Reuses the shared context command type with no structural change to the turn-owner contract. |
| packages/chat-runtime/src/__tests__/context-runtime.test.ts | Covers successful evidence projection, unknown-source normalization, optional provider attribution, and builder failure ordering. |
| packages/chat-runtime/package.json | Adds a context-runtime subpath export consistent with existing workspace package conventions. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Turn as TurnRuntime
  participant Adapter as ContextService
  participant Runtime as ContextRuntime
  participant Builder as buildRagContext
  Turn->>Adapter: build(command)
  Adapter->>Runtime: build(command)
  Runtime->>Builder: build(command.options)
  Builder-->>Runtime: context result + prompt stats
  Runtime->>Runtime: normalize sources and project receipt
  Runtime-->>Adapter: result + receipt
  Adapter-->>Turn: result + receipt
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(runtime): extract context orche..."](https://github.com/shishir435/ollama-client/commit/b6cb51822656290cd925e048962d35f66f18a190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51569510)</sub>

<!-- /greptile_comment -->