### PR TITLE
chore: standardize tests and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,18 @@ Manifest — permissions, CSP, host permissions, `browser_specific_settings` —
 
 Dev-only entrypoints (`spike-*`, `benchmark`, `persistence-verify`) are stripped from store builds by `config/wxt-hooks.ts`, and their code is dead-code-eliminated via the `__SPIKE_OPFS_OWNER__` flags in `config/wxt-vite.ts`. `src/spike/` is therefore fine to leave where it is.
 
+### Workspace packages
+
+| Package | Owns |
+|---|---|
+| `@ollama-client/contracts` | environment-independent Zod schemas, RPC/stream envelopes, durable turn/context/tool-loop contracts |
+| `@ollama-client/runtime-core` | deterministic stream reduction, thinking parsing, cancellation, retry, checkpoint, and sender-evidence primitives |
+| `@ollama-client/chat-runtime` | port-driven durable turn, context-build, and tool-loop orchestration |
+
+Packages never import React, WXT, browser APIs, persistence adapters, feature
+UI, background composition, or concrete providers. Those remain in `src/` and
+connect through package ports.
+
 ### Chat round-trip
 
 1. UI opens a runtime port keyed by `MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE`.
@@ -337,7 +349,9 @@ The set is `ControlledTextarea`, `ControlledNumberInput`, `ControlledSlider` —
 ### Testing
 
 - Vitest with `happy-dom` and `fake-indexeddb`. `src/test/setup.ts` mocks chrome APIs and IndexedDB.
-- Tests live in `src/**/__tests__/*.{test,spec}.{ts,tsx}` and `config/**/*.test.ts`.
+- Tests live in the nearest `__tests__` directory under `src/`, `packages/`,
+  `config/`, or `e2e/`. Do not place `*.test.*` or `*.spec.*` beside production
+  modules.
 - Single file: `pnpm test src/path/to/module.test.ts`.
 - Coverage excludes only test files and `.d.ts`. UI components, type modules, and barrels are included.
 - `@testing-library/user-event` is **not** a dependency — use `fireEvent`.
@@ -351,6 +365,8 @@ Contract tests worth knowing about, because they enforce conventions no reviewer
 | `components/forms/__tests__/react-hook-form-contract.test.ts` | no spread-`register` |
 | `lib/providers/__tests__/contract.test.ts` | provider list/stream parsing |
 | `config/__tests__/manifest-csp.test.ts` | no dev origin in a packaged CSP |
+| `config/__tests__/test-layout.test.ts` | every test/spec stays in a `__tests__` directory |
+| `config/__tests__/documentation-comments.test.ts` | module/declaration prose uses JSDoc instead of `//` blocks |
 | `lib/__tests__/browser-api-contract.test.ts` | guarded browser API access |
 | `lib/__tests__/architecture-boundaries.test.ts` | chat-history goes through the facade; SQLite internals stay out of UI; one SQLite engine ships |
 | `config/__tests__/wxt-build-config.test.ts` | which dev pages and WASM assets a store build carries |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.13.0]
+
+### Added
+
+- Ingestion and model-pull jobs now recover from MV3 background-worker
+  suspension. Progress is checkpointed durably, interrupted work is reconciled
+  on startup, and the UI can reconnect to the same job instead of silently
+  losing it.
+- Durable turns now resume through one background-owned lifecycle covering
+  context building, generation, cancellation, completion, and failure. The UI
+  reconnects to persisted snapshots after a worker restart rather than becoming
+  a second writer of assistant state.
+
+### Changed
+
+- Native and prompt-based tool loops now share one checkpointed orchestration
+  path for model calls, ordered tool batches, approvals, replay, and recovery.
+  Approval boundaries are flushed before waiting, so a suspended worker can
+  continue without repeating an already recorded effect.
+- Chat history now ships with one SQLite implementation. The legacy database
+  fallback runs on official sqlite-wasm instead of bundling sql.js as a second
+  engine, while preserving the original migration source and read-only export
+  recovery for damaged databases.
+- Streaming events and durable tool-loop checkpoints are versioned and runtime
+  validated before use. Invalid persisted state fails safely instead of being
+  replayed as trusted data.
+- Activity and retrieved-context labels persist translation keys with safe
+  fallback text, so restored history follows the selected language instead of
+  freezing generated labels in the language active when they were created.
+
+### Fixed
+
+- Overlapping file submissions no longer replace each other's processing rows
+  with stale UI state.
+- Durable assistant messages can no longer be overwritten by a delayed UI
+  persistence timer after the background has recorded a newer snapshot or
+  terminal state. The separately characterized legacy stream path keeps its
+  existing compatibility behavior.
+- Malformed provider configuration, secret journals, and reset journals are
+  rejected or recovered field-by-field without applying partial cleanup,
+  exposing stored credentials, or discarding forward-compatible fields.
+
+### Development
+
+- Added environment-independent `@ollama-client/contracts`,
+  `@ollama-client/runtime-core`, and `@ollama-client/chat-runtime` workspace
+  packages. They own shared schemas, deterministic runtime primitives, and
+  port-driven turn/context/tool-loop orchestration while browser, provider,
+  persistence, and React adapters remain in the extension.
+- Added architecture contracts for package dependencies, the single SQLite
+  owner, repository access, background import direction, test placement, and
+  JSDoc documentation comments.
+- Release verification now covers independent package typechecks, 2,629 unit
+  and integration tests, Chrome MV3 and Firefox MV2 packages, bundle budgets,
+  generated resources, and packaged migration/restart fixtures.
+- Dependency installation uses pnpm 11 with a seven-day minimum release age for
+  newly selected packages.
+
 ## [0.12.8]
 
 ### Fixed
@@ -829,7 +887,8 @@ No functional changes: this release is store metadata only.
 
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.12.8...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.13.0...HEAD
+[0.13.0]: https://github.com/Shishir435/ollama-client/compare/0.12.8...0.13.0
 [0.12.8]: https://github.com/Shishir435/ollama-client/compare/0.12.7...0.12.8
 [0.12.7]: https://github.com/Shishir435/ollama-client/compare/0.12.6...0.12.7
 [0.12.6]: https://github.com/Shishir435/ollama-client/compare/0.12.5...0.12.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,9 @@ Read [AGENTS.md](./AGENTS.md) for the full map. Quick orientation:
 | Chat-history persistence (SQLite-only) | `src/lib/repositories/chat-history.ts` (facade) |
 | Context and RAG orchestration | `src/application/context/` |
 | Embedding and vector primitives | `src/lib/embeddings/` |
+| Shared schemas and wire contracts | `packages/contracts/` |
+| Deterministic runtime primitives | `packages/runtime-core/` |
+| Turn, context, and tool-loop orchestration | `packages/chat-runtime/` |
 | Shared UI primitives (shadcn) | `src/components/ui/` |
 | i18n source-of-truth | `src/locales/<lang>/translation.json` (loaded as one lazy chunk per language) |
 
@@ -56,6 +59,10 @@ Read [AGENTS.md](./AGENTS.md) for the full map. Quick orientation:
 sessions, messages, files, and tool-loop checkpoints. **Always import from the
 facade, never from `sqlite-chat-history.ts` or `src/lib/sqlite/` directly.**
 Dexie remains only for vector embeddings and knowledge sets.
+
+Tests belong in the nearest `__tests__` directory. This applies to app,
+package, configuration, and browser tests; do not place `*.test.*` or
+`*.spec.*` beside production modules.
 
 ## 3. Where to add things
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ The RAG pipeline is browser-first and local-first:
 3. Hybrid retrieval combines keyword and dense search.
 4. Retrieved snippets are injected into the prompt context before generation.
 
-Chat/session/message/file history is SQLite-only through `sql.js`, persisted into IndexedDB. Vector embeddings still live in IndexedDB through the embeddings storage layer.
+Chat/session/message/file history is SQLite-only through official sqlite-wasm,
+owned by one persistence worker. Migrated profiles use OPFS; the retained legacy
+blob backend stays available for compatibility and rollback. Vector embeddings
+still live in IndexedDB through the embeddings storage layer.
 
 ## Browser Context, Images, and Tools
 
@@ -132,7 +135,7 @@ pnpm verify
 
 ## Architecture
 
-The extension is built with WXT, React 19, TypeScript 5.9, Tailwind v4, and Biome.
+The extension is built with WXT, React 19, TypeScript 6, Tailwind v4, and Biome.
 
 Key paths:
 
@@ -140,12 +143,17 @@ Key paths:
 - `src/sidepanel/` - main chat shell.
 - `src/options/` - settings and configuration shell.
 - `src/background/` - runtime message dispatcher and handlers.
-- `src/features/` - feature-owned UI, hooks, RAG, stores, and workflows.
+- `packages/contracts/` - environment-independent schemas and wire contracts.
+- `packages/runtime-core/` - deterministic streaming, cancellation, retry, and checkpoint primitives.
+- `packages/chat-runtime/` - port-driven turn, context, and tool-loop orchestration.
+- `src/application/context/` - background-owned context composition and RAG adapters.
+- `src/features/` - feature-owned UI, hooks, stores, and presentation workflows.
 - `src/components/forms/`, `src/components/layout/`, `src/components/settings/`, `src/components/feedback/`, `src/components/data-display/` - app-owned frontend primitives.
 - `src/components/ui/` - curated shadcn/Base UI primitives only.
 - `src/lib/providers/` - provider registry, factory, manager, and provider implementations.
 - `src/lib/repositories/chat-history.ts` - chat-history facade backed by SQLite.
-- `src/lib/sqlite/` - sql.js database, schema, and migrations.
+- `src/lib/persistence/` - the single sqlite-wasm owner, worker, and OPFS/legacy backends.
+- `src/lib/sqlite/` - the persistence RPC facade, schema, and forward-only migrations.
 - `src/lib/embeddings/` - chunking, embedding strategy, HNSW, keyword index, and vector storage.
 
 Runtime flow:
@@ -154,7 +162,8 @@ Runtime flow:
 2. Background dispatches to a provider handler.
 3. `ProviderFactory` resolves the selected model's provider.
 4. Provider streams tokens back through the port.
-5. UI state updates and chat history is persisted locally.
+5. The background durable runtime persists turn state while the UI folds stream
+   events into ephemeral presentation state.
 
 ## Documentation
 

--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -2,467 +2,96 @@
 
 Last reviewed: 2026-08-09
 
-This is the single living plan for the `0.13.x` foundation, package boundaries,
-the `0.14.x` browser agent, and evidence-gated compatibility removal. It
-replaces `PROGRAM_PLAN.md`, `FROM_SCRATCH_ARCHITECTURE_AUDIT.md`,
-`BOUNDARY_MAP.md`, and `AGENTIC_BROWSER_ARCHITECTURE.md`.
-
-Durable repository rules remain in `AGENTS.md`. Compatibility removal gates
-remain authoritative in `compatibility-ledger.json`. This file tracks order,
-status, scope, and release gates without duplicating either source.
+This file tracks unfinished release and product work. Completed implementation
+history belongs in the changelog and merged pull requests, while durable
+repository rules remain in `AGENTS.md` and compatibility removal gates remain
+authoritative in `compatibility-ledger.json`.
 
 Release promotion follows one path: `release/*` → `preview` → `main`.
 Release work merges into `preview` for validation; only `preview` merges into
 `main`.
 
-## Version map
+## Current status
 
-| Version | Purpose | Status |
+| Version | Remaining work | Status |
 | --- | --- | --- |
-| `0.12.6` | Migration evidence, release provenance, provider and transcript correctness | Released |
-| `0.12.7`–`0.12.8` | Fast provider, reachability, and Firefox theme fixes | Released; fixes forward-ported |
-| `0.13.0` | Solidify runtime, isolate domains, introduce first package boundaries | Release candidate; hardening complete |
-| `0.14.x` | Browser agent, built on isolated contracts and runtime kernels | Planned |
+| `0.13.0` | Promote `release/0.13.x` through `preview` to `main` | Foundation and hardening complete |
+| `0.13.x` | Finish the focused architecture follow-ups below without delaying promotion | Incremental |
+| `0.14.x` | Build the supervised browser agent | Planned |
 | Later | Remove compatibility paths only when ledger evidence permits | Evidence-gated |
 
