### PR TITLE
refactor(storage): migrate settings UI

### DIFF
--- a/src/components/bug-report-icon.tsx
+++ b/src/components/bug-report-icon.tsx
@@ -1,32 +1,18 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import type { LucideIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { TooltipActionButton } from "@/components/actions"
 import { buttonVariants } from "@/components/ui/button"
-import { STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
 import { SOCIAL_LINKS } from "@/lib/constants-ui"
 import { buildGenericIssueReportUrl } from "@/lib/error-report"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import { cn } from "@/lib/utils"
-import type { SelectedModelRef } from "@/types/model"
 
 export const BugReportIcon = ({ showText = true }: { showText?: boolean }) => {
   const { t } = useTranslation()
   const bugLink = SOCIAL_LINKS.find((link) => link.id === "bug_report")
-  const [selectedModelRef] = useStorage<SelectedModelRef | null>(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
-      instance: plasmoGlobalStorage
-    },
-    null
-  )
-  const [selectedModel] = useStorage<string>(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    ""
-  )
+  const [selectedModelRef] = useSetting(SETTINGS.SELECTED_MODEL_REF)
+  const [selectedModel] = useSetting(SETTINGS.SELECTED_MODEL)
 
   if (!bugLink) return null
 

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -1,18 +1,15 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { Globe } from "lucide-react"
 import { Trans, useTranslation } from "react-i18next"
 import { SettingsCard, SettingsSelectField } from "@/components/settings"
 import { SelectItem } from "@/components/ui/select"
+import { useSetting } from "@/hooks/use-setting"
 import { LANGUAGES } from "@/i18n/languages"
-import { EXTERNAL_URLS, STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { EXTERNAL_URLS } from "@/lib/constants"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const LanguageSelector = () => {
   const { t, i18n } = useTranslation()
-  const [_, setStoredLanguage] = useStorage({
-    key: STORAGE_KEYS.LANGUAGE,
-    instance: plasmoGlobalStorage
-  })
+  const [_, setStoredLanguage] = useSetting(SETTINGS.LANGUAGE)
 
   return (
     <SettingsCard

--- a/src/features/chat/components/__tests__/context-settings-menu.test.tsx
+++ b/src/features/chat/components/__tests__/context-settings-menu.test.tsx
@@ -17,21 +17,21 @@ const mocks = vi.hoisted(() => ({
   perSiteProfiles: { profiles: [] as unknown[] }
 }))
 
-vi.mock("@plasmohq/storage/hook", () => ({
-  useStorage: vi.fn((config: { key: string }) => {
-    if (config.key === "embeddings-use-rag") {
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn((descriptor: { key: string; defaultValue: unknown }) => {
+    if (descriptor.key === "embeddings-use-rag") {
       return [true, mocks.setUseRag]
     }
-    if (config.key === "browser-tab-access") {
+    if (descriptor.key === "browser-tab-access") {
       return [true, mocks.setTabAccess]
     }
-    if (config.key === "chat-grounded-only-mode") {
+    if (descriptor.key === "chat-grounded-only-mode") {
       return [false, mocks.setGroundedOnlyMode]
     }
-    if (config.key === "browser-per-site-profiles") {
+    if (descriptor.key === "browser-per-site-profiles") {
       return [mocks.perSiteProfiles, vi.fn()]
     }
-    return [undefined, vi.fn()]
+    return [descriptor.defaultValue, vi.fn()]
   })
 }))
 

--- a/src/features/chat/components/chat-backfill-card.tsx
+++ b/src/features/chat/components/chat-backfill-card.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { AlertCircle, Loader2, Sparkles } from "lucide-react"
 import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -8,20 +7,14 @@ import { Progress } from "@/components/ui/progress"
 import { useAutoEmbedMessages } from "@/features/chat/hooks/use-auto-embed-messages"
 import { getEmbeddableMessagesBySession } from "@/features/chat/utils/embedding-backfill"
 import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
-import { DEFAULT_MEMORY_ENABLED, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const ChatBackfillCard = () => {
   const { t } = useTranslation()
-  const [memoryEnabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.MEMORY.ENABLED,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MEMORY_ENABLED
-  )
+  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
   const [isRunning, setIsRunning] = useState(false)
   const [progress, setProgress] = useState({ current: 0, total: 0 })
   const [error, setError] = useState<string | null>(null)

--- a/src/features/chat/components/chat-input-box.tsx
+++ b/src/features/chat/components/chat-input-box.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Textarea } from "@/components/ui/textarea"
@@ -15,17 +14,12 @@ import { useTabContents } from "@/features/tabs/hooks/use-tab-contents"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
 import { useAutoResizeTextarea } from "@/hooks/use-auto-resize-textarea"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import {
-  DEFAULT_TABS_ACCESS,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import type { ProcessedFile } from "@/lib/file-processors/types"
-import {
-  getPlasmoStorageForKey,
-  plasmoGlobalStorage
-} from "@/lib/plasmo-global-storage"
+import { getPlasmoStorageForKey } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import { cn } from "@/lib/utils"
 import type { ChromeMessage, ImageAttachment } from "@/types"
 import { ChatInputDragOverlay } from "./chat-input/chat-input-drag-overlay"
@@ -87,29 +81,13 @@ export const ChatInputBox = ({
     clearImages
   } = useChatInputAttachments()
 
-  const [autoScreenshotOnVision] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.AUTO_SCREENSHOT_ON_VISION,
-      instance: plasmoGlobalStorage
-    },
-    false
+  const [autoScreenshotOnVision] = useSetting(
+    SETTINGS.AUTO_SCREENSHOT_ON_VISION
   )
 
-  const [useRAG, setUseRAG] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.USE_RAG,
-      instance: plasmoGlobalStorage
-    },
-    true
-  )
+  const [useRAG, setUseRAG] = useSetting(SETTINGS.USE_RAG)
 
-  const [tabAccess, setTabAccess] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.BROWSER.TABS_ACCESS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_TABS_ACCESS
-  )
+  const [tabAccess, setTabAccess] = useSetting(SETTINGS.TABS_ACCESS)
 
   useKeyboardShortcuts({
     focusInput: (e) => {

--- a/src/features/chat/components/chat-message-list.tsx
+++ b/src/features/chat/components/chat-message-list.tsx
@@ -1,15 +1,11 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { ChevronDown } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { TooltipActionButton } from "@/components/actions"
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_EMBEDDING_CONFIG } from "@/lib/constants"
+import { SETTINGS } from "@/lib/storage/settings"
 import { cn } from "@/lib/utils"
 import type { ActivityEvent, ChatMessage } from "@/types"
 import { ChatMessageBubble } from "./chat-message-bubble"
@@ -56,13 +52,7 @@ export const ChatMessageList = ({
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
   const [userDetachedFromBottom, setUserDetachedFromBottom] = useState(false)
-  const [embeddingConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [embeddingConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
   const filteredMessages = useMemo(
     () => messages.filter((msg) => msg.role !== "system"),
     [messages]

--- a/src/features/chat/hooks/__tests__/use-auto-embed-messages.test.ts
+++ b/src/features/chat/hooks/__tests__/use-auto-embed-messages.test.ts
@@ -1,10 +1,11 @@
 import { renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useSetting } from "@/hooks/use-setting"
 import { useAutoEmbedMessages } from "../use-auto-embed-messages"
 
 // Mock dependencies
-vi.mock("@plasmohq/storage/hook", () => ({
-  useStorage: vi.fn()
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn()
 }))
 
 vi.mock("@/lib/embeddings/embedding-client", () => ({
@@ -31,17 +32,7 @@ describe("useAutoEmbedMessages", () => {
     vi.clearAllMocks()
 
     // Reset to default enabled state
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
-      true,
-      vi.fn(),
-      {
-        setRenderValue: vi.fn(),
-        setStoreValue: vi.fn(),
-        remove: vi.fn(),
-        isLoading: false
-      }
-    ])
+    vi.mocked(useSetting).mockReturnValue([true, vi.fn(), { isLoading: false }])
   })
 
   it("should initialize with default state", () => {
@@ -173,16 +164,10 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip messages when auto-embed is disabled", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       false,
       vi.fn(),
-      {
-        setRenderValue: vi.fn(),
-        setStoreValue: vi.fn(),
-        remove: vi.fn(),
-        isLoading: false
-      }
+      { isLoading: false }
     ])
 
     const { generateEmbedding } = await import(

--- a/src/features/chat/hooks/__tests__/use-chat.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat.test.ts
@@ -22,6 +22,22 @@ vi.mock("@plasmohq/storage/hook", () => ({
   })
 }))
 
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn((descriptor) => {
+    if (descriptor.key === "provider-selected-model") {
+      return ["llama3:latest", vi.fn(), { isLoading: false }]
+    }
+    if (descriptor.key === "provider-selected-model-ref") {
+      return [
+        { providerId: "ollama", modelId: "llama3:latest" },
+        vi.fn(),
+        { isLoading: false }
+      ]
+    }
+    return [descriptor.defaultValue, vi.fn(), { isLoading: false }]
+  })
+}))
+
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: toastMock })
 }))
@@ -110,7 +126,14 @@ vi.mock("@/lib/knowledge/knowledge-sets", () => ({
 vi.mock("@/lib/plasmo-global-storage", () => ({
   plasmoGlobalStorage: {
     get: vi.fn()
-  }
+  },
+  getPlasmoStorageForKey: vi.fn(() => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    watch: vi.fn(),
+    unwatch: vi.fn()
+  }))
 }))
 
 vi.mock("@/features/chat/hooks/use-auto-embed-messages", () => ({

--- a/src/features/chat/hooks/use-auto-embed-messages.ts
+++ b/src/features/chat/hooks/use-auto-embed-messages.ts
@@ -1,14 +1,12 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useRef } from "react"
-
-import { DEFAULT_MEMORY_ENABLED, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
 import { chunkTextAsync } from "@/lib/embeddings/chunker"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { assessContentQuality } from "@/lib/embeddings/content-quality-filter"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { storeVector, vectorDb } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ChatMessage } from "@/types"
 
 /**
@@ -51,13 +49,7 @@ const checkDuplicateEmbedding = async (
  * NOW WITH QUALITY FILTERING: Filters out low-quality content before embedding
  */
 export const useAutoEmbedMessages = () => {
-  const [memoryEnabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.MEMORY.ENABLED,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MEMORY_ENABLED
-  )
+  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
 
   // Track messages currently being processed to avoid concurrent duplicates
   // Using ref to persist across renders without causing re-renders

--- a/src/features/chat/hooks/use-chat-config.ts
+++ b/src/features/chat/hooks/use-chat-config.ts
@@ -1,13 +1,5 @@
-import { useStorage } from "@plasmohq/storage/hook"
-
-import {
-  DEFAULT_GROUNDED_ONLY_MODE,
-  DEFAULT_MAX_RAG_CONTEXT_CHARS,
-  DEFAULT_MAX_TAB_CONTEXT_CHARS,
-  DEFAULT_MEMORY_ENABLED,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { SelectedModelRef } from "@/types"
 
 /**
@@ -27,55 +19,13 @@ export interface ChatConfig {
 }
 
 export const useChatConfig = (): ChatConfig => {
-  const [selectedModel] = useStorage<string>(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    ""
-  )
-  const [selectedModelRef] = useStorage<SelectedModelRef | null>(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
-      instance: plasmoGlobalStorage
-    },
-    null
-  )
-  const [selectionConflictModel] = useStorage<string | null>(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTION_CONFLICT_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    null
-  )
-  const [memoryEnabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.MEMORY.ENABLED,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MEMORY_ENABLED
-  )
-  const [maxTabContextChars] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.CHAT.MAX_TAB_CONTEXT_CHARS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_TAB_CONTEXT_CHARS
-  )
-  const [maxRagContextChars] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_RAG_CONTEXT_CHARS
-  )
-  const [groundedOnlyMode] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.GROUNDED_ONLY_MODE,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_GROUNDED_ONLY_MODE
-  )
+  const [selectedModel] = useSetting(SETTINGS.SELECTED_MODEL)
+  const [selectedModelRef] = useSetting(SETTINGS.SELECTED_MODEL_REF)
+  const [selectionConflictModel] = useSetting(SETTINGS.SELECTION_CONFLICT_MODEL)
+  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
+  const [maxTabContextChars] = useSetting(SETTINGS.MAX_TAB_CONTEXT_CHARS)
+  const [maxRagContextChars] = useSetting(SETTINGS.MAX_RAG_CONTEXT_CHARS)
+  const [groundedOnlyMode] = useSetting(SETTINGS.GROUNDED_ONLY_MODE)
 
   return {
     selectedModel,

--- a/src/features/chat/hooks/use-chat-input-attachments.ts
+++ b/src/features/chat/hooks/use-chat-input-attachments.ts
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -8,11 +7,12 @@ import {
 import { captureVisibleTabImage } from "@/features/chat/lib/capture-screenshot"
 import { useFileUpload } from "@/features/file-upload/hooks/use-file-upload"
 import { useSelectedModelCapabilities } from "@/features/model/hooks/use-selected-model-capabilities"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import { DEFAULT_MAX_IMAGE_SIZE_MB, STORAGE_KEYS } from "@/lib/constants"
+import { DEFAULT_MAX_IMAGE_SIZE_MB } from "@/lib/constants"
 import type { ProcessedFile } from "@/lib/file-processors/types"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ImageAttachment } from "@/types"
 
 export const useChatInputAttachments = () => {
@@ -40,13 +40,7 @@ export const useChatInputAttachments = () => {
   const visionSupported = capabilities?.vision ?? false
   const visionUnsupported = !visionSupported && !capabilitiesResolving
 
-  const [maxImageSizeMb] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.IMAGES.MAX_SIZE_MB,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_IMAGE_SIZE_MB
-  )
+  const [maxImageSizeMb] = useSetting(SETTINGS.MAX_IMAGE_SIZE_MB)
 
   const handleImageReject = useCallback(
     (reason: ImageRejectReason, file: File) => {

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useEffect, useMemo, useRef } from "react"
 import { useChatConfig } from "@/features/chat/hooks/use-chat-config"
 import { useChatResponse } from "@/features/chat/hooks/use-chat-response"
@@ -11,15 +10,14 @@ import { useChatSessions } from "@/features/sessions/stores/chat-session-store"
 import { useOpenTabs } from "@/features/tabs/hooks/use-open-tab"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
 import { useTabContent } from "@/features/tabs/stores/tab-content-store"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import { DEFAULT_TABS_ACCESS, STORAGE_KEYS } from "@/lib/constants"
 import {
-  DEFAULT_PER_SITE_PROFILE_SETTINGS,
   type PerSiteProfileSettings,
   parsePerSiteProfileSettings,
   resolveGroundedOnlyModeForUrls
 } from "@/lib/per-site-profiles"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const EMPTY_PROFILE_LIST: PerSiteProfileSettings["profiles"] = []
 
@@ -30,20 +28,8 @@ export const useChat = () => {
   const { input, setInput } = useChatInput()
   const { selectedTabIds, setSelectedTabIds } = useSelectedTabs()
   const { builtContent: contextText, documents: tabDocuments } = useTabContent()
-  const [tabAccess] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.BROWSER.TABS_ACCESS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_TABS_ACCESS
-  )
-  const [perSiteProfiles] = useStorage<PerSiteProfileSettings>(
-    {
-      key: STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_PER_SITE_PROFILE_SETTINGS
-  )
+  const [tabAccess] = useSetting(SETTINGS.TABS_ACCESS)
+  const [perSiteProfiles] = useSetting(SETTINGS.PER_SITE_PROFILES)
   const { tabs: openTabs } = useOpenTabs(Boolean(tabAccess))
   const perSiteProfileList =
     parsePerSiteProfileSettings(perSiteProfiles).profiles ?? EMPTY_PROFILE_LIST

--- a/src/features/chat/hooks/use-context-settings.ts
+++ b/src/features/chat/hooks/use-context-settings.ts
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import {
   AppWindow,
   BrainCircuit,
@@ -14,19 +13,13 @@ import {
   useWebSearchActive,
   useWebSearchConfig
 } from "@/features/web-search/stores/web-search-config-store"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_EXCLUDE_URLS } from "@/lib/constants"
 import {
-  DEFAULT_CONTENT_EXTRACTION_CONFIG,
-  DEFAULT_EXCLUDE_URLS,
-  DEFAULT_TABS_ACCESS,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import {
-  DEFAULT_PER_SITE_PROFILE_SETTINGS,
   type PerSiteProfileSettings,
   parsePerSiteProfileSettings
 } from "@/lib/per-site-profiles"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
-import type { ContentExtractionConfig } from "@/types"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const EMPTY_PROFILE_LIST: PerSiteProfileSettings["profiles"] = []
 
@@ -51,50 +44,17 @@ export interface ContextToggleAction {
 export const useContextSettings = () => {
   const { t } = useTranslation()
 
-  const [useRAG, setUseRAG] = useStorage<boolean>(
-    { key: STORAGE_KEYS.EMBEDDINGS.USE_RAG, instance: plasmoGlobalStorage },
-    true
+  const [useRAG, setUseRAG] = useSetting(SETTINGS.USE_RAG)
+  const [tabAccess, setTabAccess] = useSetting(SETTINGS.TABS_ACCESS)
+  const [groundedOnlyMode, setGroundedOnlyMode] = useSetting(
+    SETTINGS.GROUNDED_ONLY_MODE
   )
-  const [tabAccess, setTabAccess] = useStorage<boolean>(
-    { key: STORAGE_KEYS.BROWSER.TABS_ACCESS, instance: plasmoGlobalStorage },
-    DEFAULT_TABS_ACCESS
+  const [autoScreenshotOnVision, setAutoScreenshotOnVision] = useSetting(
+    SETTINGS.AUTO_SCREENSHOT_ON_VISION
   )
-  const [groundedOnlyMode, setGroundedOnlyMode] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.GROUNDED_ONLY_MODE,
-      instance: plasmoGlobalStorage
-    },
-    false
-  )
-  const [autoScreenshotOnVision, setAutoScreenshotOnVision] =
-    useStorage<boolean>(
-      {
-        key: STORAGE_KEYS.CHAT.AUTO_SCREENSHOT_ON_VISION,
-        instance: plasmoGlobalStorage
-      },
-      false
-    )
-  const [config] = useStorage<ContentExtractionConfig>(
-    {
-      key: STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_CONTENT_EXTRACTION_CONFIG
-  )
-  const [oldPatterns] = useStorage<string[]>(
-    {
-      key: STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EXCLUDE_URLS
-  )
-  const [perSiteProfiles] = useStorage<PerSiteProfileSettings>(
-    {
-      key: STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_PER_SITE_PROFILE_SETTINGS
-  )
+  const [config] = useSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
+  const [oldPatterns] = useSetting(SETTINGS.EXCLUDE_URL_PATTERNS)
+  const [perSiteProfiles] = useSetting(SETTINGS.PER_SITE_PROFILES)
 
   const { capabilities, isResolving } = useSelectedModelCapabilities()
   const { config: webSearchConfig } = useWebSearchConfig()

--- a/src/features/chat/hooks/use-semantic-chat-search.ts
+++ b/src/features/chat/hooks/use-semantic-chat-search.ts
@@ -1,7 +1,5 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useState } from "react"
-import type { EmbeddingConfig } from "@/lib/constants"
-import { DEFAULT_EMBEDDING_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
 import { ensureKeywordIndexBuilt } from "@/lib/embeddings/auto-index"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
@@ -9,7 +7,7 @@ import { searchHybrid } from "@/lib/embeddings/vector-store"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export interface ChatSearchResult {
   result: SearchResult
@@ -29,13 +27,7 @@ export interface UseSemanticChatSearchOptions {
 export const useSemanticChatSearch = () => {
   const [isSearching, setIsSearching] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [embeddingConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [embeddingConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
 
   const search = useCallback(
     async (

--- a/src/features/chat/hooks/use-session-metrics-preference.ts
+++ b/src/features/chat/hooks/use-session-metrics-preference.ts
@@ -1,26 +1,14 @@
-import { useStorage } from "@plasmohq/storage/hook"
-
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 
 /**
  * Hook to manage the session metrics display preference.
  *
- * Routes through `plasmoGlobalStorage` (chrome.storage.sync) like
- * every other persisted user preference. Calling `useStorage` with
- * a bare string key would default to chrome.storage.local, which
- * would silo this preference away from every other setting -- it
- * wouldn't sync across devices, wouldn't appear in backup exports,
- * and wouldn't survive a "reset all data" pass that targets sync.
+ * Routes through the registered descriptor, which owns the sync scope and
+ * keeps this preference consistent across extension surfaces and devices.
  *
  * @returns [showSessionMetrics, setShowSessionMetrics] - Current value and setter
  */
 export const useSessionMetricsPreference = () => {
-  return useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.SHOW_SESSION_METRICS,
-      instance: plasmoGlobalStorage
-    },
-    true
-  )
+  return useSetting(SETTINGS.SHOW_SESSION_METRICS)
 }

--- a/src/features/context/components/context-settings.tsx
+++ b/src/features/context/components/context-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { BookOpen, Globe, Scissors, ShieldCheck, Upload } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { SectionStack, TwoColumnGrid } from "@/components/layout"
@@ -17,19 +16,14 @@ import {
 } from "@/features/knowledge/components"
 import { MemorySettings } from "@/features/memory/components/memory-settings"
 import { WebSearchSettings } from "@/features/web-search/components/web-search-settings"
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const AutoScreenshotSettings = () => {
   const { t } = useTranslation()
-  const [autoScreenshotOnVision, setAutoScreenshotOnVision] =
-    useStorage<boolean>(
-      {
-        key: STORAGE_KEYS.CHAT.AUTO_SCREENSHOT_ON_VISION,
-        instance: plasmoGlobalStorage
-      },
-      false
-    )
+  const [autoScreenshotOnVision, setAutoScreenshotOnVision] = useSetting(
+    SETTINGS.AUTO_SCREENSHOT_ON_VISION
+  )
 
   return (
     <SettingsSwitch

--- a/src/features/context/components/grounding-mode-settings.tsx
+++ b/src/features/context/components/grounding-mode-settings.tsx
@@ -1,17 +1,12 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
 import { SettingsSwitch } from "@/components/settings"
-import { DEFAULT_GROUNDED_ONLY_MODE, STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const GroundingModeSettings = () => {
   const { t } = useTranslation()
-  const [groundedOnlyMode, setGroundedOnlyMode] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.GROUNDED_ONLY_MODE,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_GROUNDED_ONLY_MODE
+  const [groundedOnlyMode, setGroundedOnlyMode] = useSetting(
+    SETTINGS.GROUNDED_ONLY_MODE
   )
 
   return (

--- a/src/features/context/components/prompt-context-limits-settings.tsx
+++ b/src/features/context/components/prompt-context-limits-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
 import { FormGrid } from "@/components/layout"
 import {
@@ -8,14 +7,13 @@ import {
   SettingsSwitch
 } from "@/components/settings"
 import { Input } from "@/components/ui/input"
+import { useSetting } from "@/hooks/use-setting"
 import {
-  DEFAULT_AUTO_REFRESH_TAB_CONTEXT,
   DEFAULT_MAX_RAG_CONTEXT_CHARS,
   DEFAULT_MAX_TAB_CONTEXT_CHARS,
-  DEFAULT_MAX_TOOL_RESULT_CHARS,
-  STORAGE_KEYS
+  DEFAULT_MAX_TOOL_RESULT_CHARS
 } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const MIN_LIMIT = 2000
 const MAX_LIMIT = 120000
@@ -27,33 +25,17 @@ const normalizeLimit = (value: number, fallback: number) => {
 
 export const PromptContextLimitsSettings = () => {
   const { t } = useTranslation()
-  const [maxTabContextChars, setMaxTabContextChars] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.CHAT.MAX_TAB_CONTEXT_CHARS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_TAB_CONTEXT_CHARS
+  const [maxTabContextChars, setMaxTabContextChars] = useSetting(
+    SETTINGS.MAX_TAB_CONTEXT_CHARS
   )
-  const [maxRagContextChars, setMaxRagContextChars] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_RAG_CONTEXT_CHARS
+  const [maxRagContextChars, setMaxRagContextChars] = useSetting(
+    SETTINGS.MAX_RAG_CONTEXT_CHARS
   )
-  const [maxToolResultChars, setMaxToolResultChars] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.CHAT.MAX_TOOL_RESULT_CHARS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_TOOL_RESULT_CHARS
+  const [maxToolResultChars, setMaxToolResultChars] = useSetting(
+    SETTINGS.MAX_TOOL_RESULT_CHARS
   )
-  const [autoRefreshTabContext, setAutoRefreshTabContext] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.AUTO_REFRESH_TAB_CONTEXT,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_AUTO_REFRESH_TAB_CONTEXT
+  const [autoRefreshTabContext, setAutoRefreshTabContext] = useSetting(
+    SETTINGS.AUTO_REFRESH_TAB_CONTEXT
   )
 
   return (

--- a/src/features/file-upload/components/file-upload-settings.tsx
+++ b/src/features/file-upload/components/file-upload-settings.tsx
@@ -1,33 +1,21 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import type { ChangeEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { FieldStack } from "@/components/layout"
 import { SettingsFormField } from "@/components/settings"
 import { Input } from "@/components/ui/input"
+import { useSetting } from "@/hooks/use-setting"
 import {
   DEFAULT_FILE_UPLOAD_CONFIG,
-  DEFAULT_MAX_IMAGE_SIZE_MB,
-  STORAGE_KEYS
+  DEFAULT_MAX_IMAGE_SIZE_MB
 } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
-import type { FileUploadConfig } from "@/types"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const FileUploadSettings = () => {
   const { t } = useTranslation()
-  const [config, setConfig] = useStorage<FileUploadConfig>(
-    {
-      key: STORAGE_KEYS.FILE_UPLOAD.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_FILE_UPLOAD_CONFIG
-  )
+  const [config, setConfig] = useSetting(SETTINGS.FILE_UPLOAD_CONFIG)
 
-  const [maxImageSizeMb, setMaxImageSizeMb] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.IMAGES.MAX_SIZE_MB,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_IMAGE_SIZE_MB
+  const [maxImageSizeMb, setMaxImageSizeMb] = useSetting(
+    SETTINGS.MAX_IMAGE_SIZE_MB
   )
 
   const handleMaxSizeChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/features/file-upload/hooks/use-file-upload.ts
+++ b/src/features/file-upload/hooks/use-file-upload.ts
@@ -1,14 +1,13 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useState } from "react"
 import { IngestionClient } from "@/application/ingestion/ingestion-client"
-import { DEFAULT_FILE_UPLOAD_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_FILE_UPLOAD_CONFIG } from "@/lib/constants"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import type {
   FileProcessingState,
   ProcessedFile
 } from "@/lib/file-processors/types"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
-import type { FileUploadConfig } from "@/types"
+import { SETTINGS } from "@/lib/storage/settings"
 import { validateFileForUpload } from "./file-upload-pipeline"
 
 export interface UseFileUploadOptions {
@@ -18,13 +17,7 @@ export interface UseFileUploadOptions {
 }
 
 export function useFileUpload(options: UseFileUploadOptions = {}) {
-  const [config] = useStorage<FileUploadConfig>(
-    {
-      key: STORAGE_KEYS.FILE_UPLOAD.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_FILE_UPLOAD_CONFIG
-  )
+  const [config] = useSetting(SETTINGS.FILE_UPLOAD_CONFIG)
 
   const safeConfig = config || DEFAULT_FILE_UPLOAD_CONFIG
   const {

--- a/src/features/knowledge/components/__tests__/knowledge-settings.test.tsx
+++ b/src/features/knowledge/components/__tests__/knowledge-settings.test.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import {
   fireEvent,
   render,
@@ -7,6 +6,7 @@ import {
   within
 } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useSetting } from "@/hooks/use-setting"
 import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig } from "@/lib/constants"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { FeedbackSettings } from "../feedback-settings"
@@ -16,8 +16,8 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
-vi.mock("@plasmohq/storage/hook", () => ({
-  useStorage: vi.fn()
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn()
 }))
 
 vi.mock("@/components/settings", () => ({
@@ -129,7 +129,7 @@ const storageControls = {
 }
 
 const mockStorage = (config: EmbeddingConfig, setter = vi.fn()) => {
-  vi.mocked(useStorage).mockReturnValue([config, setter, storageControls])
+  vi.mocked(useSetting).mockReturnValue([config, setter, storageControls])
   return setter
 }
 

--- a/src/features/knowledge/components/feedback-settings.tsx
+++ b/src/features/knowledge/components/feedback-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { Download, RotateCcw, ThumbsUp, Trash2 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -11,26 +10,17 @@ import {
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig } from "@/lib/constants"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export function FeedbackSettings() {
   const { t } = useTranslation()
   const { toast } = useToast()
-  const [config, setConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [config, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
   const [isExporting, setIsExporting] = useState(false)
   const [isClearing, setIsClearing] = useState(false)
   const clearDialog = useConfirmAction()

--- a/src/features/knowledge/components/rag-settings.tsx
+++ b/src/features/knowledge/components/rag-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -27,12 +26,9 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { useSetting } from "@/hooks/use-setting"
 import { knowledgeConfig } from "@/lib/config/knowledge-config"
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { DEFAULT_EMBEDDING_CONFIG } from "@/lib/constants"
 import {
   createKnowledgeSet,
   DEFAULT_KNOWLEDGE_SET_ID,
@@ -43,18 +39,12 @@ import {
   setActiveKnowledgeSetId,
   updateKnowledgeSet
 } from "@/lib/knowledge/knowledge-sets"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const RAGSettings = () => {
   const { t } = useTranslation()
 
-  const [config, setConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [config, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
 
   const [topK, setTopK] = useState(
     config.defaultSearchLimit ?? DEFAULT_EMBEDDING_CONFIG.defaultSearchLimit
@@ -207,16 +197,10 @@ export const RAGSettings = () => {
   }
 
   const handleRAGToggle = async (checked: boolean) => {
-    await plasmoGlobalStorage.set(STORAGE_KEYS.EMBEDDINGS.USE_RAG, checked)
+    setUseRAG(checked)
   }
 
-  const [useRAG] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.USE_RAG,
-      instance: plasmoGlobalStorage
-    },
-    true
-  )
+  const [useRAG, setUseRAG] = useSetting(SETTINGS.USE_RAG)
 
   return (
     <div className="space-y-6">

--- a/src/features/knowledge/components/text-splitting-settings.tsx
+++ b/src/features/knowledge/components/text-splitting-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { SettingsFormField, SettingsSliderField } from "@/components/settings"
@@ -9,22 +8,15 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
+import { useSetting } from "@/hooks/use-setting"
 import {
   type ChunkingStrategy,
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
+  DEFAULT_EMBEDDING_CONFIG
 } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const TextSplittingSettings = () => {
-  const [config, setConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [config, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
 
   const { t } = useTranslation()
   const safeChunkSize = config.chunkSize ?? DEFAULT_EMBEDDING_CONFIG.chunkSize

--- a/src/features/memory/components/__tests__/memory-settings.test.tsx
+++ b/src/features/memory/components/__tests__/memory-settings.test.tsx
@@ -1,6 +1,6 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useSetting } from "@/hooks/use-setting"
 import { clearAllVectors, getStorageStats } from "@/lib/embeddings/vector-store"
 import { MemorySettings } from "../memory-settings"
 
@@ -11,8 +11,8 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-vi.mock("@plasmohq/storage/hook", () => ({
-  useStorage: vi.fn()
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn()
 }))
 
 vi.mock("@/hooks/use-toast", () => ({
@@ -29,15 +29,10 @@ describe("MemorySettings", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       true,
       setMemoryEnabled,
-      {
-        setRenderValue: vi.fn(),
-        setStoreValue: vi.fn().mockResolvedValue(null),
-        remove: vi.fn(),
-        isLoading: false
-      }
+      { isLoading: false }
     ])
     vi.mocked(getStorageStats).mockResolvedValue({
       totalVectors: 4,

--- a/src/features/memory/components/memory-settings.tsx
+++ b/src/features/memory/components/memory-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { Brain, Trash2 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -10,22 +9,16 @@ import {
 } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import { DEFAULT_MEMORY_ENABLED, STORAGE_KEYS } from "@/lib/constants"
 import { clearAllVectors, getStorageStats } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const MemorySettings = () => {
   const { t } = useTranslation()
   const { toast } = useToast()
-  const [isEnabled, setIsEnabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.MEMORY.ENABLED,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MEMORY_ENABLED
-  )
+  const [isEnabled, setIsEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
   const [isClearing, setIsClearing] = useState(false)
   const clearDialog = useConfirmAction()
   const [stats, setStats] = useState<{

--- a/src/features/model/components/content-extraction-settings.tsx
+++ b/src/features/model/components/content-extraction-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { BookOpen, Code, FileText, Sparkles, Target, Zap } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { SELECTION_ACTIONS } from "@/application/selection-actions/actions"
@@ -21,19 +20,16 @@ import {
 } from "@/features/model/components/content-extraction-fields"
 import { ExcludedUrls } from "@/features/model/components/exclude-urls"
 import { SiteSpecificOverrides } from "@/features/model/components/site-specific-overrides"
-import {
-  DEFAULT_CONTENT_EXTRACTION_CONFIG,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_CONTENT_EXTRACTION_CONFIG } from "@/lib/constants"
 import { CONTENT_SCRAPER_OPTIONS } from "@/lib/constants-ui"
 import {
   createPerSiteProfile,
   DEFAULT_PER_SITE_PROFILE_SETTINGS,
   type PerSiteProfile,
-  type PerSiteProfileSettings,
   parsePerSiteProfileSettings
 } from "@/lib/per-site-profiles"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import { cn } from "@/lib/utils"
 import type { ContentExtractionConfig, ContentScraper } from "@/types"
 import { TIMEOUT_FIELDS } from "./content-extraction-constants"
@@ -44,21 +40,10 @@ export interface ContentExtractionSettingsFormProps {
 }
 
 export const ContentExtractionSettings = () => {
-  const [config, setConfig] = useStorage<ContentExtractionConfig>(
-    {
-      key: STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_CONTENT_EXTRACTION_CONFIG
+  const [config, setConfig] = useSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
+  const [perSiteProfileSettings, setPerSiteProfileSettings] = useSetting(
+    SETTINGS.PER_SITE_PROFILES
   )
-  const [perSiteProfileSettings, setPerSiteProfileSettings] =
-    useStorage<PerSiteProfileSettings>(
-      {
-        key: STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
-        instance: plasmoGlobalStorage
-      },
-      DEFAULT_PER_SITE_PROFILE_SETTINGS
-    )
 
   if (!config) {
     return null

--- a/src/features/model/components/embedding-settings.tsx
+++ b/src/features/model/components/embedding-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { AlertTriangle, RefreshCw } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -10,14 +9,12 @@ import { useEmbeddingModelCheck } from "@/features/model/hooks/use-embedding-mod
 import { useEmbeddingRebuild } from "@/features/model/hooks/use-embedding-rebuild"
 import { useProviderModels } from "@/features/model/hooks/use-provider-models"
 import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
 import {
   DEFAULT_EMBEDDING_CONFIG,
-  DEFAULT_EMBEDDING_MODEL,
-  DEFAULT_MEMORY_ENABLED,
   DEFAULT_PROVIDER_ID,
-  type EmbeddingConfig,
-  STORAGE_KEYS
+  type EmbeddingConfig
 } from "@/lib/constants"
 import { getCacheStats } from "@/lib/embeddings/embedding-client"
 import {
@@ -30,7 +27,7 @@ import {
   removeDuplicateVectors
 } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 import { DatabaseManagementCard } from "./embedding-config/database-management-card"
 import { EmbeddingGenerationConfig } from "./embedding-config/embedding-generation-config"
@@ -61,27 +58,11 @@ export const EmbeddingSettings = () => {
   const { t } = useTranslation()
   const { toast } = useToast()
 
-  const [selectedModel, setSelectedModel] = useStorage<string>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_MODEL
+  const [selectedModel, setSelectedModel] = useSetting(
+    SETTINGS.EMBEDDING_SELECTED_MODEL
   )
-  const [config, setConfig] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
-  const [memoryEnabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.MEMORY.ENABLED,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MEMORY_ENABLED
-  )
+  const [config, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
+  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
 
   const { models } = useProviderModels()
 

--- a/src/features/model/components/embedding-status-indicator.tsx
+++ b/src/features/model/components/embedding-status-indicator.tsx
@@ -1,5 +1,4 @@
 import { RpcMethod } from "@ollama-client/contracts/rpc"
-import { useStorage } from "@plasmohq/storage/hook"
 import {
   AlertTriangle,
   Brain,
@@ -12,38 +11,24 @@ import { useTranslation } from "react-i18next"
 import { TooltipActionButton } from "@/components/actions"
 import { Button } from "@/components/ui/button"
 import { useModelPull } from "@/features/model/hooks/use-model-pull"
+import { useSetting } from "@/hooks/use-setting"
 import { useToast } from "@/hooks/use-toast"
-import type { EmbeddingConfig } from "@/lib/constants"
 import {
-  DEFAULT_EMBEDDING_CONFIG,
   DEFAULT_EMBEDDING_MODEL,
   DEFAULT_PROVIDER_ID,
-  normalizeEmbeddingModelName,
-  STORAGE_KEYS
+  normalizeEmbeddingModelName
 } from "@/lib/constants"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import { STATUS_STYLES } from "@/lib/ui-status"
 import { cn } from "@/lib/utils"
 import { extensionRpcClient } from "@/protocol/extension-client"
 
 export const EmbeddingStatusIndicator = () => {
   const { t } = useTranslation()
-  const [selectedModel] = useStorage<string>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_MODEL
-  )
-  const [config] = useStorage<EmbeddingConfig>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.CONFIG,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_EMBEDDING_CONFIG
-  )
+  const [selectedModel] = useSetting(SETTINGS.EMBEDDING_SELECTED_MODEL)
+  const [config] = useSetting(SETTINGS.EMBEDDING_CONFIG)
 
   const modelName = normalizeEmbeddingModelName(
     config?.sharedEmbeddingModel || selectedModel || DEFAULT_EMBEDDING_MODEL

--- a/src/features/model/components/provider-settings.tsx
+++ b/src/features/model/components/provider-settings.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { CheckCircle2, Info, Loader2, Trash2, XCircle, Zap } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -41,13 +40,12 @@ import { ProviderGrid } from "@/features/model/components/provider-grid"
 import { useProviderSettingsState } from "@/features/model/hooks/use-provider-settings-state"
 import {
   CATALOG_REFRESH_CHOICES_MS,
-  DEFAULT_CATALOG_REFRESH_MS,
   normalizeCatalogRefreshMs
 } from "@/features/model/lib/catalog-refresh"
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
 import { isBetaProvider } from "@/lib/providers/registry"
 import { ProviderId } from "@/lib/providers/types"
+import { SETTINGS } from "@/lib/storage/settings"
 import { cn } from "@/lib/utils"
 
 export const ProviderSettings = () => {
@@ -76,19 +74,11 @@ export const ProviderSettings = () => {
     removeProvider
   } = useProviderSettingsState()
   const [addOpen, setAddOpen] = useState(false)
-  const [iconLookup, setIconLookup] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.PROVIDER.FAVICON_LOOKUP,
-      instance: plasmoGlobalStorage
-    },
-    true
+  const [iconLookup, setIconLookup] = useSetting(
+    SETTINGS.PROVIDER_FAVICON_LOOKUP
   )
-  const [catalogRefreshMs, setCatalogRefreshMs] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.PROVIDER.CATALOG_REFRESH_MS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_CATALOG_REFRESH_MS
+  const [catalogRefreshMs, setCatalogRefreshMs] = useSetting(
+    SETTINGS.PROVIDER_CATALOG_REFRESH_MS
   )
   const [pendingRemoval, setPendingRemoval] = useState<{
     id: string

--- a/src/features/model/hooks/__tests__/use-model-config.test.ts
+++ b/src/features/model/hooks/__tests__/use-model-config.test.ts
@@ -1,11 +1,11 @@
 import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useSetting } from "@/hooks/use-setting"
 import { DEFAULT_MODEL_CONFIG } from "@/lib/constants"
 import { useModelConfig } from "../use-model-config"
 
-// Mock useStorage hook from @plasmohq/storage
-vi.mock("@plasmohq/storage/hook", () => ({
-  useStorage: vi.fn() as any
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn() as any
 }))
 
 describe("useModelConfig", () => {
@@ -17,8 +17,7 @@ describe("useModelConfig", () => {
   })
 
   it("should return default config when no stored config exists", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([{}, mockSetModelConfigs] as any)
+    vi.mocked(useSetting).mockReturnValue([{}, mockSetModelConfigs] as any)
 
     const { result } = renderHook(() => useModelConfig("llama3:latest"))
 
@@ -35,8 +34,7 @@ describe("useModelConfig", () => {
       }
     }
 
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       storedConfigs,
       mockSetModelConfigs
     ] as any)
@@ -59,8 +57,7 @@ describe("useModelConfig", () => {
       }
     }
 
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       storedConfigs,
       mockSetModelConfigs
     ] as any)
@@ -77,8 +74,7 @@ describe("useModelConfig", () => {
       }
     }
 
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       storedConfigs,
       mockSetModelConfigs
     ] as any)
@@ -89,8 +85,7 @@ describe("useModelConfig", () => {
   })
 
   it("should update config correctly", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([{}, mockSetModelConfigs] as any)
+    vi.mocked(useSetting).mockReturnValue([{}, mockSetModelConfigs] as any)
 
     const { result } = renderHook(() => useModelConfig("llama3:latest"))
 
@@ -118,8 +113,7 @@ describe("useModelConfig", () => {
       }
     }
 
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       existingConfigs,
       mockSetModelConfigs
     ] as any)
@@ -144,8 +138,7 @@ describe("useModelConfig", () => {
       "mistral:latest": { temperature: 0.6 }
     }
 
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([configs, mockSetModelConfigs] as any)
+    vi.mocked(useSetting).mockReturnValue([configs, mockSetModelConfigs] as any)
 
     const { result: result1 } = renderHook(() =>
       useModelConfig("llama3:latest")
@@ -159,8 +152,7 @@ describe("useModelConfig", () => {
   })
 
   it("should handle undefined stored config", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([
+    vi.mocked(useSetting).mockReturnValue([
       undefined,
       mockSetModelConfigs
     ] as any)
@@ -173,8 +165,7 @@ describe("useModelConfig", () => {
   })
 
   it("should update partial config fields", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([{}, mockSetModelConfigs] as any)
+    vi.mocked(useSetting).mockReturnValue([{}, mockSetModelConfigs] as any)
 
     const { result } = renderHook(() => useModelConfig("llama3:latest"))
 
@@ -191,8 +182,7 @@ describe("useModelConfig", () => {
   })
 
   it("should handle system prompt updates", async () => {
-    const { useStorage } = await import("@plasmohq/storage/hook")
-    vi.mocked(useStorage).mockReturnValue([{}, mockSetModelConfigs] as any)
+    vi.mocked(useSetting).mockReturnValue([{}, mockSetModelConfigs] as any)
 
     const { result } = renderHook(() => useModelConfig("llama3:latest"))
 

--- a/src/features/model/hooks/__tests__/use-provider-models.test.ts
+++ b/src/features/model/hooks/__tests__/use-provider-models.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook, waitFor } from "@testing-library/react"
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useSetting } from "@/hooks/use-setting"
 import { getProviderCapabilities } from "@/lib/providers/capabilities"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderManager } from "@/lib/providers/manager"
@@ -80,12 +81,20 @@ vi.mock("@plasmohq/storage/hook", () => ({
 
 // Mock dependencies
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
+  plasmoSyncStorage: {
     get: vi.fn().mockResolvedValue(undefined),
     set: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
     watch: vi.fn().mockReturnValue(() => {})
   }
+}))
+
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn((descriptor) => [
+    descriptor.defaultValue,
+    vi.fn().mockResolvedValue(undefined),
+    { isLoading: false }
+  ])
 }))
 
 vi.mock("@/lib/providers/factory", () => ({
@@ -152,6 +161,13 @@ const mockRpc = (
 describe("useProviderModels", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useSetting).mockImplementation(((descriptor: {
+      defaultValue: unknown
+    }) => [
+      descriptor.defaultValue,
+      vi.fn().mockResolvedValue(undefined),
+      { isLoading: false }
+    ]) as never)
     vi.mocked(useStorage).mockImplementation(((
       config: any,
       initialValue: any
@@ -444,21 +460,27 @@ describe("useProviderModels", () => {
             }
           ]
         }
-        if (config.key === "provider-selected-model") {
-          return ["shared-model", setSelectedModel, { isLoading: false }]
-        }
-        if (config.key === "provider-selected-model-ref") {
-          return [null, setSelectedModelRef, { isLoading: false }]
-        }
-        if (config.key === "provider-selection-conflict-model") {
-          return [null, setSelectionConflictModel, { isLoading: false }]
-        }
         return [
           initialValue,
           vi.fn().mockResolvedValue(undefined),
           { isLoading: false }
         ]
       }) as any)
+      vi.mocked(useSetting).mockImplementation(((descriptor: {
+        key: string
+        defaultValue: unknown
+      }) => {
+        if (descriptor.key === "provider-selected-model") {
+          return ["shared-model", setSelectedModel, { isLoading: false }]
+        }
+        if (descriptor.key === "provider-selected-model-ref") {
+          return [null, setSelectedModelRef, { isLoading: false }]
+        }
+        if (descriptor.key === "provider-selection-conflict-model") {
+          return [null, setSelectionConflictModel, { isLoading: false }]
+        }
+        return [descriptor.defaultValue, vi.fn(), { isLoading: false }]
+      }) as never)
 
       const { result } = renderHook(() => useProviderModels(), {
         wrapper: createWrapper()

--- a/src/features/model/hooks/use-model-config.ts
+++ b/src/features/model/hooks/use-model-config.ts
@@ -1,20 +1,16 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useMemo } from "react"
-import { DEFAULT_MODEL_CONFIG, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_MODEL_CONFIG } from "@/lib/constants"
 import {
   normalizeStoredModelConfig,
-  parseStoredModelConfigMap,
-  type StoredModelConfigMap
+  parseStoredModelConfigMap
 } from "@/lib/model-config-utils"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export type ProviderModelConfig = typeof DEFAULT_MODEL_CONFIG
 
 export const useModelConfig = (modelName: string) => {
-  const [modelConfigs, setModelConfigs] = useStorage<StoredModelConfigMap>(
-    { key: STORAGE_KEYS.PROVIDER.MODEL_CONFIGS, instance: plasmoGlobalStorage },
-    {}
-  )
+  const [modelConfigs, setModelConfigs] = useSetting(SETTINGS.MODEL_CONFIGS)
 
   const config = useMemo(() => {
     const stored = normalizeStoredModelConfig(

--- a/src/features/model/hooks/use-provider-icons.ts
+++ b/src/features/model/hooks/use-provider-icons.ts
@@ -2,10 +2,11 @@ import { RpcMethod } from "@ollama-client/contracts/rpc"
 import { useStorage } from "@plasmohq/storage/hook"
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { plasmoSyncStorage } from "@/lib/plasmo-global-storage"
 import { type ProviderConfig, ProviderStorageKey } from "@/lib/providers/types"
 import { queryKeys } from "@/lib/query-keys"
+import { SETTINGS } from "@/lib/storage/settings"
 import { extensionRpcClient } from "@/protocol/extension-client"
 
 const EMPTY_ICONS: Record<string, string> = {}
@@ -20,13 +21,7 @@ const EMPTY_ICONS: Record<string, string> = {}
  * every provider being recognized already.
  */
 export const useProviderIcons = (): Record<string, string> => {
-  const [enabled] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.PROVIDER.FAVICON_LOOKUP,
-      instance: plasmoGlobalStorage
-    },
-    true
-  )
+  const [enabled] = useSetting(SETTINGS.PROVIDER_FAVICON_LOOKUP)
 
   /*
    * Keyed on the stored provider configuration: a newly added provider must be
@@ -34,7 +29,7 @@ export const useProviderIcons = (): Record<string, string> => {
    * computed before it existed.
    */
   const [providerConfig] = useStorage<ProviderConfig[]>(
-    { key: ProviderStorageKey.CONFIG, instance: plasmoGlobalStorage },
+    { key: ProviderStorageKey.CONFIG, instance: plasmoSyncStorage },
     []
   )
 

--- a/src/features/model/hooks/use-provider-models.ts
+++ b/src/features/model/hooks/use-provider-models.ts
@@ -12,10 +12,11 @@ import {
 } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { DEFAULT_PROVIDER_ID, STORAGE_KEYS } from "@/lib/constants"
+import { useSetting } from "@/hooks/use-setting"
+import { DEFAULT_PROVIDER_ID } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { plasmoSyncStorage } from "@/lib/plasmo-global-storage"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { getProviderCapabilities } from "@/lib/providers/capabilities"
 import { ProviderFactory } from "@/lib/providers/factory"
@@ -32,11 +33,10 @@ import {
   ProviderStorageKey
 } from "@/lib/providers/types"
 import { queryKeys } from "@/lib/query-keys"
+import { SETTINGS } from "@/lib/storage/settings"
 import { extensionRpcClient } from "@/protocol/extension-client"
-import type { SelectedModelRef } from "@/types"
 import {
   catalogStaleTimeMs,
-  DEFAULT_CATALOG_REFRESH_MS,
   normalizeCatalogRefreshMs
 } from "../lib/catalog-refresh"
 import { isEmbeddingModel } from "../lib/model-utils"
@@ -123,40 +123,19 @@ export const useProviderModels = () => {
   const queryClientInstance = useQueryClient()
 
   const [selectedModel, setSelectedModel, { isLoading: isStorageLoading }] =
-    useStorage<string>(
-      {
-        key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL,
-        instance: plasmoGlobalStorage
-      },
-      ""
-    )
-  const [selectedModelRef, setSelectedModelRef] =
-    useStorage<SelectedModelRef | null>(
-      {
-        key: STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
-        instance: plasmoGlobalStorage
-      },
-      null
-    )
-  const [selectionConflictModel, setSelectionConflictModel] = useStorage<
-    string | null
-  >(
-    {
-      key: STORAGE_KEYS.PROVIDER.SELECTION_CONFLICT_MODEL,
-      instance: plasmoGlobalStorage
-    },
-    null
+    useSetting(SETTINGS.SELECTED_MODEL)
+  const [selectedModelRef, setSelectedModelRef] = useSetting(
+    SETTINGS.SELECTED_MODEL_REF
+  )
+  const [selectionConflictModel, setSelectionConflictModel] = useSetting(
+    SETTINGS.SELECTION_CONFLICT_MODEL
   )
   const [providerConfig] = useStorage<ProviderConfig[]>(
-    { key: ProviderStorageKey.CONFIG, instance: plasmoGlobalStorage },
+    { key: ProviderStorageKey.CONFIG, instance: plasmoSyncStorage },
     []
   )
-  const [storedCatalogRefreshMs] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.PROVIDER.CATALOG_REFRESH_MS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_CATALOG_REFRESH_MS
+  const [storedCatalogRefreshMs] = useSetting(
+    SETTINGS.PROVIDER_CATALOG_REFRESH_MS
   )
   const catalogRefreshMs = normalizeCatalogRefreshMs(storedCatalogRefreshMs)
 

--- a/src/features/model/lib/catalog-refresh.ts
+++ b/src/features/model/lib/catalog-refresh.ts
@@ -12,7 +12,7 @@
 /** Turns the poll off; the catalog then refreshes on open and on demand. */
 export const CATALOG_REFRESH_OFF = 0
 
-export const DEFAULT_CATALOG_REFRESH_MS = 60_000
+export const DEFAULT_CATALOG_REFRESH_MS = DEFAULT_PROVIDER_CATALOG_REFRESH_MS
 
 /**
  * Never poll faster than this. The setting is sync-safe, so a value can arrive
@@ -72,3 +72,5 @@ export const normalizeCatalogRefreshMs = (value: unknown): number => {
  */
 export const catalogStaleTimeMs = (refreshMs: number): number =>
   refreshMs > CATALOG_REFRESH_OFF ? refreshMs : DEFAULT_CATALOG_REFRESH_MS
+
+import { DEFAULT_PROVIDER_CATALOG_REFRESH_MS } from "@/lib/constants"

--- a/src/features/permissions/components/restore-sessions-limit-settings.tsx
+++ b/src/features/permissions/components/restore-sessions-limit-settings.tsx
@@ -1,15 +1,14 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
 
 import { SettingsCard, SettingsFormField } from "@/components/settings"
 import { Input } from "@/components/ui/input"
+import { useSetting } from "@/hooks/use-setting"
 import {
   DEFAULT_MAX_RESTORE_SESSIONS,
   MAX_MAX_RESTORE_SESSIONS,
   MIN_MAX_RESTORE_SESSIONS
 } from "@/lib/constants/config"
-import { STORAGE_KEYS } from "@/lib/constants/keys"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const normalize = (value: number): number => {
   if (!Number.isFinite(value)) return DEFAULT_MAX_RESTORE_SESSIONS
@@ -25,13 +24,7 @@ const normalize = (value: number): number => {
  */
 export const RestoreSessionsLimitSettings = () => {
   const { t } = useTranslation()
-  const [maxRestore, setMaxRestore] = useStorage<number>(
-    {
-      key: STORAGE_KEYS.BROWSER.MAX_RESTORE_SESSIONS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_MAX_RESTORE_SESSIONS
-  )
+  const [maxRestore, setMaxRestore] = useSetting(SETTINGS.MAX_RESTORE_SESSIONS)
 
   return (
     <SettingsCard

--- a/src/features/privacy/components/export-privacy-settings.tsx
+++ b/src/features/privacy/components/export-privacy-settings.tsx
@@ -1,9 +1,8 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
 
 import { SettingsSwitch } from "@/components/settings"
-import { STORAGE_KEYS } from "@/lib/constants/keys"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 
 /**
  * Export privacy controls. Remote images in a print/PDF export fire network
@@ -13,12 +12,8 @@ import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
  */
 export const ExportPrivacySettings = () => {
   const { t } = useTranslation()
-  const [allowRemoteImages, setAllowRemoteImages] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.EXPORT.ALLOW_REMOTE_IMAGES,
-      instance: plasmoGlobalStorage
-    },
-    false
+  const [allowRemoteImages, setAllowRemoteImages] = useSetting(
+    SETTINGS.EXPORT_ALLOW_REMOTE_IMAGES
   )
 
   return (

--- a/src/features/tabs/hooks/use-tab-contents.ts
+++ b/src/features/tabs/hooks/use-tab-contents.ts
@@ -1,19 +1,15 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useCallback, useEffect } from "react"
 import { create } from "zustand"
 import { useOpenTabs } from "@/features/tabs/hooks/use-open-tab"
 import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
+import { useSetting } from "@/hooks/use-setting"
 import {
   blockedTabAccessMessage,
   isContentScriptReadableUrl
 } from "@/lib/browser-tab-access"
-import {
-  DEFAULT_TABS_ACCESS,
-  STORAGE_KEYS,
-  TAB_CONTENT_REFRESH_INTERVAL_MS
-} from "@/lib/constants"
+import { TAB_CONTENT_REFRESH_INTERVAL_MS } from "@/lib/constants"
 import { getDisplayErrorMessage } from "@/lib/error-display"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { SETTINGS } from "@/lib/storage/settings"
 import { requestPageContentWithRecovery } from "@/lib/tools/internal/tab-utils"
 import type { ChromeResponse } from "@/types"
 
@@ -194,13 +190,7 @@ export const useTabContents = () => {
     cleanupRemovedTabs
   } = useTabFetchingStore()
 
-  const [tabAccess] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.BROWSER.TABS_ACCESS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_TABS_ACCESS
-  )
+  const [tabAccess] = useSetting(SETTINGS.TABS_ACCESS)
 
   const { tabs: openTabs } = useOpenTabs(tabAccess)
 
@@ -233,13 +223,7 @@ export const useTabContents = () => {
     })
   }, [selectedTabIds, getTabTitle, getTabUrl, fetchTabContent, setErrors])
 
-  const [autoRefreshTabContext] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.CHAT.AUTO_REFRESH_TAB_CONTEXT,
-      instance: plasmoGlobalStorage
-    },
-    false
-  )
+  const [autoRefreshTabContext] = useSetting(SETTINGS.AUTO_REFRESH_TAB_CONTEXT)
 
   useEffect(() => {
     if (!autoRefreshTabContext || selectedTabIds.length === 0) return

--- a/src/hooks/use-language-sync.ts
+++ b/src/hooks/use-language-sync.ts
@@ -1,17 +1,11 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-
-import { STORAGE_KEYS } from "@/lib/constants"
-
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { useSetting } from "@/hooks/use-setting"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export const useLanguageSync = () => {
   const { i18n } = useTranslation()
-  const [storedLanguage] = useStorage<string>({
-    key: STORAGE_KEYS.LANGUAGE,
-    instance: plasmoGlobalStorage
-  })
+  const [storedLanguage] = useSetting(SETTINGS.LANGUAGE)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.changeLanguage is a stable function reference
   useEffect(() => {

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -179,6 +179,7 @@ export const DEFAULT_MAX_TOOL_RESULT_CHARS = 10000
 export const DEFAULT_MAX_RESTORE_SESSIONS = 10
 export const MIN_MAX_RESTORE_SESSIONS = 1
 export const MAX_MAX_RESTORE_SESSIONS = 25
+export const DEFAULT_PROVIDER_CATALOG_REFRESH_MS = 60_000
 /** Central default used by storage descriptors and the section manifest. */
 export const DEFAULT_GROUNDED_ONLY_MODE = false
 export const DEFAULT_AUTO_REFRESH_TAB_CONTEXT = false

--- a/src/lib/storage/__tests__/storage-api-boundary.test.ts
+++ b/src/lib/storage/__tests__/storage-api-boundary.test.ts
@@ -1,8 +1,15 @@
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
 import { describe, expect, it } from "vitest"
 
 const ROOT = process.cwd()
+const SOURCE_ROOT = join(ROOT, "src")
+
+const walk = (directory: string): string[] =>
+  readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry)
+    return statSync(path).isDirectory() ? walk(path) : [path]
+  })
 
 const SCOPE_AWARE_UI = [
   "src/features/chat/hooks/use-speech-settings.ts",
@@ -12,6 +19,26 @@ const SCOPE_AWARE_UI = [
 ]
 
 describe("storage API boundary", () => {
+  it("limits raw React storage to legacy provider-config observers", () => {
+    const offenders = walk(SOURCE_ROOT)
+      .filter(
+        (file) =>
+          /\.tsx?$/.test(file) &&
+          !file.includes("/__tests__/") &&
+          !/\.(test|spec)\.[^.]+$/.test(file)
+      )
+      .filter((file) =>
+        readFileSync(file, "utf8").includes("@plasmohq/storage/hook")
+      )
+      .map((file) => relative(ROOT, file))
+      .sort()
+
+    expect(offenders).toEqual([
+      "src/features/model/hooks/use-provider-icons.ts",
+      "src/features/model/hooks/use-provider-models.ts"
+    ])
+  })
+
   it("keeps migrated settings UI behind useSetting descriptors", () => {
     for (const file of SCOPE_AWARE_UI) {
       const source = readFileSync(join(ROOT, file), "utf8")

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -1,5 +1,28 @@
 import { z } from "zod"
-import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  DEFAULT_AUTO_REFRESH_TAB_CONTEXT,
+  DEFAULT_CONTENT_EXTRACTION_CONFIG,
+  DEFAULT_EMBEDDING_CONFIG,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EXCLUDE_URLS,
+  DEFAULT_FILE_UPLOAD_CONFIG,
+  DEFAULT_GROUNDED_ONLY_MODE,
+  DEFAULT_MAX_IMAGE_SIZE_MB,
+  DEFAULT_MAX_RAG_CONTEXT_CHARS,
+  DEFAULT_MAX_RESTORE_SESSIONS,
+  DEFAULT_MAX_TAB_CONTEXT_CHARS,
+  DEFAULT_MAX_TOOL_RESULT_CHARS,
+  DEFAULT_MEMORY_ENABLED,
+  DEFAULT_PROVIDER_CATALOG_REFRESH_MS,
+  DEFAULT_TABS_ACCESS,
+  type EmbeddingConfig,
+  STORAGE_KEYS
+} from "@/lib/constants"
+import type { StoredModelConfigMap } from "@/lib/model-config-utils"
+import {
+  DEFAULT_PER_SITE_PROFILE_SETTINGS,
+  type PerSiteProfileSettings
+} from "@/lib/per-site-profiles"
 import type { CapabilityProbeMap } from "@/lib/providers/capability-probe"
 import type { ModelCapabilityOverrideMap } from "@/lib/providers/model-capability-overrides"
 import type { ApprovalGrantMap } from "@/lib/tools/approval/approval-grants"
@@ -8,9 +31,112 @@ import {
   type WebSearchProviderConfig,
   WebSearchProviderConfigSchema
 } from "@/lib/tools/web-search"
+import type {
+  ContentExtractionConfig,
+  FileUploadConfig,
+  SelectedModelRef
+} from "@/types"
 import { defineSetting } from "./setting-descriptor"
 
 export const SETTINGS = {
+  LANGUAGE: defineSetting<string>(STORAGE_KEYS.LANGUAGE, {
+    defaultValue: "en"
+  }),
+  SELECTED_MODEL: defineSetting<string>(STORAGE_KEYS.PROVIDER.SELECTED_MODEL, {
+    defaultValue: ""
+  }),
+  SELECTED_MODEL_REF: defineSetting<SelectedModelRef | null>(
+    STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
+    { defaultValue: null }
+  ),
+  SELECTION_CONFLICT_MODEL: defineSetting<string | null>(
+    STORAGE_KEYS.PROVIDER.SELECTION_CONFLICT_MODEL,
+    { defaultValue: null }
+  ),
+  MODEL_CONFIGS: defineSetting<StoredModelConfigMap>(
+    STORAGE_KEYS.PROVIDER.MODEL_CONFIGS,
+    { defaultValue: {} }
+  ),
+  PROVIDER_FAVICON_LOOKUP: defineSetting<boolean>(
+    STORAGE_KEYS.PROVIDER.FAVICON_LOOKUP,
+    { defaultValue: true }
+  ),
+  PROVIDER_CATALOG_REFRESH_MS: defineSetting<number>(
+    STORAGE_KEYS.PROVIDER.CATALOG_REFRESH_MS,
+    { defaultValue: DEFAULT_PROVIDER_CATALOG_REFRESH_MS }
+  ),
+  TABS_ACCESS: defineSetting<boolean>(STORAGE_KEYS.BROWSER.TABS_ACCESS, {
+    defaultValue: DEFAULT_TABS_ACCESS
+  }),
+  CONTENT_EXTRACTION_CONFIG: defineSetting<ContentExtractionConfig>(
+    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
+    { defaultValue: DEFAULT_CONTENT_EXTRACTION_CONFIG }
+  ),
+  EXCLUDE_URL_PATTERNS: defineSetting<string[]>(
+    STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS,
+    { defaultValue: DEFAULT_EXCLUDE_URLS }
+  ),
+  PER_SITE_PROFILES: defineSetting<PerSiteProfileSettings>(
+    STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
+    { defaultValue: DEFAULT_PER_SITE_PROFILE_SETTINGS }
+  ),
+  MAX_RESTORE_SESSIONS: defineSetting<number>(
+    STORAGE_KEYS.BROWSER.MAX_RESTORE_SESSIONS,
+    { defaultValue: DEFAULT_MAX_RESTORE_SESSIONS }
+  ),
+  EMBEDDING_SELECTED_MODEL: defineSetting<string>(
+    STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
+    { defaultValue: DEFAULT_EMBEDDING_MODEL }
+  ),
+  EMBEDDING_CONFIG: defineSetting<EmbeddingConfig>(
+    STORAGE_KEYS.EMBEDDINGS.CONFIG,
+    { defaultValue: DEFAULT_EMBEDDING_CONFIG }
+  ),
+  USE_RAG: defineSetting<boolean>(STORAGE_KEYS.EMBEDDINGS.USE_RAG, {
+    defaultValue: true
+  }),
+  MEMORY_ENABLED: defineSetting<boolean>(STORAGE_KEYS.MEMORY.ENABLED, {
+    defaultValue: DEFAULT_MEMORY_ENABLED
+  }),
+  FILE_UPLOAD_CONFIG: defineSetting<FileUploadConfig>(
+    STORAGE_KEYS.FILE_UPLOAD.CONFIG,
+    { defaultValue: DEFAULT_FILE_UPLOAD_CONFIG }
+  ),
+  MAX_IMAGE_SIZE_MB: defineSetting<number>(STORAGE_KEYS.IMAGES.MAX_SIZE_MB, {
+    defaultValue: DEFAULT_MAX_IMAGE_SIZE_MB
+  }),
+  SHOW_SESSION_METRICS: defineSetting<boolean>(
+    STORAGE_KEYS.CHAT.SHOW_SESSION_METRICS,
+    { defaultValue: true }
+  ),
+  MAX_TAB_CONTEXT_CHARS: defineSetting<number>(
+    STORAGE_KEYS.CHAT.MAX_TAB_CONTEXT_CHARS,
+    { defaultValue: DEFAULT_MAX_TAB_CONTEXT_CHARS }
+  ),
+  MAX_RAG_CONTEXT_CHARS: defineSetting<number>(
+    STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS,
+    { defaultValue: DEFAULT_MAX_RAG_CONTEXT_CHARS }
+  ),
+  MAX_TOOL_RESULT_CHARS: defineSetting<number>(
+    STORAGE_KEYS.CHAT.MAX_TOOL_RESULT_CHARS,
+    { defaultValue: DEFAULT_MAX_TOOL_RESULT_CHARS }
+  ),
+  GROUNDED_ONLY_MODE: defineSetting<boolean>(
+    STORAGE_KEYS.CHAT.GROUNDED_ONLY_MODE,
+    { defaultValue: DEFAULT_GROUNDED_ONLY_MODE }
+  ),
+  AUTO_REFRESH_TAB_CONTEXT: defineSetting<boolean>(
+    STORAGE_KEYS.CHAT.AUTO_REFRESH_TAB_CONTEXT,
+    { defaultValue: DEFAULT_AUTO_REFRESH_TAB_CONTEXT }
+  ),
+  AUTO_SCREENSHOT_ON_VISION: defineSetting<boolean>(
+    STORAGE_KEYS.CHAT.AUTO_SCREENSHOT_ON_VISION,
+    { defaultValue: false }
+  ),
+  EXPORT_ALLOW_REMOTE_IMAGES: defineSetting<boolean>(
+    STORAGE_KEYS.EXPORT.ALLOW_REMOTE_IMAGES,
+    { defaultValue: false }
+  ),
   TTS_RATE: defineSetting<number>(STORAGE_KEYS.TTS.RATE, { defaultValue: 1 }),
   TTS_PITCH: defineSetting<number>(STORAGE_KEYS.TTS.PITCH, {
     defaultValue: 1

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -1,4 +1,3 @@
-import { useStorage } from "@plasmohq/storage/hook"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { useEffect } from "react"
 import { browser } from "wxt/browser"
@@ -6,12 +5,8 @@ import { DevThemePane } from "@/components/dev-theme-pane"
 import { ErrorBoundary } from "@/components/ui/error-boundary"
 import { Toaster } from "@/components/ui/sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import {
-  DEFAULT_TABS_ACCESS,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import { SETTINGS } from "@/lib/storage/settings"
 import { SettingsPage } from "@/options/components/settings-page"
 import "../extension-fonts.css"
 import "../globals.css"
@@ -21,6 +16,7 @@ import { useSessionMetricsPreference } from "@/features/chat/hooks/use-session-m
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 import { useLanguageSync } from "@/hooks/use-language-sync"
 import { useProviderStorageMigration } from "@/hooks/use-provider-storage-migration"
+import { useSetting } from "@/hooks/use-setting"
 import { useThemeWatcher } from "@/hooks/use-theme-watcher"
 import { queryClient } from "@/lib/query-client"
 import { useThemeStore } from "@/stores/theme"
@@ -43,21 +39,9 @@ export const OptionsIndex = () => {
   const [showSessionMetrics, setShowSessionMetrics] =
     useSessionMetricsPreference()
 
-  const [useRAG, setUseRAG] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.EMBEDDINGS.USE_RAG,
-      instance: plasmoGlobalStorage
-    },
-    true
-  )
+  const [useRAG, setUseRAG] = useSetting(SETTINGS.USE_RAG)
 
-  const [tabAccess, setTabAccess] = useStorage<boolean>(
-    {
-      key: STORAGE_KEYS.BROWSER.TABS_ACCESS,
-      instance: plasmoGlobalStorage
-    },
-    DEFAULT_TABS_ACCESS
-  )
+  const [tabAccess, setTabAccess] = useSetting(SETTINGS.TABS_ACCESS)
 
   useKeyboardShortcuts({
     toggleTheme: (e) => {


### PR DESCRIPTION
## Summary

- add typed descriptors for registered chat, context, embedding, model, privacy, language, and upload settings
- migrate settings UI to `useSetting` so scope and defaults are owned centrally
- restrict raw Plasmo React storage to the two legacy provider-config observers
- update tests and enforce the storage API boundary

## Why

`plasmoGlobalStorage` always points at sync storage, so direct consumers bypass descriptor-owned scope and default behavior and can mishandle device-local keys. This phase moves registered UI settings to the scope-aware API while leaving legacy provider configuration and imperative migration code explicit for follow-up work.

## Impact

Settings retain their existing defaults and sync behavior, while storage ownership is centralized and new raw-hook consumers are blocked by an architecture test.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` (2,865 tests)
- production extension package and bundle-budget checks
- docs build
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes registered UI settings behind typed, scope-aware descriptors while retaining raw sync-storage observers only for legacy provider configuration.

- Adds descriptors and centralized defaults for chat, context, embedding, model, privacy, language, and upload settings.
- Migrates React consumers from raw Plasmo storage hooks to `useSetting`.
- Adds an architecture test preventing new raw-hook consumers.
- Preserves provider configuration observers and existing sync/local routing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking defect was identified.

The migrated settings continue to use the same keys and defaults while descriptor-backed access preserves scope routing, legacy local-storage migration, subscriptions, and write rollback behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/storage/settings.ts | Adds typed descriptors with centralized defaults for the migrated settings; no incorrect key, scope, or default was established. |
| src/hooks/use-language-sync.ts | Moves language synchronization to the descriptor-backed hook while retaining the existing language key and default. |
| src/features/model/hooks/use-provider-models.ts | Migrates registered model-selection settings while retaining the legacy provider-config observer on the same sync storage instance. |
| src/features/knowledge/components/rag-settings.tsx | Moves embedding and RAG settings to descriptors; the new setter provides optimistic updates and internal rollback. |
| src/lib/storage/__tests__/storage-api-boundary.test.ts | Expands the boundary test to reject raw React storage hooks outside the two intentional provider observers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI["Settings UI and feature hooks"] --> Hook["useSetting(descriptor)"]
  Hook --> Descriptor["SETTINGS descriptor<br/>key + default + parser"]
  Descriptor --> Registry["Storage key registry<br/>sync-safe or device-local"]
  Registry --> Sync["chrome.storage.sync"]
  Registry --> Local["chrome.storage.local"]
  Sync -. "legacy device-local value migration" .-> Local
  Legacy["Legacy provider-config observers"] --> Sync
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(storage): migrate settings UI"](https://github.com/shishir435/ollama-client/commit/fa3429bbf14c73e478672d50dc189076801b0892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52326517)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Settings & Options Page](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/settings-options.md)
- Knowledge Base — [Shared State Stores and Hooks](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/stores-state.md)
- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)
</details>

<!-- /greptile_comment -->