### PR TITLE
fix: harden audited runtime paths

### DIFF
--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -161,8 +161,8 @@ flowchart TD
     T -->|yes| U["Tool loop: approval gate, execute, checkpoint"]
     U --> C
     T -->|no| I["UI Stream State Update"]
-    I --> J["SQLite Chat Store"]
-    I --> K["Optional RAG Pipeline"]
+    C --> J["SQLite Chat Store (durable turn owner)"]
+    C --> K["Optional RAG Pipeline"]
     K --> L["Embedding Strategy Chain"]
     L --> M["Vector store"]
 ```
@@ -171,14 +171,14 @@ Configuration traffic does not use this path — see [Provider RPC boundary](#pr
 
 ## Provider RPC boundary
 
-Token streaming uses runtime ports, but everything else that crosses the extension-page ↔ background boundary — reading provider configuration, testing a connection, listing models, running diagnostics — goes through a versioned request/response contract in `src/protocol/` rather than ad-hoc message keys.
+Token streaming uses runtime ports, but everything else that crosses the extension-page ↔ background boundary — reading provider configuration, testing a connection, listing models, running diagnostics — goes through versioned request/response contracts in `packages/contracts/src/` rather than ad-hoc message keys.
 
 | File | Role |
 |---|---|
-| `src/protocol/rpc.ts` | Protocol version, `RpcMethod` / `RpcErrorCode` enums, request and response envelopes |
-| `src/protocol/provider-rpc.ts` | Per-method request/result schemas and the typed `RpcMap` |
-| `src/protocol/model-rpc.ts` | Model lifecycle, catalog, and embedding method schemas |
-| `src/protocol/diagnostics-rpc.ts` | Diagnostics method schemas |
+| `packages/contracts/src/rpc.ts` | Protocol version, `RpcMethod` / `RpcErrorCode` enums, request and response envelopes |
+| `packages/contracts/src/provider-rpc.ts` | Provider request/result schemas and the provider entries in the typed `RpcMap` |
+| `packages/contracts/src/model-rpc.ts` | Model lifecycle, catalog, and embedding method schemas |
+| `packages/contracts/src/diagnostics-rpc.ts` | Diagnostics method schemas |
 | `src/protocol/rpc-registry.ts` | Per-method schema, sender policy, timeout, and operation metadata |
 | `src/protocol/extension-client.ts` | Validated client used by extension pages |
 | `src/background/rpc-server.ts` | Authorization, validation, dispatch, and safe error mapping |

--- a/e2e/chromium/critical/__tests__/persistence.spec.ts
+++ b/e2e/chromium/critical/__tests__/persistence.spec.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
 import { expect, test } from "../../fixtures/extension"
 import {
   openPersistenceVerifyPage,
@@ -11,6 +13,54 @@ interface Counts {
    * Matched with toMatchObject so a new table does not fail these assertions on
    * its way in. */
   tables: Record<string, number>
+}
+
+const startFakeOllama = async () => {
+  const server = createServer((_request, response) => {
+    response.setHeader("Access-Control-Allow-Origin", "*")
+    response.setHeader("Content-Type", "application/json")
+    if (_request.url === "/api/tags") {
+      response.end(
+        JSON.stringify({
+          models: [
+            {
+              name: "verify-model",
+              model: "verify-model",
+              modified_at: new Date(0).toISOString(),
+              size: 1,
+              digest: "verify",
+              details: { family: "verify", families: ["verify"] }
+            }
+          ]
+        })
+      )
+      return
+    }
+    if (_request.url === "/api/show") {
+      response.end(
+        JSON.stringify({ capabilities: [], details: { family: "verify" } })
+      )
+      return
+    }
+    if (_request.url === "/api/chat") {
+      response.setHeader("Content-Type", "application/x-ndjson")
+      response.end(
+        `${JSON.stringify({ message: { content: "recovered" }, done: false })}\n${JSON.stringify({ message: { content: "" }, done: true })}\n`
+      )
+      return
+    }
+    response.statusCode = 404
+    response.end(JSON.stringify({ error: "not found" }))
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const { port } = server.address() as AddressInfo
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve()))
+  }
 }
 
 test("@critical fresh OPFS profile survives a browser restart", async ({
@@ -38,6 +88,38 @@ test("@critical fresh OPFS profile survives a browser restart", async ({
     messages: 2
   })
   await page.close()
+})
+
+test("@critical a generating turn completes after browser restart", async ({
+  extension
+}) => {
+  test.setTimeout(120_000)
+  const fakeOllama = await startFakeOllama()
+  try {
+    let { page, call } = await openPersistenceVerifyPage(extension)
+    await waitForOpfsMarker(call)
+    await call("configureFakeOllama", fakeOllama.baseUrl)
+    const assistantMessageId = (await call(
+      "seedGeneratingTurn",
+      "verify-restart-turn"
+    )) as number
+
+    await page.close()
+    await extension.restart()
+    ;({ page, call } = await openPersistenceVerifyPage(extension))
+    await waitForOpfsMarker(call)
+
+    await expect
+      .poll(
+        () =>
+          call("durableTurnResult", "verify-restart-turn", assistantMessageId),
+        { timeout: 30_000 }
+      )
+      .toEqual({ status: "completed", content: "recovered", done: true })
+    await page.close()
+  } finally {
+    await fakeOllama.close()
+  }
 })
 
 test("@critical sql.js migration is durable, idempotent, and preserves source", async ({

--- a/src/background/__tests__/startup-database-order.test.ts
+++ b/src/background/__tests__/startup-database-order.test.ts
@@ -214,6 +214,39 @@ describe("background database startup", () => {
     expect(peakInFlight).toBe(2)
   })
 
+  it("records the known successor overlap after a startup deadline", async () => {
+    vi.useFakeTimers()
+    try {
+      const { initializeBackgroundStartup } = await loadStartup()
+      initializeBackgroundStartup(Promise.resolve())
+      await settle()
+
+      tasks["backup-import"].release()
+      await settle()
+      expect(started).toEqual(["backup-import", "provider-migration"])
+
+      await vi.advanceTimersByTimeAsync(120_000)
+      await settle()
+
+      // The deadline currently abandons rather than cancels the migration.
+      // Preserve explicit evidence of that overlap until cancellable startup
+      // recovery replaces this expectation.
+      expect(started).toEqual([
+        "backup-import",
+        "provider-migration",
+        "embedding-migration"
+      ])
+      expect(finished).not.toContain("provider-migration")
+      expect(inFlight).toBe(2)
+
+      releaseAll()
+      await vi.runAllTimersAsync()
+      await settle()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("skips database startup when the owner never came up", async () => {
     const { initializeBackgroundStartup } = await loadStartup()
     initializeBackgroundStartup(Promise.reject(new Error("no offscreen slot")))

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -15,7 +15,10 @@ import {
   STORAGE_KEYS
 } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import { resolveModelConfig } from "@/lib/model-config-utils"
+import {
+  parseStoredModelConfigMap,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
@@ -33,7 +36,6 @@ import type {
   ChatStreamMessage,
   ChatStreamSink,
   ChatWithModelMessage,
-  ModelConfigMap,
   PortStatusFunction
 } from "@/types"
 
@@ -80,10 +82,11 @@ export const handleChatWithModel = withErrorContext(
     const ac = new AbortController()
     setAbortController(abortKey, ac)
 
-    const modelConfigMap =
-      (await plasmoGlobalStorage.get<ModelConfigMap>(
+    const modelConfigMap = parseStoredModelConfigMap(
+      await plasmoGlobalStorage.get<unknown>(
         STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
-      )) ?? {}
+      )
+    )
     const modelParams = resolveModelConfig(modelConfigMap[model])
 
     const limitedMessages = limitMessagesForModel(model, messages)

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -5,12 +5,15 @@ import { normalizeError } from "@/background/lib/error-handler"
 import { safePostChatStreamEvent } from "@/background/lib/utils"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import { resolveModelConfig } from "@/lib/model-config-utils"
+import {
+  parseStoredModelConfigMap,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { isSelectedModelRef } from "@/lib/providers/selected-model"
-import type { ChromePort, ModelConfigMap, PortStatusFunction } from "@/types"
+import type { ChromePort, PortStatusFunction } from "@/types"
 
 export const handleSelectionAction = async (
   msg: SelectionActionMessage,
@@ -50,10 +53,11 @@ export const handleSelectionAction = async (
   setAbortController(abortKey, ac)
 
   try {
-    const modelConfigMap =
-      (await plasmoGlobalStorage.get<ModelConfigMap>(
+    const modelConfigMap = parseStoredModelConfigMap(
+      await plasmoGlobalStorage.get<unknown>(
         STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
-      )) ?? {}
+      )
+    )
     const modelParams = resolveModelConfig(modelConfigMap[model])
     const provider = await ProviderFactory.getProviderForModel(
       model,

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -218,6 +218,59 @@ const handleSelectionMessage = (
   return true
 }
 
+const handleKeepToolLoopAlive = (
+  sendResponse: SendResponseFunction
+): undefined => {
+  // A visible approval prompt sends this periodically. Runtime messages reset
+  // Chromium's MV3 idle timer; SQLite recovery remains the restart fallback.
+  safeSendResponse(sendResponse, { success: true })
+}
+
+const handleJobCompleteNotification = (
+  message: ChromeMessage,
+  sendResponse: SendResponseFunction
+): true => {
+  const payload = message.payload as
+    | { id?: string; title?: unknown; message?: unknown }
+    | undefined
+  if (
+    !payload ||
+    typeof payload.title !== "string" ||
+    typeof payload.message !== "string"
+  ) {
+    safeSendResponse(sendResponse, {
+      success: false,
+      error: { status: 400, message: "Invalid message payload" }
+    })
+    return true
+  }
+
+  notifyJobComplete({
+    id: typeof payload.id === "string" ? payload.id : undefined,
+    title: payload.title,
+    message: payload.message
+  })
+    .then((result) => {
+      safeSendResponse(sendResponse, {
+        success: result.sent,
+        data: result,
+        error: result.sent
+          ? undefined
+          : { status: 0, message: result.reason || "Notification skipped" }
+      })
+    })
+    .catch((error) => {
+      safeSendResponse(sendResponse, {
+        success: false,
+        error: {
+          status: 0,
+          message: error instanceof Error ? error.message : String(error)
+        }
+      })
+    })
+  return true
+}
+
 export const registerMessageRouter = () => {
   // The polyfill types the sync listener as returning literal `true`, but we use
   // the Chrome idiom of returning `true` only for handled async responses and
@@ -308,56 +361,11 @@ export const registerMessageRouter = () => {
       }
 
       case MESSAGE_KEYS.APP.KEEP_TOOL_LOOP_ALIVE: {
-        // A visible approval prompt sends this periodically. Runtime messages
-        // reset Chromium's MV3 idle timer without adding a standing `alarms`
-        // permission; SQLite recovery remains the crash/restart fallback.
-        safeSendResponse(response, { success: true })
-        return
+        return handleKeepToolLoopAlive(response)
       }
 
       case MESSAGE_KEYS.APP.NOTIFY_JOB_COMPLETE: {
-        const payload = message.payload as
-          | { id?: string; title?: unknown; message?: unknown }
-          | undefined
-        if (
-          !payload ||
-          typeof payload.title !== "string" ||
-          typeof payload.message !== "string"
-        ) {
-          safeSendResponse(response, {
-            success: false,
-            error: { status: 400, message: "Invalid message payload" }
-          })
-          return true
-        }
-
-        notifyJobComplete({
-          id: typeof payload.id === "string" ? payload.id : undefined,
-          title: payload.title,
-          message: payload.message
-        })
-          .then((result) => {
-            safeSendResponse(response, {
-              success: result.sent,
-              data: result,
-              error: result.sent
-                ? undefined
-                : {
-                    status: 0,
-                    message: result.reason || "Notification skipped"
-                  }
-            })
-          })
-          .catch((error) => {
-            safeSendResponse(response, {
-              success: false,
-              error: {
-                status: 0,
-                message: error instanceof Error ? error.message : String(error)
-              }
-            })
-          })
-        return true
+        return handleJobCompleteNotification(message, response)
       }
 
       case MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT: {

--- a/src/entrypoints/persistence-verify/main.ts
+++ b/src/entrypoints/persistence-verify/main.ts
@@ -12,7 +12,14 @@ import {
   readPersistenceBackend
 } from "@/lib/persistence/backend"
 import { DURABLE_TABLES } from "@/lib/persistence/durable-tables"
+import { ProviderManager } from "@/lib/providers/manager"
+import { ProviderId } from "@/lib/providers/types"
 import * as chatHistory from "@/lib/repositories/sqlite-chat-history"
+import {
+  createTurnRun,
+  getTurnRun,
+  updateTurnRun
+} from "@/lib/repositories/turn-runs"
 import {
   createFixture,
   type Scale
@@ -299,6 +306,94 @@ const verifyApi = {
       })
     }
     return lastId
+  },
+
+  async configureFakeOllama(baseUrl: string): Promise<void> {
+    await ProviderManager.updateProviderConfig(ProviderId.OLLAMA, {
+      enabled: true,
+      baseUrl,
+      customModels: ["verify-model"]
+    })
+  },
+
+  /** Seed exactly what an interrupted worker leaves behind: canonical message
+   * rows plus a generating turn carrying the resumable request. */
+  async seedGeneratingTurn(turnId: string): Promise<number> {
+    const now = Date.now()
+    const sessionId = `session-${turnId}`
+    await chatHistory.addSession({
+      id: sessionId,
+      title: "durable restart verification",
+      modelId: "verify-model",
+      createdAt: now,
+      updatedAt: now,
+      messages: []
+    })
+    const userMessageId = await chatHistory.appendMessage({
+      sessionId,
+      role: "user",
+      content: "resume after restart",
+      timestamp: now
+    })
+    const assistantMessageId = await chatHistory.appendMessage({
+      sessionId,
+      role: "assistant",
+      content: "",
+      model: "verify-model",
+      parentId: userMessageId,
+      done: false,
+      timestamp: now + 1
+    })
+    await createTurnRun({
+      id: turnId,
+      sessionId,
+      mode: "new",
+      model: "verify-model",
+      providerId: ProviderId.OLLAMA,
+      createdAt: now,
+      request: {
+        version: 1,
+        context: {
+          rawInput: "resume after restart",
+          messages: [],
+          hasTabContext: false,
+          contextText: "",
+          tabDocuments: [],
+          memoryEnabled: false,
+          maxTabContextChars: 1_000,
+          maxRagContextChars: 1_000,
+          groundedOnlyMode: false,
+          selectedModel: "verify-model",
+          selectedModelRef: {
+            providerId: ProviderId.OLLAMA,
+            modelId: "verify-model"
+          }
+        },
+        userMessage: { role: "user", content: "resume after restart" }
+      }
+    })
+    await updateTurnRun(turnId, {
+      status: "building_context",
+      userMessageId,
+      assistantMessageId
+    })
+    await updateTurnRun(turnId, { status: "generating" })
+    return assistantMessageId
+  },
+
+  async durableTurnResult(
+    turnId: string,
+    assistantMessageId: number
+  ): Promise<{ status?: string; content?: string; done?: boolean }> {
+    const [turn, assistant] = await Promise.all([
+      getTurnRun(turnId),
+      chatHistory.getMessage(assistantMessageId)
+    ])
+    return {
+      status: turn?.status,
+      content: assistant?.content,
+      done: assistant?.done
+    }
   },
 
   /** Restore a payload that is not a usable database, through the production

--- a/src/features/chat/components/__tests__/chat-message-bubble.test.tsx
+++ b/src/features/chat/components/__tests__/chat-message-bubble.test.tsx
@@ -34,10 +34,32 @@ vi.mock("@/features/chat/components/chat-message-editor", () => ({
 }))
 
 vi.mock("@/features/chat/components/chat-message-footer", () => ({
-  ChatMessageFooter: () => <div>footer</div>
+  ChatMessageFooter: ({ onFork }: { onFork?: () => void }) => (
+    <div>
+      {onFork && (
+        <button type="button" onClick={onFork}>
+          fork
+        </button>
+      )}
+    </div>
+  )
 }))
 
 describe("ChatMessageBubble", () => {
+  it("hides fork while another turn is busy", () => {
+    render(
+      <ChatMessageBubble
+        msg={{ role: "user", content: "question", timestamp: 1 }}
+        isBusy
+        onFork={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "fork" })
+    ).not.toBeInTheDocument()
+  })
+
   it("does not treat normal assistant prose as a reportable app error", () => {
     render(
       <ChatMessageBubble

--- a/src/features/chat/components/chat-message-bubble.tsx
+++ b/src/features/chat/components/chat-message-bubble.tsx
@@ -16,6 +16,7 @@ export const ChatMessageBubble = memo(
     msg,
     sessionId,
     onRegenerate,
+    isBusy,
     isLoading,
     isStreaming,
     showRetrievedChunks,
@@ -28,6 +29,7 @@ export const ChatMessageBubble = memo(
     msg: ChatMessage
     sessionId?: string
     onRegenerate?: (model?: string) => void
+    isBusy?: boolean
     isLoading?: boolean
     isStreaming?: boolean
     showRetrievedChunks?: boolean
@@ -127,7 +129,9 @@ export const ChatMessageBubble = memo(
               onRegenerate={onRegenerate}
               canRetry={canRetry}
               onEdit={() => setEditorMode("edit")}
-              onFork={isUser ? () => setEditorMode("fork") : undefined}
+              onFork={
+                isUser && !isBusy ? () => setEditorMode("fork") : undefined
+              }
               onDelete={onDelete}
               onExport={handleExport}
               onNavigate={onNavigate}
@@ -141,6 +145,7 @@ export const ChatMessageBubble = memo(
     return (
       prev.msg === next.msg &&
       prev.sessionId === next.sessionId &&
+      prev.isBusy === next.isBusy &&
       prev.isLoading === next.isLoading &&
       prev.isStreaming === next.isStreaming &&
       prev.showRetrievedChunks === next.showRetrievedChunks &&

--- a/src/features/chat/components/chat-message-list.tsx
+++ b/src/features/chat/components/chat-message-list.tsx
@@ -181,6 +181,7 @@ export const ChatMessageList = ({
                 <ChatMessageBubble
                   msg={msg}
                   sessionId={sessionId}
+                  isBusy={isLoading || isStreaming}
                   isLoading={isLoading && isLastAssistantMessage}
                   isStreaming={isStreaming && isLastAssistantMessage}
                   showRetrievedChunks={showRetrievedChunks}

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -24,6 +24,8 @@ export const Chat = () => {
     pendingActivityEvents,
     sendMessage,
     generateResponse,
+    claimResponseStream,
+    releaseResponseStreamClaim,
     stopGeneration,
     isModelReady,
     hasMore,
@@ -112,27 +114,37 @@ export const Chat = () => {
     }
 
     if (prevUserIndex !== -1 && currentSessionId) {
-      const prevUserMsg = messages[prevUserIndex]
+      const streamClaim = claimResponseStream()
+      if (!streamClaim) return
+      let submitted = false
+      try {
+        const prevUserMsg = messages[prevUserIndex]
 
-      /*
-       * 1. Navigate to that user message (this sets it as the current leaf)
-       * This is crucial: if we are regenerating an old message deep in history,
-       * we must "rewind" the tip to the user message so the new assistant response is attached as a sibling of the old assistant response.
-       */
-      if (prevUserMsg.id) {
-        // Pass true for 'exact' to ensure we stop AT the user message and don't forward to its old children.
-        await navigateToNode(currentSessionId, prevUserMsg.id, true)
+        /*
+         * 1. Navigate to that user message (this sets it as the current leaf)
+         * This is crucial: if we are regenerating an old message deep in history,
+         * we must "rewind" the tip to the user message so the new assistant response is attached as a sibling of the old assistant response.
+         */
+        if (prevUserMsg.id) {
+          // Pass true for 'exact' to ensure we stop AT the user message and don't forward to its old children.
+          await navigateToNode(currentSessionId, prevUserMsg.id, true)
+        }
+
+        // 2. Prepare context (messages up to and including the user message)
+        const contextMessages = messages.slice(0, prevUserIndex + 1)
+
+        // 3. Trigger generation
+        // If model is provided, use it (switching model for this specific branch)
+        // Note: generateResponse will call addMessage, which automatically parents to currentLeafId (our user message)
+        submitted = await generateResponse(
+          model,
+          currentSessionId,
+          contextMessages,
+          { mode: "regenerate", streamClaim }
+        )
+      } finally {
+        if (!submitted) releaseResponseStreamClaim(streamClaim)
       }
-
-      // 2. Prepare context (messages up to and including the user message)
-      const contextMessages = messages.slice(0, prevUserIndex + 1)
-
-      // 3. Trigger generation
-      // If model is provided, use it (switching model for this specific branch)
-      // Note: generateResponse will call addMessage, which automatically parents to currentLeafId (our user message)
-      await generateResponse(model, currentSessionId, contextMessages, {
-        mode: "regenerate"
-      })
     }
   }
 
@@ -158,17 +170,24 @@ export const Chat = () => {
       return
     }
 
-    const newLeafId = await forkMessage(currentSessionId, message.id, content)
-    const messageIndex = messages.findIndex((item) => item.id === message.id)
-    if (messageIndex !== -1 && newLeafId) {
-      const newMessage = { ...message, id: newLeafId, content }
-      await embedMessage(newMessage, currentSessionId)
-      await generateResponse(
-        undefined,
-        currentSessionId,
-        [...messages.slice(0, messageIndex), newMessage],
-        { mode: "fork" }
-      )
+    const streamClaim = claimResponseStream()
+    if (!streamClaim) return
+    let submitted = false
+    try {
+      const newLeafId = await forkMessage(currentSessionId, message.id, content)
+      const messageIndex = messages.findIndex((item) => item.id === message.id)
+      if (messageIndex !== -1 && newLeafId) {
+        const newMessage = { ...message, id: newLeafId, content }
+        await embedMessage(newMessage, currentSessionId)
+        submitted = await generateResponse(
+          undefined,
+          currentSessionId,
+          [...messages.slice(0, messageIndex), newMessage],
+          { mode: "fork", streamClaim }
+        )
+      }
+    } finally {
+      if (!submitted) releaseResponseStreamClaim(streamClaim)
     }
   }
 

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -149,6 +149,8 @@ export const Chat = () => {
 
   const handleForkMessage = async (message: ChatMessage, content: string) => {
     if (
+      isLoading ||
+      isStreaming ||
       message.role !== "user" ||
       typeof message.id !== "number" ||
       !currentSessionId

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -97,6 +97,26 @@ describe("useChatStream", () => {
     expect(setIsStreaming).toHaveBeenCalledWith(false)
   })
 
+  it("keeps one active stream when start is called twice", () => {
+    const { result } = renderHook(() =>
+      useChatStream({ setMessages, setIsLoading, setIsStreaming })
+    )
+    const messages = [{ role: "user" as const, content: "Hello" }]
+
+    act(() => {
+      result.current.startStream({ model: "llama2", messages })
+      result.current.startStream({ model: "llama3", messages })
+    })
+
+    expect(browser.runtime.connect).toHaveBeenCalledOnce()
+    expect(mockPort.postMessage).toHaveBeenCalledOnce()
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Ignored stream start while another request is active",
+      "useChatStream",
+      expect.objectContaining({ requestId: expect.any(String) })
+    )
+  })
+
   it("submits durable turns as one background-owned command", () => {
     const { result } = renderHook(() =>
       useChatStream({ setMessages, setIsLoading, setIsStreaming })

--- a/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-stream.test.ts
@@ -117,6 +117,31 @@ describe("useChatStream", () => {
     )
   })
 
+  it("reserves ownership before asynchronous submission work", () => {
+    const { result } = renderHook(() =>
+      useChatStream({ setMessages, setIsLoading, setIsStreaming })
+    )
+    const messages = [{ role: "user" as const, content: "Hello" }]
+
+    const firstClaim = result.current.claimStream()
+    const concurrentClaim = result.current.claimStream()
+
+    expect(firstClaim).not.toBeNull()
+    expect(concurrentClaim).toBeNull()
+
+    let started = false
+    act(() => {
+      started = result.current.startStream(
+        { model: "llama2", messages },
+        firstClaim ?? undefined
+      )
+    })
+
+    expect(started).toBe(true)
+    expect(browser.runtime.connect).toHaveBeenCalledOnce()
+    expect(mockPort.postMessage).toHaveBeenCalledOnce()
+  })
+
   it("submits durable turns as one background-owned command", () => {
     const { result } = renderHook(() =>
       useChatStream({ setMessages, setIsLoading, setIsStreaming })

--- a/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -41,8 +41,10 @@ vi.mock("@/features/chat/hooks/use-chat-stream", () => ({
       capturedSetMessages = config.setMessages
       capturedOnSuccessfulResponse = config.onSuccessfulResponse ?? null
       return {
-        startStream: vi.fn(),
-        stopStream: vi.fn()
+        startStream: vi.fn(() => true),
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("claim")),
+        releaseStreamClaim: vi.fn()
       }
     }
   )
@@ -86,11 +88,13 @@ afterEach(() => {
 })
 
 describe("useChatStreaming", () => {
-  it("exposes startStream, stopStream, and the streaming-id ref", () => {
+  it("exposes stream ownership, controls, and the streaming-id ref", () => {
     const { options } = mkOptions()
     const { result } = renderHook(() => useChatStreaming(options))
     expect(typeof result.current.startStream).toBe("function")
     expect(typeof result.current.stopStream).toBe("function")
+    expect(typeof result.current.claimStream).toBe("function")
+    expect(typeof result.current.releaseStreamClaim).toBe("function")
     expect(result.current.currentStreamingMessageIdRef.current).toBeNull()
   })
 

--- a/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-turn-controller.test.ts
@@ -15,6 +15,9 @@ const baseConfig = {
 }
 
 describe("useChatTurnController", () => {
+  const claimResponseStream = vi.fn(() => Symbol("stream-claim"))
+  const releaseResponseStreamClaim = vi.fn()
+
   beforeEach(() => {
     vi.clearAllMocks()
     loadStreamStore.setState({ isLoading: false, isStreaming: false })
@@ -23,7 +26,7 @@ describe("useChatTurnController", () => {
   it("persists the user message and submits one background-owned turn", async () => {
     const addMessage = vi.fn().mockResolvedValue(1)
     const autoRenameSession = vi.fn().mockResolvedValue(undefined)
-    const generateResponse = vi.fn().mockResolvedValue(undefined)
+    const generateResponse = vi.fn().mockResolvedValue(true)
 
     const { result } = renderHook(() =>
       useChatTurnController({
@@ -40,6 +43,8 @@ describe("useChatTurnController", () => {
         autoRenameSession,
         addMessage,
         generateResponse,
+        claimResponseStream,
+        releaseResponseStreamClaim,
         toast: vi.fn()
       })
     )
@@ -63,7 +68,7 @@ describe("useChatTurnController", () => {
           content: "question"
         })
       ],
-      {
+      expect.objectContaining({
         durableTurn: {
           submission: expect.objectContaining({
             id: expect.any(String),
@@ -74,13 +79,14 @@ describe("useChatTurnController", () => {
             })
           }),
           userMessageId: 1
-        }
-      }
+        },
+        streamClaim: expect.any(Symbol)
+      })
     )
   })
 
   it("continues the turn when automatic title rename fails", async () => {
-    const generateResponse = vi.fn().mockResolvedValue(undefined)
+    const generateResponse = vi.fn().mockResolvedValue(true)
     const toast = vi.fn()
     const { result } = renderHook(() =>
       useChatTurnController({
@@ -99,6 +105,8 @@ describe("useChatTurnController", () => {
           .mockRejectedValue(new Error("rename failed")),
         addMessage: vi.fn().mockResolvedValue(1),
         generateResponse,
+        claimResponseStream,
+        releaseResponseStreamClaim,
         toast
       })
     )
@@ -131,6 +139,8 @@ describe("useChatTurnController", () => {
         autoRenameSession: vi.fn(),
         addMessage,
         generateResponse: vi.fn(),
+        claimResponseStream,
+        releaseResponseStreamClaim,
         toast
       })
     )
@@ -165,6 +175,8 @@ describe("useChatTurnController", () => {
         autoRenameSession: vi.fn(),
         addMessage,
         generateResponse: vi.fn(),
+        claimResponseStream,
+        releaseResponseStreamClaim,
         toast: vi.fn()
       })
     )
@@ -176,5 +188,92 @@ describe("useChatTurnController", () => {
 
     expect(accepted).toBe(false)
     expect(addMessage).not.toHaveBeenCalled()
+  })
+
+  it("claims the response stream before persisting the user message", async () => {
+    let activeClaim: symbol | null = null
+    const claim = vi.fn(() => {
+      if (activeClaim) return null
+      activeClaim = Symbol("stream-claim")
+      return activeClaim
+    })
+    let resolveMessage!: (id: number) => void
+    const addMessage = vi.fn(
+      () => new Promise<number>((resolve) => (resolveMessage = resolve))
+    )
+    const generateResponse = vi.fn().mockResolvedValue(true)
+    const { result } = renderHook(() =>
+      useChatTurnController({
+        config: baseConfig as any,
+        input: "question",
+        setInput: vi.fn(),
+        selectedTabIds: [],
+        contextText: "",
+        tabDocuments: [],
+        messages: [],
+        setIsLoading: vi.fn(),
+        setIsStreaming: vi.fn(),
+        ensureSessionId: vi.fn().mockResolvedValue("session-1"),
+        autoRenameSession: vi.fn().mockResolvedValue(undefined),
+        addMessage,
+        generateResponse,
+        claimResponseStream: claim,
+        releaseResponseStreamClaim: vi.fn((ownedClaim) => {
+          if (activeClaim === ownedClaim) activeClaim = null
+        }),
+        toast: vi.fn()
+      })
+    )
+
+    let sendPromise!: Promise<boolean>
+    await act(async () => {
+      sendPromise = result.current.sendMessage()
+      await vi.waitFor(() => expect(addMessage).toHaveBeenCalledOnce())
+    })
+
+    expect(claim()).toBeNull()
+
+    await act(async () => {
+      resolveMessage(1)
+      expect(await sendPromise).toBe(true)
+    })
+    expect(generateResponse).toHaveBeenCalledWith(
+      undefined,
+      "session-1",
+      expect.any(Array),
+      expect.objectContaining({ streamClaim: activeClaim })
+    )
+  })
+
+  it("does not report success when response submission is rejected", async () => {
+    const releaseClaim = vi.fn()
+    const { result } = renderHook(() =>
+      useChatTurnController({
+        config: baseConfig as any,
+        input: "question",
+        setInput: vi.fn(),
+        selectedTabIds: [],
+        contextText: "",
+        tabDocuments: [],
+        messages: [],
+        setIsLoading: vi.fn(),
+        setIsStreaming: vi.fn(),
+        ensureSessionId: vi.fn().mockResolvedValue("session-1"),
+        autoRenameSession: vi.fn().mockResolvedValue(undefined),
+        addMessage: vi.fn().mockResolvedValue(1),
+        generateResponse: vi.fn().mockResolvedValue(false),
+        claimResponseStream,
+        releaseResponseStreamClaim: releaseClaim,
+        toast: vi.fn()
+      })
+    )
+
+    let accepted = true
+    await act(async () => {
+      accepted = await result.current.sendMessage()
+    })
+
+    expect(accepted).toBe(false)
+    expect(releaseClaim).toHaveBeenCalledWith(expect.any(Symbol))
   })
 })

--- a/src/features/chat/hooks/__tests__/use-chat.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat.test.ts
@@ -121,8 +121,10 @@ vi.mock("@/features/chat/hooks/use-auto-embed-messages", () => ({
 
 vi.mock("@/features/chat/hooks/use-chat-stream", () => ({
   useChatStream: vi.fn(() => ({
-    startStream: vi.fn(),
-    stopStream: vi.fn()
+    startStream: vi.fn(() => true),
+    stopStream: vi.fn(),
+    claimStream: vi.fn(() => Symbol("stream-claim")),
+    releaseStreamClaim: vi.fn()
   }))
 }))
 
@@ -213,10 +215,12 @@ describe("useChat", () => {
     const { useChatStream } = await import(
       "@/features/chat/hooks/use-chat-stream"
     )
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
 
     const { result } = renderHook(() => useChat())
@@ -235,10 +239,12 @@ describe("useChat", () => {
     const { useChatSessions } = await import(
       "@/features/sessions/stores/chat-session-store"
     )
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
     vi.mocked(useChatSessions).mockReturnValue({
       currentSessionId: "session-1",
@@ -291,7 +297,8 @@ describe("useChat", () => {
             content: "Hello"
           })
         ])
-      })
+      }),
+      expect.any(Symbol)
     )
   })
 
@@ -306,7 +313,7 @@ describe("useChat", () => {
       "@/features/sessions/stores/chat-session-store"
     )
     const addMessage = vi.fn().mockResolvedValue(123)
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
     const setIsLoading = vi.fn()
     const setIsStreaming = vi.fn()
 
@@ -321,7 +328,9 @@ describe("useChat", () => {
     })
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
     vi.mocked(useChatSessions).mockReturnValue({
       currentSessionId: "session-1",
@@ -394,14 +403,16 @@ describe("useChat", () => {
       .fn()
       .mockResolvedValueOnce(123)
       .mockRejectedValueOnce(new Error("assistant save failed"))
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
 
     vi.mocked(plasmoGlobalStorage.get).mockRejectedValueOnce(
       new Error("storage unavailable")
     )
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
     vi.mocked(useChatSessions).mockReturnValue({
       currentSessionId: "session-1",
@@ -607,10 +618,12 @@ describe("useChat", () => {
       "@/features/chat/stores/chat-input-store"
     )
 
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
 
     vi.mocked(useSelectedTabs).mockReturnValue({
@@ -649,7 +662,8 @@ describe("useChat", () => {
             })
           })
         })
-      })
+      }),
+      expect.any(Symbol)
     )
   })
 
@@ -664,10 +678,12 @@ describe("useChat", () => {
       "@/features/chat/hooks/use-chat-stream"
     )
 
-    const startStream = vi.fn()
+    const startStream = vi.fn(() => true)
     vi.mocked(useChatStream).mockReturnValue({
       startStream,
-      stopStream: vi.fn()
+      stopStream: vi.fn(),
+      claimStream: vi.fn(() => Symbol("stream-claim")),
+      releaseStreamClaim: vi.fn()
     })
 
     vi.mocked(useSelectedTabs).mockReturnValue({
@@ -699,7 +715,8 @@ describe("useChat", () => {
             })
           })
         })
-      })
+      }),
+      expect.any(Symbol)
     )
   })
 
@@ -730,8 +747,10 @@ describe("useChat", () => {
     vi.mocked(useChatStream).mockImplementation((config: any) => {
       setMessagesCallback = config.setMessages
       return {
-        startStream: vi.fn(),
-        stopStream: vi.fn()
+        startStream: vi.fn(() => true),
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("stream-claim")),
+        releaseStreamClaim: vi.fn()
       }
     })
 
@@ -803,10 +822,12 @@ describe("useChat", () => {
       const { useChatStream } = await import(
         "@/features/chat/hooks/use-chat-stream"
       )
-      const startStream = vi.fn()
+      const startStream = vi.fn(() => true)
       vi.mocked(useChatStream).mockReturnValue({
         startStream,
-        stopStream: vi.fn()
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("stream-claim")),
+        releaseStreamClaim: vi.fn()
       })
 
       const { result } = renderHook(() => useChat())
@@ -836,10 +857,12 @@ describe("useChat", () => {
       const { useChatStream } = await import(
         "@/features/chat/hooks/use-chat-stream"
       )
-      const startStream = vi.fn()
+      const startStream = vi.fn(() => true)
       vi.mocked(useChatStream).mockReturnValue({
         startStream,
-        stopStream: vi.fn()
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("stream-claim")),
+        releaseStreamClaim: vi.fn()
       })
 
       vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(true) // RAG enabled
@@ -904,7 +927,8 @@ describe("useChat", () => {
               })
             })
           })
-        })
+        }),
+        expect.any(Symbol)
       )
     })
 
@@ -921,10 +945,12 @@ describe("useChat", () => {
       const { useChatStream } = await import(
         "@/features/chat/hooks/use-chat-stream"
       )
-      const startStream = vi.fn()
+      const startStream = vi.fn(() => true)
       vi.mocked(useChatStream).mockReturnValue({
         startStream,
-        stopStream: vi.fn()
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("stream-claim")),
+        releaseStreamClaim: vi.fn()
       })
 
       vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(true)
@@ -971,7 +997,8 @@ describe("useChat", () => {
               })
             })
           })
-        })
+        }),
+        expect.any(Symbol)
       )
     })
 
@@ -988,10 +1015,12 @@ describe("useChat", () => {
       const { useChatStream } = await import(
         "@/features/chat/hooks/use-chat-stream"
       )
-      const startStream = vi.fn()
+      const startStream = vi.fn(() => true)
       vi.mocked(useChatStream).mockReturnValue({
         startStream,
-        stopStream: vi.fn()
+        stopStream: vi.fn(),
+        claimStream: vi.fn(() => Symbol("stream-claim")),
+        releaseStreamClaim: vi.fn()
       })
 
       vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(true)
@@ -1041,7 +1070,8 @@ describe("useChat", () => {
               })
             })
           })
-        })
+        }),
+        expect.any(Symbol)
       )
     })
   })

--- a/src/features/chat/hooks/use-chat-response.ts
+++ b/src/features/chat/hooks/use-chat-response.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/application/context/build-context"
 import type { DurableTurnStart } from "@/application/turns/turn-contract"
 import type { useChatConfig } from "@/features/chat/hooks/use-chat-config"
+import type { ChatStreamClaim } from "@/features/chat/hooks/use-chat-stream"
 import type { ChatMessage } from "@/types"
 
 interface ChatResponseOptions {
@@ -13,15 +14,20 @@ interface ChatResponseOptions {
   currentSessionId: string | null
   messages: ChatMessage[]
   addMessage: (sessionId: string, message: ChatMessage) => Promise<number>
-  startStream: (options: {
-    model: string
-    providerId?: string
-    messages: ChatMessage[]
-    sessionId: string
-    generatedMessage: ChatMessage
-    clientContextPrepared?: boolean
-    durableTurn?: DurableTurnStart & { assistantMessageId: number }
-  }) => void
+  startStream: (
+    options: {
+      model: string
+      providerId?: string
+      messages: ChatMessage[]
+      sessionId: string
+      generatedMessage: ChatMessage
+      clientContextPrepared?: boolean
+      durableTurn?: DurableTurnStart & { assistantMessageId: number }
+    },
+    claim: ChatStreamClaim
+  ) => boolean
+  claimStream: () => ChatStreamClaim | null
+  releaseStreamClaim: (claim: ChatStreamClaim) => void
   currentStreamingMessageIdRef: { current: number | null }
   currentStreamingSessionIdRef: { current: string | null }
 }
@@ -32,6 +38,8 @@ export const useChatResponse = ({
   messages,
   addMessage,
   startStream,
+  claimStream,
+  releaseStreamClaim,
   currentStreamingMessageIdRef,
   currentStreamingSessionIdRef
 }: ChatResponseOptions) => {
@@ -58,94 +66,116 @@ export const useChatResponse = ({
       contextPrepared?: boolean
       durableTurn?: DurableTurnStart
       mode?: TurnMode
+      streamClaim?: ChatStreamClaim
     }
-  ) => {
+  ): Promise<boolean> => {
     const sessionId = sessionIdParam || currentSessionId
-    if (!sessionId) return
+    if (!sessionId) {
+      if (options?.streamClaim) releaseStreamClaim(options.streamClaim)
+      return false
+    }
 
     const modelForRequest =
       customModel || config.selectedModelRef?.modelId || config.selectedModel
-    if (!modelForRequest) return
+    if (!modelForRequest) {
+      if (options?.streamClaim) releaseStreamClaim(options.streamClaim)
+      return false
+    }
 
-    const assistantMessage: ChatMessage = {
-      role: "assistant",
-      content: "",
-      // Persist the in-flight turn as not-done so a worker/sidepanel death
-      // mid-stream leaves a `done=0` row. Startup recovery finalizes any such
-      // orphan (marking it interrupted); a normal completion flips it to done.
-      done: false,
-      model: modelForRequest,
-      metrics: ragSourcesRef.current
-        ? {
-            ragSources: ragSourcesRef.current.sources,
-            ragQuery: ragSourcesRef.current.query,
-            ...(promptContextStatsRef.current || {})
+    const streamClaim = options?.streamClaim ?? claimStream()
+    if (!streamClaim) return false
+
+    try {
+      const assistantMessage: ChatMessage = {
+        role: "assistant",
+        content: "",
+        // Persist the in-flight turn as not-done so a worker/sidepanel death
+        // mid-stream leaves a `done=0` row. Startup recovery finalizes any such
+        // orphan (marking it interrupted); a normal completion flips it to done.
+        done: false,
+        model: modelForRequest,
+        metrics: ragSourcesRef.current
+          ? {
+              ragSources: ragSourcesRef.current.sources,
+              ragQuery: ragSourcesRef.current.query,
+              ...(promptContextStatsRef.current || {})
+            }
+          : promptContextStatsRef.current || undefined
+      }
+      clearNextResponseMetrics()
+
+      const assistantId = await addMessage(sessionId, assistantMessage)
+      currentStreamingMessageIdRef.current = assistantId
+      currentStreamingSessionIdRef.current = sessionId
+
+      let durableTurn = options?.durableTurn
+      if (!durableTurn && contextMessages) {
+        let userMessageIndex = -1
+        for (let index = contextMessages.length - 1; index >= 0; index -= 1) {
+          if (contextMessages[index].role === "user") {
+            userMessageIndex = index
+            break
           }
-        : promptContextStatsRef.current || undefined
-    }
-    clearNextResponseMetrics()
-
-    const assistantId = await addMessage(sessionId, assistantMessage)
-    currentStreamingMessageIdRef.current = assistantId
-    currentStreamingSessionIdRef.current = sessionId
-
-    let durableTurn = options?.durableTurn
-    if (!durableTurn && contextMessages) {
-      let userMessageIndex = -1
-      for (let index = contextMessages.length - 1; index >= 0; index -= 1) {
-        if (contextMessages[index].role === "user") {
-          userMessageIndex = index
-          break
         }
-      }
-      const userMessage = contextMessages[userMessageIndex]
-      if (userMessage && typeof userMessage.id === "number") {
-        const turnId =
-          globalThis.crypto?.randomUUID?.() ??
-          `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`
-        durableTurn = {
-          submission: {
-            id: turnId,
-            sessionId,
-            mode: options?.mode ?? "regenerate",
-            model: modelForRequest,
-            providerId: config.selectedModelRef?.providerId,
-            request: {
-              version: 1,
-              context: {
-                rawInput: userMessage.content,
-                messages: contextMessages.slice(0, userMessageIndex),
-                hasTabContext: false,
-                contextText: "",
-                tabDocuments: [],
-                memoryEnabled: config.memoryEnabled,
-                maxTabContextChars: config.maxTabContextChars,
-                maxRagContextChars: config.maxRagContextChars,
-                groundedOnlyMode: false,
-                selectedModel: config.selectedModel,
-                selectedModelRef: config.selectedModelRef,
-                customModel
+        const userMessage = contextMessages[userMessageIndex]
+        if (userMessage && typeof userMessage.id === "number") {
+          const turnId =
+            globalThis.crypto?.randomUUID?.() ??
+            `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`
+          durableTurn = {
+            submission: {
+              id: turnId,
+              sessionId,
+              mode: options?.mode ?? "regenerate",
+              model: modelForRequest,
+              providerId: config.selectedModelRef?.providerId,
+              request: {
+                version: 1,
+                context: {
+                  rawInput: userMessage.content,
+                  messages: contextMessages.slice(0, userMessageIndex),
+                  hasTabContext: false,
+                  contextText: "",
+                  tabDocuments: [],
+                  memoryEnabled: config.memoryEnabled,
+                  maxTabContextChars: config.maxTabContextChars,
+                  maxRagContextChars: config.maxRagContextChars,
+                  groundedOnlyMode: false,
+                  selectedModel: config.selectedModel,
+                  selectedModelRef: config.selectedModelRef,
+                  customModel
+                },
+                userMessage
               },
-              userMessage
+              createdAt: Date.now()
             },
-            createdAt: Date.now()
-          },
-          userMessageId: userMessage.id
+            userMessageId: userMessage.id
+          }
         }
       }
-    }
 
-    startStream({
-      model: modelForRequest,
-      providerId: config.selectedModelRef?.providerId,
-      messages: contextMessages || messages,
-      sessionId,
-      generatedMessage: { ...assistantMessage, id: assistantId },
-      clientContextPrepared: options?.contextPrepared ?? false,
-      durableTurn: durableTurn
-        ? { ...durableTurn, assistantMessageId: assistantId }
-        : undefined
-    })
+      const started = startStream(
+        {
+          model: modelForRequest,
+          providerId: config.selectedModelRef?.providerId,
+          messages: contextMessages || messages,
+          sessionId,
+          generatedMessage: { ...assistantMessage, id: assistantId },
+          clientContextPrepared: options?.contextPrepared ?? false,
+          durableTurn: durableTurn
+            ? { ...durableTurn, assistantMessageId: assistantId }
+            : undefined
+        },
+        streamClaim
+      )
+      if (!started) {
+        throw new Error("Reserved chat stream could not start")
+      }
+      return true
+    } catch (error) {
+      releaseStreamClaim(streamClaim)
+      throw error
+    }
   }
 
   return {

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -35,6 +35,8 @@ interface StreamOptions {
   durableTurn?: DurableTurnStart & { assistantMessageId: number }
 }
 
+export type ChatStreamClaim = symbol
+
 export interface UseChatStreamProps {
   setMessages: (messages: ChatMessage[]) => void | Promise<void>
   setIsLoading: (v: boolean) => void
@@ -54,6 +56,7 @@ export const useChatStream = ({
   const { t } = useTranslation()
   const { toast } = useToast()
   const portRef = useRef<browser.Runtime.Port | null>(null)
+  const streamClaimRef = useRef<ChatStreamClaim | null>(null)
   const currentMessagesRef = useRef<ChatMessage[]>([])
   const currentRequestIdRef = useRef<string | null>(null)
   // The request id of a turn the user explicitly stopped. Lets the disconnect
@@ -67,23 +70,44 @@ export const useChatStream = ({
   // never runs on a manual stop and the row would otherwise stay `done=0`.
   const finalizeCleanRef = useRef<(() => void) | null>(null)
 
-  const startStream = ({
-    model,
-    providerId,
-    messages,
-    sessionId,
-    generatedMessage,
-    clientContextPrepared,
-    durableTurn
-  }: StreamOptions) => {
+  const claimStream = (): ChatStreamClaim | null => {
+    if (portRef.current || streamClaimRef.current) return null
+    const claim = Symbol("chat-stream-claim")
+    streamClaimRef.current = claim
+    return claim
+  }
+
+  const releaseStreamClaim = (claim: ChatStreamClaim) => {
+    if (streamClaimRef.current === claim) streamClaimRef.current = null
+  }
+
+  const startStream = (
+    {
+      model,
+      providerId,
+      messages,
+      sessionId,
+      generatedMessage,
+      clientContextPrepared,
+      durableTurn
+    }: StreamOptions,
+    claim?: ChatStreamClaim
+  ): boolean => {
     if (portRef.current) {
       logger.warn(
         "Ignored stream start while another request is active",
         "useChatStream",
         { requestId: currentRequestIdRef.current }
       )
-      return
+      if (claim) releaseStreamClaim(claim)
+      return false
     }
+    const streamClaim = claim ?? claimStream()
+    if (!streamClaim || streamClaimRef.current !== streamClaim) {
+      logger.warn("Ignored stream start without ownership", "useChatStream")
+      return false
+    }
+    streamClaimRef.current = null
     // Create port synchronously BEFORE any async operations
     let port = browser.runtime.connect({
       name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
@@ -470,6 +494,7 @@ export const useChatStream = ({
     port.onMessage.addListener(listener)
     port.onDisconnect.addListener(handleDisconnect)
     port.postMessage(requestMessage)
+    return true
   }
 
   const stopStream = () => {
@@ -510,6 +535,8 @@ export const useChatStream = ({
 
   return {
     startStream,
-    stopStream
+    stopStream,
+    claimStream,
+    releaseStreamClaim
   }
 }

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -76,6 +76,14 @@ export const useChatStream = ({
     clientContextPrepared,
     durableTurn
   }: StreamOptions) => {
+    if (portRef.current) {
+      logger.warn(
+        "Ignored stream start while another request is active",
+        "useChatStream",
+        { requestId: currentRequestIdRef.current }
+      )
+      return
+    }
     // Create port synchronously BEFORE any async operations
     let port = browser.runtime.connect({
       name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE

--- a/src/features/chat/hooks/use-chat-streaming.ts
+++ b/src/features/chat/hooks/use-chat-streaming.ts
@@ -97,106 +97,112 @@ export const useChatStreaming = ({
     }, 1000)
   }
 
-  const { startStream: baseStartStream, stopStream: baseStopStream } =
-    useChatStream({
-      setMessages: async (newMessages) => {
-        if (!currentStreamingMessageIdRef.current || newMessages.length === 0) {
-          return
-        }
-
-        const streamedMsg =
-          newMessages.find(
-            (m) => m.id === currentStreamingMessageIdRef.current
-          ) || newMessages[newMessages.length - 1]
-        if (!streamedMsg) return
-
-        // Fast path: update local state only, skipping the DB write.
-        updateMessage(
-          currentStreamingMessageIdRef.current,
-          {
-            content: streamedMsg.content,
-            thinking: streamedMsg.thinking,
-            replayArtifact: streamedMsg.replayArtifact,
-            metrics: streamedMsg.metrics,
-            done: streamedMsg.done,
-            error: streamedMsg.error
-          },
-          true
-        )
-
-        // START_TURN is persisted by DurableTurnRuntime. Writing the same row
-        // from this UI debounce lets an older token snapshot land after the
-        // background has persisted a newer or terminal snapshot. Keep Zustand
-        // immediate, but leave SQLite exclusively to the durable owner.
-        if (backgroundOwnsPersistenceRef.current) {
-          if (streamedMsg.done) {
-            if (currentSessionId) {
-              embedMessages(newMessages, currentSessionId, false).catch(
-                (err) => {
-                  logger.error("Failed to embed messages", "useChat", {
-                    error: err
-                  })
-                }
-              )
-            }
-            backgroundOwnsPersistenceRef.current = false
-          }
-          return
-        }
-
-        if (!streamedMsg.done) {
-          // Ensure the token-independent liveness beat is running for this turn.
-          startLivenessBeat(currentStreamingMessageIdRef.current)
-          debouncedDbUpdate(
-            currentStreamingMessageIdRef.current,
-            streamedMsg.content,
-            streamedMsg.thinking
-          )
-          return
-        }
-
-        // Final chunk: stop the liveness beat, flush DB immediately, embed.
-        stopLivenessBeat()
-        if (dbUpdateTimeoutRef.current) {
-          clearTimeout(dbUpdateTimeoutRef.current)
-        }
-        await updateMessage(
-          currentStreamingMessageIdRef.current,
-          {
-            content: streamedMsg.content,
-            thinking: streamedMsg.thinking,
-            replayArtifact: streamedMsg.replayArtifact,
-            metrics: streamedMsg.metrics,
-            done: true,
-            error: streamedMsg.error
-          },
-          false
-        )
-        if (currentSessionId) {
-          embedMessages(newMessages, currentSessionId, false).catch((err) => {
-            logger.error("Failed to embed messages", "useChat", { error: err })
-          })
-        }
-      },
-      setIsLoading,
-      setIsStreaming,
-      onSuccessfulResponse: async (message) => {
-        if (!message.content.trim()) return
-        try {
-          await completeOnboardingAfterFirstResponse(
-            currentStreamingSessionIdRef.current
-          )
-        } catch (error) {
-          logger.debug("Failed to complete onboarding", "useChatStreaming", {
-            error
-          })
-        }
+  const chatStream = useChatStream({
+    setMessages: async (newMessages) => {
+      if (!currentStreamingMessageIdRef.current || newMessages.length === 0) {
+        return
       }
-    })
 
-  const startStream: typeof baseStartStream = (options) => {
-    backgroundOwnsPersistenceRef.current = Boolean(options.durableTurn)
-    baseStartStream(options)
+      const streamedMsg =
+        newMessages.find(
+          (m) => m.id === currentStreamingMessageIdRef.current
+        ) || newMessages[newMessages.length - 1]
+      if (!streamedMsg) return
+
+      // Fast path: update local state only, skipping the DB write.
+      updateMessage(
+        currentStreamingMessageIdRef.current,
+        {
+          content: streamedMsg.content,
+          thinking: streamedMsg.thinking,
+          replayArtifact: streamedMsg.replayArtifact,
+          metrics: streamedMsg.metrics,
+          done: streamedMsg.done,
+          error: streamedMsg.error
+        },
+        true
+      )
+
+      // START_TURN is persisted by DurableTurnRuntime. Writing the same row
+      // from this UI debounce lets an older token snapshot land after the
+      // background has persisted a newer or terminal snapshot. Keep Zustand
+      // immediate, but leave SQLite exclusively to the durable owner.
+      if (backgroundOwnsPersistenceRef.current) {
+        if (streamedMsg.done) {
+          if (currentSessionId) {
+            embedMessages(newMessages, currentSessionId, false).catch((err) => {
+              logger.error("Failed to embed messages", "useChat", {
+                error: err
+              })
+            })
+          }
+          backgroundOwnsPersistenceRef.current = false
+        }
+        return
+      }
+
+      if (!streamedMsg.done) {
+        // Ensure the token-independent liveness beat is running for this turn.
+        startLivenessBeat(currentStreamingMessageIdRef.current)
+        debouncedDbUpdate(
+          currentStreamingMessageIdRef.current,
+          streamedMsg.content,
+          streamedMsg.thinking
+        )
+        return
+      }
+
+      // Final chunk: stop the liveness beat, flush DB immediately, embed.
+      stopLivenessBeat()
+      if (dbUpdateTimeoutRef.current) {
+        clearTimeout(dbUpdateTimeoutRef.current)
+      }
+      await updateMessage(
+        currentStreamingMessageIdRef.current,
+        {
+          content: streamedMsg.content,
+          thinking: streamedMsg.thinking,
+          replayArtifact: streamedMsg.replayArtifact,
+          metrics: streamedMsg.metrics,
+          done: true,
+          error: streamedMsg.error
+        },
+        false
+      )
+      if (currentSessionId) {
+        embedMessages(newMessages, currentSessionId, false).catch((err) => {
+          logger.error("Failed to embed messages", "useChat", { error: err })
+        })
+      }
+    },
+    setIsLoading,
+    setIsStreaming,
+    onSuccessfulResponse: async (message) => {
+      if (!message.content.trim()) return
+      try {
+        await completeOnboardingAfterFirstResponse(
+          currentStreamingSessionIdRef.current
+        )
+      } catch (error) {
+        logger.debug("Failed to complete onboarding", "useChatStreaming", {
+          error
+        })
+      }
+    }
+  })
+  const {
+    startStream: baseStartStream,
+    stopStream: baseStopStream,
+    claimStream,
+    releaseStreamClaim
+  } = chatStream
+
+  const startStream: typeof baseStartStream = (options, claim) => {
+    const started = baseStartStream(options, claim)
+    if (started) {
+      backgroundOwnsPersistenceRef.current = Boolean(options.durableTurn)
+    }
+    return started
   }
 
   const stopStream = () => {
@@ -208,6 +214,8 @@ export const useChatStreaming = ({
   return {
     startStream,
     stopStream,
+    claimStream,
+    releaseStreamClaim,
     currentStreamingMessageIdRef,
     currentStreamingSessionIdRef
   }

--- a/src/features/chat/hooks/use-chat-turn-controller.ts
+++ b/src/features/chat/hooks/use-chat-turn-controller.ts
@@ -9,6 +9,7 @@ import {
   type TurnToast
 } from "@/features/chat/hooks/turn-preparation"
 import type { useChatConfig } from "@/features/chat/hooks/use-chat-config"
+import type { ChatStreamClaim } from "@/features/chat/hooks/use-chat-stream"
 import { loadStreamStore } from "@/features/chat/stores/load-stream-store"
 import type { ProcessedFile } from "@/lib/file-processors/types"
 import { logger } from "@/lib/logger"
@@ -41,8 +42,11 @@ interface UseChatTurnControllerOptions {
       contextPrepared?: boolean
       durableTurn?: DurableTurnStart
       mode?: import("@ollama-client/contracts/turns").TurnMode
+      streamClaim?: ChatStreamClaim
     }
   ) => Promise<boolean>
+  claimResponseStream: () => ChatStreamClaim | null
+  releaseResponseStreamClaim: (claim: ChatStreamClaim) => void
   toast: ToastFn
 }
 
@@ -60,6 +64,8 @@ export const useChatTurnController = ({
   autoRenameSession,
   addMessage,
   generateResponse,
+  claimResponseStream,
+  releaseResponseStreamClaim,
   toast
 }: UseChatTurnControllerOptions) => {
   const [pendingActivityEvents, setPendingActivityEvents] = useState<
@@ -111,6 +117,12 @@ export const useChatTurnController = ({
       return false
     }
 
+    // Reserve response ownership before creating a session or persisting the
+    // user turn. Fork and regenerate use the same claim, so none of these
+    // actions can overtake an ordinary send while its durable work is pending.
+    const streamClaim = claimResponseStream()
+    if (!streamClaim) return false
+
     setIsLoading(true)
     const preparingEvent: ActivityEvent = {
       id: "preparing-context",
@@ -130,6 +142,7 @@ export const useChatTurnController = ({
       logger.error("Failed to create chat session", "useChat", { error })
       setPendingActivityEvents([])
       setIsLoading(false)
+      releaseResponseStreamClaim(streamClaim)
       toast({
         variant: "destructive",
         title: t("chat.errors.chat_create_failed_title"),
@@ -140,6 +153,7 @@ export const useChatTurnController = ({
     if (!sessionId) {
       setPendingActivityEvents([])
       setIsLoading(false)
+      releaseResponseStreamClaim(streamClaim)
       return false
     }
 
@@ -161,6 +175,7 @@ export const useChatTurnController = ({
       logger.error("Failed to persist user message", "useChat", { error })
       setPendingActivityEvents([])
       setIsLoading(false)
+      releaseResponseStreamClaim(streamClaim)
       toast({
         variant: "destructive",
         title: t("chat.errors.message_save_failed_title"),
@@ -217,16 +232,26 @@ export const useChatTurnController = ({
     }
 
     try {
-      await generateResponse(
+      const submitted = await generateResponse(
         customModel,
         sessionId,
         [...messages, userMessage],
         {
-          durableTurn
+          durableTurn,
+          streamClaim
         }
       )
+      if (!submitted) {
+        releaseResponseStreamClaim(streamClaim)
+        setPendingActivityEvents([])
+        setIsLoading(false)
+        setIsStreaming(false)
+        return false
+      }
     } catch (error) {
       logger.error("Failed to submit durable turn", "useChat", { error })
+      releaseResponseStreamClaim(streamClaim)
+      setPendingActivityEvents([])
       setIsLoading(false)
       setIsStreaming(false)
       toast({

--- a/src/features/chat/hooks/use-chat-turn-controller.ts
+++ b/src/features/chat/hooks/use-chat-turn-controller.ts
@@ -42,7 +42,7 @@ interface UseChatTurnControllerOptions {
       durableTurn?: DurableTurnStart
       mode?: import("@ollama-client/contracts/turns").TurnMode
     }
-  ) => Promise<void>
+  ) => Promise<boolean>
   toast: ToastFn
 }
 

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -71,6 +71,8 @@ export const useChat = () => {
   const {
     startStream,
     stopStream,
+    claimStream,
+    releaseStreamClaim,
     currentStreamingMessageIdRef,
     currentStreamingSessionIdRef
   } = useChatStreaming({
@@ -110,6 +112,8 @@ export const useChat = () => {
     messages,
     addMessage,
     startStream,
+    claimStream,
+    releaseStreamClaim,
     currentStreamingMessageIdRef,
     currentStreamingSessionIdRef
   })
@@ -157,6 +161,8 @@ export const useChat = () => {
     isModelReady,
     sendMessage,
     generateResponse,
+    claimResponseStream: claimStream,
+    releaseResponseStreamClaim: releaseStreamClaim,
     stopGeneration: stopStream,
     scrollRef,
     hasMore: hasMoreMessages,

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -146,6 +146,8 @@ export const useChat = () => {
     autoRenameSession,
     addMessage,
     generateResponse,
+    claimResponseStream: claimStream,
+    releaseResponseStreamClaim: releaseStreamClaim,
     toast
   })
 

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -16,6 +16,7 @@ import { DEFAULT_TABS_ACCESS, STORAGE_KEYS } from "@/lib/constants"
 import {
   DEFAULT_PER_SITE_PROFILE_SETTINGS,
   type PerSiteProfileSettings,
+  parsePerSiteProfileSettings,
   resolveGroundedOnlyModeForUrls
 } from "@/lib/per-site-profiles"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
@@ -44,7 +45,8 @@ export const useChat = () => {
     DEFAULT_PER_SITE_PROFILE_SETTINGS
   )
   const { tabs: openTabs } = useOpenTabs(Boolean(tabAccess))
-  const perSiteProfileList = perSiteProfiles?.profiles ?? EMPTY_PROFILE_LIST
+  const perSiteProfileList =
+    parsePerSiteProfileSettings(perSiteProfiles).profiles ?? EMPTY_PROFILE_LIST
   const { isLoading, setIsLoading, isStreaming, setIsStreaming } =
     useLoadStream()
 

--- a/src/features/chat/hooks/use-context-settings.ts
+++ b/src/features/chat/hooks/use-context-settings.ts
@@ -22,7 +22,8 @@ import {
 } from "@/lib/constants"
 import {
   DEFAULT_PER_SITE_PROFILE_SETTINGS,
-  type PerSiteProfileSettings
+  type PerSiteProfileSettings,
+  parsePerSiteProfileSettings
 } from "@/lib/per-site-profiles"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import type { ContentExtractionConfig } from "@/types"
@@ -165,6 +166,8 @@ export const useContextSettings = () => {
     toggleActions,
     excludedPatterns:
       config?.excludedUrlPatterns || oldPatterns || DEFAULT_EXCLUDE_URLS,
-    perSiteProfileList: perSiteProfiles?.profiles ?? EMPTY_PROFILE_LIST
+    perSiteProfileList:
+      parsePerSiteProfileSettings(perSiteProfiles).profiles ??
+      EMPTY_PROFILE_LIST
   }
 }

--- a/src/features/model/components/content-extraction-settings.tsx
+++ b/src/features/model/components/content-extraction-settings.tsx
@@ -30,7 +30,8 @@ import {
   createPerSiteProfile,
   DEFAULT_PER_SITE_PROFILE_SETTINGS,
   type PerSiteProfile,
-  type PerSiteProfileSettings
+  type PerSiteProfileSettings,
+  parsePerSiteProfileSettings
 } from "@/lib/per-site-profiles"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { cn } from "@/lib/utils"
@@ -83,7 +84,7 @@ export const ContentExtractionSettings = () => {
       }
     })
     setPerSiteProfileSettings((prev) => {
-      const profiles = prev?.profiles ?? []
+      const profiles = parsePerSiteProfileSettings(prev).profiles
       if (profiles.some((profile) => profile.pattern === pattern))
         return prev ?? DEFAULT_PER_SITE_PROFILE_SETTINGS
       return {
@@ -106,7 +107,7 @@ export const ContentExtractionSettings = () => {
       return { ...base, siteOverrides: remaining }
     })
     setPerSiteProfileSettings((prev) => ({
-      profiles: (prev?.profiles ?? []).filter(
+      profiles: parsePerSiteProfileSettings(prev).profiles.filter(
         (profile) => profile.pattern !== pattern
       )
     }))
@@ -137,7 +138,7 @@ export const ContentExtractionSettings = () => {
     updates: Partial<Pick<PerSiteProfile, "tabContext" | "groundedOnly">>
   ) => {
     setPerSiteProfileSettings((prev) => {
-      const profiles = prev?.profiles ?? []
+      const profiles = parsePerSiteProfileSettings(prev).profiles
       const existing = profiles.find((profile) => profile.pattern === pattern)
       const nextProfile = existing
         ? { ...existing, ...updates }
@@ -187,7 +188,9 @@ export const ContentExtractionSettings = () => {
       <SettingsLevelGate settingId="site-overrides">
         <SiteSpecificOverrides
           config={config}
-          perSiteProfiles={perSiteProfileSettings?.profiles ?? []}
+          perSiteProfiles={
+            parsePerSiteProfileSettings(perSiteProfileSettings).profiles
+          }
           onAddSiteOverride={handleAddSiteOverride}
           onRemoveSiteOverride={handleRemoveSiteOverride}
           onUpdateSiteOverride={handleUpdateSiteOverride}

--- a/src/features/model/hooks/use-model-config.ts
+++ b/src/features/model/hooks/use-model-config.ts
@@ -1,21 +1,25 @@
 import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useMemo } from "react"
 import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
-import { normalizeStoredModelConfig } from "@/lib/model-config-utils"
+import {
+  normalizeStoredModelConfig,
+  parseStoredModelConfigMap,
+  type StoredModelConfigMap
+} from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
 export type ProviderModelConfig = typeof DEFAULT_MODEL_CONFIG
 
 export const useModelConfig = (modelName: string) => {
-  const [modelConfigs, setModelConfigs] = useStorage<
-    Record<string, typeof DEFAULT_MODEL_CONFIG>
-  >(
+  const [modelConfigs, setModelConfigs] = useStorage<StoredModelConfigMap>(
     { key: STORAGE_KEYS.PROVIDER.MODEL_CONFIGS, instance: plasmoGlobalStorage },
     {}
   )
 
   const config = useMemo(() => {
-    const stored = normalizeStoredModelConfig(modelConfigs?.[modelName])
+    const stored = normalizeStoredModelConfig(
+      parseStoredModelConfigMap(modelConfigs)[modelName]
+    )
     return {
       ...DEFAULT_MODEL_CONFIG,
       ...(stored ?? {})
@@ -25,9 +29,10 @@ export const useModelConfig = (modelName: string) => {
   const update = useCallback(
     (newConfig: Partial<typeof DEFAULT_MODEL_CONFIG>) => {
       setModelConfigs((prev) => {
-        const prevConfig = normalizeStoredModelConfig(prev?.[modelName]) ?? {}
+        const parsed = parseStoredModelConfigMap(prev)
+        const prevConfig = normalizeStoredModelConfig(parsed[modelName]) ?? {}
         return {
-          ...prev,
+          ...parsed,
           [modelName]: {
             ...DEFAULT_MODEL_CONFIG,
             ...prevConfig,

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -16,7 +16,8 @@ import {
   isCustomProviderId,
   type ProviderConfig,
   ProviderId,
-  type ProviderServiceProfile
+  ProviderServiceProfile,
+  ProviderType
 } from "@/lib/providers/types"
 import { extensionRpcClient } from "@/protocol/extension-client"
 import { useProviderHealth } from "./use-provider-health"
@@ -33,7 +34,40 @@ type ProviderSettingsConfig = ProviderConfig & {
 
 const toSettingsConfig = (
   provider: PublicProviderConfig
-): ProviderSettingsConfig => provider as unknown as ProviderSettingsConfig
+): ProviderSettingsConfig => ({
+  id: provider.id,
+  type:
+    provider.type === "ollama"
+      ? ProviderType.OLLAMA
+      : provider.type === "openai"
+        ? ProviderType.OPENAI
+        : provider.type === "anthropic"
+          ? ProviderType.ANTHROPIC
+          : ProviderType.CUSTOM,
+  enabled: provider.enabled,
+  name: provider.name,
+  hasApiKey: provider.hasApiKey,
+  ...(provider.baseUrl !== undefined ? { baseUrl: provider.baseUrl } : {}),
+  ...(provider.modelId !== undefined ? { modelId: provider.modelId } : {}),
+  ...(provider.customModels !== undefined
+    ? { customModels: provider.customModels }
+    : {}),
+  ...(provider.serviceProfile !== undefined
+    ? {
+        serviceProfile:
+          provider.serviceProfile === "openai"
+            ? ProviderServiceProfile.OPENAI
+            : provider.serviceProfile === "anthropic"
+              ? ProviderServiceProfile.ANTHROPIC
+              : provider.serviceProfile === "openrouter"
+                ? ProviderServiceProfile.OPENROUTER
+                : ProviderServiceProfile.GENERIC
+      }
+    : {}),
+  ...(provider.compatibility !== undefined
+    ? { compatibility: provider.compatibility }
+    : {})
+})
 
 const isLocalhostEndpoint = (baseUrl?: string) => {
   const url = baseUrl?.trim()

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { logger } from "@/lib/logger"
 import * as repo from "@/lib/repositories/chat-history"
 import { chatSessionStore } from "../chat-session-store"
 
@@ -43,6 +44,63 @@ function resetStore() {
 beforeEach(() => {
   resetStore()
   vi.clearAllMocks()
+})
+
+describe("loadMoreMessages", () => {
+  it("does not publish pagination state after the active session changes", async () => {
+    let resolveParent: (value: unknown) => void = () => undefined
+    mockRepo.getMessage.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveParent = resolve
+        }) as any
+    )
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "Old",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [
+            {
+              id: 2,
+              parentId: 1,
+              role: "assistant" as const,
+              content: "latest"
+            }
+          ]
+        },
+        {
+          id: "session-new",
+          title: "New",
+          createdAt: 2,
+          updatedAt: 2,
+          messages: []
+        }
+      ],
+      currentSessionId: SESSION_ID,
+      hasMoreMessages: true
+    })
+
+    const pending = chatSessionStore.getState().loadMoreMessages()
+    chatSessionStore.setState({
+      currentSessionId: "session-new",
+      hasMoreMessages: false
+    })
+    resolveParent({
+      id: 1,
+      sessionId: SESSION_ID,
+      role: "user",
+      content: "older"
+    })
+    await pending
+
+    expect(chatSessionStore.getState().hasMoreMessages).toBe(false)
+    expect(chatSessionStore.getState().sessions[0].messages).toHaveLength(1)
+    expect(mockRepo.getFilesByMessageIds).not.toHaveBeenCalled()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -308,6 +366,54 @@ describe("updateMessage", () => {
     // deleteVectors is called asynchronously — flush microtasks
     await Promise.resolve()
     expect(deleteVectors).toHaveBeenCalledWith({ messageId: 11 })
+  })
+})
+
+describe("deleteMessage", () => {
+  it("contains a failed post-delete refresh", async () => {
+    mockRepo.getMessage.mockResolvedValue({
+      id: 11,
+      sessionId: SESSION_ID,
+      role: "user",
+      content: "delete me"
+    } as any)
+    mockRepo.getMessagesBySession.mockResolvedValue([
+      { id: 11, sessionId: SESSION_ID }
+    ] as any)
+    mockRepo.getSession
+      .mockResolvedValueOnce({ id: SESSION_ID, currentLeafId: 11 } as any)
+      .mockRejectedValueOnce(new Error("read-back failed"))
+    mockRepo.updateSession.mockResolvedValue(undefined as any)
+    mockRepo.bulkDeleteMessages.mockResolvedValue(undefined as any)
+    mockRepo.deleteFilesByMessageIds.mockResolvedValue(undefined as any)
+
+    chatSessionStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 11, role: "user", content: "delete me" }],
+          currentLeafId: 11
+        }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await expect(
+      chatSessionStore.getState().deleteMessage(11)
+    ).resolves.toBeUndefined()
+    expect(chatSessionStore.getState().sessions[0].messages).toEqual([])
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to refresh messages after delete",
+      "chatSessionStore",
+      expect.objectContaining({
+        error: expect.any(Error),
+        sessionId: SESSION_ID,
+        messageId: 11
+      })
+    )
   })
 })
 

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -17,6 +17,7 @@ import type { ChatMessage, ChatSessionState } from "@/types"
 import type { ChatSessionGet, ChatSessionSet } from "./chat-session-store-types"
 
 let loadSessionMessagesRequestId = 0
+let loadMoreMessagesRequestId = 0
 
 export const createChatSessionMessageActions = (
   set: ChatSessionSet,
@@ -96,6 +97,10 @@ export const createChatSessionMessageActions = (
   loadMoreMessages: async () => {
     const { currentSessionId, sessions } = get()
     if (!currentSessionId) return
+    const requestId = ++loadMoreMessagesRequestId
+    const isStaleLoad = () =>
+      requestId !== loadMoreMessagesRequestId ||
+      get().currentSessionId !== currentSessionId
 
     const currentSession = sessions.find((s) => s.id === currentSessionId)
     if (!currentSession?.messages?.length) return
@@ -112,12 +117,14 @@ export const createChatSessionMessageActions = (
       CHAT_PAGINATION_LIMIT,
       (id) => repo.getMessage(id)
     )
+    if (isStaleLoad()) return
 
     const messageIds = path
       .map((m) => m.id)
       .filter((id): id is number => typeof id === "number")
     const files =
       messageIds.length > 0 ? await repo.getFilesByMessageIds(messageIds) : []
+    if (isStaleLoad()) return
     const filesByMessageId = groupFilesByMessageId(files)
 
     const parentIds = path
@@ -126,10 +133,12 @@ export const createChatSessionMessageActions = (
     let siblingCandidates: ChatMessage[] = []
     if (parentIds.length > 0) {
       siblingCandidates = await repo.getMessagesByParents(parentIds)
+      if (isStaleLoad()) return
     }
     if (path.some((m) => !m.parentId)) {
       const rootSiblings =
         await repo.getRootMessagesForSession(currentSessionId)
+      if (isStaleLoad()) return
       siblingCandidates = [...siblingCandidates, ...rootSiblings]
     }
     const siblingsMap = buildSiblingsMap(siblingCandidates)
@@ -375,6 +384,16 @@ export const createChatSessionMessageActions = (
       )
     }))
 
-    get().loadSessionMessages(sessionId)
+    try {
+      await get().loadSessionMessages(sessionId)
+    } catch (error) {
+      // The delete and local state update already succeeded. Keep that state
+      // usable and report only the failed read-back.
+      logger.error(
+        "Failed to refresh messages after delete",
+        "chatSessionStore",
+        { error, sessionId, messageId }
+      )
+    }
   }
 })

--- a/src/lib/__tests__/model-config-utils.test.ts
+++ b/src/lib/__tests__/model-config-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 import { DEFAULT_MODEL_CONFIG } from "@/lib/constants"
-import { resolveModelConfig } from "@/lib/model-config-utils"
+import {
+  parseStoredModelConfigMap,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 
 describe("resolveModelConfig", () => {
   it("uses 64k context when no stored config exists", () => {
@@ -15,5 +18,19 @@ describe("resolveModelConfig", () => {
 
   it("preserves custom context size", () => {
     expect(resolveModelConfig({ num_ctx: 32768 }).num_ctx).toBe(32768)
+  })
+})
+
+describe("parseStoredModelConfigMap", () => {
+  it("rejects malformed stored settings", () => {
+    expect(
+      parseStoredModelConfigMap({ model: { temperature: "hot" } })
+    ).toEqual({})
+  })
+
+  it("accepts partial model settings", () => {
+    expect(parseStoredModelConfigMap({ model: { temperature: 0.25 } })).toEqual(
+      { model: { temperature: 0.25 } }
+    )
   })
 })

--- a/src/lib/__tests__/per-site-profiles.test.ts
+++ b/src/lib/__tests__/per-site-profiles.test.ts
@@ -26,6 +26,17 @@ describe("per-site profiles", () => {
     })
   })
 
+  it("rejects malformed stored profile settings", async () => {
+    const { getPerSiteProfileSettings } = await import(
+      "@/lib/per-site-profiles"
+    )
+    mocks.getPlasmoStoredValue.mockResolvedValue({
+      profiles: [{ id: "broken", pattern: 42 }]
+    })
+
+    await expect(getPerSiteProfileSettings()).resolves.toEqual({ profiles: [] })
+  })
+
   it("matches enabled profiles by URL pattern", async () => {
     const { getMatchingPerSiteProfile } = await import(
       "@/lib/per-site-profiles"

--- a/src/lib/model-config-utils.ts
+++ b/src/lib/model-config-utils.ts
@@ -1,8 +1,43 @@
+import { z } from "zod"
 import {
   DEFAULT_MODEL_CONFIG,
   LEGACY_DEFAULT_MODEL_CONTEXT_SIZE
 } from "@/lib/constants"
 import type { ModelConfig } from "@/types"
+
+export const ModelConfigSchema = z
+  .object({
+    temperature: z.number(),
+    top_k: z.number(),
+    top_p: z.number(),
+    repeat_penalty: z.number(),
+    stop: z.array(z.string()),
+    system: z.string(),
+    num_ctx: z.number(),
+    repeat_last_n: z.number(),
+    seed: z.number(),
+    num_predict: z.number(),
+    min_p: z.number(),
+    num_thread: z.number().optional(),
+    num_gpu: z.number().optional(),
+    num_batch: z.number().optional(),
+    keep_alive: z.union([z.string(), z.number()]).optional(),
+    warm_on_select: z.boolean().optional(),
+    unload_on_switch: z.boolean().optional()
+  })
+  .partial()
+  .passthrough()
+
+export const ModelConfigMapSchema = z.record(z.string(), ModelConfigSchema)
+
+export type StoredModelConfigMap = Record<string, Partial<ModelConfig>>
+
+export const parseStoredModelConfigMap = (
+  value: unknown
+): StoredModelConfigMap => {
+  const parsed = ModelConfigMapSchema.safeParse(value)
+  return parsed.success ? parsed.data : {}
+}
 
 export const normalizeStoredModelConfig = (
   stored?: Partial<ModelConfig>

--- a/src/lib/per-site-profiles.ts
+++ b/src/lib/per-site-profiles.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { STORAGE_KEYS } from "@/lib/constants"
 import {
   getPlasmoStoredValue,
@@ -20,19 +21,42 @@ export interface PerSiteProfileSettings {
   profiles: PerSiteProfile[]
 }
 
+const PerSiteRuleModeSchema = z.enum(["inherit", "always", "never"])
+
+export const PerSiteProfileSettingsSchema = z
+  .object({
+    profiles: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          name: z.string(),
+          pattern: z.string(),
+          enabled: z.boolean(),
+          tabContext: PerSiteRuleModeSchema,
+          groundedOnly: PerSiteRuleModeSchema
+        })
+        .strict()
+    )
+  })
+  .strict()
+
 export const DEFAULT_PER_SITE_PROFILE_SETTINGS: PerSiteProfileSettings = {
   profiles: []
 }
 
+export const parsePerSiteProfileSettings = (
+  value: unknown
+): PerSiteProfileSettings => {
+  const parsed = PerSiteProfileSettingsSchema.safeParse(value)
+  return parsed.success ? parsed.data : DEFAULT_PER_SITE_PROFILE_SETTINGS
+}
+
 export const getPerSiteProfileSettings =
   async (): Promise<PerSiteProfileSettings> => {
-    const stored = await getPlasmoStoredValue<Partial<PerSiteProfileSettings>>(
+    const stored = await getPlasmoStoredValue<unknown>(
       STORAGE_KEYS.BROWSER.PER_SITE_PROFILES
     )
-
-    return {
-      profiles: Array.isArray(stored?.profiles) ? stored.profiles : []
-    }
+    return parsePerSiteProfileSettings(stored)
   }
 
 export const setPerSiteProfileSettings = async (

--- a/src/lib/providers/__tests__/contract.test.ts
+++ b/src/lib/providers/__tests__/contract.test.ts
@@ -188,6 +188,23 @@ describe("provider contracts", () => {
     }
   })
 
+  it("OpenAI-compatible providers reject malformed model catalogs", async () => {
+    const provider = new OpenAICompatibleProvider({
+      id: ProviderId.OPENAI,
+      name: "OpenAI",
+      type: ProviderType.OPENAI,
+      enabled: true,
+      baseUrl: "http://openai.test/v1"
+    })
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ data: [{ id: 42 }] }))
+
+    await expect(provider.getModels()).rejects.toMatchObject({
+      message: "Provider returned an invalid model catalog",
+      kind: "provider",
+      phase: "response"
+    })
+  })
+
   it("shares terminal SSE handling across compatible provider classes", async () => {
     const providers = [
       new OpenAICompatibleProvider({

--- a/src/lib/providers/model-rpc-service.ts
+++ b/src/lib/providers/model-rpc-service.ts
@@ -16,14 +16,17 @@ import type {
 import { DEFAULT_MODEL_LIBRARY_BASE_URL, STORAGE_KEYS } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { resolveModelConfig } from "@/lib/model-config-utils"
+import {
+  parseStoredModelConfigMap,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderManager } from "@/lib/providers/manager"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { ProviderId } from "@/lib/providers/types"
-import type { ModelConfigMap, ProviderModelDetails } from "@/types"
+import type { ProviderModelDetails } from "@/types"
 
 /**
  * Background-owned model lifecycle and catalog operations behind the RPC
@@ -141,10 +144,9 @@ const parseKeepAliveMs = (value?: string | number): number | undefined => {
 }
 
 const getModelConfig = async (model: string) => {
-  const configs =
-    (await plasmoGlobalStorage.get<ModelConfigMap>(
-      STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
-    )) ?? {}
+  const configs = parseStoredModelConfigMap(
+    await plasmoGlobalStorage.get<unknown>(STORAGE_KEYS.PROVIDER.MODEL_CONFIGS)
+  )
   return resolveModelConfig(configs[model])
 }
 

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -2,6 +2,7 @@ import {
   isRetryableProviderStatus,
   parseRetryAfter
 } from "@ollama-client/runtime-core/retry"
+import { z } from "zod"
 import { createAppError } from "@/lib/error-utils"
 import { toDataUrl } from "@/lib/image-utils"
 import { logger } from "@/lib/logger"
@@ -33,6 +34,26 @@ import {
   ProviderId,
   ProviderServiceProfile
 } from "./types"
+
+const OpenAIModelCatalogSchema = z
+  .object({
+    data: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          context_length: z.number().positive().nullish(),
+          architecture: z
+            .object({
+              input_modalities: z.array(z.string()).nullish()
+            })
+            .passthrough()
+            .nullish(),
+          supported_parameters: z.array(z.string()).nullish()
+        })
+        .passthrough()
+    )
+  })
+  .passthrough()
 
 /** Normalized tool → OpenAI `tools` entry. */
 const toOpenAITool = (tool: ToolDefinition) => ({
@@ -239,53 +260,52 @@ export class OpenAICompatibleProvider implements LLMProvider {
       if (!response.ok) {
         await this.responseError(response, "Model list failed", baseUrl)
       }
-      const data = await response.json()
-      return (
-        (
-          data.data as Array<{
-            id: string
-            context_length?: number
-            architecture?: {
-              input_modalities?: string[]
-            }
-            supported_parameters?: string[]
-          }>
-        )?.map((m) => ({
-          name: m.id,
-          model: m.id,
-          modified_at: new Date().toISOString(),
-          size: 0,
-          digest: "",
-          details: {
-            parent_model: "",
-            format: "",
-            family: "openai",
-            families: [],
-            // `/v1/models` reports no size: the OpenAI schema has no field for
-            // one, and neither vLLM, LocalAI, KoboldCPP, nor an LM Studio
-            // fallback list adds one. So a self-hosted "Qwen3-8B" showed a
-            // blank badge beside genuine sizes from Ollama and llama.cpp. The
-            // id is the only source, and the parser refuses ambiguous ids
-            // rather than guessing, so hosted catalogs naming no size (gpt-4o)
-            // stay blank instead of inventing one.
-            parameter_size: parameterSizeFromModelId(m.id),
-            quantization_level: ""
-          },
-          ...((m.context_length ||
-            m.architecture?.input_modalities ||
-            m.supported_parameters) && {
-            capabilityHints: {
-              ...(m.context_length ? { contextLength: m.context_length } : {}),
-              ...(m.architecture?.input_modalities && {
-                modalities: [...new Set(m.architecture.input_modalities)]
-              }),
-              ...(m.supported_parameters && {
-                supportedParameters: m.supported_parameters
-              })
-            }
-          })
-        })) || []
-      )
+      const parsed = OpenAIModelCatalogSchema.safeParse(await response.json())
+      if (!parsed.success) {
+        throw createAppError("Provider returned an invalid model catalog", {
+          kind: "provider",
+          phase: "response",
+          providerId: this.id,
+          providerName: this.config.name,
+          baseUrl,
+          userMessage: "The provider returned an invalid model list."
+        })
+      }
+      return parsed.data.data.map((m) => ({
+        name: m.id,
+        model: m.id,
+        modified_at: new Date().toISOString(),
+        size: 0,
+        digest: "",
+        details: {
+          parent_model: "",
+          format: "",
+          family: "openai",
+          families: [],
+          // `/v1/models` reports no size: the OpenAI schema has no field for
+          // one, and neither vLLM, LocalAI, KoboldCPP, nor an LM Studio
+          // fallback list adds one. So a self-hosted "Qwen3-8B" showed a
+          // blank badge beside genuine sizes from Ollama and llama.cpp. The
+          // id is the only source, and the parser refuses ambiguous ids
+          // rather than guessing, so hosted catalogs naming no size (gpt-4o)
+          // stay blank instead of inventing one.
+          parameter_size: parameterSizeFromModelId(m.id),
+          quantization_level: ""
+        },
+        ...((m.context_length ||
+          m.architecture?.input_modalities ||
+          m.supported_parameters) && {
+          capabilityHints: {
+            ...(m.context_length ? { contextLength: m.context_length } : {}),
+            ...(m.architecture?.input_modalities && {
+              modalities: [...new Set(m.architecture.input_modalities)]
+            }),
+            ...(m.supported_parameters && {
+              supportedParameters: m.supported_parameters
+            })
+          }
+        })
+      }))
     } catch (e) {
       if (!signal?.aborted) {
         logger.error("Failed to fetch models", "OpenAICompatibleProvider", {


### PR DESCRIPTION
## Summary

- prevent stale session pagination writes and duplicate active streams
- validate OpenAI model catalogs, model settings, and per-site profiles
- remove provider settings double cast and extract retained router handlers
- correct architecture documentation and add startup timeout evidence
- verify durable turn recovery through a fake Ollama server after Chromium restart

## Why

Architecture audit found stale async state publication, unchecked external and stored data, unclear stream ownership, and missing browser-level durable restart proof. These fixes harden those boundaries without changing persistence ownership.

Startup timeout coverage intentionally records current abandon-versus-cancel overlap. Cancellable startup recovery remains separately tracked.

## Validation

- pnpm typecheck
- pnpm lint:check
- pnpm test:run (341 files, 2860 tests)
- pnpm docs:build
- pnpm generate:resources
- pnpm benchmark:build
- Chromium durable restart E2E
- pre-commit and pre-push gates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens audited runtime boundaries while preserving the background-owned durable-turn architecture.
- Reserves chat stream ownership before send, fork, and regeneration persistence work and propagates stream-start rejection.
- Validates stored model configuration, provider catalogs, and per-site settings before use.
- Adds durable browser-restart coverage, startup-overlap evidence, pagination race protection, and supporting contract tests.
- Extracts retained message-router handlers and corrects architecture documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the three previously reported stream-ownership races are addressed by acquiring one identity-checked claim before any durable mutation and retaining active-port exclusion through completion.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/chat/hooks/use-chat-stream.ts | Adds identity-based pre-stream claims while retaining active-port ownership and request-id-guarded reconnection. |
| src/features/chat/hooks/use-chat-turn-controller.ts | Claims stream ownership before session or message persistence and propagates submission rejection to callers. |
| src/features/chat/hooks/use-chat-response.ts | Consumes reserved claims, returns explicit submission status, and preserves durable assistant placeholders. |
| src/features/chat/components/chat.tsx | Applies the shared ownership claim before fork and regeneration mutations and suppresses busy fork actions. |
| src/features/sessions/stores/chat-session-message-actions.ts | Prevents stale pagination results from publishing after the session or request generation changes. |
| src/lib/providers/openai-compatible.ts | Validates and normalizes OpenAI-compatible catalog responses before exposing model records. |
| src/lib/model-config-utils.ts | Adds runtime parsing for persisted per-model configuration maps. |
| src/entrypoints/persistence-verify/main.ts | Adds a development verification API for seeding and observing durable turn recovery across browser restarts. |
| e2e/chromium/critical/__tests__/persistence.spec.ts | Exercises durable generating-turn recovery after a Chromium restart against a local fake Ollama server. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Chat UI
  participant Claim as Stream ownership
  participant DB as Durable chat store
  participant BG as Background turn owner
  participant Provider as Model provider

  UI->>Claim: Claim response stream
  alt Claim unavailable
    Claim-->>UI: Reject before persistence
  else Claim acquired
    UI->>DB: Persist user or branch mutation
    UI->>DB: Persist assistant placeholder
    UI->>BG: Start durable turn with claim
    BG->>Provider: Begin generation
    Provider-->>BG: Stream response events
    BG->>DB: Persist durable progress and completion
    BG-->>UI: Deliver sequenced stream updates
    BG-->>Claim: Release active port on terminal state
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(chat): reserve ordinary send streams"](https://github.com/shishir435/ollama-client/commit/19f56d5ee0e3c3e31fd75d44ef6ebd02a48f9c56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52292427)</sub>

**Context used:**

- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)
- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)

<!-- /greptile_comment -->