-## Current state
-
-Landed on `release/0.13.x`:
-
-- Durable turn orchestration and MV3 restart recovery; sole logical writer is
-  still an audit closure gate below.
-- Typed, validated streaming protocol with centralized event names.
-- Durable ingestion and model-pull jobs.
-- Per-table migration verification and retained rollback evidence.
-- Single SQLite owner. Legacy blob fallback now uses official sqlite-wasm;
-  sql.js and its duplicate WASM asset are gone from shipped package.
-- Provider fixes from quick `0.12.7` and `0.12.8` releases.
-- pnpm 11 and strict seven-day minimum dependency age.
-- Activity labels and app-generated context titles persist translation keys.
-
-Not on current release branch:
-
-- Browser-agent runtime. Old agent branch is design and selective-port source,
-  never a branch to merge wholesale.
-
-Package boundaries now on the release branch:
-
-- `@ollama-client/contracts` owns environment-independent schemas and wire
-  contracts.
-- `@ollama-client/runtime-core` owns deterministic stream, cancellation, retry,
-  checkpoint, and sender-evidence primitives.
-- `@ollama-client/chat-runtime` owns port-driven turn, context-build, and
-  tool-loop orchestration. Browser, provider, persistence, and UI adapters stay
-  in `src/`.
-
-## Architecture audit refresh — 2026-08-09
-
-Overall rating: **8/10**. Architecture has moved well past the concerns in the
-original audit brief: entrypoints are thin, request/response traffic is typed
-and validated, provider behavior is capability-driven, chat persistence has one
-engine and one physical owner, and durable turn/job recovery accounts for MV3
-worker suspension. Remaining work is boundary completion, not a rewrite.
-
-### Current dependency map
-
-```text
-React shells and feature UI
-  -> UI hooks/adapters
-     -> versioned stream contracts | typed extension RPC
-        -> background composition and authorization
-           -> turn/context/ingestion/model-pull application services
-              -> provider | browser | storage adapters
-                 -> provider endpoints | browser APIs | SQLite/Dexie/storage
-
-Persistence host
-  -> one chat-db worker
-     -> official sqlite-wasm
-        -> OPFS, or read-only/compatibility legacy blob path
-```
-
-This direction is partly realized. `TurnService`, stream reducers, RPC schemas,
-provider adapters, repository facades, and the persistence owner are strong
-seams to preserve. `build-context.ts`, reminder tools, settings access, and the
-UI streaming bridge still cross the intended direction in specific places.
-
-### Strongest areas to preserve
-
-- `src/protocol/` connects request and response types, validates both ends,
-  authorizes senders, distinguishes queries from commands, and propagates
-  cancellation. Do not replace it with ad-hoc messages or a generic event bus.
-- `src/application/turns/turn-service.ts` expresses orchestration through small
-  ports and has deterministic tests. Use this pattern for extracted runtime
-  kernels; do not add repository interfaces everywhere.
-- `src/background/durable-turn-runtime.ts`, durable job tables, and reconnecting
-  stream snapshots make worker restart a designed path rather than an error
-  case.
-- `src/lib/providers/` keeps chat behind `LLMProvider` while retaining explicit
-  capability and provider-specific management behavior. Preserve capability
-  evidence order; do not build a lowest-common-denominator superclass.
-- `src/lib/repositories/chat-history.ts`, the persistence host, and architecture
-  contract tests enforce one SQLite engine, one owner, and one public facade.
-- `storage-key-registry.ts`, provider-secret journaling, and sync quota guards
-  establish useful storage ownership and recovery rules even though typed
-  descriptor adoption is incomplete.
-
-### Findings and required direction
-
-| Severity | Evidence | Failure mode | Direction | Timing |
-| --- | --- | --- | --- | --- |
-| Critical | `use-chat-streaming.ts` debounces assistant-row writes while `durable-turn-runtime.ts` persists the same row | A delayed UI write can overwrite a newer background snapshot or terminal state; unmount does not clear the pending DB timer | Durable turns: background is sole durable writer. UI folds validated events into ephemeral state and reconciles from persisted snapshots. Keep a separately characterized compatibility path only if a non-durable caller remains | Before package moves, M |
-| Critical | `tool-loop-runs.ts` casts `JSON.parse(row.state)` to `DurableToolLoopState` | Corrupt or older checkpoint can crash restart recovery at the point durability is needed most | Add versioned Zod checkpoint schema, validate nested messages/tool calls, and convert invalid rows into a safe failed/exportable recovery result | Before package moves, S–M |
-| High | `build-context.ts` reads extension storage and constructs providers directly | Pure context tests still need extension/provider infrastructure; `runtime-core` extraction would move coupling instead of removing it | Inject settings, knowledge access, clock, and one-shot model invocation through `ContextService` composition; keep retrieval algorithms pure | Phase 2, M |
-| High | `use-chat-stream.ts` owns port lifecycle, reconnect policy, reducer effects, i18n/error presentation, issue-link browser effects, and stop finalization | Restart, error, or stop changes touch one high-branch hook and can regress unrelated behavior | Extract a framework-free stream transport/session client around existing schemas/reducer; leave React hook as presentation adapter | Phase 2, M |
-| High | About 35 production UI files still import deprecated `plasmoGlobalStorage`; only three use `useSetting` descriptors | Storage scope is guarded, but malformed persisted values and inconsistent defaults can still enter typed UI state | Migrate high-risk structured values first, attach runtime schemas, then move simple booleans opportunistically; no flag-day rewrite | `0.13.x` incremental, M total |
-| High | `schedule-reminder-tool.ts` imports `background/lib/reminders.ts` | Lower-level tool registry depends upward on background composition, blocking clean package rules and alternate runtimes | Move reminder domain/service contract below background; keep alarms/notification registration in background adapter | Before boundary freeze, S |
-| Medium | `ProviderManager` combines compatibility migration, validation, secret recovery, CRUD, and model mappings | Routine provider changes can disturb migration or credential recovery behavior | Preserve `ProviderManager` facade; extract private mapping and migration collaborators only with characterization tests | Later `0.13.x`, M |
-| Medium | `message-router.ts` remains a large authorized switch for retained one-way/content-script traffic | Adding a case can mix sender policy, browser effects, response shape, and dispatch | Keep narrow non-RPC transports, but move case bodies to named handlers and keep registry/source-policy contract tests | Opportunistic, S–M |
-| Medium | `use-file-upload.ts` clones captured `processingStates` before async work | Overlapping file submissions can replace another invocation's rows with stale state | Use functional state updates and move queue/registration coordination into the ingestion client/pipeline | `0.13.x` quick win, S |
-| Low | Audit found public docs describing shipped `sql.js`, UI-owned final persistence, old RAG paths, and obsolete message guidance | Contributors could follow retired boundaries and recreate removed architecture | Corrected in this audit; keep factual architecture in docs and active sequencing here, with drift checks where cheap | Corrected; guard later, S |
-
-No finding justifies a repository-wide rewrite. Existing runtime behavior should
-remain usable after every change.
-
-### Top stability risks
-
-1. Stale UI debounce overwrites background-owned durable assistant state.
-2. Invalid tool-loop checkpoint shape breaks recovery after worker restart.
-3. Provider config/journal values are read through TypeScript generics without
-   complete runtime schemas; malformed sync/import data can fail deep in CRUD.
-4. Stop/disconnect/reconnect behavior remains concentrated in one React hook,
-   making race fixes high-blast-radius.
-5. Context building constructs providers and reads mutable storage mid-run,
-   making replay less deterministic than its durable request suggests.
-6. Concurrent `processFiles()` calls can lose UI processing-state entries.
-7. Provider compatibility migration and ordinary CRUD share one manager path;
-   a normal edit can accidentally affect recovery behavior.
-8. Tool code importing background implementation hides runtime direction and
-   makes a future agent/runtime package browser-bound.
-9. Raw structured settings may admit stale shapes despite compile-time types.
-10. No automated drift guard covers contributor paths, so deleted RAG,
-    messaging, or persistence guidance can recur.
-
-### Target boundary
-
-```text
-React UI
-  -> presentation hooks
-     -> StreamClient | ExtensionRpcClient
-        -> background composition root
-           -> application services and pure state machines
-              -> explicit ports
-                 -> provider, browser, repository, and storage adapters
-```
-
-SQLite remains a separate persistence-owner process boundary. RPC and streaming
-stay separate transports because request/response and token delivery have
-different lifecycle needs; they share schemas, failures, request ids, and
-cancellation semantics rather than one universal abstraction.
-
-Do not abstract concrete provider wire formats, browser permission differences,
-SQLite/Dexie into one generic store, every browser API, or every one-implementation
-module. Do not move code into packages until imports prove the boundary.
-
-### Ranked quick wins
-
-| Rank | Change | Impact | Effort | Risk |
-| --- | --- | --- | --- | --- |
-| 1 | Stop UI DB writes for durable assistant streams | Very high | M | Medium |
-| 2 | Validate and version `DurableToolLoopState` | Very high | S–M | Low |
-| 3 | Add contract test banning `src/lib/** -> src/background/**` | High | S | Low |
-| 4 | Fix functional updates in `use-file-upload.ts` | High | S | Low |
-| 5 | Runtime-validate provider configs and persistence journals | High | M | Medium |
-| 6 | Move reminder service below background adapter | Medium | S | Low |
-| 7 | Extract stream error presentation from port lifecycle | Medium | S–M | Low |
-| 8 | Migrate highest-risk structured settings to descriptors | Medium | M | Low |
-| 9 | Add package-candidate import contract tests before moving files | Medium | S | Low |
-| 10 | Keep architecture/contributor docs synchronized with source contracts | Medium | S | Low |
-
-## `0.13.0` phases
-
-### Phase 1 — stabilization tails
-
-Status: complete on branch worktree, 2026-08-09.
-
-- Activity output previews and generated source titles now carry structured,
-  translatable text while old persisted string values remain readable.
-- `ActivityEventSchema` and `UsedContextChunkSchema` have one shared definition;
-  stream validation no longer silently drops fields from a duplicate schema.
-- RAG source keys use i18next JSON v4 plural suffixes.
-- YouTube transcript extraction recognizes `/watch`, `/live/{id}`, and
-  `/shorts/{id}` through one URL parser, with path tests.
-- Locale catalogs regenerate cleanly; focused tests and typecheck pass.
-
-### Phase 2 — package boundaries
-
-Goal: chat and agent evolve independently. Neither domain may import the other.
-Both depend downward on stable contracts and pure runtime kernels. Browser,
-storage, provider, and UI adapters stay outside those kernels.
-
-Package only proven seams. Do not turn `0.13.0` into a whole-repository move.
-
-#### Audit closure gate — ownership before movement
-
-Status: complete on `feature/prepackage-architecture-fixes`, 2026-08-09.
-
-- Background is now the only durable assistant-row writer for durable turns;
-  the characterized legacy stream path retains its UI debounce and heartbeat.
-- Tool-loop checkpoints use a versioned Zod envelope; legacy rows validate
-  through the same state schema, and malformed rows fail before replay.
-- Reminder domain operations moved below background composition, with a source
-  contract test preventing `application/lib/protocol -> background` imports.
-- Overlapping file-upload submissions merge state through functional updates.
-- Public architecture and contributor guidance match current runtime paths.
-
-Exit gate: restart, reconnect, stop, and completion tests prove one logical
-durable writer; corrupted checkpoint tests fail safely; lower layers do not
-import background implementation.
-
-#### P0 — freeze dependency rules
-
-Status: complete on `release/0.13.x` via PR #243, 2026-08-09.
-
-- Stored provider arrays validate required identity fields before runtime use,
-  recover malformed optional fields independently, and preserve unknown fields
-  across downgrade/upgrade cycles.
-- Provider writes validate before journaling. Secret maps and both persistence
-  and reset journals validate on recovery; malformed journals are discarded
-  without applying partial cleanup or exposing stored values.
-- Source contracts keep chat and the future agent mutually independent and
-  keep current contract/runtime candidates free of UI, browser, persistence,
-  background, and concrete-provider adapters.
-- Forward-compatible provider fields remain preserved in storage while the
-  provider RPC boundary explicitly projects known public fields, so newer
-  fields cannot invalidate list responses or expose future credential fields.
-- Boundary matching covers bound imports, type imports, side-effect imports,
-  dynamic imports, and re-exports.
-
-Completed:
-
-- Architecture contracts are in place before files move.
-- `chat` cannot import `agent`; `agent` cannot import `chat`.
-- Current contract/runtime candidates cannot import React, WXT, browser and
-  persistence adapters, feature UI, background composition, or concrete
-  providers.
-- Current composition remains in extension/background roots.
-
-Remaining package work:
-
-- P1: complete in `release/0.13.x` via PRs #244–#246.
-- P2: complete in `release/0.13.x` via PR #247.
-- P3: complete in `release/0.13.x` via PRs #248–#250. Agent runtime remains
-  scheduled for `0.14.x`.
-
-#### P1 — `packages/contracts`
-
-Status: complete in `release/0.13.x` via PRs #244–#246, 2026-08-09.
-
-Completed in the first extraction slice:
-
-- Added the `@ollama-client/contracts` workspace package.
-- Moved RPC envelope/version/method contracts, structured failure schemas, and
-  stream version/event identifiers behind its public exports.
-- Kept error conversion and browser/extension transport adapters in `src/`.
-- Added package-only Node tests, an independent no-DOM typecheck, and a source
-  contract that permits only relative imports and Zod.
-
-Completed in the turn-schema slice:
-
-- Moved shared chat, persisted context, and persisted turn Zod schemas into
-  package subpath exports.
-- Kept normalized application command types behind explicit compatibility
-  adapters because legacy attachment bytes and replay artifacts have broader
-  persisted shapes than runtime `ChatMessage`.
-- Migrated stream and persistence schema consumers to package APIs directly and
-  added clean-Node coverage for nested turn contracts and UTF-8 replay limits.
-
-Completed in the provider/model RPC schema slice:
-
-- Moved provider configuration, discovery, capability-probe, and connection
-  request/result schemas behind the `@ollama-client/contracts/provider-rpc`
-  export.
-- Migrated the registry, provider service, and UI consumers to the package API;
-  kept only application-wide `RpcMap` assembly in `src/protocol`.
-- Added clean-Node tests for strict provider commands, credential-free public
-  results, and provider-model normalization. Test tooling remains owned by the
-  root workspace, not the runtime contracts package.
-- Moved model lifecycle, library lookup, and embedding preparation/check
-  request/result schemas into `@ollama-client/contracts/model-rpc`, with direct
-  registry, service, and UI consumers.
-- Added clean-Node coverage for model-detail defaults, bounded library inputs,
-  loaded-model validation, and embedding error limits.
-
-Completed in the final P1 slice:
-
-- Moved diagnostics, ingestion-job, and model-pull-job request/result schemas
-  behind package subpath exports and migrated their registry, service, runtime,
-  UI, and test consumers directly.
-- Added clean-Node tests for privacy-bounded support bundles, durable ingestion
-  snapshots, model-pull progress, and sanitized failures.
-- Removed temporary `src/protocol`, `src/types`, and `src/application` schema
-  re-exports. `src/protocol/rpc-map.ts` now contains only application-wide
-  method composition.
-- Retained `toAppFailure`, `toRuntimeChatMessage`,
-  `parseDurableContextOptions`, and `parsePersistedTurnRequest` as real
-  application normalization adapters; they convert errors or persisted legacy
-  shapes and do not re-export package contracts.
-
-Remaining in P1: none.
-
-Candidate ownership:
-
-- Shared Zod schemas and inferred types.
-- Streaming envelopes and stable event contracts.
-- Failure taxonomy, command/result envelopes, receipts, and cancellation IDs.
-
-Exit gate: package has no environment imports and both current app and tests
-consume it through its public exports.
-
-#### P2 — `packages/runtime-core`
-
-Status: complete in `release/0.13.x` via PR #247, 2026-08-09.
-
-Completed:
-
-- Added the environment-independent `@ollama-client/runtime-core` workspace
-  package with its own no-DOM typecheck and clean-Node test project.
-- Moved the stateful streaming reasoning-tag parser into the package and
-  migrated both chat and selection stream consumers to its public export.
-- Moved the pure chat-stream reducer and its duplicate/out-of-order, thinking,
-  tool, replay, empty-output, and terminal transitions into the package.
-- Added keyed cancellation ownership and timeout lifecycle primitives; RPC,
-  chat, selection, model-pull, and embedding-download callers retain only
-  environment policy and adapters.
-- Moved sender-evidence classification into runtime-core while leaving the
-  message/port allowlist in the extension transport-policy registry.
-- Moved Retry-After parsing and transient provider-status classification into
-  the package while keeping provider-specific user messaging in `src/`.
-- Added an injectable clock and persistence-writer port around checkpoint
-  transitions, used by ingestion and model-pull durable jobs.
-- Added an architecture contract that permits only relative modules and
-  `@ollama-client/contracts` imports from runtime-core.
-
-Remaining in P2: none. Browser transport authorization remains extension
-policy; turn, context, and tool-loop
-orchestration remain domain-runtime work for P3.
-
-Candidate ownership:
-
-- Deterministic state-machine helpers.
-- Retry, cancellation, checkpoint, evidence, and transition primitives.
-- Ports/interfaces for clock, persistence, model invocation, and effects.
-
-Exit gate: deterministic tests run without browser globals or extension setup.
-
-#### P3 — domain runtimes
-
-Status: complete in `release/0.13.x` via PRs #248–#250, 2026-08-09.
-
-Completed in the first turn-orchestration slice:
-
-- Added the environment-independent `@ollama-client/chat-runtime` workspace
-  package with a clean-Node test project and independent no-DOM typecheck.
-- Moved durable turn submission, context/generation transitions, resume,
-  completion/cancellation, and failure persistence into a port-driven runtime.
-- Kept persisted-shape normalization, context callbacks, failure conversion,
-  SQLite repositories, provider invocation, and browser streaming in extension
-  composition.
-- Added a source contract allowing only relative modules plus contracts and
-  runtime-core dependencies from chat-runtime.
-
-Merged in `release/0.13.x` via PR #248.
-
-Completed in the context-orchestration slice:
-
-- Moved context build command/output contracts, injected builder coordination,
-  clock ownership, receipt projection, and source normalization into
-  `@ollama-client/chat-runtime`.
-- Kept RAG retrieval, provider and storage access, browser-derived inputs,
-  activity callbacks, warnings, and prompt construction in the extension
-  adapter.
-- Added clean-Node tests for deterministic evidence, provider attribution,
-  forward-compatible source normalization, and failed builds that mint no
-  receipt.
-
-Merged in `release/0.13.x` via PR #249.
-
-Completed in the tool-loop orchestration slice:
-
-- Moved the versioned durable tool-loop state and checkpoint envelope schemas
-  behind `@ollama-client/contracts/tool-loop` while retaining legacy-row
-  decoding and SQLite failure conversion in the repository adapter.
-- Added a shared `@ollama-client/chat-runtime` coordinator for new/resumed
-  state, model/tool transitions, cursor checkpoints, approval boundaries,
-  taint advancement, trace reuse, and phase cleanup.
-- Converged native and non-native ordered parallel batches on the same runtime
-  executor; provider streaming, protocol formatting, tool execution, approval
-  policy, browser effects, and persistence remain extension ports.
-- Added clean-Node contract/runtime coverage and retained restart, approval,
-  corrupt-checkpoint, taint, replay, native, and non-native integration tests.
-
-Remaining P3 work: none.
-
-Deferred to `0.14.x`: `packages/agent-runtime` task compiler, policy, approval,
-controller, verification, and recovery.
-
-Keep in extension `src/`:
-
-- WXT entrypoints and browser messaging adapters.
-- Chrome/Firefox permissions and page execution.
-- React UI and feature stores.
-- SQLite, OPFS, extension storage, and migration hosts.
-- Concrete provider implementations until their storage dependency is removed.
-
-#### Mechanical risks
-
-- WXT expects `src/entrypoints/`.
-- `@/` aliases, test setup, Biome, knip, source-contract tests, and bundle checks
-  currently assume one source root.
-- Storage is systematic coupling, not a file-move problem.
-- Package extraction must not disturb migration compatibility or bundle budgets.
-
-### Phase 3 — release hardening
-
-Status: complete in `release/0.13.x` via PR #251, 2026-08-09.
-
-Completed evidence:
-
-- `pnpm verify` passed package and app typechecks, Biome, knip, strict i18n,
-  generated-resource drift, the compatibility ledger, and 2,629 tests across
-  323 files. A frozen-lockfile install was already up to date.
-- Chrome MV3 and Firefox MV2 production builds and ZIP packages passed manifest,
-  CSP, permissions, lazy-locale, and bundle-budget checks. No duplicate shipped
-  assets were present; package sizes remained below their release budgets.
-- Packaged Chrome and Firefox migration fixtures passed fresh-profile startup,
-  concurrent facade writes, every-table legacy import, integrity and foreign-key
-  verification, migration receipts, legacy override, and OPFS export.
-- Chrome additionally passed interrupted-migration resume, rejected-restore
-  safety, and the critical install/restart/migration Playwright gates.
-- Both browsers preserved the 3,457,024-byte rollback source byte-for-byte with
-  SHA-256 `8c39ee7d447ed19837295a6f0bbf2f302cebef151a8857b0ed8dfb7e516a1fdf`.
-- The production build contains one persistence-host worker and official
-  sqlite-wasm engine. sql.js remains confined to benchmark fixture generation.
-- A focused 79-test soak passed provider connection, model catalog/RPC,
-  durable-turn recovery, interrupted-turn recovery, ingestion recovery, and
-  theme persistence behavior.
-
-Audit observation, not a shipped release blocker: `pnpm audit --prod` includes
-the docs workspace and reported nine advisories (two already ignored by policy).
-The only direct extension dependency reported was DOMPurify; the affected
-`IN_PLACE` hook mode is not used. Its patched release and Mermaid's docs-only
-patch are still younger than the strict seven-day dependency-age window, so the
-lockfile was not forced past policy. Re-evaluate them after they age in rather
-than adding a security-patch exception during release hardening.
-
-Remaining Phase 3 work: none. Promote only through
-`release/0.13.x` → `preview` → `main`.
+The `0.13.0` runtime foundation is established in code: shared contracts,
+deterministic runtime primitives, and turn/context/tool-loop orchestration live
+in environment-independent workspace packages. Browser, provider, persistence,
+and UI adapters remain in `src/`. Architecture contracts, runtime schemas,
+restart tests, test-layout checks, and documentation-comment checks guard those
+boundaries automatically.
+
+## Remaining foundation follow-ups
+
+These are bounded improvements, not release blockers and not authorization for
+a repository-wide rewrite.
+
+### Chat stream presentation boundary
+
+`src/features/chat/hooks/use-chat-stream.ts` still combines port lifecycle,
+reconnect and stop behavior, reducer effects, error presentation, and browser
+side effects.
+
+- Extract a framework-independent stream transport/session client around the
+  existing schemas and pure reducer.
+- Leave React state, translated errors, issue links, and other presentation
+  effects in a thin hook adapter.
+- Preserve restart, reconnect, stop, completion, and legacy-stream behavior with
+  characterization tests throughout the extraction.
+
+### Turn submission boundary
+
+`src/features/chat/hooks/use-chat-turn-controller.ts` still combines UI
+preconditions, session and user-message preparation, persistence error
+presentation, and durable command construction.
+
+- Move deterministic submission preparation and durable command construction
+  behind a tested application boundary.
+- Keep React state and translated toast presentation in the hook.
+- Keep `use-chat.ts` as composition and wiring only.
+
+### Structured settings validation
+
+Raw `plasmoGlobalStorage` access remains widespread, while schema-backed
+descriptors cover only part of the settings surface.
+
+- Migrate high-risk structured values first and validate persisted/imported
+  shapes at runtime.
+- Preserve sync-versus-local ownership from `storage-key-registry.ts`.
+- Move simple values opportunistically; do not use a flag-day migration.
+
+### Provider manager decomposition
+
+`src/lib/providers/manager.ts` still combines compatibility migration,
+validation, secret recovery, provider CRUD, and model mappings.
+
+- Preserve the public `ProviderManager` facade.
+- Extract private mapping and migration collaborators only behind existing
+  characterization coverage.
+- Keep unknown-field preservation, journal recovery, and secret handling
+  behavior unchanged.
+
+### Message router decomposition
+
+`src/background/message-router.ts` remains the authorized switch for retained
+one-way and content-script traffic.
+
+- Keep request/response provider and model operations on typed extension RPC.
+- Move retained case bodies to named handlers without widening sender policy.
+- Preserve registry and source-policy contract tests.
 
 ## `0.14.x` browser-agent phases
 
 ### Product boundary
 
 Ship one supervised browser agent first. Multi-agent remains a future extension
-point, not initial runtime complexity. Agent operates through structured
+point, not initial runtime complexity. The agent operates through structured
 observations, commands, policy, approval, execution, and verified effects.
 
 Agent and chat may share contracts, model ports, tool primitives, and UI design
@@ -472,54 +101,58 @@ language. They do not share mutable stores, controllers, or feature internals.
 
 - Treat `feature/agent-interaction-phase-1` as prior art only.
 - Inventory code against current contracts and package boundaries.
-- Port small reviewed slices; never merge old branch wholesale.
-- Keep agent unreachable from production UI until safety and recovery gates pass.
+- Port small reviewed slices; never merge the old branch wholesale.
+- Keep the agent unreachable from production UI until safety and recovery gates
+  pass.
 
 ### A1 — domain and controller skeleton
 
-- Compile user request into explicit task specification, constraints, and
-  completion criteria.
+- Compile the user request into an explicit task specification, constraints,
+  and completion criteria.
 - Use deterministic states such as observing, deciding, awaiting approval,
   executing, verifying, paused, completed, and failed.
-- Model proposes typed decisions; controller owns transitions.
+- Let the model propose typed decisions while the controller owns transitions.
 
 ### A2 — perception and command boundary
 
 - Build bounded, ordered page snapshots with stable element references.
 - Mark page content and tool output as untrusted.
-- Initial actions: navigate, click, type/replace, select, scroll, read, and wait.
+- Start with navigate, click, type/replace, select, scroll, read, and wait.
 - Never guess an unsafe target when binding is ambiguous.
 
 ### A3 — policy, approval, and execution
 
-- Read-only observation stays distinct from effectful commands.
-- Policy evaluates origin changes, sensitive fields, destructive effects,
-  downloads, submissions, and user constraints.
-- Approval shows exact target, effect, origin, and relevant data before execution.
-- Page text cannot lower policy or approval requirements.
+- Keep read-only observation distinct from effectful commands.
+- Evaluate origin changes, sensitive fields, destructive effects, downloads,
+  submissions, and user constraints in policy.
+- Show the exact target, effect, origin, and relevant data before approval.
+- Never let page text lower policy or approval requirements.
 
 ### A4 — effect verification and completion
 
-- Successful API/DOM execution is not proof of intended effect.
-- Capture post-action evidence and compare expected effects.
+- Treat successful API or DOM execution as insufficient proof of intended
+  effect.
+- Capture post-action evidence and compare it with expected effects.
 - Detect navigation, DOM replacement, stale targets, and user interference.
-- Only controller may declare completion after criteria are verified.
+- Let only the controller declare completion after criteria are verified.
 
 ### A5 — durability and UI
 
-- Checkpoint at model, command, approval, execution, and verification boundaries.
+- Checkpoint at model, command, approval, execution, and verification
+  boundaries.
 - Resume safely after MV3 worker restart without repeating unverified effects.
 - Provide pause, resume, stop, heartbeat, and redacted debug export.
-- UI separates conversation, work log, approvals, evidence, and final result.
+- Separate conversation, work log, approvals, evidence, and final result in the
+  UI.
 - Preserve keyboard access and clear persistent running state.
 
 ### A6 — soak and compatibility
 
 - Unit-test compiler, policy, reducer, verifier, redaction, and recovery.
