### PR TITLE
fix(persistence): enforce trusted RPC boundary

### DIFF
--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -15,8 +15,8 @@ Release work merges into `preview` for validation; only `preview` merges into
 
 | Version | Remaining work | Status |
 | --- | --- | --- |
-| `0.13.0` | Promote `release/0.13.x` through `preview` to `main` | Foundation and hardening complete |
-| `0.13.x` | Finish the focused architecture follow-ups below without delaying promotion | Incremental |
+| `0.13.0` | Close the architecture-audit release blockers, soak on `preview`, then promote to `main` | Hardening required |
+| `0.13.x` | Finish the focused non-blocking architecture follow-ups below | Incremental |
 | `0.14.x` | Build the supervised browser agent | Planned |
 | Later | Remove compatibility paths only when ledger evidence permits | Evidence-gated |
 
@@ -27,10 +27,368 @@ and UI adapters remain in `src/`. Architecture contracts, runtime schemas,
 restart tests, test-layout checks, and documentation-comment checks guard those
 boundaries automatically.
 
+## `0.13.0` architecture-audit closure
+
+The 2026-08-09 branch audit rated the architecture **7.5/10**. The target for
+`0.13.0` is **9+/10**, meaning the release has no known Critical or High
+architecture findings, privileged boundaries reject invalid callers and
+payloads by construction, durable lifecycle intent survives worker loss, and
+growth/recovery behavior is measured rather than assumed.
+
+This section is release-blocking. Complete it in the order below because later
+phases depend on the trust, startup, and lifecycle guarantees established by
+earlier ones. Each phase must merge independently with the application usable
+and all existing compatibility behavior preserved.
+
+### Pull-request sequence
+
+Use seven implementation pull requests plus one release-evidence pull request.
+Do not combine them into one architecture branch: each PR must leave the
+release usable and establish the tests required by its successor.
+
+1. **Persistence trust boundary (H0 + H1):** reproduce hostile/malformed
+   traffic, add wire schemas, authorize senders, revalidate at the worker, and
+   prove a rejected request cannot stall the engine.
+2. **Persistence readiness (H2):** add the shared startup promise and owner-ready
+   handshake after PR 1 makes that handshake a validated protocol operation.
+3. **Durable turn lifecycle (H3):** persist cancellation intent, guard state
+   transitions, make lifecycle commands idempotent, and preserve structured
+   failures.
+4. **Durable turn retention (H4):** compact terminal requests and migrate/prune
+   retained rows after PR 3 makes terminal transitions authoritative.
+5. **Provider discovery policy (H5):** extract the single discovery service.
+   This may run beside PRs 3–4 after PR 1 merges.
+6. **Durable turn composition (H6):** split observer, generation, and recovery
+   adapters only after lifecycle and retention behavior is stable.
+7. **Boundary type/error closure (H7):** decode durable rows, split contract
+   concepts, and finish typed persistence errors against the settled modules.
+8. **Release evidence (H8):** run full Chrome/Firefox gates, record `preview`
+   soak evidence, update release documentation, and promote only when the 9+/10
+   criteria pass.
+
+Critical path: **PR 1 → PR 2 → PR 3 → PR 4 → PR 6 → PR 7 → PR 8**. PR 5 may
+merge any time after PR 1, but must land before PR 8.
+
+### H0 — Freeze evidence and reproduce failures
+
+Scope: S. Behavior change: none. Dependencies: none.
+
+- Add failing tests for content-script persistence access, malformed
+  persistence operations, a DB call racing owner registration, worker loss
+  during stop, terminal turn compaction, and catalog-less tool capability
+  resolution.
+- Add one browser fixture for a cold Chromium owner and one Firefox MV2
+  in-process-owner fixture; unit mocks alone cannot prove extension-context
+  readiness.
+- Capture representative `turn_runs.request` byte sizes for short, long,
+  attachment-heavy, and page-context-heavy conversations before choosing the
+  compaction threshold.
+- Keep the audit findings traceable in pull-request checklists. Do not start
+  structural extraction until the failure behavior is reproduced.
+
+Exit gate:
+
+- Every Critical and High finding has a failing regression test or a written
+  reason why only a browser gate can reproduce it.
+
+### H1 — Secure and validate the persistence control plane
+
+Scope: M. Behavior change: unauthorized and malformed persistence traffic is
+rejected. Dependencies: H0.
+
+Affected modules:
+
+- `src/lib/persistence/protocol.ts`
+- `src/lib/persistence/owner-host.ts`
+- `src/lib/persistence/chromium-owner.ts`
+- `src/lib/persistence/client.ts`
+- `src/lib/persistence/chat-db-worker.ts`
+- `src/lib/persistence/chat-db-engine.ts`
+- `packages/runtime-core/src/runtime-sender.ts`
+
+Work:
+
+- Define Zod discriminated schemas for every persistence request, operation,
+  bind value, marker action, and response envelope. Set explicit limits for SQL
+  text, bind count/blob size, transaction tokens, and imported database bytes.
+- Classify sender evidence before handling `PERSISTENCE_ENSURE`,
+  `PERSISTENCE_RPC`, `PERSISTENCE_MARKER`, or ingestion-processor traffic.
+  Content scripts and untrusted senders must never receive raw SQL, export,
+  import, reset, transaction, backend-marker, receipt, or override capability.
+- Represent trusted owner/background traffic explicitly. Do not weaken the
+  existing extension-page RPC policy to make persistence fit.
+- Validate again at the worker boundary. A malformed in-process caller must not
+  enter the engine scheduler or leave queued promises unresolved.
+- Reject unknown operations deterministically with a typed, safe error. Ensure
+  one invalid request cannot stall later valid operations.
+- Add contract tests for every operation and negative sender/payload case,
+  including a transaction-lease denial-of-service attempt.
+
+Exit gate:
+
+- No privileged persistence mutation accepts a content-script or untrusted
+  sender.
+- No unchecked `PersistenceRpcRequest`/`PersistenceOp` cast remains on a wire
+  boundary.
+- Fuzzed malformed messages leave the worker responsive to a following `ping`.
+
+### H2 — Make persistence startup deterministic
+
+Scope: M. Behavior change: cold-start DB operations wait for a ready owner
+instead of failing. Dependencies: H1.
+
+Affected modules:
+
+- `src/background/index.ts`
+- `src/background/startup.ts`
+- `src/lib/persistence/chromium-owner.ts`
+- `src/lib/persistence/owner-host.ts`
+- `src/lib/persistence/client.ts`
+
+Work:
+
+- Replace the unawaited persistence-topology import with one shared readiness
+  promise owned by the background composition root.
+- Make DB-touching startup tasks await lifecycle recovery and persistence
+  readiness before running. Document ordering for backup recovery, provider
+  migration, schema migration, turn recovery, ingestion recovery, and model
+  pull recovery.
+- Add an owner-ready handshake that proves the host listener, worker, WASM, and
+  selected backend can answer `ping`; `createDocument()` completion alone is
+  not readiness.
+- Coalesce concurrent ensure calls and clear rejected readiness promises so a
+  later request can retry.
+- Preserve the no-retry rule for writes with uncertain commit outcome. A write
+  known not to have reached a ready owner may retry safely only when the
+  protocol can prove non-execution.
+- Bound startup recovery concurrency. Preserve deterministic order per durable
+  workflow while avoiding one long turn starving unrelated ingestion or model
+  pull recovery.
+
+Exit gate:
+
+- Cold Chromium and Firefox starts can immediately query and write without a
+  dropped ensure/RPC message.
+- Owner crash/recreation tests distinguish definitely-not-executed writes from
+  writes with unknown commit outcome.
+
+### H3 — Make turn cancellation and transitions durable
+
+Scope: M. Behavior change: a stopped turn cannot restart after worker loss.
+Dependencies: H2.
+
+Affected modules:
+
+- `packages/contracts/src/turns.ts`
+- `packages/chat-runtime/src/turn-runtime.ts`
+- `src/background/port-router.ts`
+- `src/background/durable-turn-runtime.ts`
+- `src/lib/repositories/turn-runs.ts`
+
+Work:
+
+- Add a durable `cancelling` state or equivalent cancellation-intent field.
+  Commit intent before aborting the in-memory controller.
+- Make recovery exclude cancellation-intent and cancelled rows. Startup may
+  finalize interrupted cancellation, but must never reissue provider work.
+- Encode allowed compare-and-set transitions in the repository: submitted →
+  building-context → generating → terminal, with cancellation permitted from
+  each live state. Terminal rows never regress.
+- Make duplicate start, resume, reconnect, stop, and terminal messages
+  idempotent by turn ID.
+- Preserve the original structured `AppFailure` from terminal stream event to
+  assistant row, turn row, reconnect snapshot, diagnostics, and UI. Do not
+  convert it to plain `Error` and reconstruct a weaker failure.
+- Quarantine or terminally fail malformed persisted turn rows with a safe
+  diagnostic. Do not silently omit the same incomplete row on every boot.
+- Test worker death before cancellation commit, after cancellation commit,
+  during provider abort, and before terminal snapshot delivery.
+
+Exit gate:
+
+- No test schedule can resurrect a stopped turn or regress a terminal state.
+- Duplicate lifecycle messages produce one provider generation and one
+  terminal assistant result.
+
+### H4 — Bound durable turn storage and privacy retention
+
+Scope: M–L. Behavior change: terminal runs retain a compact receipt instead of
+the complete resumable request. Dependencies: H3.
+
+Affected modules:
+
+- `packages/contracts/src/context.ts`
+- `packages/contracts/src/turns.ts`
+- `src/lib/repositories/turn-runs.ts`
+- `src/lib/sqlite/schema.ts`
+- `src/lib/sqlite/migrations/`
+- `src/lib/diagnostics/diagnostics-service.ts`
+
+Work:
+
+- Separate resumable live-turn input from terminal lifecycle receipt. Live rows
+  may retain data required to resume; terminal rows must clear or compact prior
+  messages, extracted file text, page context, and tab-document bodies.
+- Prefer canonical message/file IDs and bounded evidence over copied content
+  where restart correctness permits it. Do not make recovery depend on mutable
+  UI or Zustand state.
+- Define retention for completed, failed, cancelled, and quarantined runs.
+  Keep enough evidence for diagnostics and replay without permanent duplicate
+  conversation payloads.
+- Add a forward-only migration and backward-compatible parser. Preserve live
+  rows created by an older `0.13.0` prerelease until they reach a terminal state.
+- Add diagnostics for live/terminal run counts, total bytes, largest row, and
+  compaction failures without exposing message or page content.
+- Test long conversations, image/file attachments, full tab context, failed
+  turns, cancellation, backup export/import, and session cascade deletion.
+
+Exit gate:
+
+- Terminal turn storage grows O(turn count), not O(conversation length²).
+- Terminal rows contain no full copied page/file body unless a documented,
+  bounded recovery requirement proves it necessary.
+- Backup size and restore behavior remain within measured release budgets.
+
+### H5 — Centralize provider discovery policy
+
+Scope: S–M. Behavior change: tool capability resolution honors remembered
+catalog absence and real discovery failures. Dependencies: H1; may run beside
+H3/H4.
+
+Affected modules:
+
+- `src/lib/providers/provider-rpc-service.ts`
+- `src/lib/providers/model-catalog-support.ts`
+- `src/background/lib/resolve-model-tools.ts`
+- provider discovery/capability tests
+
+Work:
+
+- Extract `discoverModels` into a provider-domain service shared by RPC model
+  listing, connection tests, health checks, and tool capability resolution.
+- Keep catalog absence, endpoint reachability, and provider failure as distinct
+  verdicts. Only 404/405/501 record absence; never record auth, rate-limit,
+  network, or 5xx failures.
+- Preserve force-reprobe behavior for explicit Test and the no-inference rule
+  for stored health checks.
+- Remove production `provider.getModels()` callers that bypass discovery policy,
+  except provider contract tests and the discovery service itself.
+- Test TTL expiry, config fingerprint changes, concurrent discovery, custom
+  model merge, and catalog-less tool gating.
+
+Exit gate:
+
+- One production path owns model catalog policy.
+- A known catalog-less provider receives no background catalog request until
+  force, fingerprint change, or TTL expiry.
+
+### H6 — Split the durable-turn composition hub
+
+Scope: M. Behavior change: none. Dependencies: H3 and H4.
+
+Affected module: `src/background/durable-turn-runtime.ts`.
+
+- Extract an observer registry responsible only for attach, buffer, forward,
+  terminal cleanup, and reconnect snapshots.
+- Extract a generation adapter responsible for provider invocation, stream
+  reduction, and assistant persistence.
+- Extract a recovery coordinator responsible for incomplete-run claims and
+  restart ordering.
+- Replace the synthetic `ChromePort` cast with a narrow typed stream sink port.
+  Keep legacy handler adaptation at one explicit boundary while it remains.
+- Keep `TurnRuntime` environment-independent and leave browser/provider/SQLite
+  imports in `src/` composition.
+- Add dependency-boundary tests so background adapters cannot leak into
+  workspace packages.
+
+Exit gate:
+
+- No module owns both observer lifecycle and provider generation.
+- No `as unknown as ChromePort` remains in durable turn composition.
+- Characterization tests show identical stream, reconnect, persistence, and
+  failure behavior.
+
+### H7 — Close medium-risk type and error gaps
+
+Scope: M. Behavior change: invalid state/data fails explicitly. Dependencies:
+H3–H6.
+
+- Replace unchecked SQLite row-array assertions for durable job repositories
+  with shared row decoders or local Zod schemas at query boundaries.
+- Split `packages/contracts/src/chat.ts` by message, metrics/activity,
+  attachments, and replay concepts while preserving current public subpath
+  exports and wire shapes.
+- Define typed persistence errors with operation, retryability, and safe
+  fallback text. Preserve causes inside diagnostics; never expose SQL, secrets,
+  replay artifacts, or content bodies.
+- Add contract tests proving result schemas, repository row schemas, and error
+  envelopes remain aligned.
+
+Exit gate:
+
+- Durable storage and messaging boundaries parse untrusted/runtime data before
+  application use.
+- Errors retain actionable phase and recovery context across worker, host,
+  background, and UI boundaries.
+
+### H8 — Release verification and 9+/10 gate
+
+Scope: M. Behavior change: none. Dependencies: H0–H7.
+
+Required automated gates:
+
+```bash
+pnpm typecheck
+pnpm lint:check
+pnpm check:dead
+pnpm check:i18n
+pnpm test:run
+pnpm check:generated
+pnpm check:compatibility
+pnpm docs:build
+pnpm build
+pnpm build:firefox
+pnpm verify:opfs-migration
+pnpm verify:firefox-opfs-migration
+pnpm e2e:chromium:critical
+```
+
+Required soak evidence on `preview`:
+
+- Cold start, active-stream worker termination, stop during stream, stop during
+  tool loop, approval wait, owner recreation, backup import interruption, and
+  catalog-less provider scenarios pass on Chromium.
+- Firefox MV2 validates persistent-background ownership, migration fallback,
+  restart recovery, cancellation, and import/export.
+- No duplicate provider call, terminal-state regression, stuck transaction,
+  unbounded turn-row growth, raw sensitive logging, or unauthorized persistence
+  request appears during soak.
+- Diagnostics bundle records safe support evidence for owner startup,
+  migration, durable recovery, and compaction without recording chat/page/file
+  contents or credentials.
+
+`0.13.0` earns the **9+/10** architecture rating only when:
+
+1. All Critical and High audit findings are fixed and regression-guarded.
+2. Persistence and application RPC share equivalent sender, schema, timeout,
+   cancellation, and safe-error rigor even if their transports remain separate.
+3. Durable start, stop, resume, reconnect, and terminal transitions are
+   idempotent under worker loss.
+4. Terminal durable-state growth is bounded and measured.
+5. Provider discovery has one policy owner.
+6. Background composition exposes explicit readiness and dependency order.
+7. Workspace package boundaries remain environment-independent.
+8. Full Chrome/Firefox release gates and `preview` soak pass with recorded
+   evidence.
+
+The score does **not** require eliminating every Medium/Low cleanup item. It
+does require each remaining item to have one clear owner, bounded risk, a
+regression guard where practical, and an explicit later milestone below.
+
 ## Remaining foundation follow-ups
 
