### PR TITLE
fix(models): scroll the provider rail past ten providers

### DIFF
--- a/src/features/model/components/__tests__/model-menu.test.tsx
+++ b/src/features/model/components/__tests__/model-menu.test.tsx
@@ -149,4 +149,29 @@ describe("ModelMenu", () => {
     )
     expect(screen.getByText("trustedrouter/cheap")).toBeInTheDocument()
   })
+
+  it("scrolls the provider rail without a visible thumb and keeps all-models pinned", () => {
+    render(
+      <ModelMenu
+        trigger={<button type="button">Choose model</button>}
+        tooltipTextContent="Choose model"
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }))
+
+    const rail = screen.getByTestId("provider-rail-scroll")
+    expect(rail.className).toContain("overflow-y-auto")
+    expect(rail.className).toContain("scrollbar-none")
+
+    expect(rail).toContainElement(
+      screen.getByRole("button", { name: "Trusted Router" })
+    )
+    expect(rail).toContainElement(
+      screen.getByRole("button", { name: "Ollama" })
+    )
+    expect(rail).not.toContainElement(
+      screen.getByRole("button", { name: "model.menu.models_label" })
+    )
+  })
 })

--- a/src/features/model/components/model-menu.tsx
+++ b/src/features/model/components/model-menu.tsx
@@ -311,7 +311,7 @@ export const ModelMenu = ({
           <div className="flex h-96 min-h-0 overflow-hidden rounded-xl bg-popover text-popover-foreground">
             <nav
               aria-label={t("settings.tabs.providers")}
-              className="flex w-12 shrink-0 flex-col items-center gap-1 border-r border-border/50 bg-muted/15 p-1.5">
+              className="flex w-12 shrink-0 flex-col items-center gap-1 overflow-hidden border-r border-border/50 bg-muted/15 p-1.5">
               <button
                 type="button"
                 aria-label={t("model.menu.models_label")}
@@ -322,45 +322,49 @@ export const ModelMenu = ({
                   setSearchQuery("")
                 }}
                 className={cn(
-                  "flex size-9 items-center justify-center rounded-control text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "flex size-9 shrink-0 items-center justify-center rounded-control text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   activeProviderId === null &&
                     "bg-muted text-foreground shadow-sm"
                 )}>
                 <Layers3 className="icon-md" />
               </button>
 
-              <div className="my-0.5 h-px w-7 bg-border/60" />
+              <div className="my-0.5 h-px w-7 shrink-0 bg-border/60" />
 
-              {providerEntries.map(([providerId, group]) => {
-                const isActive = activeProviderId === providerId
-                return (
-                  <button
-                    key={providerId}
-                    type="button"
-                    aria-label={group.name}
-                    title={`${group.name} · ${group.models.length}`}
-                    aria-pressed={isActive}
-                    onClick={() => {
-                      setActiveProviderId(providerId)
-                      setSearchQuery("")
-                    }}
-                    className={cn(
-                      "relative flex size-9 items-center justify-center rounded-control text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      isActive && "bg-muted text-foreground shadow-sm"
-                    )}>
-                    <ProviderIcon
-                      providerId={providerId}
-                      brand={group.brand}
-                      fallbackName={group.name}
-                      iconUrl={providerIcons[providerId]}
-                      className="icon-md"
-                    />
-                    {providerId === selectedProviderId && (
-                      <span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary" />
-                    )}
-                  </button>
-                )
-              })}
+              <div
+                data-testid="provider-rail-scroll"
+                className="flex min-h-0 w-full flex-1 flex-col items-center gap-1 overflow-y-auto scrollbar-none">
+                {providerEntries.map(([providerId, group]) => {
+                  const isActive = activeProviderId === providerId
+                  return (
+                    <button
+                      key={providerId}
+                      type="button"
+                      aria-label={group.name}
+                      title={`${group.name} · ${group.models.length}`}
+                      aria-pressed={isActive}
+                      onClick={() => {
+                        setActiveProviderId(providerId)
+                        setSearchQuery("")
+                      }}
+                      className={cn(
+                        "relative flex size-9 shrink-0 items-center justify-center rounded-control text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                        isActive && "bg-muted text-foreground shadow-sm"
+                      )}>
+                      <ProviderIcon
+                        providerId={providerId}
+                        brand={group.brand}
+                        fallbackName={group.name}
+                        iconUrl={providerIcons[providerId]}
+                        className="icon-md"
+                      />
+                      {providerId === selectedProviderId && (
+                        <span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary" />
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
             </nav>
 
             <div className="flex min-w-0 flex-1 flex-col p-1">


### PR DESCRIPTION
The provider rail is a fixed-height column inside a 384px popover. Nine provider icons plus the all-models button fill it exactly; a tenth was clipped with no way to reach it.

The provider buttons move into their own scroll container so the all-models button and its divider stay pinned, and the thumb is hidden — a 48px rail has no room for one, and the icons themselves already indicate there is more below.

Test asserts the scroll container carries `overflow-y-auto scrollbar-none`, holds every provider button, and does not hold the all-models button.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the fixed-height provider icon rail independently scrollable while keeping the all-models control and divider pinned.
- Adds a constrained vertical scroll container around all provider buttons.
- Hides the narrow rail’s scrollbar without disabling native scrolling.
- Adds a component test covering the container classes and pinned-control structure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional, accessibility, security, or repository-rule defect identified.

The nested flex container has the required minimum-height constraint and native vertical overflow, the hidden-scrollbar utility preserves scrolling, and provider controls remain ordinary focusable buttons.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/model/components/model-menu.tsx | Moves provider buttons into a correctly constrained native scroll region while preserving the pinned all-models control. |
| src/features/model/components/__tests__/model-menu.test.tsx | Verifies the scroll utility classes, provider-button containment, and exclusion of the pinned all-models button. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): scroll the provider rail pa..."](https://github.com/shishir435/ollama-client/commit/eefebe1c5a301fb7ff6fb96a41c8b8e17d21f497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51900362)</sub>

<!-- /greptile_comment -->