-- Contract-test model adapters, observation schema, commands, and checkpoints.
-- Browser fixtures cover forms, navigation, dynamic DOM, rich editors, prompt
-  injection, stale targets, and restart recovery.
-- Evaluate task success, unsafe-action rate, unnecessary approvals, recovery,
+- Contract-test model adapters, observation schemas, commands, and checkpoints.
+- Cover forms, navigation, dynamic DOM, rich editors, prompt injection, stale
+  targets, and restart recovery in browser fixtures.
+- Measure task success, unsafe-action rate, unnecessary approvals, recovery,
   latency, token cost, and local-model behavior.
 
 Initial non-goals:
@@ -535,15 +168,15 @@ Initial non-goals:
 Compatibility work runs beside release phases; dates alone never authorize
 removal.
 
-- Legacy blob live fallback evidence window opened 2026-07-31 and lasts two to
-  three months. Earliest target remains `0.14.x`, subject to every gate in
-  `compatibility-ledger.json`.
-- Retain migration receipts, diagnostics, untouched source blob, rollback
-  switch, and packaged Chrome/Firefox fixtures through that window.
-- Damaged profiles use read-only export/backup recovery, not a normal serving
-  path that pretends integrity.
-- Legacy blob reader remains an import/recovery capability unless direct upgrade
-  support is explicitly narrowed.
+- The legacy blob live-fallback evidence window opened 2026-07-31 and lasts two
+  to three months. The earliest target remains `0.14.x`, subject to every gate
+  in `compatibility-ledger.json`.
+- Retain migration receipts, diagnostics, the untouched source blob, rollback
+  switch, and packaged Chrome/Firefox fixtures throughout that window.
+- Treat damaged profiles as read-only export/backup recovery, not a normal
+  serving path that pretends integrity.
+- Retain the legacy blob reader as an import/recovery capability unless direct
+  upgrade support is explicitly narrowed.
 
 ## Architecture invariants
 
@@ -551,35 +184,28 @@ removal.
 - One persistence owner; queries do not commit stale state after caller timeout.
 - Cancellation reaches provider and long-running browser work.
 - Provider catalog absence does not prove failure or reachability.
-- Unknown model capability resolves false unless user override enables it.
+- Unknown model capability resolves false unless a user override enables it.
 - Provider replay artifacts remain opaque, bounded, unlogged, and unrendered.
 - Content scripts cannot cross extension-page RPC policy boundaries.
-- Browser/page content is untrusted input, never policy.
-- App-generated persisted prose carries translation identity plus safe fallback.
+- Browser and page content is untrusted input, never policy.
+- App-generated persisted prose carries translation identity plus a safe
+  fallback.
 - Compatibility paths leave only after ledger evidence, never cleanup instinct.
 
 ## Deferred items
 
-- Provider/page permission split: revisit with tested upgrade, denial, revoke UX.
+- Provider/page permission split: revisit with tested upgrade, denial, and
+  revoke UX.
 - One top-frame selection owner: revisit after cross-origin design and tests.
 - Dev harness relocation: revisit with separate build configuration.
 - Coverage thresholds: add only where meaningful domain thresholds exist.
-- Tab capture: ship only as complete user-gesture capability with visible stop,
-  preserved audio, revoke handling, and ephemeral data.
-
-## Decision log
-
-- `0.13.0` is foundation and isolation release, not agent-feature release.
-- Package phase revived because chat/agent isolation supplies a real second
-  consumer, even without CLI or desktop plans.
-- Extract stable contracts and pure kernels first; avoid package theater and
-  wholesale monorepo churn.
-- Single-agent first. Multi-agent only after measured need and stable role ports.
-- Agent old branch is selective-port source, never merge source.
-- Four private, globally ignored plans retired in favor of this committed plan.
+- Tab capture: ship only as a complete user-gesture capability with a visible
+  stop control, preserved audio, revoke handling, and ephemeral data.
 
 ## Maintenance rule
 
-Update this file in same change that changes phase status, release scope, or a
-decision above. Do not create another active roadmap. Deep implementation detail
-belongs near code, in tests, or in a focused ADR linked from here.
+Remove work from this file once code and automated regression guards establish
+it. Record shipped implementation history in the changelog and pull requests,
+not in this roadmap. Update this file in the same change that alters unfinished
+scope, phase order, release gates, or the decisions above; do not create another
+active roadmap.

--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -44,8 +44,16 @@ Not on current release branch:
 
 - Browser-agent runtime. Old agent branch is design and selective-port source,
   never a branch to merge wholesale.
-- Package extraction. Existing `src/application/**` boundaries are useful prior
-  art, but physical packages have not landed.
+
+Package boundaries now on the release branch:
+
+- `@ollama-client/contracts` owns environment-independent schemas and wire
+  contracts.
+- `@ollama-client/runtime-core` owns deterministic stream, cancellation, retry,
+  checkpoint, and sender-evidence primitives.
+- `@ollama-client/chat-runtime` owns port-driven turn, context-build, and
+  tool-loop orchestration. Browser, provider, persistence, and UI adapters stay
+  in `src/`.
 
 ## Architecture audit refresh — 2026-08-09
 
@@ -349,8 +357,7 @@ Exit gate: deterministic tests run without browser globals or extension setup.
 
 #### P3 — domain runtimes
 
-Status: complete on `feature/chat-runtime-tool-loop-orchestration`, pending
-merge, 2026-08-09.
+Status: complete in `release/0.13.x` via PRs #248–#250, 2026-08-09.
 
 Completed in the first turn-orchestration slice:
 
@@ -394,7 +401,9 @@ Completed in the tool-loop orchestration slice:
 - Added clean-Node contract/runtime coverage and retained restart, approval,
   corrupt-checkpoint, taint, replay, native, and non-native integration tests.
 
-Remaining P3 work: none after this branch merges.
+Merged in `release/0.13.x` via PR #250.
+
+Remaining P3 work: none.
 
 Deferred to `0.14.x`: `packages/agent-runtime` task compiler, policy, approval,
 controller, verification, and recovery.
@@ -417,15 +426,23 @@ Keep in extension `src/`:
 
 ### Phase 3 — release hardening
 
-- Run `pnpm typecheck`, `pnpm lint:check`, and `pnpm test:run`.
-- Run Chrome and Firefox production builds and packages.
-- Run docs/resource generation when touched.
-- Pass packaged-browser migration fixtures and preserve byte-level rollback
-  evidence.
-- Confirm one chat database writer and no second persistence engine.
-- Confirm dependency-age policy, lockfile integrity, and bundle budgets.
-- Soak provider connection, model discovery, chat recovery, ingestion recovery,
-  and Firefox theme behavior.
+Status: automated gates complete on `feature/test-docs-cleanup`, 2026-08-09.
+
+- `pnpm verify` passes package/app typecheck, lint, dead-code, i18n, 2,629
+  tests, generated-resource, and compatibility-ledger checks.
+- Chrome MV3 and Firefox MV2 production builds and release packages complete;
+  packaged manifest, entrypoint, locale, CSP, and permission smoke checks pass.
+- The critical Chromium install, restart, and migration browser suite passes.
+- Packaged Chrome and Firefox migration verifiers pass every durable-table,
+  integrity, rollback-blob digest, override, and export gate.
+- Docs and generated resource builds complete after the architecture audit.
+- Architecture contracts continue to enforce one chat database owner and no
+  second shipped persistence engine.
+
+Manual pre-promotion soak remains: provider connection, model discovery, chat
+and ingestion recovery, and Firefox theme behavior against representative live
+profiles.
+
 - Release only after package-boundary work is mechanically boring and behavior
   remains unchanged.
 

--- a/config/__tests__/documentation-comments.test.ts
+++ b/config/__tests__/documentation-comments.test.ts
@@ -1,0 +1,91 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { relative, resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const root = resolve(import.meta.dirname, "../..")
+const sourceRoots = ["src", "packages", "config", "tools"].map((path) =>
+  resolve(root, path)
+)
+const ignoredDirectories = new Set([
+  "__tests__",
+  "build",
+  "dist",
+  "node_modules"
+])
+const sourceFilePattern = /\.(?:[cm]?[jt]sx?)$/
+const testFilePattern = /\.(?:test|spec)\./
+const declarationPattern =
+  /^(?:export\s+)?(?:declare\s+)?(?:async\s+)?(?:import\b|interface\b|type\b|class\b|function\b|const\b|let\b|var\b|enum\b|namespace\b|module\b)/
+const documentationPrefix =
+  /^(?:note|usage|why|purpose|contract|invariant|lifecycle|end-to-end|production|dev-only|migration-time)\b/i
+const collectSourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.isDirectory() && ignoredDirectories.has(entry.name)) return []
+
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return collectSourceFiles(path)
+    if (
+      !sourceFilePattern.test(entry.name) ||
+      testFilePattern.test(entry.name)
+    ) {
+      return []
+    }
+    return [path]
+  })
+
+const misplacedDocumentation = (file: string): string[] => {
+  const lines = readFileSync(file, "utf8").split("\n")
+  const findings: string[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^\/\/(?!\/)/.test(lines[index])) continue
+
+    const first = index
+    while (index + 1 < lines.length && /^\/\/(?!\/)/.test(lines[index + 1])) {
+      index += 1
+    }
+
+    const block = lines.slice(first, index + 1)
+    if (
+      block.some((line) =>
+        /biome-ignore|@ts-|eslint|istanbul|c8 ignore/.test(line)
+      )
+    ) {
+      continue
+    }
+
+    const content = block.map((line) =>
+      line.replace(/^\s*\/\/ ?/, "").trimEnd()
+    )
+    const prose = content
+      .filter((line) => !/^[-=─—]{12,}$/.test(line.trim()))
+      .filter(Boolean)
+      .join(" ")
+    if (!prose) continue
+
+    let next = index + 1
+    while (next < lines.length && lines[next].trim() === "") next += 1
+    if (
+      !declarationPattern.test(lines[next]?.trim() ?? "") &&
+      prose.length < 80 &&
+      !documentationPrefix.test(prose)
+    ) {
+      continue
+    }
+
+    findings.push(`${relative(root, file)}:${first + 1}`)
+  }
+
+  return findings
+}
+
+describe("documentation comments", () => {
+  it("uses JSDoc for module and declaration documentation", () => {
+    const findings = sourceRoots
+      .flatMap(collectSourceFiles)
+      .flatMap(misplacedDocumentation)
+      .sort()
+
+    expect(findings).toEqual([])
+  })
+})

--- a/config/__tests__/test-layout.test.ts
+++ b/config/__tests__/test-layout.test.ts
@@ -1,0 +1,34 @@
+import { readdirSync } from "node:fs"
+import { basename, relative, resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const root = resolve(import.meta.dirname, "../..")
+const ignoredDirectories = new Set([
+  ".git",
+  ".wxt",
+  "artifacts",
+  "build",
+  "dist",
+  "node_modules"
+])
+const testFilePattern = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/
+
+const collectTestFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.isDirectory() && ignoredDirectories.has(entry.name)) return []
+
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return collectTestFiles(path)
+    return testFilePattern.test(entry.name) ? [path] : []
+  })
+
+describe("test layout", () => {
+  it("keeps test files in __tests__ directories", () => {
+    const misplaced = collectTestFiles(root)
+      .filter((path) => basename(resolve(path, "..")) !== "__tests__")
+      .map((path) => relative(root, path))
+      .sort()
+
+    expect(misplaced).toEqual([])
+  })
+})

--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -455,9 +455,10 @@ There is no OCR pipeline, and no cross-encoder reranking. Retrieval precision co
 - Two storage engines: chat history is SQLite-only, but vectors and knowledge sets are still Dexie. The Dexie *chat* fallback is retired — this is a split by domain, not a migration in progress.
 - Typed setting descriptors cover only part of structured extension storage;
   high-risk config should gain runtime schemas incrementally.
-- Context building still constructs providers and reads settings directly;
-  package extraction must introduce explicit ports rather than move that
-  coupling unchanged.
+- The environment-independent context coordinator now lives in
+  `@ollama-client/chat-runtime`, but its extension adapter still owns provider,
+  retrieval, and storage access. Keep that environment coupling outside the
+  package boundary.
 - Retrieval quality depends on chunking / threshold tuning and model quality.
 
 ## Desktop design notes
@@ -471,6 +472,8 @@ These are non-implementation notes for a hypothetical desktop port.
 
 ## Near-term priorities
 
-1. Freeze package-candidate import boundaries in source-contract tests.
-2. Introduce context-service ports before extracting runtime code.
+1. Preserve the contracts, runtime-core, and chat-runtime source boundaries as
+   browser-agent work begins.
+2. Build agent task, policy, approval, verification, and recovery kernels on
+   those ports rather than importing extension adapters.
 3. Improve retrieval observability and failure diagnostics.

--- a/docs/src/content/docs/legal/privacy-policy.md
+++ b/docs/src/content/docs/legal/privacy-policy.md
@@ -25,7 +25,8 @@ The extension does **not** run first-party analytics, ad trackers, or telemetry 
 
 ## Where data is stored
 
-- Local browser storage backed by SQL WASM (`sql.js`).
+- Local browser storage backed by official sqlite-wasm. Migrated chat history
+  uses OPFS; retained legacy profiles use a compatibility blob in IndexedDB.
 - Optional ZIP backups stored locally when you export.
 - No default cloud sync from the extension itself.
 