-These are bounded improvements, not release blockers and not authorization for
-a repository-wide rewrite.
+These are bounded improvements after H0–H8, not additional `0.13.0` release
+blockers and not authorization for a repository-wide rewrite.
 
 ### Chat stream presentation boundary
 

--- a/src/lib/ingestion/ingestion-processor-host.ts
+++ b/src/lib/ingestion/ingestion-processor-host.ts
@@ -1,4 +1,5 @@
 import { processFile } from "@/lib/file-processors"
+import { isTrustedPersistenceSender } from "@/lib/persistence/host-authorization"
 import { ingestionPayloadDb } from "./ingestion-payload-db"
 import {
   INGESTION_PROCESS_REQUEST,
@@ -38,12 +39,13 @@ export const processStagedIngestionPayload = async (
 export const registerIngestionProcessorHost = (): void => {
   if (registered) return
   registered = true
+  const extensionUrlPrefix = chrome.runtime.getURL("")
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const request = message as { type?: string; jobId?: unknown } | undefined
     if (
       request?.type !== INGESTION_PROCESS_REQUEST ||
       typeof request.jobId !== "string" ||
-      sender.id !== chrome.runtime.id
+      !isTrustedPersistenceSender(sender, chrome.runtime.id, extensionUrlPrefix)
     ) {
       return false
     }

--- a/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
+++ b/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
@@ -129,6 +129,15 @@ describe("legacy blob backend", () => {
     ).rejects.toThrow(/missing_table/)
   })
 
+  it("rejects a malformed operation without stalling the scheduler", async () => {
+    const engine = await bootEngine()
+
+    await expect(
+      engine.submit({ op: "query", sql: 42, injected: true })
+    ).rejects.toThrow("Invalid persistence operation")
+    await expect(engine.submit({ op: "ping" })).resolves.toEqual({ ok: true })
+  })
+
   it("reports lastInsertRowid and changes from inside the same op", async () => {
     const engine = await bootEngine()
     await addSession(engine, "counted")

--- a/src/lib/persistence/__tests__/persistence-message-boundary.test.ts
+++ b/src/lib/persistence/__tests__/persistence-message-boundary.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest"
+import { handleChromiumPersistenceControlMessage } from "../chromium-owner"
+import { handlePersistenceHostMessage } from "../owner-host"
+import {
+  PERSISTENCE_ENSURE,
+  PERSISTENCE_MARKER,
+  PERSISTENCE_RPC
+} from "../protocol"
+
+const extensionPage = {
+  id: "test-extension-id",
+  url: "chrome-extension://test/options.html"
+}
+const contentScript = {
+  id: "test-extension-id",
+  url: "https://example.com/page",
+  tab: { id: 7 }
+}
+const ownerPage = {
+  id: "test-extension-id",
+  url: "chrome-extension://test/persistence-host.html?owner=1"
+}
+
+describe("persistence host message boundary", () => {
+  it("accepts a strict ensure request from an extension page", () => {
+    const respond = vi.fn()
+
+    expect(
+      handlePersistenceHostMessage(
+        { type: PERSISTENCE_ENSURE },
+        extensionPage,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({ ok: true })
+  })
+
+  it("rejects persistence RPC from a content script before worker access", () => {
+    const respond = vi.fn()
+
+    expect(
+      handlePersistenceHostMessage(
+        { type: PERSISTENCE_RPC, request: { op: "ping" } },
+        contentScript,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({
+      ok: false,
+      error: "Persistence request forbidden"
+    })
+  })
+
+  it("rejects malformed RPC from a trusted extension page", () => {
+    const respond = vi.fn()
+
+    expect(
+      handlePersistenceHostMessage(
+        {
+          type: PERSISTENCE_RPC,
+          request: { op: "ping", injected: "DROP TABLE sessions" }
+        },
+        extensionPage,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({
+      ok: false,
+      error: "Invalid persistence request"
+    })
+  })
+
+  it("does not claim unrelated runtime messages", () => {
+    expect(
+      handlePersistenceHostMessage(
+        { type: "unrelated" },
+        extensionPage,
+        vi.fn()
+      )
+    ).toBe(false)
+  })
+})
+
+describe("Chromium persistence control boundary", () => {
+  it("rejects ensure requests from content scripts", () => {
+    const respond = vi.fn()
+
+    expect(
+      handleChromiumPersistenceControlMessage(
+        { type: PERSISTENCE_ENSURE },
+        contentScript,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({
+      ok: false,
+      error: "Persistence request forbidden"
+    })
+  })
+
+  it("rejects marker access from ordinary extension pages", () => {
+    const respond = vi.fn()
+
+    expect(
+      handleChromiumPersistenceControlMessage(
+        { type: PERSISTENCE_MARKER, action: "get", scope: "backend" },
+        extensionPage,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({
+      ok: false,
+      error: "Persistence marker forbidden"
+    })
+  })
+
+  it("validates marker payloads even from the owner document", () => {
+    const respond = vi.fn()
+
+    expect(
+      handleChromiumPersistenceControlMessage(
+        {
+          type: PERSISTENCE_MARKER,
+          action: "set",
+          scope: "override",
+          value: "yes"
+        },
+        ownerPage,
+        respond
+      )
+    ).toBe(true)
+    expect(respond).toHaveBeenCalledWith({
+      ok: false,
+      error: "Invalid persistence marker request"
+    })
+  })
+
+  it("allows a validated marker read from the owner document", async () => {
+    const respond = vi.fn()
+    vi.mocked(
+      chrome.storage.local.get as never as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      persistence_backend_v1: { backend: "opfs" }
+    })
+
+    expect(
+      handleChromiumPersistenceControlMessage(
+        { type: PERSISTENCE_MARKER, action: "get", scope: "backend" },
+        ownerPage,
+        respond
+      )
+    ).toBe(true)
+    await vi.waitFor(() =>
+      expect(respond).toHaveBeenCalledWith({
+        ok: true,
+        value: { backend: "opfs" }
+      })
+    )
+  })
+})

--- a/src/lib/persistence/__tests__/persistence-protocol.test.ts
+++ b/src/lib/persistence/__tests__/persistence-protocol.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest"
+import {
+  isPersistenceOwnerSender,
+  isTrustedPersistenceSender
+} from "../host-authorization"
+import {
+  decodePersistenceWireOp,
+  PERSISTENCE_ENSURE,
+  PERSISTENCE_LIMITS,
+  PERSISTENCE_MARKER,
+  PERSISTENCE_RPC,
+  PersistenceEnsureRequestSchema,
+  PersistenceEnsureResponseSchema,
+  PersistenceOpSchema,
+  PersistenceRpcRequestSchema,
+  PersistenceRpcResponseSchema,
+  PersistenceStateRequestSchema
+} from "../protocol"
+
+const extensionId = "extension-id"
+const extensionUrlPrefix = "chrome-extension://extension-id/"
+const ownerUrl = `${extensionUrlPrefix}persistence-host.html?owner=1`
+
+describe("persistence operation contracts", () => {
+  it("decodes a validated wire BLOB into the engine operation", () => {
+    const parsed = PersistenceRpcRequestSchema.parse({
+      type: PERSISTENCE_RPC,
+      request: {
+        op: "run",
+        sql: "INSERT INTO files (data) VALUES (?)",
+        bind: [{ __persistenceBlob: true, bytes: [0, 128, 255] }]
+      }
+    })
+
+    const operation = decodePersistenceWireOp(parsed.request)
+    expect(operation).toEqual({
+      op: "run",
+      sql: "INSERT INTO files (data) VALUES (?)",
+      bind: [Uint8Array.from([0, 128, 255])]
+    })
+    expect(PersistenceOpSchema.safeParse(operation).success).toBe(true)
+  })
+
+  it("rejects host-only, unknown, and extra-field wire operations", () => {
+    for (const request of [
+      { op: "setBackend", backend: "legacy" },
+      { op: "destroyEverything" },
+      { op: "ping", sql: "DROP TABLE sessions" }
+    ]) {
+      expect(
+        PersistenceRpcRequestSchema.safeParse({
+          type: PERSISTENCE_RPC,
+          request
+        }).success
+      ).toBe(false)
+    }
+  })
+
+  it("rejects malformed values before they reach the worker", () => {
+    expect(
+      PersistenceRpcRequestSchema.safeParse({
+        type: PERSISTENCE_RPC,
+        request: {
+          op: "run",
+          sql: "SELECT 1",
+          bind: [{ __persistenceBlob: true, bytes: [256] }]
+        }
+      }).success
+    ).toBe(false)
+    expect(
+      PersistenceOpSchema.safeParse({ op: "query", sql: "", bind: [] }).success
+    ).toBe(false)
+    expect(
+      PersistenceOpSchema.safeParse({
+        op: "txBegin",
+        token: "x".repeat(PERSISTENCE_LIMITS.transactionTokenChars + 1)
+      }).success
+    ).toBe(false)
+  })
+
+  it("keeps ensure and response envelopes strict", () => {
+    expect(
+      PersistenceEnsureRequestSchema.safeParse({ type: PERSISTENCE_ENSURE })
+        .success
+    ).toBe(true)
+    expect(
+      PersistenceEnsureRequestSchema.safeParse({
+        type: PERSISTENCE_ENSURE,
+        injected: true
+      }).success
+    ).toBe(false)
+    expect(
+      PersistenceRpcResponseSchema.safeParse({ ok: true, result: "pong" })
+        .success
+    ).toBe(true)
+    expect(
+      PersistenceEnsureResponseSchema.safeParse({ ok: true }).success
+    ).toBe(true)
+    expect(
+      PersistenceEnsureResponseSchema.safeParse({
+        ok: true,
+        result: "not allowed"
+      }).success
+    ).toBe(false)
+    expect(
+      PersistenceRpcResponseSchema.safeParse({ ok: false, error: 500 }).success
+    ).toBe(false)
+  })
+})
+
+describe("persistence marker contracts", () => {
+  it("accepts exact owner marker reads and writes", () => {
+    expect(
+      PersistenceStateRequestSchema.safeParse({
+        type: PERSISTENCE_MARKER,
+        action: "get",
+        scope: "backend"
+      }).success
+    ).toBe(true)
+    expect(
+      PersistenceStateRequestSchema.safeParse({
+        type: PERSISTENCE_MARKER,
+        action: "set",
+        scope: "override",
+        value: true
+      }).success
+    ).toBe(true)
+  })
+
+  it("rejects invalid marker values and undeclared fields", () => {
+    expect(
+      PersistenceStateRequestSchema.safeParse({
+        type: PERSISTENCE_MARKER,
+        action: "set",
+        scope: "override",
+        value: "true"
+      }).success
+    ).toBe(false)
+    expect(
+      PersistenceStateRequestSchema.safeParse({
+        type: PERSISTENCE_MARKER,
+        action: "get",
+        scope: "receipt",
+        value: { forged: true }
+      }).success
+    ).toBe(false)
+  })
+})
+
+describe("persistence sender authorization", () => {
+  it("accepts extension pages and background sender evidence", () => {
+    expect(
+      isTrustedPersistenceSender(
+        { id: extensionId, url: `${extensionUrlPrefix}sidepanel.html` },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe(true)
+    expect(
+      isTrustedPersistenceSender(
+        { id: extensionId },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe(true)
+  })
+
+  it("rejects content scripts, foreign extensions, and web pages", () => {
+    expect(
+      isTrustedPersistenceSender(
+        { id: extensionId, tab: { id: 1 }, url: "https://example.com" },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe(false)
+    expect(
+      isTrustedPersistenceSender(
+        { id: "foreign", url: `${extensionUrlPrefix}options.html` },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe(false)
+    expect(
+      isTrustedPersistenceSender(
+        { url: "https://example.com" },
+        extensionId,
+        extensionUrlPrefix
+      )
+    ).toBe(false)
+  })
+
+  it("reserves marker access for the exact owner document", () => {
+    expect(
+      isPersistenceOwnerSender(
+        { id: extensionId, url: ownerUrl },
+        extensionId,
+        extensionUrlPrefix,
+        ownerUrl
+      )
+    ).toBe(true)
+    expect(
+      isPersistenceOwnerSender(
+        { id: extensionId, url: `${extensionUrlPrefix}options.html` },
+        extensionId,
+        extensionUrlPrefix,
+        ownerUrl
+      )
+    ).toBe(false)
+    expect(
+      isPersistenceOwnerSender(
+        { id: extensionId, url: `${extensionUrlPrefix}persistence-host.html` },
+        extensionId,
+        extensionUrlPrefix,
+        ownerUrl
+      )
+    ).toBe(false)
+  })
+})

--- a/src/lib/persistence/backend.ts
+++ b/src/lib/persistence/backend.ts
@@ -6,7 +6,11 @@ import type {
   TableCountMismatch,
   TableCounts
 } from "./durable-tables"
-import { PERSISTENCE_MARKER, type PersistenceStateScope } from "./protocol"
+import {
+  PERSISTENCE_MARKER,
+  PersistenceStateResponseSchema,
+  type PersistenceStateScope
+} from "./protocol"
 
 /**
  * Active chat persistence topology. `legacy` is the historical sql.js image;
@@ -96,15 +100,17 @@ const readState = async <T>(
     const stored = await browser.storage.local.get(key)
     return stored[key] as T | undefined
   }
-  const response = (await browser.runtime.sendMessage({
+  const rawResponse = await browser.runtime.sendMessage({
     type: PERSISTENCE_MARKER,
     action: "get",
     scope
-  })) as { ok: boolean; value?: unknown; error?: string } | undefined
-  if (!response?.ok) {
-    throw new Error(response?.error ?? `${scope} read message dropped`)
+  })
+  const response = PersistenceStateResponseSchema.safeParse(rawResponse)
+  if (!response.success) {
+    throw new Error(`${scope} read returned an invalid response`)
   }
-  return response.value as T | undefined
+  if (!response.data.ok) throw new Error(response.data.error)
+  return response.data.value as T | undefined
 }
 
 const writeState = async (
@@ -115,15 +121,17 @@ const writeState = async (
     await browser.storage.local.set({ [STORAGE_KEY_BY_SCOPE[scope]]: value })
     return
   }
-  const response = (await browser.runtime.sendMessage({
+  const rawResponse = await browser.runtime.sendMessage({
     type: PERSISTENCE_MARKER,
     action: "set",
     scope,
     value
-  })) as { ok: boolean; error?: string } | undefined
-  if (!response?.ok) {
-    throw new Error(response?.error ?? `${scope} write message dropped`)
+  })
+  const response = PersistenceStateResponseSchema.safeParse(rawResponse)
+  if (!response.success) {
+    throw new Error(`${scope} write returned an invalid response`)
   }
+  if (!response.data.ok) throw new Error(response.data.error)
 }
 
 /**

--- a/src/lib/persistence/chat-db-engine.ts
+++ b/src/lib/persistence/chat-db-engine.ts
@@ -41,6 +41,7 @@ import type {
   SqlValue,
   SurveyResult
 } from "./protocol"
+import { PersistenceOpSchema } from "./protocol"
 
 /**
  * The chat-history database engine. One instance exists per browser session,
@@ -88,7 +89,7 @@ export interface ChatDbEngineOptions {
 
 export interface ChatDbEngine {
   /** Run one op. Serialization and the transaction lease are handled inside. */
-  submit: (request: PersistenceOp) => Promise<unknown>
+  submit: (request: unknown) => Promise<unknown>
 }
 
 export const createChatDbEngine = (
@@ -733,10 +734,15 @@ export const createChatDbEngine = (
   }
 
   return {
-    submit: (request) =>
-      new Promise((resolve, reject) => {
-        queue.push({ request, resolve, reject })
+    submit: (request) => {
+      const parsed = PersistenceOpSchema.safeParse(request)
+      if (!parsed.success) {
+        return Promise.reject(new Error("Invalid persistence operation"))
+      }
+      return new Promise((resolve, reject) => {
+        queue.push({ request: parsed.data, resolve, reject })
         void pump()
       })
+    }
   }
 }

--- a/src/lib/persistence/chat-db-worker.ts
+++ b/src/lib/persistence/chat-db-worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 import { type ChatDbEngine, createChatDbEngine } from "./chat-db-engine"
-import type { PersistenceOp } from "./protocol"
+import { PersistenceOpSchema } from "./protocol"
 
 /**
  * Message plumbing for the chat-history database owner. Exactly one instance
@@ -15,12 +15,7 @@ import type { PersistenceOp } from "./protocol"
 
 interface WorkerRequest {
   id: number
-  request: PersistenceOp
-}
-
-interface InitMessage {
-  init: true
-  wasmBinary: ArrayBuffer
+  request: unknown
 }
 
 let resolveWasmBinary: (binary: ArrayBuffer) => void
@@ -41,7 +36,9 @@ const getEngine = (): ChatDbEngine => {
 
 const respond = async (message: WorkerRequest): Promise<void> => {
   try {
-    const result = await getEngine().submit(message.request)
+    const parsed = PersistenceOpSchema.safeParse(message.request)
+    if (!parsed.success) throw new Error("Invalid persistence operation")
+    const result = await getEngine().submit(parsed.data)
     if (result instanceof ArrayBuffer) {
       self.postMessage({ id: message.id, ok: true, result }, [result])
     } else {
@@ -56,12 +53,32 @@ const respond = async (message: WorkerRequest): Promise<void> => {
   }
 }
 
-self.onmessage = (event: MessageEvent<WorkerRequest | InitMessage>) => {
-  if ("init" in event.data) {
-    resolveWasmBinary(event.data.wasmBinary)
+self.onmessage = (event: MessageEvent<unknown>) => {
+  const message = event.data
+  if (typeof message !== "object" || message === null) {
+    console.error("[chat-db] Invalid worker message")
+    return
+  }
+  if ("init" in message) {
+    if (
+      message.init !== true ||
+      !("wasmBinary" in message) ||
+      !(message.wasmBinary instanceof ArrayBuffer)
+    ) {
+      console.error("[chat-db] Invalid worker initialization message")
+      return
+    }
+    resolveWasmBinary(message.wasmBinary)
+    return
+  }
+  if (!("id" in message) || typeof message.id !== "number") {
+    console.error("[chat-db] Invalid worker request envelope")
     return
   }
   // The engine owns ordering and the transaction lease, so requests are handed
   // over as they arrive.
-  void respond(event.data)
+  void respond({
+    id: message.id,
+    request: "request" in message ? message.request : undefined
+  })
 }

--- a/src/lib/persistence/chromium-owner.ts
+++ b/src/lib/persistence/chromium-owner.ts
@@ -1,9 +1,15 @@
+import type { RuntimeSenderLike } from "@ollama-client/runtime-core/runtime-sender"
 import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
 import {
+  isPersistenceOwnerSender,
+  isTrustedPersistenceSender
+} from "./host-authorization"
+import {
   PERSISTENCE_ENSURE,
   PERSISTENCE_MARKER,
-  type PersistenceStateRequest,
+  PersistenceEnsureRequestSchema,
+  PersistenceStateRequestSchema,
   type PersistenceStateScope
 } from "./protocol"
 
@@ -101,48 +107,76 @@ export const ensurePersistenceOwner = async (): Promise<void> => {
 /** Register on Chromium background startup: pages ask the service worker to
  * ensure the owner exists; the SW's own database calls use the globalThis
  * ensure hook (a service worker cannot runtime-message itself). */
+export const handleChromiumPersistenceControlMessage = (
+  message: unknown,
+  sender: RuntimeSenderLike,
+  sendResponse: (response: unknown) => void
+): boolean => {
+  const extensionUrlPrefix = chrome.runtime.getURL("")
+  const ownerUrl = chrome.runtime.getURL(OFFSCREEN_URL)
+  const type = (message as { type?: string } | undefined)?.type
+  if (type === PERSISTENCE_ENSURE) {
+    if (
+      !isTrustedPersistenceSender(
+        sender,
+        chrome.runtime.id,
+        extensionUrlPrefix
+      ) ||
+      !PersistenceEnsureRequestSchema.safeParse(message).success
+    ) {
+      sendResponse({ ok: false, error: "Persistence request forbidden" })
+      return true
+    }
+    ensurePersistenceOwner()
+      .then(() => sendResponse({ ok: true }))
+      .catch((error: unknown) =>
+        sendResponse({ ok: false, error: String(error) })
+      )
+    return true
+  }
+  if (type === PERSISTENCE_MARKER) {
+    if (
+      !isPersistenceOwnerSender(
+        sender,
+        chrome.runtime.id,
+        extensionUrlPrefix,
+        ownerUrl
+      )
+    ) {
+      sendResponse({ ok: false, error: "Persistence marker forbidden" })
+      return true
+    }
+    const parsed = PersistenceStateRequestSchema.safeParse(message)
+    if (!parsed.success) {
+      sendResponse({ ok: false, error: "Invalid persistence marker request" })
+      return true
+    }
+    // The offscreen owner has no chrome.storage; read/write the backend marker,
+    // migration receipt, and operator override on its behalf.
+    const request = parsed.data
+    const key = STORAGE_KEY_BY_SCOPE[request.scope]
+    ;(async () => {
+      if (request.action === "get") {
+        const stored = await chrome.storage.local.get(key)
+        sendResponse({ ok: true, value: stored[key] })
+        return
+      }
+      await chrome.storage.local.set({
+        [key]: stampExtensionVersion(request.scope, request.value)
+      })
+      sendResponse({ ok: true })
+    })().catch((error: unknown) =>
+      sendResponse({ ok: false, error: String(error) })
+    )
+    return true
+  }
+  return false
+}
+
 export const registerChromiumPersistenceControl = (): void => {
   globalThis.__persistenceEnsureOwner = ensurePersistenceOwner
 
-  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-    const type = (message as { type?: string } | undefined)?.type
-    if (type === PERSISTENCE_ENSURE) {
-      ensurePersistenceOwner()
-        .then(() => sendResponse({ ok: true }))
-        .catch((error: unknown) =>
-          sendResponse({ ok: false, error: String(error) })
-        )
-      return true
-    }
-    if (type === PERSISTENCE_MARKER) {
-      // The offscreen owner has no chrome.storage; read/write the backend
-      // marker, migration receipt, and operator override on its behalf.
-      const request = message as PersistenceStateRequest
-      const key = STORAGE_KEY_BY_SCOPE[request.scope]
-      if (!key) {
-        sendResponse({
-          ok: false,
-          error: `Unknown persistence state scope: ${String(request.scope)}`
-        })
-        return true
-      }
-      ;(async () => {
-        if (request.action === "get") {
-          const stored = await chrome.storage.local.get(key)
-          sendResponse({ ok: true, value: stored[key] })
-          return
-        }
-        await chrome.storage.local.set({
-          [key]: stampExtensionVersion(request.scope, request.value)
-        })
-        sendResponse({ ok: true })
-      })().catch((error: unknown) =>
-        sendResponse({ ok: false, error: String(error) })
-      )
-      return true
-    }
-    return false
-  })
+  chrome.runtime.onMessage.addListener(handleChromiumPersistenceControlMessage)
 
   // Create the owner eagerly so the one-time legacy migration runs at boot,
   // not on the first user interaction.

--- a/src/lib/persistence/client.ts
+++ b/src/lib/persistence/client.ts
@@ -5,8 +5,9 @@ import {
   encodeBind,
   PERSISTENCE_ENSURE,
   PERSISTENCE_RPC,
+  PersistenceEnsureResponseSchema,
   type PersistenceOp,
-  type PersistenceRpcResponse,
+  PersistenceRpcResponseSchema,
   type QueryRow,
   RETRYABLE_OPS,
   type RunResult
@@ -62,12 +63,15 @@ export const ensurePersistenceHost = async (): Promise<void> => {
     await globalThis.__persistenceEnsureOwner()
     return
   }
-  const response = (await withTimeout(
+  const rawResponse = await withTimeout(
     browser.runtime.sendMessage({ type: PERSISTENCE_ENSURE }),
     "ensure"
-  )) as PersistenceRpcResponse | undefined
-  if (!response) throw new Error("Persistence ensure message dropped")
-  if (!response.ok) throw new Error(response.error)
+  )
+  const response = PersistenceEnsureResponseSchema.safeParse(rawResponse)
+  if (!response.success) {
+    throw new Error("Persistence ensure returned an invalid response")
+  }
+  if (!response.data.ok) throw new Error(response.data.error)
 }
 
 const sendOnce = async (request: PersistenceOp): Promise<unknown> => {
@@ -81,13 +85,15 @@ const sendOnce = async (request: PersistenceOp): Promise<unknown> => {
       : request.op === "importDb" && request.bytes instanceof ArrayBuffer
         ? { ...request, bytes: Array.from(new Uint8Array(request.bytes)) }
         : request
-  const response = (await withTimeout(
+  const rawResponse = await withTimeout(
     browser.runtime.sendMessage({ type: PERSISTENCE_RPC, request: wire }),
     request.op
-  )) as PersistenceRpcResponse | undefined
-  if (!response) throw new Error("Persistence RPC message dropped")
-  if (!response.ok) throw new Error(response.error)
-  return response.result
+  )
+  const response = PersistenceRpcResponseSchema.safeParse(rawResponse)
+  if (!response.success)
+    throw new Error("Persistence RPC returned invalid data")
+  if (!response.data.ok) throw new Error(response.data.error)
+  return response.data.result
 }
 
 const send = async (request: PersistenceOp): Promise<unknown> => {

--- a/src/lib/persistence/host-authorization.ts
+++ b/src/lib/persistence/host-authorization.ts
@@ -1,0 +1,37 @@
+import {
+  classifyRuntimeSender,
+  type RuntimeSenderLike
+} from "@ollama-client/runtime-core/runtime-sender"
+
+/** Privileged persistence traffic is never available to content scripts. */
+export const isTrustedPersistenceSender = (
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string
+): boolean =>
+  classifyRuntimeSender(sender, extensionId, extensionUrlPrefix) ===
+  "extension-page"
+
+/** Marker writes are reserved for the Chromium offscreen owner document. */
+export const isPersistenceOwnerSender = (
+  sender: RuntimeSenderLike,
+  extensionId: string,
+  extensionUrlPrefix: string,
+  ownerUrl: string
+): boolean => {
+  if (!isTrustedPersistenceSender(sender, extensionId, extensionUrlPrefix)) {
+    return false
+  }
+  if (!sender.url) return false
+  try {
+    const actual = new URL(sender.url)
+    const expected = new URL(ownerUrl)
+    return (
+      actual.origin === expected.origin &&
+      actual.pathname === expected.pathname &&
+      actual.searchParams.get("owner") === "1"
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/lib/persistence/owner-host.ts
+++ b/src/lib/persistence/owner-host.ts
@@ -1,3 +1,4 @@
+import type { RuntimeSenderLike } from "@ollama-client/runtime-core/runtime-sender"
 import { logger } from "@/lib/logger"
 import {
   markOpfsBackend,
@@ -15,15 +16,18 @@ import {
   isSoundDatabase,
   type TableCountMismatch
 } from "./durable-tables"
+import { isTrustedPersistenceSender } from "./host-authorization"
 import type { ImportResult, SurveyResult } from "./protocol"
 import {
-  decodeBind,
+  decodePersistenceWireOp,
   encodeRows,
   encodeValue,
   PERSISTENCE_ENSURE,
   PERSISTENCE_RPC,
+  PersistenceEnsureRequestSchema,
   type PersistenceOp,
-  type PersistenceRpcRequest,
+  PersistenceOpSchema,
+  PersistenceRpcRequestSchema,
   type QueryRow
 } from "./protocol"
 
@@ -151,15 +155,16 @@ const ensureWorker = (): Worker => {
 }
 
 export const callWorker = (request: PersistenceOp): Promise<unknown> => {
+  const validated = PersistenceOpSchema.parse(request)
   requestId += 1
   const id = requestId
   return new Promise((resolve, reject) => {
     pending.set(id, { resolve, reject })
-    if (request.op === "importDb" && request.bytes instanceof ArrayBuffer) {
-      ensureWorker().postMessage({ id, request }, [request.bytes])
+    if (validated.op === "importDb" && validated.bytes instanceof ArrayBuffer) {
+      ensureWorker().postMessage({ id, request: validated }, [validated.bytes])
       return
     }
-    ensureWorker().postMessage({ id, request })
+    ensureWorker().postMessage({ id, request: validated })
   })
 }
 
@@ -350,6 +355,71 @@ export const ensureMigrated = (): Promise<void> => {
 
 /** RPC listener */
 
+export const handlePersistenceHostMessage = (
+  message: unknown,
+  sender: RuntimeSenderLike,
+  sendResponse: (response: unknown) => void
+): boolean => {
+  const extensionUrlPrefix = chrome.runtime.getURL("")
+  const type = (message as { type?: string } | undefined)?.type
+  if (type === PERSISTENCE_ENSURE) {
+    if (
+      !isTrustedPersistenceSender(
+        sender,
+        chrome.runtime.id,
+        extensionUrlPrefix
+      ) ||
+      !PersistenceEnsureRequestSchema.safeParse(message).success
+    ) {
+      sendResponse({ ok: false, error: "Persistence request forbidden" })
+      return true
+    }
+    // The host answering at all proves the owner exists.
+    sendResponse({ ok: true })
+    return true
+  }
+  if (type !== PERSISTENCE_RPC) return false
+  if (
+    !isTrustedPersistenceSender(sender, chrome.runtime.id, extensionUrlPrefix)
+  ) {
+    sendResponse({ ok: false, error: "Persistence request forbidden" })
+    return true
+  }
+  const parsed = PersistenceRpcRequestSchema.safeParse(message)
+  if (!parsed.success) {
+    sendResponse({ ok: false, error: "Invalid persistence request" })
+    return true
+  }
+  ;(async () => {
+    try {
+      await ensureMigrated()
+      // Runtime messages JSON-serialize on Chromium: decode blob-encoded
+      // binds/bytes into real Uint8Arrays before the worker sees them,
+      // and encode binary results before sendResponse.
+      const request = decodePersistenceWireOp(parsed.data.request)
+      const result = await callWorker(request)
+      if (request.op === "query") {
+        sendResponse({ ok: true, result: encodeRows(result as QueryRow[]) })
+        return
+      }
+      if (result instanceof ArrayBuffer) {
+        sendResponse({
+          ok: true,
+          result: encodeValue(new Uint8Array(result))
+        })
+        return
+      }
+      sendResponse({ ok: true, result })
+    } catch (error) {
+      sendResponse({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  })()
+  return true
+}
+
 export const registerPersistenceHost = (): void => {
   // In-process fast path for code running inside the host context itself
   // (the Firefox background page is both host and a heavy client).
@@ -364,60 +434,5 @@ export const registerPersistenceHost = (): void => {
     // requests reject until a later boot brings the owner up.
   })
 
-  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-    const type = (message as { type?: string } | undefined)?.type
-    if (type === PERSISTENCE_ENSURE) {
-      // The host answering at all proves the owner exists.
-      sendResponse({ ok: true })
-      return true
-    }
-    const rpc = message as PersistenceRpcRequest | undefined
-    if (rpc?.type !== PERSISTENCE_RPC) return false
-    ;(async () => {
-      try {
-        // Which topology a profile serves from is the host's decision, taken
-        // once from the marker and the migration outcome. Nothing that arrives
-        // over messaging gets to move a profile between backends — this
-        // listener answers any sender the browser hands it.
-        if (rpc.request?.op === "setBackend") {
-          sendResponse({ ok: false, error: "setBackend is host-only" })
-          return
-        }
-        await ensureMigrated()
-        // Runtime messages JSON-serialize on Chromium: decode blob-encoded
-        // binds/bytes into real Uint8Arrays before the worker sees them,
-        // and encode binary results before sendResponse.
-        const request = { ...rpc.request } as PersistenceOp
-        if (request.op === "query" || request.op === "run") {
-          request.bind = decodeBind(request.bind as unknown[])
-        }
-        if (
-          request.op === "importDb" &&
-          Array.isArray(request.bytes as unknown)
-        ) {
-          request.bytes = Uint8Array.from(request.bytes as unknown as number[])
-            .buffer as ArrayBuffer
-        }
-        const result = await callWorker(request)
-        if (request.op === "query") {
-          sendResponse({ ok: true, result: encodeRows(result as QueryRow[]) })
-          return
-        }
-        if (result instanceof ArrayBuffer) {
-          sendResponse({
-            ok: true,
-            result: encodeValue(new Uint8Array(result))
-          })
-          return
-        }
-        sendResponse({ ok: true, result })
-      } catch (error) {
-        sendResponse({
-          ok: false,
-          error: error instanceof Error ? error.message : String(error)
-        })
-      }
-    })()
-    return true
-  })
+  chrome.runtime.onMessage.addListener(handlePersistenceHostMessage)
 }

--- a/src/lib/persistence/protocol.ts
+++ b/src/lib/persistence/protocol.ts
@@ -1,3 +1,6 @@
+import { z } from "zod"
+import type { IntegrityReport, TableCounts } from "./durable-tables"
+
 /**
  * Production wire key between stateless database clients and the session's
  * single SQLite owner (Chromium offscreen document or Firefox background page).
@@ -7,10 +10,73 @@ export const PERSISTENCE_ENSURE = "persistence-ensure"
 /** Storage-marker proxy key used because offscreen documents lack storage. */
 export const PERSISTENCE_MARKER = "persistence-marker"
 
-import type { IntegrityReport, TableCounts } from "./durable-tables"
-
 export type SqlValue = string | number | null | Uint8Array
 export type QueryRow = Record<string, SqlValue>
+
+/** Generous abuse limits. Normal application operations remain far below them. */
+export const PERSISTENCE_LIMITS = {
+  sqlChars: 1_000_000,
+  bindValues: 20_000,
+  textValueChars: 128 * 1024 * 1024,
+  blobBytes: 128 * 1024 * 1024,
+  importBytes: 1024 * 1024 * 1024,
+  transactionTokenChars: 200
+} as const
+
+const byteSchema = z.number().int().min(0).max(255)
+const byteArraySchema = (limit: number) => z.array(byteSchema).max(limit)
+const boundedStringSchema = z.string().max(PERSISTENCE_LIMITS.textValueChars)
+const transactionTokenSchema = z
+  .string()
+  .min(1)
+  .max(PERSISTENCE_LIMITS.transactionTokenChars)
+const sqlSchema = z.string().min(1).max(PERSISTENCE_LIMITS.sqlChars)
+
+const Uint8ArraySchema = z
+  .instanceof(Uint8Array)
+  .refine(
+    (value) => value.byteLength <= PERSISTENCE_LIMITS.blobBytes,
+    "Persistence BLOB exceeds the size limit"
+  )
+
+const ArrayBufferSchema = z
+  .instanceof(ArrayBuffer)
+  .refine(
+    (value) => value.byteLength <= PERSISTENCE_LIMITS.importBytes,
+    "Persistence database payload exceeds the size limit"
+  )
+
+const SqlValueSchema = z.union([
+  boundedStringSchema,
+  z.number().finite(),
+  z.null(),
+  Uint8ArraySchema
+])
+
+const EncodedBlobSchema = z
+  .object({
+    __persistenceBlob: z.literal(true),
+    bytes: byteArraySchema(PERSISTENCE_LIMITS.blobBytes)
+  })
+  .strict()
+
+const WireSqlValueSchema = z.union([
+  boundedStringSchema,
+  z.number().finite(),
+  z.null(),
+  EncodedBlobSchema
+])
+
+const transactionField = { tx: transactionTokenSchema.optional() }
+const bindField = {
+  bind: z.array(SqlValueSchema).max(PERSISTENCE_LIMITS.bindValues).optional()
+}
+const wireBindField = {
+  bind: z
+    .array(WireSqlValueSchema)
+    .max(PERSISTENCE_LIMITS.bindValues)
+    .optional()
+}
 
 /** Which topology the owner is serving from. Mirrors `PersistenceBackend` in
  * backend.ts, kept here so the wire types do not depend on the marker module. */
@@ -59,6 +125,103 @@ export type PersistenceOp =
   | { op: "reset" }
   | { op: "ping" }
 
+/** Strict runtime validator used by in-process callers and the worker. */
+export const PersistenceOpSchema = z.discriminatedUnion("op", [
+  z
+    .object({
+      op: z.literal("query"),
+      sql: sqlSchema,
+      ...bindField,
+      ...transactionField
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("run"),
+      sql: sqlSchema,
+      ...bindField,
+      ...transactionField
+    })
+    .strict(),
+  z
+    .object({ op: z.literal("txBegin"), token: transactionTokenSchema })
+    .strict(),
+  z
+    .object({ op: z.literal("txCommit"), token: transactionTokenSchema })
+    .strict(),
+  z
+    .object({ op: z.literal("txRollback"), token: transactionTokenSchema })
+    .strict(),
+  z
+    .object({
+      op: z.literal("setBackend"),
+      backend: z.enum(["legacy", "opfs"]),
+      integrity: z
+        .object({
+          integrityCheck: z.string(),
+          foreignKeyViolations: z.number().int().nonnegative()
+        })
+        .strict()
+        .optional()
+    })
+    .strict(),
+  z.object({ op: z.literal("flush") }).strict(),
+  z.object({ op: z.literal("exportDb") }).strict(),
+  z.object({ op: z.literal("importDb"), bytes: ArrayBufferSchema }).strict(),
+  z.object({ op: z.literal("surveyDb"), bytes: ArrayBufferSchema }).strict(),
+  z.object({ op: z.literal("counts") }).strict(),
+  z.object({ op: z.literal("reset") }).strict(),
+  z.object({ op: z.literal("ping") }).strict()
+])
+
+/** Runtime-message shape before encoded BLOBs and database bytes are decoded. */
+export const PersistenceWireOpSchema = z.discriminatedUnion("op", [
+  z
+    .object({
+      op: z.literal("query"),
+      sql: sqlSchema,
+      ...wireBindField,
+      ...transactionField
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("run"),
+      sql: sqlSchema,
+      ...wireBindField,
+      ...transactionField
+    })
+    .strict(),
+  z
+    .object({ op: z.literal("txBegin"), token: transactionTokenSchema })
+    .strict(),
+  z
+    .object({ op: z.literal("txCommit"), token: transactionTokenSchema })
+    .strict(),
+  z
+    .object({ op: z.literal("txRollback"), token: transactionTokenSchema })
+    .strict(),
+  z.object({ op: z.literal("flush") }).strict(),
+  z.object({ op: z.literal("exportDb") }).strict(),
+  z
+    .object({
+      op: z.literal("importDb"),
+      bytes: byteArraySchema(PERSISTENCE_LIMITS.importBytes)
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal("surveyDb"),
+      bytes: byteArraySchema(PERSISTENCE_LIMITS.importBytes)
+    })
+    .strict(),
+  z.object({ op: z.literal("counts") }).strict(),
+  z.object({ op: z.literal("reset") }).strict(),
+  z.object({ op: z.literal("ping") }).strict()
+])
+
+export type PersistenceWireOp = z.infer<typeof PersistenceWireOpSchema>
+
 export interface RunResult {
   lastInsertRowid: number
   changes: number
@@ -83,10 +246,18 @@ export interface SurveyResult extends ImportResult {
   schemaVersion: number
 }
 
-export interface PersistenceRpcRequest {
-  type: typeof PERSISTENCE_RPC
-  request: PersistenceOp
-}
+export const PersistenceEnsureRequestSchema = z
+  .object({ type: z.literal(PERSISTENCE_ENSURE) })
+  .strict()
+
+export const PersistenceRpcRequestSchema = z
+  .object({
+    type: z.literal(PERSISTENCE_RPC),
+    request: PersistenceWireOpSchema
+  })
+  .strict()
+
+export type PersistenceRpcRequest = z.infer<typeof PersistenceRpcRequestSchema>
 
 /**
  * Device-local persistence state the offscreen owner cannot reach itself.
@@ -96,16 +267,127 @@ export interface PersistenceRpcRequest {
  */
 export type PersistenceStateScope = "backend" | "receipt" | "override"
 
-export interface PersistenceStateRequest {
-  type: typeof PERSISTENCE_MARKER
-  action: "get" | "set"
-  scope: PersistenceStateScope
-  value?: unknown
-}
+const BackendMarkerSchema = z
+  .object({
+    backend: z.enum(["legacy", "opfs"]),
+    migratedAt: z.number().int().nonnegative().optional(),
+    sourceCounts: z
+      .object({
+        sessions: z.number().int().nonnegative(),
+        messages: z.number().int().nonnegative()
+      })
+      .strict()
+      .optional()
+  })
+  .strict()
 
-export type PersistenceRpcResponse =
-  | { ok: true; result: unknown }
-  | { ok: false; error: string }
+const IntegrityReportSchema = z
+  .object({
+    integrityCheck: z.string(),
+    foreignKeyViolations: z.number().int().nonnegative()
+  })
+  .strict()
+
+const TableCountMapSchema = z.record(z.string(), z.number().int().nonnegative())
+
+const MigrationReceiptSchema = z
+  .object({
+    version: z.literal(1),
+    outcome: z.enum(["migrated", "fresh", "failed", "skipped"]),
+    recordedAt: z.number().int().nonnegative(),
+    extensionVersion: z.string(),
+    attempts: z.number().int().positive(),
+    sourceSchemaVersion: z.number().int().nonnegative().optional(),
+    sourceBytes: z.number().int().nonnegative().optional(),
+    sourceCounts: TableCountMapSchema.optional(),
+    importedCounts: TableCountMapSchema.optional(),
+    sourceIntegrity: IntegrityReportSchema.optional(),
+    importedIntegrity: IntegrityReportSchema.optional(),
+    mismatches: z
+      .array(
+        z
+          .object({
+            table: z.string(),
+            source: z.number().int().nonnegative(),
+            imported: z.number().int().nonnegative()
+          })
+          .strict()
+      )
+      .optional(),
+    failure: z.string().optional()
+  })
+  .strict()
+
+export const PersistenceStateRequestSchema = z.union([
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("get"),
+      scope: z.literal("backend")
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("get"),
+      scope: z.literal("receipt")
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("get"),
+      scope: z.literal("override")
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("set"),
+      scope: z.literal("backend"),
+      value: BackendMarkerSchema
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("set"),
+      scope: z.literal("receipt"),
+      value: MigrationReceiptSchema
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal(PERSISTENCE_MARKER),
+      action: z.literal("set"),
+      scope: z.literal("override"),
+      value: z.boolean()
+    })
+    .strict()
+])
+
+export type PersistenceStateRequest = z.infer<
+  typeof PersistenceStateRequestSchema
+>
+
+export const PersistenceEnsureResponseSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }).strict(),
+  z.object({ ok: z.literal(false), error: z.string() }).strict()
+])
+
+export const PersistenceRpcResponseSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), result: z.unknown() }).strict(),
+  z.object({ ok: z.literal(false), error: z.string() }).strict()
+])
+
+export type PersistenceRpcResponse = z.infer<
+  typeof PersistenceRpcResponseSchema
+>
+
+export const PersistenceStateResponseSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), value: z.unknown().optional() }).strict(),
+  z.object({ ok: z.literal(false), error: z.string() }).strict()
+])
 
 /** Ops a client may retry after an owner restart: they either do not write or
  * are safe to repeat. `run` is NOT retryable — a lost response cannot prove
@@ -153,6 +435,22 @@ export const encodeBind = (bind?: SqlValue[]): unknown[] | undefined =>
 
 export const decodeBind = (bind?: unknown[]): SqlValue[] | undefined =>
   bind?.map((value) => decodeValue(value)) as SqlValue[] | undefined
+
+/** Convert a validated runtime-message operation into the engine contract. */
+export const decodePersistenceWireOp = (
+  request: PersistenceWireOp
+): PersistenceOp => {
+  if (request.op === "query" || request.op === "run") {
+    return { ...request, bind: decodeBind(request.bind) }
+  }
+  if (request.op === "importDb" || request.op === "surveyDb") {
+    return {
+      ...request,
+      bytes: Uint8Array.from(request.bytes).buffer as ArrayBuffer
+    }
+  }
+  return request
+}
 
 export const encodeRows = (rows: QueryRow[]): unknown[] =>
   rows.map((row) => {


### PR DESCRIPTION
## Summary

- validate persistence requests, responses, worker operations, and marker messages with strict schemas
- reject content-script and untrusted senders at privileged persistence and ingestion boundaries
- restrict backend-marker access to the exact persistence owner page
- add malformed-payload, authorization, and scheduler-liveness regression tests
- document the 0.13.0 architecture hardening PR sequence and acceptance gates

## Why

Persistence runtime messages previously trusted extension identity alone. A content script or malformed extension message could therefore reach privileged storage operations without the same sender and schema guarantees used by the versioned application RPC boundary.

## Impact

Persistence traffic now fails closed at the host, Chromium controller, worker, engine, and client boundaries. Valid extension-page flows remain unchanged; invalid input is rejected before it can enter the serialized database scheduler.

## Validation

- `pnpm verify`
- 325 test files / 2,647 tests
- Chrome MV3 production build and package
- Firefox MV2 production build
- bundle-size budgets
- docs production build
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens persistence and ingestion boundaries by validating runtime payloads, authorizing senders, and revalidating operations at the worker and engine layers.
- Adds strict schemas and size limits for persistence operations, marker messages, and response envelopes.
- Restricts persistence RPC and ingestion processing to trusted extension contexts, with marker access reserved for the owner document.
- Adds malformed-input, authorization, and scheduler-liveness regression coverage.
- Documents the architecture-hardening sequence and release acceptance gates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure remaining after checking authorization, schema compatibility, and worker scheduling paths.

The trusted extension and owner flows remain reachable, production operation and marker shapes satisfy the new schemas, malformed requests are rejected before scheduler entry, and no accepted blocking or non-blocking defect was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/persistence/protocol.ts | Defines strict wire, engine-operation, marker, and response schemas with bounded SQL, bind, blob, import, and transaction-token inputs. |
| src/lib/persistence/owner-host.ts | Authorizes runtime senders, validates requests before migration and worker access, and safely encodes persistence responses. |
| src/lib/persistence/chromium-owner.ts | Gates owner creation and marker access by sender classification and strict request schemas. |
| src/lib/persistence/host-authorization.ts | Centralizes trusted extension-page and exact owner-URL authorization checks. |
| src/lib/persistence/chat-db-worker.ts | Validates worker envelopes and operations before invoking the database engine. |
| src/lib/persistence/chat-db-engine.ts | Adds final operation validation before requests enter the serialized scheduler. |
| src/lib/persistence/client.ts | Validates ensure and RPC response envelopes while preserving retry and binary-codec behavior. |
| src/lib/ingestion/ingestion-processor-host.ts | Rejects content-script and untrusted ingestion-processing requests before staged payload access. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Extension client
    participant H as Persistence host
    participant W as DB worker
    participant E as DB engine
    C->>H: Runtime persistence request
    H->>H: Authorize sender and parse wire schema
    alt Unauthorized or malformed
        H-->>C: Safe rejection
    else Valid request
        H->>W: Validated operation
        W->>W: Revalidate operation
        W->>E: Submit operation
        E->>E: Revalidate and serialize execution
        E-->>W: Result or error
        W-->>H: Response envelope
        H-->>C: Encoded result or safe error
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(persistence): enforce trusted RPC bo..."](https://github.com/shishir435/ollama-client/commit/6722b6e72c3706b7aa63a8932e833fadc3d2689c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51583999)</sub>

<!-- /greptile_comment -->