### PR TITLE
build: stop emitting module preload hints in extension pages

### DIFF
--- a/config/__tests__/wxt-build-config.test.ts
+++ b/config/__tests__/wxt-build-config.test.ts
@@ -250,3 +250,18 @@ describe("env wiring", () => {
     expect(definesFor("firefox").__SPIKE_OPFS_OWNER_MV2__).toBe("false")
   })
 })
+
+describe("module preloading", () => {
+  it("emits no preload hints for either browser", () => {
+    // Extension chunks are on local disk, so a preload hint starts nothing
+    // early — and Chrome charges for each unused one twice, as "preloaded but
+    // not used" and as a cross-world resource mismatch. That was 46 console
+    // warnings on one page load, burying the extension's own logs.
+    for (const browser of ["chrome", "firefox"]) {
+      const config = vite({ browser } as Parameters<typeof vite>[0]) as {
+        build?: { modulePreload?: unknown }
+      }
+      expect(config.build?.modulePreload).toBe(false)
+    }
+  })
+})

--- a/config/wxt-vite.ts
+++ b/config/wxt-vite.ts
@@ -69,8 +69,25 @@ const dropRedundantSqliteWasm = {
   }
 }
 
+/**
+ * No `<link rel="modulepreload">` in extension pages.
+ *
+ * Preload hints exist to start a network fetch before the import graph asks
+ * for it. Extension chunks are already on local disk, so the hint buys nothing
+ * measurable — and Chrome charges for it twice in the console: once per chunk
+ * that is not evaluated within a few seconds of load (the offscreen host
+ * evaluates almost nothing itself; its work is in a Worker), and once per
+ * "cross-world extension resource mismatch", because a preload issued in one
+ * extension world does not satisfy a fetch from another. That was 46 warnings
+ * on a single page load, drowning the extension's own logs.
+ *
+ * `false` disables the preload links and the polyfill together. Chunks still
+ * load, on demand through the module graph, which is what was happening
+ * anyway.
+ */
 export const vite: WxtViteFactory = (env) =>
   ({
+    build: { modulePreload: false },
     define: persistenceDefines({
       browser: env.browser,
       spikeOwner: process.env.WXT_SPIKE_OWNER === "1"


### PR DESCRIPTION
46 console warnings on a single page load — "preloaded but not used" plus "cross-world extension resource mismatch", once each per chunk — burying the extension's own logs.

Preload hints start a network fetch early; extension chunks are on local disk, so they start nothing. `build.modulePreload: false` drops the links and the polyfill. Verified on both targets: zero `rel="modulepreload"` in every HTML entry, module script tags unchanged. Guarded in `wxt-build-config.test.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disables Vite module-preload hint and polyfill generation across Chrome and Firefox extension builds to eliminate redundant console warnings while preserving normal module-graph loading.

- Adds `build.modulePreload: false` to the shared WXT Vite configuration.
- Adds coverage confirming the setting is applied to both browser targets.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or build issues identified.

The shared build configuration disables an optional preload optimization without changing module script or dynamic-import semantics, and both supported browser configurations are covered.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/wxt-vite.ts | Disables module-preload generation globally while leaving the remaining WXT Vite configuration unchanged. |
| config/__tests__/wxt-build-config.test.ts | Verifies that both supported browser configurations disable module preloading. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build: stop emitting module preload hint..."](https://github.com/shishir435/ollama-client/commit/1bfc591f82179442a13f789118769700065801b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52186219)</sub>

<!-- /greptile_comment -->