--- a/e2e/chromium/critical/__tests__/install-and-boot.spec.ts
+++ b/e2e/chromium/critical/__tests__/install-and-boot.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { expect, test } from "../fixtures/extension"
+import { expect, test } from "../../fixtures/extension"
 
 test("@critical production extension installs and boots", async ({
   extension

--- a/e2e/chromium/critical/__tests__/persistence.spec.ts
+++ b/e2e/chromium/critical/__tests__/persistence.spec.ts
@@ -1,8 +1,8 @@
-import { expect, test } from "../fixtures/extension"
+import { expect, test } from "../../fixtures/extension"
 import {
   openPersistenceVerifyPage,
   waitForOpfsMarker
-} from "../fixtures/persistence"
+} from "../../fixtures/persistence"
 
 interface Counts {
   sessions: number

--- a/packages/contracts/src/__tests__/contracts.test.ts
+++ b/packages/contracts/src/__tests__/contracts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
-import { AppFailureSchema } from "./app-failure"
-import { ChatMessageSchema } from "./chat"
-import { DurableContextOptionsSchema } from "./context"
+import { AppFailureSchema } from "../app-failure"
+import { ChatMessageSchema } from "../chat"
+import { DurableContextOptionsSchema } from "../context"
 import {
   createRpcResponseEnvelopeSchema,
   RPC_PROTOCOL_VERSION,
@@ -10,13 +10,13 @@ import {
   RpcErrorCode,
   RpcMethod,
   RpcRequestEnvelopeSchema
-} from "./rpc"
+} from "../rpc"
 import {
   CHAT_STREAM_EVENT_TYPES,
   MODEL_PULL_EVENT_TYPES,
   STREAM_PROTOCOL_VERSION
-} from "./streams"
-import { PersistedTurnRequestSchema } from "./turns"
+} from "../streams"
+import { PersistedTurnRequestSchema } from "../turns"
 
 describe("contracts package", () => {
   it("runs without application or browser test shims", () => {

--- a/packages/contracts/src/__tests__/diagnostics-rpc.test.ts
+++ b/packages/contracts/src/__tests__/diagnostics-rpc.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   DiagnosticEventSchema,
   DiagnosticsGetBundleResultSchema
-} from "./diagnostics-rpc"
+} from "../diagnostics-rpc"
 
 describe("diagnostics RPC contracts", () => {
   it("accepts sanitized diagnostic events and rejects free-form fields", () => {

--- a/packages/contracts/src/__tests__/durable-job-rpc.test.ts
+++ b/packages/contracts/src/__tests__/durable-job-rpc.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { IngestionJobResultSchema } from "./ingestion-rpc"
+import { IngestionJobResultSchema } from "../ingestion-rpc"
 import {
   ModelPullJobResultSchema,
   ModelPullListActiveRequestSchema
-} from "./model-pull-rpc"
+} from "../model-pull-rpc"
 
 const jobId = "123e4567-e89b-12d3-a456-426614174000"
 

--- a/packages/contracts/src/__tests__/model-rpc.test.ts
+++ b/packages/contracts/src/__tests__/model-rpc.test.ts
@@ -4,7 +4,7 @@ import {
   ModelsGetDetailsResultSchema,
   ModelsListLoadedResultSchema,
   ModelsSearchLibraryRequestSchema
-} from "./model-rpc"
+} from "../model-rpc"
 
 describe("model RPC contracts", () => {
   it("normalizes optional model detail fields", () => {

--- a/packages/contracts/src/__tests__/provider-rpc.test.ts
+++ b/packages/contracts/src/__tests__/provider-rpc.test.ts
@@ -3,7 +3,7 @@ import {
   ProvidersListModelsResultSchema,
   ProvidersListResultSchema,
   ProvidersUpsertRequestSchema
-} from "./provider-rpc"
+} from "../provider-rpc"
 
 describe("provider RPC contracts", () => {
   it("accepts complete provider commands and rejects unknown input", () => {

--- a/packages/contracts/src/chat.ts
+++ b/packages/contracts/src/chat.ts
@@ -16,7 +16,7 @@ const optionalBoolean = z.preprocess(
   z.boolean().optional()
 )
 
-// ---- Metrics (used inside messages and for SQLite parseMetrics) ----
+/** ---- Metrics (used inside messages and for SQLite parseMetrics) ---- */
 
 const RagSourceSchema = z.object({
   id: z.union([z.number(), z.string()]),
@@ -301,8 +301,6 @@ const ImageAttachmentSchema = z.object({
   messageId: z.number().optional()
 })
 
-// ---- ChatMessage ----
-
 /** Partial safe failure persisted on a terminal assistant message. */
 export const ChatMessageErrorSchema = AppFailureSchema.partial()
 
@@ -332,8 +330,6 @@ export const ChatMessageSchema = z.object({
   siblingIds: z.array(z.union([z.number(), z.string()])).optional()
 })
 
-// ---- ChatSession ----
-
 /** Version-independent persisted chat-session metadata and optional messages. */
 export const ChatSessionSchema = z.object({
   id: z.string(),
@@ -349,8 +345,6 @@ export const ChatSessionSchema = z.object({
 export const ChatSessionImportSchema = ChatSessionSchema.extend({
   messages: z.array(ChatMessageSchema)
 })
-
-// -- Output type aliases for consumers that need typed results --
 
 /** Persisted message shape before application attachment normalization. */
 export type ChatMessageParsed = z.infer<typeof ChatMessageSchema>

--- a/src/application/context/rag/rag-retriever.ts
+++ b/src/application/context/rag/rag-retriever.ts
@@ -69,9 +69,11 @@ const scoreKeywordMatch = (text: string, terms: string[]): number => {
   return uniqueMatches * 2 + totalMatches
 }
 
-// Extract sentences relevant to the query; keep ±1 neighbor for context flow.
-// Skips compression when content is too short, no terms match, or the content
-// contains structured markup (code fences, tables, lists) that sentence-splitting would corrupt.
+/**
+ * Extract sentences relevant to the query; keep ±1 neighbor for context flow.
+ * Skips compression when content is too short, no terms match, or the content
+ * contains structured markup (code fences, tables, lists) that sentence-splitting would corrupt.
+ */
 const STRUCTURED_CONTENT_RE = /```|~~~|^\s*\|.+\|/m
 const LIST_ITEM_RE = /^\s*[-*+]\s|^\s*\d+\.\s/m
 

--- a/src/application/file-processing/processors/docx-processor.ts
+++ b/src/application/file-processing/processors/docx-processor.ts
@@ -1,7 +1,7 @@
 import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 
-// Lazy load mammoth to reduce initial bundle size
+/** Lazy load mammoth to reduce initial bundle size */
 let mammothLib: typeof import("mammoth") | null = null
 
 async function getMammothLib() {

--- a/src/application/file-processing/processors/pdf-processor.ts
+++ b/src/application/file-processing/processors/pdf-processor.ts
@@ -3,7 +3,7 @@ import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import type { FileProcessor, ProcessedFile } from "@/lib/file-processors/types"
 import { logger } from "@/lib/logger"
 
-// Define necessary types from pdfjs-dist
+/** Define necessary types from pdfjs-dist */
 type PDFDocumentProxy =
   import("pdfjs-dist/types/src/display/api").PDFDocumentProxy
 type TextItem = import("pdfjs-dist/types/src/display/api").TextItem
@@ -103,7 +103,7 @@ export class PdfProcessor implements FileProcessor {
   }
 }
 
-// Helper: promise with timeout
+/** Helper: promise with timeout */
 function promiseTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let settled = false

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,16 +4,18 @@ import { registerMessageRouter } from "@/background/message-router"
 import { registerPortRouter } from "@/background/port-router"
 import { initializeBackgroundStartup } from "@/background/startup"
 
-// Production persistence topology. Chromium: the service worker guarantees
-// the offscreen owner document exists (for itself and for extension pages).
-// Firefox: the persistent background page IS the owner and hosts the SQLite
-// worker directly.
-//
-// The branch is resolved at build time via __FIREFOX_BG_OWNER__ (not a runtime
-// browser check) so the bundler dead-code eliminates the unused arm. On
-// Chromium that drops owner-host and its ~1.4 MB SQLite worker chunk from the
-// background entry entirely — the offscreen document (persistence-host) is the
-// only Chromium worker host.
+/**
+ * Production persistence topology. Chromium: the service worker guarantees
+ * the offscreen owner document exists (for itself and for extension pages).
+ * Firefox: the persistent background page IS the owner and hosts the SQLite
+ * worker directly.
+ *
+ * The branch is resolved at build time via __FIREFOX_BG_OWNER__ (not a runtime
+ * browser check) so the bundler dead-code eliminates the unused arm. On
+ * Chromium that drops owner-host and its ~1.4 MB SQLite worker chunk from the
+ * background entry entirely — the offscreen document (persistence-host) is the
+ * only Chromium worker host.
+ */
 function registerPersistenceTopology() {
   // Test environments mock a minimal chrome; the topology only registers
   // where runtime messaging actually exists.
@@ -56,16 +58,20 @@ registerPortRouter()
 registerMessageRouter()
 registerPersistenceTopology()
 
-// Dev-only section 9.4 spike host (offscreen OPFS owner). The flag is false
-// in store builds, so this branch and its chunk are eliminated entirely.
+/**
+ * Dev-only section 9.4 spike host (offscreen OPFS owner). The flag is false
+ * in store builds, so this branch and its chunk are eliminated entirely.
+ */
 if (typeof __SPIKE_OPFS_OWNER__ !== "undefined" && __SPIKE_OPFS_OWNER__) {
   void import("@/spike/opfs/background-owner-host").then((module) =>
     module.registerSpikeOwnerHost()
   )
 }
 
-// Firefox MV2 variant: the persistent background page hosts the owner worker
-// itself — no offscreen API exists there. Same dead-code elimination rule.
+/**
+ * Firefox MV2 variant: the persistent background page hosts the owner worker
+ * itself — no offscreen API exists there. Same dead-code elimination rule.
+ */
 if (
   typeof __SPIKE_OPFS_OWNER_MV2__ !== "undefined" &&
   __SPIKE_OPFS_OWNER_MV2__

--- a/src/background/lib/omnibox.ts
+++ b/src/background/lib/omnibox.ts
@@ -5,12 +5,14 @@ import { logger } from "@/lib/logger"
 import { setPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import type { PendingOmniboxQuery } from "@/types/messaging"
 
-// Cache of the active tab, kept fresh so the omnibox `onInputEntered` listener
-// can open the side panel SYNCHRONOUSLY. `chrome.sidePanel.open()` requires an
-// active user gesture, which Chrome consumes at the first `await`. Querying the
-// tab inside the listener (an async call) would discard the gesture and make
-// `open()` throw, falling back to a popup window. So we resolve the window ahead
-// of time and refresh it on tab/window focus changes.
+/**
+ * Cache of the active tab, kept fresh so the omnibox `onInputEntered` listener
+ * can open the side panel SYNCHRONOUSLY. `chrome.sidePanel.open()` requires an
+ * active user gesture, which Chrome consumes at the first `await`. Querying the
+ * tab inside the listener (an async call) would discard the gesture and make
+ * `open()` throw, falling back to a popup window. So we resolve the window ahead
+ * of time and refresh it on tab/window focus changes.
+ */
 let cachedTab: { id?: number; windowId?: number } | undefined
 
 const queryActiveTab = async (): Promise<Tabs.Tab | undefined> => {

--- a/src/background/lib/scheduled-jobs.ts
+++ b/src/background/lib/scheduled-jobs.ts
@@ -122,8 +122,10 @@ export const runScheduledJob = async (jobId: ScheduledJobId): Promise<void> => {
   }
 }
 
-// Guards a double-add when registration runs both at startup and again on a
-// runtime `alarms` permission grant within the same service-worker session.
+/**
+ * Guards a double-add when registration runs both at startup and again on a
+ * runtime `alarms` permission grant within the same service-worker session.
+ */
 let scheduledJobsRegistered = false
 
 export const registerScheduledJobs = (): void => {

--- a/src/background/lib/stream-chat-with-non-native-tools.ts
+++ b/src/background/lib/stream-chat-with-non-native-tools.ts
@@ -46,10 +46,12 @@ interface StreamChatWithNonNativeToolsOptions {
 
 const DEFAULT_MAX_ITERATIONS = 5
 
-// Parser call ids restart at `<name>_0` on every parse. A per-invocation stream
-// sequence keeps callIds unique across turns and concurrent streams — the
-// confirmation registry and the UI's answered-set are both keyed by callId, so
-// a repeat would silently suppress the second confirmation prompt.
+/**
+ * Parser call ids restart at `<name>_0` on every parse. A per-invocation stream
+ * sequence keeps callIds unique across turns and concurrent streams — the
+ * confirmation registry and the UI's answered-set are both keyed by callId, so
+ * a repeat would silently suppress the second confirmation prompt.
+ */
 let streamSeq = 0
 
 const TOOL_LIMIT_FALLBACK_MESSAGE =

--- a/src/background/startup.ts
+++ b/src/background/startup.ts
@@ -146,12 +146,14 @@ const registerInstallHandlers = () => {
   browser.runtime.onStartup.addListener(() => updateDNRRules())
 }
 
-// Point the browser's post-uninstall tab at the docs feedback page. Runs on
-// both Chromium and Firefox (both implement setUninstallURL), so it is NOT
-// gated behind isChromiumBased(). Set on every worker boot so the version
-// param tracks upgrades. Only anonymous context is attached — extension
-// version and UI locale — so a churn spike can be traced to a release without
-// identifying the user.
+/**
+ * Point the browser's post-uninstall tab at the docs feedback page. Runs on
+ * both Chromium and Firefox (both implement setUninstallURL), so it is NOT
+ * gated behind isChromiumBased(). Set on every worker boot so the version
+ * param tracks upgrades. Only anonymous context is attached — extension
+ * version and UI locale — so a churn spike can be traced to a release without
+ * identifying the user.
+ */
 const setUninstallFeedbackURL = () => {
   if (!browser.runtime?.setUninstallURL) return
 
@@ -191,9 +193,11 @@ const registerToolRegistryInvalidation = () => {
   })
 }
 
-// Resolves true when lifecycle flags were read and handled (or none exist);
-// false when even a retry could not resolve them — in that case a pending
-// destructive reset may still be queued, so database startup must not run.
+/**
+ * Resolves true when lifecycle flags were read and handled (or none exist);
+ * false when even a retry could not resolve them — in that case a pending
+ * destructive reset may still be queued, so database startup must not run.
+ */
 const resumeLifecycleWithRetry = async (): Promise<boolean> => {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {

--- a/src/components/layout/list-row.tsx
+++ b/src/components/layout/list-row.tsx
@@ -67,9 +67,11 @@ const SURFACE: Record<ListRowSurface, string> = {
   outline: "border border-border/40"
 }
 
-// Four static templates rather than one interpolated string so Tailwind can see
-// every class it has to emit. Empty `auto` tracks would still take a column gap,
-// which is the phantom-gutter bug this primitive exists to prevent.
+/**
+ * Four static templates rather than one interpolated string so Tailwind can see
+ * every class it has to emit. Empty `auto` tracks would still take a column gap,
+ * which is the phantom-gutter bug this primitive exists to prevent.
+ */
 const TEMPLATE = {
   both: "grid-cols-[auto_minmax(0,1fr)_auto]",
   leading: "grid-cols-[auto_minmax(0,1fr)]",

--- a/src/entrypoints/persistence-host/main.ts
+++ b/src/entrypoints/persistence-host/main.ts
@@ -1,17 +1,19 @@
 import { registerIngestionProcessorHost } from "@/lib/ingestion/ingestion-processor-host"
 import { registerPersistenceHost } from "@/lib/persistence/owner-host"
 
-// Chromium offscreen document: the production chat-database owner. Created
-// only by the background service worker (see chromium-owner.ts). The page is
-// also reachable as a normal tab by URL, and a tab must never become a
-// second owner — the opfs-sahpool VFS is single-instance and a competing
-// host would race RPC responses.
-//
-// Guard, verified empirically: offscreen documents expose runtime messaging
-// but NOT chrome.storage (and their location.search reads empty, and
-// visibilityState reports "visible" — neither is usable). A user-opened tab
-// of an extension page always has chrome.storage, so its absence identifies
-// the real offscreen context.
+/**
+ * Chromium offscreen document: the production chat-database owner. Created
+ * only by the background service worker (see chromium-owner.ts). The page is
+ * also reachable as a normal tab by URL, and a tab must never become a
+ * second owner — the opfs-sahpool VFS is single-instance and a competing
+ * host would race RPC responses.
+ *
+ * Guard, verified empirically: offscreen documents expose runtime messaging
+ * but NOT chrome.storage (and their location.search reads empty, and
+ * visibilityState reports "visible" — neither is usable). A user-opened tab
+ * of an extension page always has chrome.storage, so its absence identifies
+ * the real offscreen context.
+ */
 
 const isOffscreenDocument = !chrome.storage?.local
 

--- a/src/entrypoints/persistence-verify/main.ts
+++ b/src/entrypoints/persistence-verify/main.ts
@@ -24,19 +24,23 @@ import {
 } from "@/lib/sqlite/db"
 import { LATEST_SCHEMA_VERSION } from "@/lib/sqlite/migrations/migration-runner"
 
-// Dev-only verification surface for the production OPFS migration. Every
-// call below exercises the REAL production path: the repository facade, the
-// backend dispatcher, the persistence RPC, and the owner worker. Only the
-// legacy-blob seeding writes directly, because it must reproduce what an
-// unmigrated 0.11.x profile leaves behind.
-//
-// Extension APIs go through `browser`, never the `chrome` alias: on Firefox
-// the `chrome` namespace is callback-only, so `await chrome.storage.local.get`
-// resolves to undefined rather than the stored value. That made every hook
-// here silently unusable on the Firefox runner while working on Chromium.
+/**
+ * Dev-only verification surface for the production OPFS migration. Every
+ * call below exercises the REAL production path: the repository facade, the
+ * backend dispatcher, the persistence RPC, and the owner worker. Only the
+ * legacy-blob seeding writes directly, because it must reproduce what an
+ * unmigrated 0.11.x profile leaves behind.
+ *
+ * Extension APIs go through `browser`, never the `chrome` alias: on Firefox
+ * the `chrome` namespace is callback-only, so `await chrome.storage.local.get`
+ * resolves to undefined rather than the stored value. That made every hook
+ * here silently unusable on the Firefox runner while working on Chromium.
+ */
 
-// Rows the fixture adds outside sessions/messages, so per-table migration
-// verification has something to verify.
+/**
+ * Rows the fixture adds outside sessions/messages, so per-table migration
+ * verification has something to verify.
+ */
 const PROMPT_TEMPLATE_SEED = 7
 const KV_SEED = 3
 

--- a/src/entrypoints/print/main.ts
+++ b/src/entrypoints/print/main.ts
@@ -2,14 +2,16 @@ import { sanitizeExportFragment } from "@/lib/exporters/export-sanitizer"
 import { consumePrintJob, purgeStalePrintJobs } from "@/lib/exporters/print-job"
 import { getPdfStyles } from "@/lib/exporters/styles"
 
-// The print payload arrives via localStorage, which any extension page can
-// write. Treat it as untrusted: re-sanitize with the same shared config the
-// exporter used, and — unless the user opted in to remote export images —
-// install a CSP meta before injecting so no remote resource (img, CSS url())
-// can load even if a crafted payload slipped past the DOM-level strip.
-//
-// Each print window consumes only its own job (`?job=<id>`), so concurrent
-// exports cannot overwrite or clear each other's documents.
+/**
+ * The print payload arrives via localStorage, which any extension page can
+ * write. Treat it as untrusted: re-sanitize with the same shared config the
+ * exporter used, and — unless the user opted in to remote export images —
+ * install a CSP meta before injecting so no remote resource (img, CSS url())
+ * can load even if a crafted payload slipped past the DOM-level strip.
+ *
+ * Each print window consumes only its own job (`?job=<id>`), so concurrent
+ * exports cannot overwrite or clear each other's documents.
+ */
 const BLOCK_REMOTE_CSP =
   "default-src 'none'; img-src 'self' data: blob:; style-src 'unsafe-inline'"
 

--- a/src/entrypoints/spike-owner-offscreen/main.ts
+++ b/src/entrypoints/spike-owner-offscreen/main.ts
@@ -1,7 +1,9 @@
 import { createOwnerHost } from "@/spike/opfs/owner-host-core"
 
-// Section 9.4 spike phase 2: the Chromium offscreen owner document. Hosts
-// the one SQLite worker via the shared owner-host core; the background
-// service worker creates/closes this document (see background-owner-host.ts).
+/**
+ * Section 9.4 spike phase 2: the Chromium offscreen owner document. Hosts
+ * the one SQLite worker via the shared owner-host core; the background
+ * service worker creates/closes this document (see background-owner-host.ts).
+ */
 
 createOwnerHost().registerRpcListener()

--- a/src/entrypoints/spike-owner/main.ts
+++ b/src/entrypoints/spike-owner/main.ts
@@ -7,9 +7,11 @@ import {
   SPIKE_OWNER_RPC
 } from "@/spike/opfs/owner-protocol"
 
-// Section 9.4 spike phase 2: extension-page client of the single owner.
-// Exposes window.__spikeOwner / window.__spikeOwnerControl for the Playwright
-// gate runner; the buttons are for manual use.
+/**
+ * Section 9.4 spike phase 2: extension-page client of the single owner.
+ * Exposes window.__spikeOwner / window.__spikeOwnerControl for the Playwright
+ * gate runner; the buttons are for manual use.
+ */
 
 const statusLine = document.getElementById("status") as HTMLParagraphElement
 const output = document.getElementById("output") as HTMLPreElement

--- a/src/features/chat/components/chat-error-report-action.tsx
+++ b/src/features/chat/components/chat-error-report-action.tsx
@@ -22,9 +22,11 @@ import { cn } from "@/lib/utils"
 import { extensionRpcClient } from "@/protocol/extension-client"
 import type { ChatMessage } from "@/types"
 
-// Compact chips: the sidepanel is ~400px wide, so the three actions only share
-// a row at this sizing. `min-w-0` lets the label truncate rather than push a
-// sibling out of the row.
+/**
+ * Compact chips: the sidepanel is ~400px wide, so the three actions only share
+ * a row at this sizing. `min-w-0` lets the label truncate rather than push a
+ * sibling out of the row.
+ */
 const errorChipCls =
   "h-6 min-w-0 gap-1 rounded-chip border px-2 text-micro shadow-none hover:border-border/50"
 const recoveryChipCls = cn(

--- a/src/features/chat/hooks/use-omnibox-query.ts
+++ b/src/features/chat/hooks/use-omnibox-query.ts
@@ -8,14 +8,18 @@ const pendingOmniboxStorage = getPlasmoStorageForKey(
   STORAGE_KEYS.BROWSER.PENDING_OMNIBOX_QUERY
 )
 
-// Drop duplicate deliveries of the same query within this window. The omnibox
-// fans a single query out across storage + runtime message, so it can arrive
-// more than once.
+/**
+ * Drop duplicate deliveries of the same query within this window. The omnibox
+ * fans a single query out across storage + runtime message, so it can arrive
+ * more than once.
+ */
 const DEDUPE_WINDOW_MS = 2000
 
-// Discard a persisted query older than this. A query stored while no model was
-// ready (and never consumed — e.g. the panel was closed) must not auto-send on
-// a much later side-panel open. Comfortably longer than model hydration.
+/**
+ * Discard a persisted query older than this. A query stored while no model was
+ * ready (and never consumed — e.g. the panel was closed) must not auto-send on
+ * a much later side-panel open. Comfortably longer than model hydration.
+ */
 const PENDING_QUERY_TTL_MS = 60_000
 
 interface UseOmniboxQueryOptions {

--- a/src/features/model/components/provider-grid.tsx
+++ b/src/features/model/components/provider-grid.tsx
@@ -9,7 +9,7 @@ import { isBetaProvider } from "@/lib/providers/registry"
 import { isCustomProviderId, type ProviderConfig } from "@/lib/providers/types"
 import { cn } from "@/lib/utils"
 
-// Status dot color is picked by the first rule that matches.
+/** Status dot color is picked by the first rule that matches. */
 const dotStatusRules = [
   { test: (enabled: boolean) => !enabled, cls: "bg-muted-foreground/40" },
   {

--- a/src/features/model/hooks/use-provider-models.ts
+++ b/src/features/model/hooks/use-provider-models.ts
@@ -31,8 +31,10 @@ import { extensionRpcClient } from "@/protocol/extension-client"
 import type { SelectedModelRef } from "@/types"
 import { isEmbeddingModel } from "../lib/model-utils"
 
-// Stable identities: a fresh literal on every render would restart the effects
-// and memos that take `models`.
+/**
+ * Stable identities: a fresh literal on every render would restart the effects
+ * and memos that take `models`.
+ */
 const EMPTY_MODELS: ProvidersListModelsResult["models"] = []
 const EMPTY_FAILURES: ProvidersListModelsResult["failures"] = []
 

--- a/src/features/selection-actions/content-settings.ts
+++ b/src/features/selection-actions/content-settings.ts
@@ -68,10 +68,12 @@ export async function loadAvailablePanelModels(): Promise<ProviderModel[]> {
   )
 }
 
-// The theme preference is written by the zustand persist store through
-// @plasmohq/storage, so the raw chrome.storage value is JSON-encoded twice
-// and shaped like {"state":{"theme":"dark"},"version":0}. Unwrap defensively;
-// a bare legacy "dark"/"light" string is also accepted.
+/**
+ * The theme preference is written by the zustand persist store through
+ * @plasmohq/storage, so the raw chrome.storage value is JSON-encoded twice
+ * and shaped like {"state":{"theme":"dark"},"version":0}. Unwrap defensively;
+ * a bare legacy "dark"/"light" string is also accepted.
+ */
 function parseStoredTheme(raw: unknown): string | null {
   let value: unknown = raw
   for (let depth = 0; typeof value === "string" && depth < 2; depth += 1) {

--- a/src/features/settings/presets.ts
+++ b/src/features/settings/presets.ts
@@ -24,8 +24,10 @@ export interface SettingsPreset {
 
 const { CHAT, EMBEDDINGS, BROWSER, WEB_SEARCH } = STORAGE_KEYS
 
-// Balanced = the recommended defaults for the tunable sections. Sourced from
-// the F2 manifest so it tracks any future default change automatically.
+/**
+ * Balanced = the recommended defaults for the tunable sections. Sourced from
+ * the F2 manifest so it tracks any future default change automatically.
+ */
 const BALANCED_WRITES: SettingWrite[] = [
   ...getSectionDefaults("prompt-budget"),
   ...getSectionDefaults("grounding"),

--- a/src/hooks/use-markdown-parser.ts
+++ b/src/hooks/use-markdown-parser.ts
@@ -10,9 +10,11 @@ import sup from "markdown-it-sup"
 import taskLists from "markdown-it-task-lists"
 import { useEffect, useMemo, useState } from "react"
 
-// highlight.js (core + ~20 languages) is heavy; keep it out of the eager
-// side-panel bundle. Load it on demand the first time a code fence appears,
-// then re-render to colorise. Until then code blocks render escaped + plain.
+/**
+ * highlight.js (core + ~20 languages) is heavy; keep it out of the eager
+ * side-panel bundle. Load it on demand the first time a code fence appears,
+ * then re-render to colorise. Until then code blocks render escaped + plain.
+ */
 let hljsModule: typeof import("@/lib/hljs") | null = null
 let hljsLoading: Promise<void> | null = null
 const ensureHljs = (): Promise<void> => {

--- a/src/lib/app-reset.ts
+++ b/src/lib/app-reset.ts
@@ -16,13 +16,15 @@ import { resetSQLiteDatabase } from "@/lib/sqlite/db"
 
 export type ResetKey = keyof ReturnType<typeof getAllResetKeys> | "all"
 
-// Destructive resets (chat database, full wipe) must not run while extension
-// pages hold IndexedDB handles: deleteDatabase blocks on open connections and
-// re-initialization then fails mid-delete. The flow is therefore: persist a
-// pending-reset flag, runtime.reload() the whole extension (closing every
-// page), and execute the reset from the fresh background worker before
-// anything else touches the database. The options page is reopened afterward
-// so the reload does not look like a crash.
+/**
+ * Destructive resets (chat database, full wipe) must not run while extension
+ * pages hold IndexedDB handles: deleteDatabase blocks on open connections and
+ * re-initialization then fails mid-delete. The flow is therefore: persist a
+ * pending-reset flag, runtime.reload() the whole extension (closing every
+ * page), and execute the reset from the fresh background worker before
+ * anything else touches the database. The options page is reopened afterward
+ * so the reload does not look like a crash.
+ */
 
 interface PendingReset {
   key: ResetKey
@@ -35,9 +37,11 @@ interface ReopenOptions {
   sidePanelWindowIds?: number[]
 }
 
-// Which browser windows had the side panel open when the reload was
-// scheduled. chrome.runtime.getContexts is Chromium 116+; elsewhere (or on
-// failure) reopening is simply skipped.
+/**
+ * Which browser windows had the side panel open when the reload was
+ * scheduled. chrome.runtime.getContexts is Chromium 116+; elsewhere (or on
+ * failure) reopening is simply skipped.
+ */
 const getOpenSidePanelWindowIds = async (): Promise<number[]> => {
   try {
     const getContexts = (
@@ -133,11 +137,13 @@ export const scheduleReloadWithReopen = async (url: string): Promise<void> => {
   browser.runtime.reload()
 }
 
-// Restore the chat surface after a self-reload. chrome.sidePanel.open()
-// requires a user gesture (verified empirically: it rejects from a fresh
-// worker), so the native panel is attempted first for the day Chrome relaxes
-// this, and the extension's existing popup-window chat surface is the
-// fallback. One popup at most, however many windows had panels.
+/**
+ * Restore the chat surface after a self-reload. chrome.sidePanel.open()
+ * requires a user gesture (verified empirically: it rejects from a fresh
+ * worker), so the native panel is attempted first for the day Chrome relaxes
+ * this, and the extension's existing popup-window chat surface is the
+ * fallback. One popup at most, however many windows had panels.
+ */
 const reopenChatSurface = async (windowIds: number[]): Promise<void> => {
   if (windowIds.length === 0) return
   const sidePanel = (

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -82,11 +82,13 @@ const requestLiveSqliteFlush = async (): Promise<void> => {
   }
 }
 
-// Deleting a Dexie database while another context (an open sidepanel) holds a
-// connection blocks the delete and surfaces "Another connection wants to
-// delete database" warnings on the extensions page. Ask every context —
-// including this one — to close its handles first; the post-import
-// runtime.reload() reopens everything fresh.
+/**
+ * Deleting a Dexie database while another context (an open sidepanel) holds a
+ * connection blocks the delete and surfaces "Another connection wants to
+ * delete database" warnings on the extensions page. Ask every context —
+ * including this one — to close its handles first; the post-import
+ * runtime.reload() reopens everything fresh.
+ */
 const reopenDexieConnectionsEverywhere = async (): Promise<void> => {
   try {
     await browser.runtime.sendMessage({ type: MESSAGE_KEYS.APP.REOPEN_DEXIE })

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -187,7 +187,6 @@ export const DEFAULT_MEMORY_ENABLED = true
 export const MIN_EVAL_DURATION_FOR_SPEED_NS = 10_000_000
 export const MAX_REASONABLE_TOKENS_PER_SECOND = 2_000
 
-// ── Timeouts / Intervals ─────────────────────────────────────────
 /** How long (ms) to wait for first stream chunk before aborting */
 export const STREAM_FIRST_CHUNK_TIMEOUT_MS = 120000
 /** Max time (ms) for PDF.js to load a document */

--- a/src/lib/constants/errors.ts
+++ b/src/lib/constants/errors.ts
@@ -1,5 +1,7 @@
-// Shared script content from tools/ollama-env.sh
-// This ensures both error messages have the same script content
+/**
+ * Shared script content from tools/ollama-env.sh
+ * This ensures both error messages have the same script content
+ */
 import { EXTERNAL_URLS } from "@/lib/constants/urls"
 
 const OLLAMA_ENV_SCRIPT_CONTENT = `#!/bin/bash

--- a/src/lib/embeddings/embedding-client.ts
+++ b/src/lib/embeddings/embedding-client.ts
@@ -24,7 +24,7 @@ export interface EmbeddingError {
   code?: string
 }
 
-// Cache for embeddings with timestamp for TTL (content hash -> { embedding, timestamp })
+/** Cache for embeddings with timestamp for TTL (content hash -> { embedding, timestamp }) */
 interface CacheEntry {
   embedding: number[]
   timestamp: number

--- a/src/lib/embeddings/keyword-index.ts
+++ b/src/lib/embeddings/keyword-index.ts
@@ -181,5 +181,5 @@ class KeywordIndexManager {
   }
 }
 
-// Export singleton instance
+/** Export singleton instance */
 export const keywordIndexManager = new KeywordIndexManager()

--- a/src/lib/embeddings/storage.ts
+++ b/src/lib/embeddings/storage.ts
@@ -2,7 +2,6 @@ import { hnswIndexManager } from "@/lib/embeddings/hnsw-index"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-// import logger to debug
 
 import { getEmbeddingConfig } from "./config"
 import { vectorDb } from "./db"

--- a/src/lib/embeddings/vector-store.ts
+++ b/src/lib/embeddings/vector-store.ts
@@ -1,5 +1,7 @@
-// This file is now a facade exporting from smaller modules
-// This ensures backward compatibility while the codebase is running
+/**
+ * This file is now a facade exporting from smaller modules
+ * This ensures backward compatibility while the codebase is running
+ */
 
 export * from "./cache"
 export * from "./config"

--- a/src/lib/file-processors/index.ts
+++ b/src/lib/file-processors/index.ts
@@ -7,7 +7,7 @@ import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import type { FileProcessor, ProcessedFile } from "./types"
 
-// Processor priority order: specific formats first, then generic text
+/** Processor priority order: specific formats first, then generic text */
 const processors: FileProcessor[] = [
   new PdfProcessor(), // PDF has highest priority
   new DocxProcessor(), // DOCX second

--- a/src/lib/ingestion/ingestion-processor-protocol.ts
+++ b/src/lib/ingestion/ingestion-processor-protocol.ts
@@ -8,11 +8,13 @@ export type IngestionProcessResponse =
   | { ok: true }
   | { ok: false; error: string }
 
-// A cold host answers nothing: on Chromium the offscreen document may not
-// exist yet, on Firefox the hidden processor frame may still be loading, and
-// Chrome rejects a sendMessage with no receiver outright. Neither is a parsing
-// failure, so back off across a real startup budget (~12s) before giving up —
-// a permanent failure here compensates and destroys a valid staged job.
+/**
+ * A cold host answers nothing: on Chromium the offscreen document may not
+ * exist yet, on Firefox the hidden processor frame may still be loading, and
+ * Chrome rejects a sendMessage with no receiver outright. Neither is a parsing
+ * failure, so back off across a real startup budget (~12s) before giving up —
+ * a permanent failure here compensates and destroys a valid staged job.
+ */
 const READY_RETRY_DELAYS_MS = [50, 100, 200, 400, 800, 1600, 3200, 3200, 3200]
 
 const requestOnce = async (

--- a/src/lib/ingestion/ingestion-service.ts
+++ b/src/lib/ingestion/ingestion-service.ts
@@ -52,8 +52,10 @@ const resultFromRun = (run: IngestionRun): IngestionJobResult => ({
   ...(run.failure && { failure: run.failure })
 })
 
-// A processed payload that was never acknowledged (the page closed before the
-// result was consumed) is pruned on the next background boot.
+/**
+ * A processed payload that was never acknowledged (the page closed before the
+ * result was consumed) is pruned on the next background boot.
+ */
 const UNACKED_PAYLOAD_RETENTION_MS = 24 * 60 * 60 * 1000
 
 const isTerminal = (run: IngestionRun): boolean =>

--- a/src/lib/persistence/backend.ts
+++ b/src/lib/persistence/backend.ts
@@ -47,12 +47,14 @@ const STORAGE_KEY_BY_SCOPE: Record<PersistenceStateScope, string> = {
   override: STORAGE_KEYS.PERSISTENCE.LEGACY_OVERRIDE
 }
 
-// Only "opfs" is cached permanently — it is the terminal state. "legacy" is
-// transitional (the owner may flip the marker at any moment), so it is
-// re-read on demand and the cache is invalidated live through
-// storage.onChanged where the API exists. Pinning "legacy" for a page's
-// lifetime would keep it writing the rollback blob after migration —
-// split-brain history.
+/**
+ * Only "opfs" is cached permanently — it is the terminal state. "legacy" is
+ * transitional (the owner may flip the marker at any moment), so it is
+ * re-read on demand and the cache is invalidated live through
+ * storage.onChanged where the API exists. Pinning "legacy" for a page's
+ * lifetime would keep it writing the rollback blob after migration —
+ * split-brain history.
+ */
 let cachedBackend: PersistenceBackend | null = null
 let cachedOverride: boolean | null = null
 
@@ -74,14 +76,16 @@ const registerMarkerWatcher = (): void => {
   }
 }
 
-// Offscreen documents expose runtime messaging but not storage; the background
-// answers these reads/writes on their behalf.
-//
-// Probed through `browser` — the promise-based polyfill — and not the `chrome`
-// alias. On Firefox `chrome` is callback-only, so `await chrome.storage.local
-// .get(key)` resolves to undefined and the property read below throws. That
-// threw on every marker read, readPersistenceBackend swallowed it and answered
-// "legacy", and Firefox therefore never left the sql.js blob backend.
+/**
+ * Offscreen documents expose runtime messaging but not storage; the background
+ * answers these reads/writes on their behalf.
+ *
+ * Probed through `browser` — the promise-based polyfill — and not the `chrome`
+ * alias. On Firefox `chrome` is callback-only, so `await chrome.storage.local
+ * .get(key)` resolves to undefined and the property read below throws. That
+ * threw on every marker read, readPersistenceBackend swallowed it and answered
+ * "legacy", and Firefox therefore never left the sql.js blob backend.
+ */
 const hasStorageApi = (): boolean => Boolean(browser.storage?.local)
 
 const readState = async <T>(
@@ -192,10 +196,12 @@ export const readMigrationReceipt =
     }
   }
 
-// Read through the `chrome` alias: getManifest is synchronous, so the
-// callback-vs-promise split that forces `browser` elsewhere does not apply, and
-// the polyfill did not answer it in the offscreen owner — every receipt written
-// there recorded the version as "unknown".
+/**
+ * Read through the `chrome` alias: getManifest is synchronous, so the
+ * callback-vs-promise split that forces `browser` elsewhere does not apply, and
+ * the polyfill did not answer it in the offscreen owner — every receipt written
+ * there recorded the version as "unknown".
+ */
 const extensionVersion = (): string => {
   try {
     return chrome.runtime.getManifest().version

--- a/src/lib/persistence/chat-db-engine.ts
+++ b/src/lib/persistence/chat-db-engine.ts
@@ -42,31 +42,35 @@ import type {
   SurveyResult
 } from "./protocol"
 
-// The chat-history database engine. One instance exists per browser session,
-// inside the worker the persistence host owns
-// (src/lib/persistence/chat-db-worker.ts) — this module is the engine itself,
-// split out so it can be driven in-process by tests, where no Worker and no
-// OPFS exist.
-//
-// Two backends, one engine, one writer:
-//
-//   "opfs"   — production. One database behind the opfs-sahpool VFS. All writes
-//              are incremental page writes; no full-database export on any hot
-//              path.
-//   "legacy" — the historical blob, in WASM memory and persisted to IndexedDB
-//              as one image (see legacy-blob-db.ts). Only reached by a profile
-//              whose migration has not completed, or one pinned there by the
-//              operator override.
-//
-// Concurrency model: ops execute strictly serially. A transaction lease
-// (txBegin/txCommit/txRollback with a client token) parks every op that does
-// not carry the active token, so one client's multi-statement transaction can
-// never interleave with another client's statements. Within one op the engine
-// is atomic, which is what makes run's lastInsertRowid race-free.
+/**
+ * The chat-history database engine. One instance exists per browser session,
+ * inside the worker the persistence host owns
+ * (src/lib/persistence/chat-db-worker.ts) — this module is the engine itself,
+ * split out so it can be driven in-process by tests, where no Worker and no
+ * OPFS exist.
+ *
+ * Two backends, one engine, one writer:
+ *
+ *   "opfs"   — production. One database behind the opfs-sahpool VFS. All writes
+ *              are incremental page writes; no full-database export on any hot
+ *              path.
+ *   "legacy" — the historical blob, in WASM memory and persisted to IndexedDB
+ *              as one image (see legacy-blob-db.ts). Only reached by a profile
+ *              whose migration has not completed, or one pinned there by the
+ *              operator override.
+ *
+ * Concurrency model: ops execute strictly serially. A transaction lease
+ * (txBegin/txCommit/txRollback with a client token) parks every op that does
+ * not carry the active token, so one client's multi-statement transaction can
+ * never interleave with another client's statements. Within one op the engine
+ * is atomic, which is what makes run's lastInsertRowid race-free.
+ */
 
 const DB_PATH = "/chat-history.sqlite"
-// Scratch path an incoming database is verified in before it is allowed to
-// replace DB_PATH. Never opened by anything but the verification probe.
+/**
+ * Scratch path an incoming database is verified in before it is allowed to
+ * replace DB_PATH. Never opened by anything but the verification probe.
+ */
 const PROBE_PATH = "/chat-history-import-probe.sqlite"
 
 const TX_LEASE_TIMEOUT_MS = 15_000

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -2,14 +2,16 @@
 import { type ChatDbEngine, createChatDbEngine } from "./chat-db-engine"
 import type { PersistenceOp } from "./protocol"
 
-// Message plumbing for the chat-history database owner. Exactly one instance
-// runs per browser session, hosted by the Chromium offscreen document or the
-// Firefox MV2 background page.
-//
-// Everything this file used to do is now in chat-db-engine.ts. The split is not
-// cosmetic: the engine serves both backends and there is no Worker and no OPFS
-// in the test environment, so an engine that could only be reached through
-// `postMessage` could only be tested through a browser harness.
+/**
+ * Message plumbing for the chat-history database owner. Exactly one instance
+ * runs per browser session, hosted by the Chromium offscreen document or the
+ * Firefox MV2 background page.
+ *
+ * Everything this file used to do is now in chat-db-engine.ts. The split is not
+ * cosmetic: the engine serves both backends and there is no Worker and no OPFS
+ * in the test environment, so an engine that could only be reached through
+ * `postMessage` could only be tested through a browser harness.
+ */
 
 interface WorkerRequest {
   id: number

--- a/src/lib/persistence/chromium-owner.ts
+++ b/src/lib/persistence/chromium-owner.ts
@@ -41,15 +41,19 @@ const stampExtensionVersion = (
   }
 }
 
-// Chromium control plane for the persistence owner. The background service
-// worker never opens the database itself: it guarantees that the offscreen
-// owner document exists (for its own calls and on behalf of extension pages,
-// which cannot create offscreen documents).
+/**
+ * Chromium control plane for the persistence owner. The background service
+ * worker never opens the database itself: it guarantees that the offscreen
+ * owner document exists (for its own calls and on behalf of extension pages,
+ * which cannot create offscreen documents).
+ */
 
 const OFFSCREEN_PATH = "persistence-host.html"
-// The owner=1 parameter is the host page's registration guard: only the
-// document the background creates carries it, so a user-opened tab of the
-// same page never becomes a second owner.
+/**
+ * The owner=1 parameter is the host page's registration guard: only the
+ * document the background creates carries it, so a user-opened tab of the
+ * same page never becomes a second owner.
+ */
 const OFFSCREEN_URL = `${OFFSCREEN_PATH}?owner=1`
 
 let creating: Promise<void> | null = null

--- a/src/lib/persistence/client.ts
+++ b/src/lib/persistence/client.ts
@@ -12,16 +12,18 @@ import {
   type RunResult
 } from "./protocol"
 
-// Client side of the persistence RPC. Every context that is not the owner —
-// sidepanel, options, popup, and the Chromium background service worker —
-// talks to the database exclusively through this module.
-//
-// In-process fast path: the owner host context (Firefox MV2 background page,
-// Chromium offscreen document) registers globalThis hooks; calls made from
-// inside the host skip runtime messaging entirely. The Chromium service
-// worker registers an ensure hook so it can create its own offscreen
-// document without messaging itself (runtime messages are never delivered
-// back to the sending context).
+/**
+ * Client side of the persistence RPC. Every context that is not the owner —
+ * sidepanel, options, popup, and the Chromium background service worker —
+ * talks to the database exclusively through this module.
+ *
+ * In-process fast path: the owner host context (Firefox MV2 background page,
+ * Chromium offscreen document) registers globalThis hooks; calls made from
+ * inside the host skip runtime messaging entirely. The Chromium service
+ * worker registers an ensure hook so it can create its own offscreen
+ * document without messaging itself (runtime messages are never delivered
+ * back to the sending context).
+ */
 
 const RPC_TIMEOUT_MS = 30_000
 
@@ -99,9 +101,7 @@ const send = async (request: PersistenceOp): Promise<unknown> => {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Typed surface used by the db facade
-// ---------------------------------------------------------------------------
+/** Typed surface used by the db facade */
 
 export const rpcQuery = async (
   sql: string,

--- a/src/lib/persistence/legacy-blob-db.ts
+++ b/src/lib/persistence/legacy-blob-db.ts
@@ -15,29 +15,31 @@ import {
 } from "./durable-tables"
 import { readLegacyBlobBytes } from "./legacy-blob-reader"
 
-// The legacy blob backend: the whole database in WASM memory, persisted as one
-// IndexedDB value. Serves profiles whose migration to OPFS has not completed,
-// and profiles pinned to the blob by the operator override.
-//
-// It runs inside the chat-db worker, alongside the OPFS backend and on the same
-// engine. Two things follow from that, and both are the point:
-//
-//   - The extension ships one SQLite. This was sql.js until 0.13.x, in every
-//     context that touched history. Official sqlite-wasm reads the same file
-//     format, but its JS glue is an order of magnitude larger than sql.js's
-//     (578KB against 46KB) and pulls an emitted worker asset with it, so an
-//     in-page swap put ~1.4MB into the background bundle. In the worker the
-//     glue is already paid for.
-//   - There is exactly one writer. The per-context database this replaces
-//     needed an import-generation guard and a backend re-read before every save
-//     to keep a stale page from overwriting a newer image. A single owner
-//     cannot have a stale writer, so neither guard has anything left to defend.
-//
-// Durability keeps the old shape deliberately: a debounced full-image export,
-// not per-transaction writes. The IndexedDB blob stays the system of record and
-// the rollback artifact for a profile on this backend, and a file that is being
-// preserved as evidence should be written in whole images, the way it was
-// written before.
+/**
+ * The legacy blob backend: the whole database in WASM memory, persisted as one
+ * IndexedDB value. Serves profiles whose migration to OPFS has not completed,
+ * and profiles pinned to the blob by the operator override.
+ *
+ * It runs inside the chat-db worker, alongside the OPFS backend and on the same
+ * engine. Two things follow from that, and both are the point:
+ *
+ *   - The extension ships one SQLite. This was sql.js until 0.13.x, in every
+ *     context that touched history. Official sqlite-wasm reads the same file
+ *     format, but its JS glue is an order of magnitude larger than sql.js's
+ *     (578KB against 46KB) and pulls an emitted worker asset with it, so an
+ *     in-page swap put ~1.4MB into the background bundle. In the worker the
+ *     glue is already paid for.
+ *   - There is exactly one writer. The per-context database this replaces
+ *     needed an import-generation guard and a backend re-read before every save
+ *     to keep a stale page from overwriting a newer image. A single owner
+ *     cannot have a stale writer, so neither guard has anything left to defend.
+ *
+ * Durability keeps the old shape deliberately: a debounced full-image export,
+ * not per-transaction writes. The IndexedDB blob stays the system of record and
+ * the rollback artifact for a profile on this backend, and a file that is being
+ * preserved as evidence should be written in whole images, the way it was
+ * written before.
+ */
 
 const SAVE_DEBOUNCE_MS = 1000
 
@@ -59,10 +61,6 @@ export interface LegacyBlobDb {
   exportImage: () => Uint8Array
   close: () => void
 }
-
-// ---------------------------------------------------------------------------
-// IndexedDB
-// ---------------------------------------------------------------------------
 
 /**
  * Every helper closes the connection it opens. A lingering handle makes
@@ -121,10 +119,6 @@ export const deleteLegacyBlob = (): Promise<void> =>
     // closes. Resolving optimistically matches what the caller can act on.
     request.onblocked = () => resolve()
   })
-
-// ---------------------------------------------------------------------------
-// Engine
-// ---------------------------------------------------------------------------
 
 /**
  * The WASM glue admits a buffer only by `instanceof Uint8Array`, which is a

--- a/src/lib/persistence/legacy-blob-reader.ts
+++ b/src/lib/persistence/legacy-blob-reader.ts
@@ -1,12 +1,14 @@
 import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
 
-// Migration-time reader for the legacy IndexedDB blob. Loaded lazily so it
-// stays out of every startup chunk once a profile has migrated.
-//
-// This module holds no SQLite engine. The blob is a valid SQLite file, so the
-// database owner's worker surveys it through the `surveyDb` op on official
-// sqlite-wasm — the same engine that performs the import. Reading it here with
-// a second engine is what kept sql.js in the package for a read.
+/**
+ * Migration-time reader for the legacy IndexedDB blob. Loaded lazily so it
+ * stays out of every startup chunk once a profile has migrated.
+ *
+ * This module holds no SQLite engine. The blob is a valid SQLite file, so the
+ * database owner's worker surveys it through the `surveyDb` op on official
+ * sqlite-wasm — the same engine that performs the import. Reading it here with
+ * a second engine is what kept sql.js in the package for a read.
+ */
 
 /**
  * Normalize whatever the structured clone handed back.

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -27,11 +27,13 @@ import {
   type QueryRow
 } from "./protocol"
 
-// Host side of the production persistence topology. Runs in exactly one
-// context per browser session: the Chromium offscreen document
-// (src/entrypoints/persistence-host/) or the Firefox MV2 persistent
-// background page. Owns the only chat-db worker, answers persistence-rpc
-// runtime messages, and performs the one-time legacy-blob migration.
+/**
+ * Host side of the production persistence topology. Runs in exactly one
+ * context per browser session: the Chromium offscreen document
+ * (src/entrypoints/persistence-host/) or the Firefox MV2 persistent
+ * background page. Owns the only chat-db worker, answers persistence-rpc
+ * runtime messages, and performs the one-time legacy-blob migration.
+ */
 
 let worker: Worker | null = null
 let requestId = 0
@@ -161,9 +163,7 @@ export const callWorker = (request: PersistenceOp): Promise<unknown> => {
   })
 }
 
-// ---------------------------------------------------------------------------
-// One-time migration from the legacy IndexedDB blob
-// ---------------------------------------------------------------------------
+/** One-time migration from the legacy IndexedDB blob */
 
 let migrationPromise: Promise<void> | null = null
 
@@ -348,9 +348,7 @@ export const ensureMigrated = (): Promise<void> => {
   return migrationPromise
 }
 
-// ---------------------------------------------------------------------------
-// RPC listener
-// ---------------------------------------------------------------------------
+/** RPC listener */
 
 export const registerPersistenceHost = (): void => {
   // In-process fast path for code running inside the host context itself

--- a/src/lib/persistence/protocol.ts
+++ b/src/lib/persistence/protocol.ts
@@ -121,13 +121,13 @@ export const RETRYABLE_OPS = new Set<PersistenceOp["op"]>([
   "setBackend"
 ])
 
-// ---------------------------------------------------------------------------
-// Blob codec. chrome.runtime messages are JSON-serialized on Chromium, so a
-// Uint8Array (file attachment BLOBs) silently becomes {}. Binds and result
-// rows are therefore encoded before crossing the messaging boundary and
-// decoded on the other side. Worker<->host postMessage uses structured clone
-// and keeps real Uint8Arrays.
-// ---------------------------------------------------------------------------
+/**
+ * Blob codec. chrome.runtime messages are JSON-serialized on Chromium, so a
+ * Uint8Array (file attachment BLOBs) silently becomes {}. Binds and result
+ * rows are therefore encoded before crossing the messaging boundary and
+ * decoded on the other side. Worker<->host postMessage uses structured clone
+ * and keeps real Uint8Arrays.
+ */
 
 interface EncodedBlob {
   __persistenceBlob: true

--- a/src/lib/providers/capabilities.ts
+++ b/src/lib/providers/capabilities.ts
@@ -106,21 +106,23 @@ export interface ModelCapabilityInput {
   } | null
 }
 
-// LM Studio /api/v0/models model `type` values.
+/** LM Studio /api/v0/models model `type` values. */
 const LM_STUDIO_TYPE_VLM = "vlm"
 const LM_STUDIO_TYPE_EMBEDDINGS = "embeddings"
 
-// LM Studio /api/v0/models `capabilities[]` tag.
-//
-// "tool_use" is the only value a live server was observed to emit, and the
-// vocabulary demonstrably does not cover reasoning: `qwen3-4b-thinking-2507`
-// reports exactly ["tool_use"] while streaming `reasoning_content`, as does
-// `gemma-4-12b`. So this list is evidence about tool calling only — the absence
-// of a tag says nothing about any other capability, and reasoning must stay
-// unknown here so a probe or override can settle it.
+/**
+ * LM Studio /api/v0/models `capabilities[]` tag.
+ *
+ * "tool_use" is the only value a live server was observed to emit, and the
+ * vocabulary demonstrably does not cover reasoning: `qwen3-4b-thinking-2507`
+ * reports exactly ["tool_use"] while streaming `reasoning_content`, as does
+ * `gemma-4-12b`. So this list is evidence about tool calling only — the absence
+ * of a tag says nothing about any other capability, and reasoning must stay
+ * unknown here so a probe or override can settle it.
+ */
 const LM_STUDIO_CAP_TOOL_USE = "tool_use"
 
-// Ollama /api/show capability tag → normalized capability.
+/** Ollama /api/show capability tag → normalized capability. */
 const OLLAMA_CAP_COMPLETION = "completion"
 const OLLAMA_CAP_INSERT = "insert"
 const OLLAMA_CAP_VISION = "vision"

--- a/src/lib/providers/factory.ts
+++ b/src/lib/providers/factory.ts
@@ -18,8 +18,10 @@ import { VllmProvider } from "./vllm"
 
 type ProviderConstructor = new (config: ProviderConfig) => LLMProvider
 
-// Subclasses of the shared OpenAI-compatible base, keyed by ProviderId.
-// Anything not in this map uses the plain OpenAI-compatible provider.
+/**
+ * Subclasses of the shared OpenAI-compatible base, keyed by ProviderId.
+ * Anything not in this map uses the plain OpenAI-compatible provider.
+ */
 const OPENAI_COMPAT_CONSTRUCTORS: Record<string, ProviderConstructor> = {
   [ProviderId.LM_STUDIO]: LMStudioProvider,
   [ProviderId.LLAMA_CPP]: LlamaCppProvider,

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -76,8 +76,10 @@ const REMOVED_BETA_DEFAULTS: Record<
   }
 }
 
-// Built-in ids and user-added `custom:` ids survive; anything else is stale
-// data from an old version and gets dropped.
+/**
+ * Built-in ids and user-added `custom:` ids survive; anything else is stale
+ * data from an old version and gets dropped.
+ */
 const isKnownProviderId = (id: string): boolean =>
   DEFAULT_PROVIDER_IDS.has(id as ProviderId) || isCustomProviderId(id)
 

--- a/src/lib/providers/model-id-metadata.ts
+++ b/src/lib/providers/model-id-metadata.ts
@@ -12,9 +12,11 @@
  * deliberately narrow and refuses to guess.
  */
 
-// A whole token that is a number followed by "b": "12b", "0.6b", "8b".
-// Requiring the token to *be* this — not merely contain it — is what keeps
-// "4k" (a context window) and "2507" (a date) out.
+/**
+ * A whole token that is a number followed by "b": "12b", "0.6b", "8b".
+ * Requiring the token to *be* this — not merely contain it — is what keeps
+ * "4k" (a context window) and "2507" (a date) out.
+ */
 const PARAMETER_TOKEN = /^(\d+(?:\.\d+)?)b$/
 
 /**

--- a/src/lib/providers/model-rpc-service.ts
+++ b/src/lib/providers/model-rpc-service.ts
@@ -115,9 +115,7 @@ const normalizeLmStudioLoaded = (model: LmStudioModel): LoadedModel => ({
   quantizationLevel: model.quantization ?? ""
 })
 
-// ---------------------------------------------------------------------------
-// Warmup
-// ---------------------------------------------------------------------------
+/** Warmup */
 
 const warmupHistory = new Map<string, number>()
 

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -25,10 +25,12 @@ import {
   ProviderId
 } from "./types"
 
-// Ceiling on the per-list `/api/show` fan-out that recovers metadata missing
-// from `/api/tags`. Sized above a normal library's count of non-GGUF models so
-// the cap never bites in practice, and low enough that a server reporting no
-// metadata at all cannot turn one list request into dozens.
+/**
+ * Ceiling on the per-list `/api/show` fan-out that recovers metadata missing
+ * from `/api/tags`. Sized above a normal library's count of non-GGUF models so
+ * the cap never bites in practice, and low enough that a server reporting no
+ * metadata at all cannot turn one list request into dozens.
+ */
 const OLLAMA_DETAIL_BACKFILL_LIMIT = 12
 
 /**

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -113,7 +113,7 @@ const fileFromRow = (row: Row): StoredFile => ({
   data: (row.data as Uint8Array | null) ?? undefined
 })
 
-// Build a `?, ?, ?` placeholder list for an IN clause.
+/** Build a `?, ?, ?` placeholder list for an IN clause. */
 const placeholders = (n: number) => Array(n).fill("?").join(", ")
 
 const normalizeFileData = (data: unknown): Uint8Array | undefined => {
@@ -181,7 +181,7 @@ const putSessionRow = async (
   )
 }
 
-// ----- Sessions ------------------------------------------------------------
+/** ----- Sessions ------------------------------------------------------------ */
 
 export const getAllSessionsOrderedByRecency = async (): Promise<
   ChatSession[]
@@ -372,7 +372,7 @@ export const deleteSessionRow = async (id: string): Promise<void> => {
   await run("DELETE FROM sessions WHERE id = ?", [id])
 }
 
-// ----- Messages ------------------------------------------------------------
+/** ----- Messages ------------------------------------------------------------ */
 
 export const getMessage = async (
   id: number | string
@@ -682,7 +682,7 @@ export const bulkDeleteMessages = async (ids: number[]): Promise<void> => {
   )
 }
 
-// ----- Files ---------------------------------------------------------------
+/** ----- Files --------------------------------------------------------------- */
 
 export const getFilesByMessageIds = async (
   messageIds: number[]
@@ -747,8 +747,6 @@ export const deleteFilesByMessageIds = async (
   )
   return (before[0]?.count as number) ?? 0
 }
-
-// ----- Database-level operations ------------------------------------------
 
 /**
  * Drop the SQLite-backed chat database. Used by the user-facing

--- a/src/lib/sqlite/benchmark/persistence-benchmark-core.ts
+++ b/src/lib/sqlite/benchmark/persistence-benchmark-core.ts
@@ -133,7 +133,7 @@ const createLinearMessages = (database: Database, scale: Scale): void => {
   }
 }
 
-// Explicit message ids so parentId wiring and currentLeafId stay deterministic.
+/** Explicit message ids so parentId wiring and currentLeafId stay deterministic. */
 const createTreeMessages = (database: Database, scale: Scale): void => {
   const plan = scale.tree
   if (!plan) throw new Error("Tree scale requires a tree plan")

--- a/src/lib/sqlite/db.ts
+++ b/src/lib/sqlite/db.ts
@@ -13,22 +13,24 @@ import {
 } from "@/lib/persistence/client"
 import type { RunResult } from "@/lib/persistence/protocol"
 
-// Chat-history database facade. Every operation goes to the single database
-// owner over persistence RPC — the Chromium offscreen document or the Firefox
-// MV2 background page, which hosts the only chat-db worker.
-//
-// The owner serves one of two backends, and this module does not care which:
-//
-//   "opfs"   — the production topology, one sqlite-wasm database behind
-//              opfs-sahpool. Durability is per-transaction.
-//   "legacy" — the historical blob in WASM memory, persisted to IndexedDB as
-//              one image, for a profile whose migration has not completed.
-//
-// Until 0.13.x this module dispatched on the backend marker and, for "legacy",
-// opened a database *in the calling context* on a second SQLite build. That is
-// what made a stale-writer guard necessary — every page was a writer — and it
-// is why the extension shipped two engines. Both are gone: one owner, one
-// engine, and clients that hold no database handle at all.
+/**
+ * Chat-history database facade. Every operation goes to the single database
+ * owner over persistence RPC — the Chromium offscreen document or the Firefox
+ * MV2 background page, which hosts the only chat-db worker.
+ *
+ * The owner serves one of two backends, and this module does not care which:
+ *
+ *   "opfs"   — the production topology, one sqlite-wasm database behind
+ *              opfs-sahpool. Durability is per-transaction.
+ *   "legacy" — the historical blob in WASM memory, persisted to IndexedDB as
+ *              one image, for a profile whose migration has not completed.
+ *
+ * Until 0.13.x this module dispatched on the backend marker and, for "legacy",
+ * opened a database *in the calling context* on a second SQLite build. That is
+ * what made a stale-writer guard necessary — every page was a writer — and it
+ * is why the extension shipped two engines. Both are gone: one owner, one
+ * engine, and clients that hold no database handle at all.
+ */
 
 type SqlValue = string | number | null | Uint8Array
 type QueryResult = Record<string, SqlValue>
@@ -39,16 +41,16 @@ export interface SqlExecutor {
   runWithMeta: (sql: string, bind?: SqlValue[]) => Promise<RunResult>
 }
 
-// ---------------------------------------------------------------------------
-// Transaction scope. Every public statement and transaction acquires this
-// context-local mutex. Transaction callbacks receive a scoped executor that
-// bypasses the mutex and carries the owner's lease token.
-//
-// Do not represent async transaction ownership with a process-global token:
-// unrelated work can run while a callback is awaiting and would accidentally
-// inherit that token. Explicit executors keep those operations outside the
-// transaction; the mutex parks them until commit/rollback.
-// ---------------------------------------------------------------------------
+/**
+ * Transaction scope. Every public statement and transaction acquires this
+ * context-local mutex. Transaction callbacks receive a scoped executor that
+ * bypasses the mutex and carries the owner's lease token.
+ *
+ * Do not represent async transaction ownership with a process-global token:
+ * unrelated work can run while a callback is awaiting and would accidentally
+ * inherit that token. Explicit executors keep those operations outside the
+ * transaction; the mutex parks them until commit/rollback.
+ */
 
 let dbMutex: Promise<void> = Promise.resolve()
 
@@ -97,9 +99,7 @@ export const withTransaction = async (
     }
   })
 
-// ---------------------------------------------------------------------------
-// Core statement API
-// ---------------------------------------------------------------------------
+/** Core statement API */
 
 export const query = async (
   sql: string,
@@ -119,9 +119,7 @@ export const runWithMeta = async (
   bind: SqlValue[] = []
 ): Promise<RunResult> => withDbLock(() => executor().runWithMeta(sql, bind))
 
-// ---------------------------------------------------------------------------
-// Lifecycle
-// ---------------------------------------------------------------------------
+/** Lifecycle */
 
 export const initSQLite = async (): Promise<void> => {
   await rpcPing()

--- a/src/lib/sqlite/migrations/database.ts
+++ b/src/lib/sqlite/migrations/database.ts
@@ -1,14 +1,16 @@
-// The database surface the forward-only migrations are written against.
-//
-// This used to be sql.js's `Database` type, which is why every migration
-// imported a type from an engine that no longer runs in the extension. The
-// shape is unchanged — these are the members the migrations actually call — so
-// the runner keeps working against both engines without a compatibility cast.
-//
-// Two implementations exist, both official sqlite-wasm underneath:
-//   - the OPFS owner worker (src/lib/persistence/chat-db-worker.ts)
-//   - the legacy in-memory blob fallback (src/lib/persistence/legacy-blob-db.ts)
-// Both obtain one through `asMigrationDatabase` below.
+/**
+ * The database surface the forward-only migrations are written against.
+ *
+ * This used to be sql.js's `Database` type, which is why every migration
+ * imported a type from an engine that no longer runs in the extension. The
+ * shape is unchanged — these are the members the migrations actually call — so
+ * the runner keeps working against both engines without a compatibility cast.
+ *
+ * Two implementations exist, both official sqlite-wasm underneath:
+ *   - the OPFS owner worker (src/lib/persistence/chat-db-worker.ts)
+ *   - the legacy in-memory blob fallback (src/lib/persistence/legacy-blob-db.ts)
+ * Both obtain one through `asMigrationDatabase` below.
+ */
 
 import type { Database as SqliteWasmDatabase } from "@sqlite.org/sqlite-wasm"
 

--- a/src/lib/storage/backup-storage-policy.ts
+++ b/src/lib/storage/backup-storage-policy.ts
@@ -79,10 +79,12 @@ const sanitizePortableValue = (value: unknown): unknown => {
   return sanitized
 }
 
-// @plasmohq/storage JSON-stringifies every value it persists, so raw
-// chrome.storage reads return encoded strings. Sanitization cannot strip
-// secrets it cannot see inside a string, so encoded values are decoded
-// before sanitizing and re-encoded after to preserve the stored format.
+/**
+ * @plasmohq/storage JSON-stringifies every value it persists, so raw
+ * chrome.storage reads return encoded strings. Sanitization cannot strip
+ * secrets it cannot see inside a string, so encoded values are decoded
+ * before sanitizing and re-encoded after to preserve the stored format.
+ */
 const decodePlasmoValue = (
   value: unknown
 ): { decoded: unknown; wasEncoded: boolean } => {

--- a/src/lib/tools/non-native/non-native-tool-parser.ts
+++ b/src/lib/tools/non-native/non-native-tool-parser.ts
@@ -11,9 +11,11 @@
  */
 import type { ToolCall } from "../types"
 
-// Non-greedy so adjacent blocks don't merge; `[\s\S]` to span newlines.
-// Built fresh per use: a shared `g`-flagged regex carries mutable `lastIndex`
-// state across calls, which is easy to break when extending these functions.
+/**
+ * Non-greedy so adjacent blocks don't merge; `[\s\S]` to span newlines.
+ * Built fresh per use: a shared `g`-flagged regex carries mutable `lastIndex`
+ * state across calls, which is easy to break when extending these functions.
+ */
 const toolCallPattern = () => /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/g
 const CODE_FENCE_PATTERN = /^```(?:json)?\s*([\s\S]*?)\s*```$/
 

--- a/src/lib/tools/web-search/backends/brave.ts
+++ b/src/lib/tools/web-search/backends/brave.ts
@@ -29,7 +29,7 @@ const safeSearchMap = {
   strict: "strict"
 } as const
 
-// Brave expresses recency via `freshness`: pd/pw/pm/py = past day/week/month/year.
+/** Brave expresses recency via `freshness`: pd/pw/pm/py = past day/week/month/year. */
 const freshnessMap = {
   day: "pd",
   week: "pw",

--- a/src/lib/tools/web-search/web-search-tool.ts
+++ b/src/lib/tools/web-search/web-search-tool.ts
@@ -11,8 +11,10 @@ import type { WebSearchResult } from "./types"
 
 const PER_SNIPPET_CHAR_LIMIT = 500
 const TOOL_OUTPUT_CHAR_LIMIT = 6000
-// The UI shows the full snippet (search snippets are short); this is just a
-// guard against a pathologically long one bloating persisted message metrics.
+/**
+ * The UI shows the full snippet (search snippets are short); this is just a
+ * guard against a pathologically long one bloating persisted message metrics.
+ */
 const SOURCE_EXCERPT_CHAR_LIMIT = 1200
 const TRACKING_PARAMS = new Set([
   "fbclid",

--- a/src/spike/opfs/background-owner-host.ts
+++ b/src/spike/opfs/background-owner-host.ts
@@ -5,11 +5,13 @@ import {
   SPIKE_OWNER_RPC
 } from "./owner-protocol"
 
-// Section 9.4 spike phase 2: background side of the single-owner topology.
-// The service worker never opens the database; it only guarantees that the
-// offscreen owner document exists and can issue writes through it while all
-// visible extension pages are closed (gate 3). Registered from
-// src/background/index.ts behind a dev-only build flag.
+/**
+ * Section 9.4 spike phase 2: background side of the single-owner topology.
+ * The service worker never opens the database; it only guarantees that the
+ * offscreen owner document exists and can issue writes through it while all
+ * visible extension pages are closed (gate 3). Registered from
+ * src/background/index.ts behind a dev-only build flag.
+ */
 
 const OFFSCREEN_URL = "spike-owner-offscreen.html"
 
@@ -58,11 +60,13 @@ const ensureOwner = async (): Promise<void> => {
   await creating
 }
 
-// Gate 3: a durable write initiated by background code itself while no
-// extension page is open. This is a direct function (also exposed on
-// globalThis for the gate runner) because chrome.runtime.sendMessage never
-// delivers to the sender's own context — background code cannot message
-// itself, it calls the owner client directly.
+/**
+ * Gate 3: a durable write initiated by background code itself while no
+ * extension page is open. This is a direct function (also exposed on
+ * globalThis for the gate runner) because chrome.runtime.sendMessage never
+ * delivers to the sender's own context — background code cannot message
+ * itself, it calls the owner client directly.
+ */
 const backgroundWrite = async (payload: unknown): Promise<unknown> => {
   await ensureOwner()
   return chrome.runtime.sendMessage({

--- a/src/spike/opfs/owner-host-core.ts
+++ b/src/spike/opfs/owner-host-core.ts
@@ -16,10 +16,12 @@ export interface OwnerHost {
   registerRpcListener: () => void
 }
 
-// Fetched once per host; each worker generation gets a structured-clone
-// copy. Benchmark builds copy sqlite3.wasm to this stable path (see the
-// build:publicAssets hook) because bundler ?url imports get inlined as
-// data: URLs in Firefox MV2 iife output, which fetch() rejects.
+/**
+ * Fetched once per host; each worker generation gets a structured-clone
+ * copy. Benchmark builds copy sqlite3.wasm to this stable path (see the
+ * build:publicAssets hook) because bundler ?url imports get inlined as
+ * data: URLs in Firefox MV2 iife output, which fetch() rejects.
+ */
 let wasmBinaryPromise: Promise<ArrayBuffer> | null = null
 const getWasmBinary = (): Promise<ArrayBuffer> => {
   if (!wasmBinaryPromise) {

--- a/src/spike/opfs/owner-worker.ts
+++ b/src/spike/opfs/owner-worker.ts
@@ -11,10 +11,12 @@ import type {
   OwnerOp
 } from "./owner-protocol"
 
-// Section 9.4 spike phase 2: the single database-owner worker. Hosted by the
-// offscreen document only — no other context may open this database. The
-// database handle stays open for the worker's lifetime; a terminated worker
-// mid-transaction must roll back via the journal on the next open (gate 5).
+/**
+ * Section 9.4 spike phase 2: the single database-owner worker. Hosted by the
+ * offscreen document only — no other context may open this database. The
+ * database handle stays open for the worker's lifetime; a terminated worker
+ * mid-transaction must roll back via the journal on the next open (gate 5).
+ */
 
 const DB_PATH = "/spike-owner.sqlite"
 
@@ -40,10 +42,12 @@ interface WorkerRequest {
   payload?: unknown
 }
 
-// The host fetches the wasm and hands the bytes over before the first op.
-// Fetching inside the worker is not portable: Firefox MV2 worker chunks get
-// the ?url asset inlined as a giant data: URL, which Emscripten's streaming
-// fetch rejects with NetworkError.
+/**
+ * The host fetches the wasm and hands the bytes over before the first op.
+ * Fetching inside the worker is not portable: Firefox MV2 worker chunks get
+ * the ?url asset inlined as a giant data: URL, which Emscripten's streaming
+ * fetch rejects with NetworkError.
+ */
 interface InitMessage {
   op: "init"
   wasmBinary: ArrayBuffer
@@ -237,9 +241,11 @@ const processRequest = async (request: WorkerRequest): Promise<void> => {
   }
 }
 
-// The owner serializes all database operations through one chain — async
-// handlers would otherwise interleave at await points and break the
-// single-writer ordering the topology exists to guarantee.
+/**
+ * The owner serializes all database operations through one chain — async
+ * handlers would otherwise interleave at await points and break the
+ * single-writer ordering the topology exists to guarantee.
+ */
 let operationChain: Promise<void> = Promise.resolve()
 
 self.onmessage = (event: MessageEvent<WorkerRequest | InitMessage>) => {

--- a/src/spike/opfs/sahpool-worker.ts
+++ b/src/spike/opfs/sahpool-worker.ts
@@ -16,10 +16,12 @@ import type {
   SpikeWorkerResult
 } from "./protocol"
 
-// Section 9.4 spike: official sqlite-wasm with the opfs-sahpool VFS inside
-// one dedicated worker. This measures the candidate persistence topology's
-// physical import and incremental durable writes — the two properties the
-// current full-blob sql.js topology lacks.
+/**
+ * Section 9.4 spike: official sqlite-wasm with the opfs-sahpool VFS inside
+ * one dedicated worker. This measures the candidate persistence topology's
+ * physical import and incremental durable writes — the two properties the
+ * current full-blob sql.js topology lacks.
+ */
 
 const DB_PATH = "/spike-benchmark.sqlite"
 const CHECKPOINT_BATCH = 20
@@ -255,9 +257,11 @@ const processRequest = async (request: SpikeRequest): Promise<void> => {
   }
 }
 
-// Async handlers interleave at await points, so requests are serialized
-// through one chain: a cleanup arriving mid-run must not wipeFiles() under
-// the active database connection.
+/**
+ * Async handlers interleave at await points, so requests are serialized
+ * through one chain: a cleanup arriving mid-run must not wipeFiles() under
+ * the active database connection.
+ */
 let operationChain: Promise<void> = Promise.resolve()
 
 self.onmessage = (event: MessageEvent<SpikeRequest>) => {

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -36,7 +36,7 @@ export const useThemeStore = create<ThemeState>()(
   )
 )
 
-// Listen for changes from other contexts (e.g. sidebar changing theme should update options page)
+/** Listen for changes from other contexts (e.g. sidebar changing theme should update options page) */
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName === "sync" && changes[STORAGE_KEYS.THEME.PREFERENCE]) {
     const newValue = changes[STORAGE_KEYS.THEME.PREFERENCE].newValue

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -23,7 +23,7 @@ Object.defineProperty(globalThis.navigator, "locks", {
   value: { request: requestTestWebLock }
 })
 
-// Mock chrome extension APIs
+/** Shared Chrome extension API mock for unit tests. */
 global.chrome = {
   runtime: {
     id: "test-extension-id",
@@ -50,7 +50,7 @@ global.chrome = {
   }
 } as unknown as typeof chrome
 
-/*
+/**
  * Production code reaches extension APIs through `browser`
  * (webextension-polyfill), never the `chrome` alias — see the contract test in
  * src/lib/__tests__/browser-api-contract.test.ts for why. Point the global at
@@ -93,12 +93,12 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
   }
 }))
 
-// Reset mocks after each test
+/** Prevent mock state from leaking between tests. */
 afterEach(() => {
   vi.clearAllMocks()
 })
 
-// Setup fake-indexeddb
+/** Reset per-test IndexedDB state supplied by fake-indexeddb. */
 beforeEach(() => {
   // fake-indexeddb is already set up globally
   // No additional setup needed

--- a/src/types/ui-state.schemas.ts
+++ b/src/types/ui-state.schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import type { PromptTemplate, Theme } from "./ui-state"
 
-// ---- PromptTemplate ----
+/** ---- PromptTemplate ---- */
 
 export const PromptTemplateSchema = z.object({
   id: z.string(),
@@ -27,11 +27,11 @@ export const PromptTemplateSchema = z.object({
   usageCount: z.number().min(0).optional().default(0)
 })
 
-// ---- Theme ----
+/** ---- Theme ---- */
 
 export const ThemeSchema = z.enum(["dark", "light", "system"])
 
-// ---- Zustand persisted state wrapper (minimal) ----
+/** ---- Zustand persisted state wrapper (minimal) ---- */
 
 export const ZustandPersistedStateSchema = z
   .object({
@@ -39,8 +39,7 @@ export const ZustandPersistedStateSchema = z
   })
   .passthrough()
 
-// ---- Compile-time conformance checks ----
-
+/** Compile-time checks that schemas still satisfy their application types. */
 void (0 as unknown as z.infer<
   typeof PromptTemplateSchema
 > satisfies PromptTemplate)

--- a/src/types/vendor.d.ts
+++ b/src/types/vendor.d.ts
@@ -1,6 +1,8 @@
-// Ambient declarations for untyped vendor modules.
-// These ship no types and have no @types package; declaring them keeps
-// strict-mode `noImplicitAny` happy without falling back to blanket `any`.
+/**
+ * Ambient declarations for untyped vendor modules.
+ * These ship no types and have no @types package; declaring them keeps
+ * strict-mode `noImplicitAny` happy without falling back to blanket `any`.
+ */
 
 declare module "markdown-it-deflist" {
   import type { PluginSimple } from "markdown-it"
@@ -42,30 +44,38 @@ declare module "markdown-it-task-lists" {
   export default plugin
 }
 
-// Side-effect-only import to register the pdf.js worker; exposes no bindings.
+/** Side-effect-only import to register the pdf.js worker; exposes no bindings. */
 declare module "pdfjs-dist/build/pdf.worker.min.mjs" {
   const worker: unknown
   export default worker
 }
 
-// Vite `?url` asset import for the official SQLite WASM binary, used by the
-// section 9.4 OPFS spike worker.
+/**
+ * Vite `?url` asset import for the official SQLite WASM binary, used by the
+ * section 9.4 OPFS spike worker.
+ */
 declare module "@sqlite.org/sqlite-wasm/sqlite3.wasm?url" {
   const url: string
   export default url
 }
 
-// Compile-time flag defined in wxt.config.ts vite `define`; true only for
-// WXT_BENCHMARK=1 builds that carry the section 9.4 spike owner host.
+/**
+ * Compile-time flag defined in wxt.config.ts vite `define`; true only for
+ * WXT_BENCHMARK=1 builds that carry the section 9.4 spike owner host.
+ */
 declare const __SPIKE_OPFS_OWNER__: boolean
 
-// True only for WXT_BENCHMARK=1 Firefox builds: the MV2 background page
-// hosts the section 9.4 spike owner worker directly (no offscreen API).
+/**
+ * True only for WXT_BENCHMARK=1 Firefox builds: the MV2 background page
+ * hosts the section 9.4 spike owner worker directly (no offscreen API).
+ */
 declare const __SPIKE_OPFS_OWNER_MV2__: boolean
 
-// Compile-time flag defined in wxt.config.ts vite `define`; true only for
-// Firefox (MV2) builds, whose persistent background page hosts the SQLite
-// persistence worker directly. On Chromium (false) the offscreen document is
-// the owner, so this lets the bundler dead-code-eliminate the owner-host +
-// worker chunk out of the Chromium background entry.
+/**
+ * Compile-time flag defined in wxt.config.ts vite `define`; true only for
+ * Firefox (MV2) builds, whose persistent background page hosts the SQLite
+ * persistence worker directly. On Chromium (false) the offscreen document is
+ * the owner, so this lets the bundler dead-code-eliminate the owner-host +
+ * worker chunk out of the Chromium background entry.
+ */
 declare const __FIREFOX_BG_OWNER__: boolean

--- a/tools/benchmark-browser-persistence.ts
+++ b/tools/benchmark-browser-persistence.ts
@@ -1,20 +1,22 @@
 #!/usr/bin/env node
 
-// Drives the dev-only benchmark.html page (src/entrypoints/benchmark/) in
-// real browsers and collects the section 9.8 measurements as JSON.
-//
-// Chromium: loads the packaged benchmark build as a real unpacked MV3
-// extension (same technique as verify-browser-automation-local.ts), so the
-// numbers come from the actual chrome-extension:// origin.
-// Firefox: Playwright cannot install extensions, so the Firefox MV2 benchmark
-// build is served over local HTTP and measured at engine level. Quota and
-// origin policy of a packaged moz-extension:// install are not covered.
-//
-// Usage:
-//   pnpm benchmark:browser [--browser=chromium|firefox|all]
-//     [--scales=small,medium,binary,tree] [--iterations=3] [--headful]
-//
-// Requires: pnpm benchmark:build (and benchmark:build:firefox for Firefox).
+/**
+ * Drives the dev-only benchmark.html page (src/entrypoints/benchmark/) in
+ * real browsers and collects the section 9.8 measurements as JSON.
+ *
+ * Chromium: loads the packaged benchmark build as a real unpacked MV3
+ * extension (same technique as verify-browser-automation-local.ts), so the
+ * numbers come from the actual chrome-extension:// origin.
+ * Firefox: Playwright cannot install extensions, so the Firefox MV2 benchmark
+ * build is served over local HTTP and measured at engine level. Quota and
+ * origin policy of a packaged moz-extension:// install are not covered.
+ *
+ * Usage:
+ *   pnpm benchmark:browser [--browser=chromium|firefox|all]
+ *     [--scales=small,medium,binary,tree] [--iterations=3] [--headful]
+ *
+ * Requires: pnpm benchmark:build (and benchmark:build:firefox for Firefox).
+ */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { createServer } from "node:http"

--- a/tools/spike-firefox-owner-gates.ts
+++ b/tools/spike-firefox-owner-gates.ts
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
-// Section 9.4 spike: packaged-Firefox verification of the MV2 owner host.
-// Installs build/firefox-mv2-benchmark as a temporary add-on in real Firefox
-// via geckodriver, opens spike-owner.html on the real moz-extension:// origin
-// (fixed internal UUID via the extensions.webextensions.uuids pref), and
-// drives the owner RPC end to end: durable appends, checkpoint roundtrip,
-// worker-termination recovery, verified export, and transaction rollback.
-//
-// Usage: pnpm spike:firefox-owner-gates [--headful]
-// Requires: pnpm spike:build:firefox and a local Firefox install
-// (override the binary with FIREFOX_BIN).
+/**
+ * Section 9.4 spike: packaged-Firefox verification of the MV2 owner host.
+ * Installs build/firefox-mv2-benchmark as a temporary add-on in real Firefox
+ * via geckodriver, opens spike-owner.html on the real moz-extension:// origin
+ * (fixed internal UUID via the extensions.webextensions.uuids pref), and
+ * drives the owner RPC end to end: durable appends, checkpoint roundtrip,
+ * worker-termination recovery, verified export, and transaction rollback.
+ *
+ * Usage: pnpm spike:firefox-owner-gates [--headful]
+ * Requires: pnpm spike:build:firefox and a local Firefox install
+ * (override the binary with FIREFOX_BIN).
+ */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { resolve } from "node:path"
@@ -24,8 +26,10 @@ const firefoxBin =
 const headful = process.argv.includes("--headful")
 
 const GECKO_ID = "shishirchaurasiya435@gmail.com"
-// Any fixed UUID works; pinning it makes the moz-extension origin knowable
-// before install.
+/**
+ * Any fixed UUID works; pinning it makes the moz-extension origin knowable
+ * before install.
+ */
 const UUID = "6c1c1f9e-2f5f-4c9a-9c11-000000abcdef"
 
 interface CheckResult {

--- a/tools/spike-owner-gates.ts
+++ b/tools/spike-owner-gates.ts
@@ -1,34 +1,36 @@
 #!/usr/bin/env node
 
-// Section 9.4 spike phase 2: drives the single-owner topology gates in real
-// packaged Chromium (unpacked MV3 extension, real chrome-extension:// origin).
-//
-// Gates exercised (numbering from PRIVATE_ARCHITECTURE_REBUILD_PLAN.md 9.4):
-//   2. Two extension pages issue concurrent repository commands through the
-//      one owner with no lost update.
-//   3. Background durably writes and rereads a checkpoint while all visible
-//      extension pages are closed.
-//   4. Owner-document close and SQLite-worker termination recover on the next
-//      call without manual reload, preserving durable state.
-//   5. A worker terminated inside an open transaction rolls back to the
-//      pre-transaction state on the next worker generation.
-//   7. Export serializes a consistent, verifiable snapshot while another
-//      client keeps writing.
-//   8. Two writers keep writing (with client-side retry) across a deliberate
-//      owner-document recreation, with no lost or duplicated update.
-//   4c. Full browser restart (same profile relaunch) preserves durable rows
-//       and the owner topology recovers without manual intervention.
-//
-// Forced service-worker termination mid-write (gate 4d) is covered by a
-// separate runner, tools/spike-sw-termination.ts (pnpm spike:sw-termination):
-// Playwright pins any worker it attaches to, so that gate launches Chromium
-// itself and kills the worker over the DevTools HTTP endpoint. Also not
-// covered here: incognito/split mode (explicitly unsupported for the spike),
-// packaged Firefox (offscreen API is Chromium-only; MV2 uses a background
-// page host).
-//
-// Usage: pnpm spike:owner-gates [--headful]
-// Requires: pnpm spike:build
+/**
+ * Section 9.4 spike phase 2: drives the single-owner topology gates in real
+ * packaged Chromium (unpacked MV3 extension, real chrome-extension:// origin).
+ *
+ * Gates exercised (numbering from PRIVATE_ARCHITECTURE_REBUILD_PLAN.md 9.4):
+ *   2. Two extension pages issue concurrent repository commands through the
+ *      one owner with no lost update.
+ *   3. Background durably writes and rereads a checkpoint while all visible
+ *      extension pages are closed.
+ *   4. Owner-document close and SQLite-worker termination recover on the next
+ *      call without manual reload, preserving durable state.
+ *   5. A worker terminated inside an open transaction rolls back to the
+ *      pre-transaction state on the next worker generation.
+ *   7. Export serializes a consistent, verifiable snapshot while another
+ *      client keeps writing.
+ *   8. Two writers keep writing (with client-side retry) across a deliberate
+ *      owner-document recreation, with no lost or duplicated update.
+ *   4c. Full browser restart (same profile relaunch) preserves durable rows
+ *       and the owner topology recovers without manual intervention.
+ *
+ * Forced service-worker termination mid-write (gate 4d) is covered by a
+ * separate runner, tools/spike-sw-termination.ts (pnpm spike:sw-termination):
+ * Playwright pins any worker it attaches to, so that gate launches Chromium
+ * itself and kills the worker over the DevTools HTTP endpoint. Also not
+ * covered here: incognito/split mode (explicitly unsupported for the spike),
+ * packaged Firefox (offscreen API is Chromium-only; MV2 uses a background
+ * page host).
+ *
+ * Usage: pnpm spike:owner-gates [--headful]
+ * Requires: pnpm spike:build
+ */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"

--- a/tools/spike-sw-termination.ts
+++ b/tools/spike-sw-termination.ts
@@ -1,35 +1,37 @@
 #!/usr/bin/env node
 
-// Section 9.4 gate 4d: forced service-worker termination mid-write.
-//
-// This is the one lifecycle gate spike-owner-gates.ts could not cover. It runs
-// in its own runner because Playwright globally auto-attaches to every service
-// worker it discovers, and an attached (inspected) MV3 worker is pinned alive —
-// Chromium will not terminate it, so no kill primitive fires. Confirmed dead
-// ends under Playwright: ServiceWorker.stopAllWorkers (page and browser CDP
-// session), Target.closeTarget, Runtime.terminateExecution, and idle timeout.
-//
-// The working approach: launch Chromium ourselves with --remote-debugging-port
-// so NOTHING attaches a debugger to the worker, drive the spike-owner page over
-// raw CDP (attaching to a page target does not pin the worker), and terminate
-// the background worker with the DevTools HTTP endpoint /json/close/<targetId>.
-// On this topology the SQLite owner lives in the offscreen document, a context
-// the service worker's death does not touch — so gate 4d certifies the
-// partial-topology failure that gate 4c (full browser restart) does not:
-// the worker dies mid-write, the offscreen owner survives, and a fresh worker
-// generation resumes serving.
-//
-// Two writes bracket the kill so both properties are proven: a committed write
-// (awaited) that MUST survive — durability — and a burst of unawaited writes
-// still crossing the SW -> offscreen boundary when it dies — atomicity. The
-// crash window counts as exercised only when the kill SPLITS the burst (some
-// writes commit, some are dropped: 0 < landed < total); an unsplit outcome is
-// retried, not accepted. Every surviving row must carry its exact state, never
-// partial/duplicated. Owner continuity (same ownerId and workerGeneration
-// across the kill) proves the offscreen owner was not replaced.
-//
-// Usage: pnpm spike:sw-termination
-// Requires: pnpm spike:build
+/**
+ * Section 9.4 gate 4d: forced service-worker termination mid-write.
+ *
+ * This is the one lifecycle gate spike-owner-gates.ts could not cover. It runs
+ * in its own runner because Playwright globally auto-attaches to every service
+ * worker it discovers, and an attached (inspected) MV3 worker is pinned alive —
+ * Chromium will not terminate it, so no kill primitive fires. Confirmed dead
+ * ends under Playwright: ServiceWorker.stopAllWorkers (page and browser CDP
+ * session), Target.closeTarget, Runtime.terminateExecution, and idle timeout.
+ *
+ * The working approach: launch Chromium ourselves with --remote-debugging-port
+ * so NOTHING attaches a debugger to the worker, drive the spike-owner page over
+ * raw CDP (attaching to a page target does not pin the worker), and terminate
+ * the background worker with the DevTools HTTP endpoint /json/close/<targetId>.
+ * On this topology the SQLite owner lives in the offscreen document, a context
+ * the service worker's death does not touch — so gate 4d certifies the
+ * partial-topology failure that gate 4c (full browser restart) does not:
+ * the worker dies mid-write, the offscreen owner survives, and a fresh worker
+ * generation resumes serving.
+ *
+ * Two writes bracket the kill so both properties are proven: a committed write
+ * (awaited) that MUST survive — durability — and a burst of unawaited writes
+ * still crossing the SW -> offscreen boundary when it dies — atomicity. The
+ * crash window counts as exercised only when the kill SPLITS the burst (some
+ * writes commit, some are dropped: 0 < landed < total); an unsplit outcome is
+ * retried, not accepted. Every surviving row must carry its exact state, never
+ * partial/duplicated. Owner continuity (same ownerId and workerGeneration
+ * across the kill) proves the offscreen owner was not replaced.
+ *
+ * Usage: pnpm spike:sw-termination
+ * Requires: pnpm spike:build
+ */
 
 import { spawn } from "node:child_process"
 import {
@@ -46,9 +48,11 @@ import { chromium } from "playwright"
 const chromeBuildPath = resolve("build/chrome-mv3-spike")
 const artifactDir = resolve("artifacts/persistence-benchmark")
 
-// Chromium picks a free port when launched with --remote-debugging-port=0 and
-// writes it to DevToolsActivePort in the profile dir. Resolving it per run
-// keeps concurrent runners (and a busy 9333) from colliding on a shared port.
+/**
+ * Chromium picks a free port when launched with --remote-debugging-port=0 and
+ * writes it to DevToolsActivePort in the profile dir. Resolving it per run
+ * keeps concurrent runners (and a busy 9333) from colliding on a shared port.
+ */
 let debugPort = 0
 
 interface GateResult {
@@ -94,17 +98,21 @@ const listTargets = async (): Promise<CdpTarget[]> => {
   return Array.isArray(list) ? (list as CdpTarget[]) : []
 }
 
-// Our extension's worker registers at background.js; Chromium's built-in
-// component extensions use other script names (e.g. thunk.js), so this filter
-// selects our worker uniquely without hardcoding an id.
+/**
+ * Our extension's worker registers at background.js; Chromium's built-in
+ * component extensions use other script names (e.g. thunk.js), so this filter
+ * selects our worker uniquely without hardcoding an id.
+ */
 const findServiceWorker = (targets: CdpTarget[]): CdpTarget | undefined =>
   targets.find(
     (target) =>
       target.type === "service_worker" && target.url.endsWith("/background.js")
   )
 
-// Minimal CDP-over-WebSocket client. Only what this gate needs: attach to a
-// page target (flat protocol) and evaluate expressions in it.
+/**
+ * Minimal CDP-over-WebSocket client. Only what this gate needs: attach to a
+ * page target (flat protocol) and evaluate expressions in it.
+ */
 class PageSession {
   private ws: WebSocket
   private nextId = 1
@@ -199,7 +207,7 @@ class PageSession {
   }
 }
 
-// A page-context call into window.__spikeOwner, serialized as an expression.
+/** A page-context call into window.__spikeOwner, serialized as an expression. */
 const ownerCall = (op: string, payload?: unknown): string =>
   `window.__spikeOwner(${JSON.stringify(op)}${
     payload === undefined ? "" : `, ${JSON.stringify(payload)}`

--- a/tools/verify-ci-parity.ts
+++ b/tools/verify-ci-parity.ts
@@ -58,8 +58,10 @@ if (dirty) {
   )
 }
 
-// `git worktree add` refuses a path that already exists, so mkdtemp only
-// provides the parent and git creates the leaf itself.
+/**
+ * `git worktree add` refuses a path that already exists, so mkdtemp only
+ * provides the parent and git creates the leaf itself.
+ */
 const scratch = mkdtempSync(join(tmpdir(), "ollama-client-ci-parity-"))
 const worktree = join(scratch, "repo")
 let failed: string | undefined

--- a/tools/verify-firefox-opfs-migration.ts
+++ b/tools/verify-firefox-opfs-migration.ts
@@ -1,56 +1,58 @@
 #!/usr/bin/env node
 
-// Firefox MV2 mirror of tools/verify-opfs-migration.ts: end-to-end
-// verification of the PRODUCTION OPFS persistence backend in real, packaged
-// Firefox.
-//
-// Why this exists separately from spike-firefox-owner-gates.ts: that spike
-// drives spike-owner.html, a purpose-built page that talks to the owner
-// directly. It proves the MV2 owner topology works. It does not prove the
-// production path works, because it never goes through the repository facade
-// or the backend dispatcher. Chromium has had that stronger claim since
-// verify-opfs-migration.ts; Firefox has not, and section 17 makes this mirror
-// a prerequisite for removing the legacy blob fallback — the reader must not
-// be deleted while one of two shipped browsers has no production-path
-// lifecycle evidence.
-//
-// Scenarios are deliberately the same four as the Chromium runner, with the
-// same check names, so the two reports diff directly:
-//   1. Fresh profile: the owner boots, finds no legacy blob, initializes the
-//      OPFS backend and flips the marker.
-//   2. Production writes: two tabs append through the facade concurrently;
-//      counts are exact (single-owner, no lost update).
-//   3. Real migration: seed a legacy blob (section 9.8 fixture), clear
-//      the backend marker, restart the browser on the same profile; the owner
-//      migrates the blob, verifies row counts, flips the marker — and the blob
-//      stays untouched as the rollback artifact.
-//   4. Backup export comes from the OPFS owner and is a valid SQLite file.
-//
-// Firefox-specific mechanics, none of which the Chromium runner needs:
-//   - The owner is the MV2 persistent background page, not an offscreen
-//     document, so there is nothing to create and nothing to keep alive.
-//   - The extension UUID is pinned through the extensions.webextensions.uuids
-//     pref, because the moz-extension:// origin has to be knowable before
-//     install and stable across the restart in scenario 3. OPFS and IndexedDB
-//     are keyed to that origin; a fresh UUID would silently produce an empty
-//     profile and a scenario 3 that passes for the wrong reason.
-//   - The profile directory is passed with `-profile` so geckodriver reuses it
-//     instead of minting a temporary one. Without this the restart starts from
-//     a blank profile and there is no legacy blob left to migrate.
-//   - A temporary add-on does not survive a browser restart, so it is
-//     reinstalled after relaunch. With the UUID pinned, the origin — and
-//     therefore the stored data — is the same one.
-//   - Firefox 153 refuses `WebDriver:Navigate` to a moz-extension:// URL
-//     ("Navigation ... is not allowed in this context"), and a content page
-//     cannot reach one either without web_accessible_resources. The page is
-//     therefore opened from Firefox's own chrome context with a system
-//     principal, which requires geckodriver's `--allow-system-access`. This is
-//     also why tools/spike-firefox-owner-gates.ts no longer runs as written;
-//     see the note at the bottom of this file.
-//
-// Usage: pnpm verify:firefox-opfs-migration [--headful]
-// Requires: pnpm benchmark:build:firefox (the verify page is dev-gated) and a
-// local Firefox install (override the binary with FIREFOX_BIN).
+/**
+ * Firefox MV2 mirror of tools/verify-opfs-migration.ts: end-to-end
+ * verification of the PRODUCTION OPFS persistence backend in real, packaged
+ * Firefox.
+ *
+ * Why this exists separately from spike-firefox-owner-gates.ts: that spike
+ * drives spike-owner.html, a purpose-built page that talks to the owner
+ * directly. It proves the MV2 owner topology works. It does not prove the
+ * production path works, because it never goes through the repository facade
+ * or the backend dispatcher. Chromium has had that stronger claim since
+ * verify-opfs-migration.ts; Firefox has not, and section 17 makes this mirror
+ * a prerequisite for removing the legacy blob fallback — the reader must not
+ * be deleted while one of two shipped browsers has no production-path
+ * lifecycle evidence.
+ *
+ * Scenarios are deliberately the same four as the Chromium runner, with the
+ * same check names, so the two reports diff directly:
+ *   1. Fresh profile: the owner boots, finds no legacy blob, initializes the
+ *      OPFS backend and flips the marker.
+ *   2. Production writes: two tabs append through the facade concurrently;
+ *      counts are exact (single-owner, no lost update).
+ *   3. Real migration: seed a legacy blob (section 9.8 fixture), clear
+ *      the backend marker, restart the browser on the same profile; the owner
+ *      migrates the blob, verifies row counts, flips the marker — and the blob
+ *      stays untouched as the rollback artifact.
+ *   4. Backup export comes from the OPFS owner and is a valid SQLite file.
+ *
+ * Firefox-specific mechanics, none of which the Chromium runner needs:
+ *   - The owner is the MV2 persistent background page, not an offscreen
+ *     document, so there is nothing to create and nothing to keep alive.
+ *   - The extension UUID is pinned through the extensions.webextensions.uuids
+ *     pref, because the moz-extension:// origin has to be knowable before
+ *     install and stable across the restart in scenario 3. OPFS and IndexedDB
+ *     are keyed to that origin; a fresh UUID would silently produce an empty
+ *     profile and a scenario 3 that passes for the wrong reason.
+ *   - The profile directory is passed with `-profile` so geckodriver reuses it
+ *     instead of minting a temporary one. Without this the restart starts from
+ *     a blank profile and there is no legacy blob left to migrate.
+ *   - A temporary add-on does not survive a browser restart, so it is
+ *     reinstalled after relaunch. With the UUID pinned, the origin — and
+ *     therefore the stored data — is the same one.
+ *   - Firefox 153 refuses `WebDriver:Navigate` to a moz-extension:// URL
+ *     ("Navigation ... is not allowed in this context"), and a content page
+ *     cannot reach one either without web_accessible_resources. The page is
+ *     therefore opened from Firefox's own chrome context with a system
+ *     principal, which requires geckodriver's `--allow-system-access`. This is
+ *     also why tools/spike-firefox-owner-gates.ts no longer runs as written;
+ *     see the note at the bottom of this file.
+ *
+ * Usage: pnpm verify:firefox-opfs-migration [--headful]
+ * Requires: pnpm benchmark:build:firefox (the verify page is dev-gated) and a
+ * local Firefox install (override the binary with FIREFOX_BIN).
+ */
 
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -65,10 +67,12 @@ const firefoxBin =
   process.env.FIREFOX_BIN ?? "/Applications/Firefox.app/Contents/MacOS/firefox"
 const headful = process.argv.includes("--headful")
 
-// Must match browser_specific_settings.gecko.id in the built manifest.
+/** Must match browser_specific_settings.gecko.id in the built manifest. */
 const GECKO_ID = "shishirchaurasiya435@gmail.com"
-// Any fixed UUID works; pinning it makes the moz-extension origin knowable
-// before install and identical after the scenario 3 restart.
+/**
+ * Any fixed UUID works; pinning it makes the moz-extension origin knowable
+ * before install and identical after the scenario 3 restart.
+ */
 const UUID = "6c1c1f9e-2f5f-4c9a-9c11-000000abcdef"
 const VERIFY_URL = `moz-extension://${UUID}/persistence-verify.html`
 

--- a/tools/verify-opfs-migration.ts
+++ b/tools/verify-opfs-migration.ts
@@ -1,31 +1,33 @@
 #!/usr/bin/env node
 
-// End-to-end verification of the production OPFS persistence backend in
-// packaged Chromium. Drives the dev-only persistence-verify.html page, whose
-// hooks call the REAL repository facade → backend dispatcher → persistence
-// RPC → offscreen owner worker.
-//
-// Scenarios:
-//   1. Fresh profile: the owner boots, finds no legacy blob, initializes the
-//      OPFS backend and flips the marker.
-//   2. Production writes: two pages append through the facade concurrently;
-//      counts are exact (single-owner, no lost update).
-//   3. Real migration: seed a legacy blob (section 9.8 fixture),
-//      clear the backend marker, reload the extension; the owner migrates
-//      the blob, verifies every durable table, records a receipt, flips the
-//      marker — and the blob stays untouched as the rollback artifact.
-//   4. Host loss during migration: the browser (and with it the offscreen
-//      owner) is torn down while the migration is in flight. The next boot
-//      must complete it with exact per-table counts and a sound database.
-//   5. Operator override: with the device-local switch set, the profile serves
-//      chat history from the retained blob again and the migration stays
-//      skipped; clearing it migrates on the next boot.
-//   6. A restore whose payload is not a usable database is rejected with the
-//      existing chat history still in place.
-//   7. Backup export comes from the OPFS owner and is a valid SQLite file.
-//
-// Usage: pnpm verify:opfs-migration [--headful]
-// Requires: pnpm benchmark:build (the verify page is dev-gated).
+/**
+ * End-to-end verification of the production OPFS persistence backend in
+ * packaged Chromium. Drives the dev-only persistence-verify.html page, whose
+ * hooks call the REAL repository facade → backend dispatcher → persistence
+ * RPC → offscreen owner worker.
+ *
+ * Scenarios:
+ *   1. Fresh profile: the owner boots, finds no legacy blob, initializes the
+ *      OPFS backend and flips the marker.
+ *   2. Production writes: two pages append through the facade concurrently;
+ *      counts are exact (single-owner, no lost update).
+ *   3. Real migration: seed a legacy blob (section 9.8 fixture),
+ *      clear the backend marker, reload the extension; the owner migrates
+ *      the blob, verifies every durable table, records a receipt, flips the
+ *      marker — and the blob stays untouched as the rollback artifact.
+ *   4. Host loss during migration: the browser (and with it the offscreen
+ *      owner) is torn down while the migration is in flight. The next boot
+ *      must complete it with exact per-table counts and a sound database.
+ *   5. Operator override: with the device-local switch set, the profile serves
+ *      chat history from the retained blob again and the migration stays
+ *      skipped; clearing it migrates on the next boot.
+ *   6. A restore whose payload is not a usable database is rejected with the
+ *      existing chat history still in place.
+ *   7. Backup export comes from the OPFS owner and is a valid SQLite file.
+ *
+ * Usage: pnpm verify:opfs-migration [--headful]
+ * Requires: pnpm benchmark:build (the verify page is dev-gated).
+ */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"


### PR DESCRIPTION
## Summary

- move every test/spec file into its nearest `__tests__` directory
- convert top-level module and declaration documentation from `//` prose to JSDoc while preserving local implementation comments
- add repository contracts that prevent test-layout and documentation-comment drift
- update contributor, architecture, persistence, package-boundary, roadmap, and privacy documentation for the merged P1–P3 runtime extraction
- record completed automated release-hardening evidence and the remaining manual live-profile soak

## Why

The package extraction introduced tests outside the repository convention, while several public and contributor docs still described the retired sql.js topology and P3 as pending. Keeping layout and documentation rules executable prevents the same drift from recurring.

## Impact

No runtime behavior changes. Test discovery paths, generated API documentation, and contributor guidance are standardized.

## Validation

- `pnpm verify` — 323 files / 2,629 tests
- `pnpm docs:build`
- Chrome MV3 and Firefox MV2 production builds and release packages
- `pnpm verify:browser-smoke`
- critical Playwright suite — 3/3 passed
- `pnpm verify:opfs-migration`
- `pnpm verify:firefox-opfs-migration`
- pre-commit and pre-push hooks, including bundle budgets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes test placement and source documentation comments while refreshing contributor and release documentation for the extracted runtime architecture.

- Moves test and specification files into nearby `__tests__` directories.
- Adds executable contracts for test layout and documentation-comment conventions.
- Converts module and declaration prose to JSDoc without changing runtime logic.
- Updates architecture, persistence, privacy, roadmap, and release documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/__tests__/test-layout.test.ts | Adds a repository-wide contract requiring test and specification files to reside under `__tests__`. |
| config/__tests__/documentation-comments.test.ts | Adds a filesystem-based convention check that distinguishes documentation prose from local implementation comments. |
| AGENTS.md | Documents workspace-package boundaries, standardized test placement, and the new convention checks. |
| RELEASE_ROADMAP.md | Replaces completed extraction history with focused remaining architecture and release work. |
| README.md | Updates public architecture and persistence descriptions to match the current package and sqlite-wasm topology. |
| CHANGELOG.md | Records the 0.13.0 runtime, persistence, package-extraction, and release-hardening changes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(changelog): add 0.13.0 release note..."](https://github.com/shishir435/ollama-client/commit/0fc74c6a7cf872cd510b7431255b35b3bead2146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51574859)</sub>

<!-- /greptile_comment -->