### PR TITLE
refactor(storage): validate persisted settings

### DIFF
--- a/src/application/context/__tests__/build-context.test.ts
+++ b/src/application/context/__tests__/build-context.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/knowledge/knowledge-sets", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: vi.fn(),
   plasmoGlobalStorage: {
     get: vi.fn(),
     set: vi.fn(),
@@ -57,7 +58,7 @@ import {
   getActiveKnowledgeSet,
   getKnowledgeSetFileIds
 } from "@/lib/knowledge/knowledge-sets"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import type { ChatMessage } from "@/types"
 
@@ -69,7 +70,7 @@ const mockedRetrieveFromSources = vi.mocked(retrieveContextFromSources)
 const mockedReformulate = vi.mocked(reformulateQuestion)
 const mockedGetActiveKnowledgeSet = vi.mocked(getActiveKnowledgeSet)
 const mockedGetKnowledgeSetFileIds = vi.mocked(getKnowledgeSetFileIds)
-const mockedStorageGet = vi.mocked(plasmoGlobalStorage.get)
+const mockedStorageGet = vi.mocked(getPlasmoStoredValue)
 const mockedGetProvider = vi.mocked(ProviderFactory.getProviderForModel)
 const mockedRetrieveEnhanced = vi.mocked(retrieveContextEnhanced)
 const mockedFormatEnhanced = vi.mocked(formatEnhancedResults)

--- a/src/application/context/build-context.ts
+++ b/src/application/context/build-context.ts
@@ -16,7 +16,6 @@ import {
   formatEnhancedResults,
   retrieveContextEnhanced
 } from "@/application/context/rag/rag-pipeline"
-import { STORAGE_KEYS } from "@/lib/constants"
 import {
   DEFAULT_KNOWLEDGE_SET_ID,
   DEFAULT_RAG_PROMPT,
@@ -25,9 +24,10 @@ import {
   type KnowledgeSetRecord
 } from "@/lib/knowledge/knowledge-sets"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type {
   ActivityEvent,
   RagSource,
@@ -280,9 +280,7 @@ export const buildRagContext = async (
     })
   }
 
-  const useRag =
-    (await plasmoGlobalStorage.get<boolean>(STORAGE_KEYS.EMBEDDINGS.USE_RAG)) ??
-    true
+  const useRag = await readSetting(SETTINGS.USE_RAG)
 
   let ragInstruction = DEFAULT_RAG_PROMPT
   let ragInstructionAdded = false

--- a/src/background/handlers/__tests__/handle-chat-memory.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-memory.test.ts
@@ -92,13 +92,13 @@ describe("handleChatWithModel - Contextual Memory", () => {
   })
 
   it("should inject context when memory is enabled", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     const { retrieveContextEnhanced, formatEnhancedResults } = await import(
       "@/application/context/rag/rag-pipeline"
     )
 
     // Mock Memory Enabled
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.MEMORY.ENABLED) return true
       return undefined
     })
@@ -149,14 +149,14 @@ describe("handleChatWithModel - Contextual Memory", () => {
   })
 
   it("should NOT retrieve memory when the client already prepared context", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     const { retrieveContextEnhanced } = await import(
       "@/application/context/rag/rag-pipeline"
     )
 
     // Memory enabled, but the UI already built page/file/memory context for
     // this turn — the background must not run a second memory retrieval.
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.MEMORY.ENABLED) return true
       return undefined
     })
@@ -191,7 +191,7 @@ describe("handleChatWithModel - Contextual Memory", () => {
   })
 
   it("should NOT inject memory on a regenerate turn when retrieval tools are active", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     const { retrieveContextEnhanced } = await import(
       "@/application/context/rag/rag-pipeline"
     )
@@ -199,7 +199,7 @@ describe("handleChatWithModel - Contextual Memory", () => {
     // Memory enabled, regenerate path (clientContextPrepared unset), but the
     // model has rag_search/file_search this turn — it pulls memory itself, so
     // the background must not also inject it into the system prompt.
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.MEMORY.ENABLED) return true
       return undefined
     })
@@ -233,13 +233,13 @@ describe("handleChatWithModel - Contextual Memory", () => {
   })
 
   it("should NOT inject context when memory is disabled", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     const { retrieveContextEnhanced } = await import(
       "@/application/context/rag/rag-pipeline"
     )
 
     // Mock Memory Disabled
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.MEMORY.ENABLED) return false
       return undefined
     })

--- a/src/background/handlers/__tests__/handle-chat-with-model.test.ts
+++ b/src/background/handlers/__tests__/handle-chat-with-model.test.ts
@@ -84,6 +84,8 @@ describe("handleChatWithModel", () => {
     mockIsPortClosed = createMockIsPortClosed(false)
     vi.clearAllMocks()
     mockProvider.config.enabled = true
+    const storage = await import("@/lib/plasmo-global-storage")
+    vi.mocked(storage.getPlasmoStoredValue).mockResolvedValue(undefined)
 
     // clearAllMocks resets calls but not implementations, so restore the RAG
     // mock defaults here. This makes every test start with empty memory and
@@ -192,10 +194,10 @@ describe("handleChatWithModel", () => {
     })
 
     it("should inject system prompt from model config", async () => {
-      const { plasmoGlobalStorage } = await import(
+      const { getPlasmoStoredValue } = await import(
         "@/lib/plasmo-global-storage"
       )
-      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
         if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
           return {
             "llama3:latest": {
@@ -233,10 +235,10 @@ describe("handleChatWithModel", () => {
     })
 
     it("should not inject system prompt if one already exists", async () => {
-      const { plasmoGlobalStorage } = await import(
+      const { getPlasmoStoredValue } = await import(
         "@/lib/plasmo-global-storage"
       )
-      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
         if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
           return {
             "llama3:latest": {
@@ -272,10 +274,10 @@ describe("handleChatWithModel", () => {
     })
 
     it("caps injected memory context to the RAG char budget", async () => {
-      const { plasmoGlobalStorage } = await import(
+      const { getPlasmoStoredValue } = await import(
         "@/lib/plasmo-global-storage"
       )
-      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
         if (key === STORAGE_KEYS.MEMORY.ENABLED) return true
         if (key === STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS) return 20
         return undefined
@@ -310,10 +312,10 @@ describe("handleChatWithModel", () => {
     })
 
     it("should include keep_alive and runtime options from model config", async () => {
-      const { plasmoGlobalStorage } = await import(
+      const { getPlasmoStoredValue } = await import(
         "@/lib/plasmo-global-storage"
       )
-      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
         if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
           return {
             "llama3:latest": {
@@ -356,10 +358,10 @@ describe("handleChatWithModel", () => {
     })
 
     it("should upgrade legacy default context before streaming", async () => {
-      const { plasmoGlobalStorage } = await import(
+      const { getPlasmoStoredValue } = await import(
         "@/lib/plasmo-global-storage"
       )
-      vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+      vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
         if (key === STORAGE_KEYS.PROVIDER.MODEL_CONFIGS) {
           return {
             "llama3:latest": {

--- a/src/background/handlers/__tests__/handle-embedding-download.test.ts
+++ b/src/background/handlers/__tests__/handle-embedding-download.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { STORAGE_KEYS } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
-import {
-  plasmoGlobalStorage,
-  setPlasmoStoredValue
-} from "@/lib/plasmo-global-storage"
+import { setPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import {
   checkEmbeddingModelExists,
   downloadEmbeddingModelSilently
@@ -21,10 +18,6 @@ vi.mock("@/background/lib/utils", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    set: vi.fn(),
-    get: vi.fn()
-  },
   setPlasmoStoredValue: vi.fn()
 }))
 
@@ -212,7 +205,7 @@ describe("Handle Embedding Download", () => {
         STORAGE_KEYS.EMBEDDINGS.AUTO_DOWNLOADED,
         true
       )
-      expect(plasmoGlobalStorage.set).toHaveBeenCalledWith(
+      expect(setPlasmoStoredValue).toHaveBeenCalledWith(
         STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
         "nomic-embed-text"
       )
@@ -279,10 +272,10 @@ describe("Handle Embedding Download", () => {
         .mockResolvedValueOnce(createMockResponse(null))
 
       let finishSelectedModelWrite: (() => void) | undefined
-      vi.mocked(plasmoGlobalStorage.set).mockImplementationOnce(
+      vi.mocked(setPlasmoStoredValue).mockImplementationOnce(
         () =>
-          new Promise<null>((resolve) => {
-            finishSelectedModelWrite = () => resolve(null)
+          new Promise<void>((resolve) => {
+            finishSelectedModelWrite = () => resolve()
           })
       )
 
@@ -293,7 +286,7 @@ describe("Handle Embedding Download", () => {
       )
 
       await vi.waitFor(() =>
-        expect(plasmoGlobalStorage.set).toHaveBeenCalledWith(
+        expect(setPlasmoStoredValue).toHaveBeenCalledWith(
           STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
           "nomic-embed-text"
         )
@@ -307,9 +300,9 @@ describe("Handle Embedding Download", () => {
         true
       )
       expect(
-        vi.mocked(plasmoGlobalStorage.set).mock.invocationCallOrder[0]
+        vi.mocked(setPlasmoStoredValue).mock.invocationCallOrder[0]
       ).toBeLessThan(
-        vi.mocked(setPlasmoStoredValue).mock.invocationCallOrder[0] as number
+        vi.mocked(setPlasmoStoredValue).mock.invocationCallOrder[1] as number
       )
     })
   })

--- a/src/background/handlers/__tests__/handle-selection-action.test.ts
+++ b/src/background/handlers/__tests__/handle-selection-action.test.ts
@@ -32,10 +32,7 @@ const { mockProvider, mockStreamChat } = vi.hoisted(() => {
 })
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    get: vi.fn(),
-    set: vi.fn()
-  }
+  getPlasmoStoredValue: vi.fn()
 }))
 
 vi.mock("@/background/lib/abort-controller-registry", () => ({
@@ -64,17 +61,19 @@ const message: SelectionActionMessage = {
 }
 
 describe("handleSelectionAction", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     clearHandlerMocks()
     setupHandlerMocks()
     vi.clearAllMocks()
     mockProvider.config.enabled = true
+    const storage = await import("@/lib/plasmo-global-storage")
+    vi.mocked(storage.getPlasmoStoredValue).mockResolvedValue(undefined)
   })
 
   it("streams selection action chunks through selected provider", async () => {
     const { ProviderFactory } = await import("@/lib/providers/factory")
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
         return { modelId: "llama3:latest", providerId: "ollama" }
       }
@@ -110,8 +109,8 @@ describe("handleSelectionAction", () => {
   })
 
   it("passes the configured model system prompt into the selection action", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
         return { modelId: "llama3:latest", providerId: "ollama" }
       }
@@ -136,8 +135,8 @@ describe("handleSelectionAction", () => {
   })
 
   it("does not inject the default model system prompt when none is configured", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
         return { modelId: "llama3:latest", providerId: "ollama" }
       }
@@ -156,8 +155,8 @@ describe("handleSelectionAction", () => {
   })
 
   it("returns friendly error when no model is selected", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(undefined)
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue(undefined)
 
     const port = createMockPort(MESSAGE_KEYS.PROVIDER.START_SELECTION_ACTION)
     await handleSelectionAction(message, port, createMockIsPortClosed(false))
@@ -173,8 +172,8 @@ describe("handleSelectionAction", () => {
   })
 
   it("preserves disabled-provider recovery details", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
         return { modelId: "llama3:latest", providerId: "ollama" }
       }
@@ -208,8 +207,8 @@ describe("handleSelectionAction", () => {
     const { setAbortController } = await import(
       "@/background/lib/abort-controller-registry"
     )
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
-    vi.mocked(plasmoGlobalStorage.get).mockImplementation(async (key) => {
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF) {
         return { modelId: "llama3:latest", providerId: "ollama" }
       }

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -9,17 +9,8 @@ import { hasRetrievalTool } from "@/background/lib/retrieval-tools"
 import { streamChatWithNonNativeTools } from "@/background/lib/stream-chat-with-non-native-tools"
 import { streamChatWithTools } from "@/background/lib/stream-chat-with-tools"
 import { safePostChatStreamEvent } from "@/background/lib/utils"
-import {
-  DEFAULT_MAX_RAG_CONTEXT_CHARS,
-  DEFAULT_MEMORY_ENABLED,
-  STORAGE_KEYS
-} from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import {
-  parseStoredModelConfigMap,
-  resolveModelConfig
-} from "@/lib/model-config-utils"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
@@ -30,6 +21,8 @@ import {
   saveToolLoopRun,
   type ToolLoopMode
 } from "@/lib/repositories/tool-loop-runs"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import { CHAT_STREAM_EVENT_TYPES } from "@/protocol/streams"
 import type {
   ChatMessage,
@@ -82,20 +75,14 @@ export const handleChatWithModel = withErrorContext(
     const ac = new AbortController()
     setAbortController(abortKey, ac)
 
-    const modelConfigMap = parseStoredModelConfigMap(
-      await plasmoGlobalStorage.get<unknown>(
-        STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
-      )
-    )
+    const modelConfigMap = await readSetting(SETTINGS.MODEL_CONFIGS)
     const modelParams = resolveModelConfig(modelConfigMap[model])
 
     const limitedMessages = limitMessagesForModel(model, messages)
     const preparedMessages = [...limitedMessages]
 
     // --- System Prompt & Context Injection ---
-    const isMemoryEnabled =
-      (await plasmoGlobalStorage.get<boolean>(STORAGE_KEYS.MEMORY.ENABLED)) ??
-      DEFAULT_MEMORY_ENABLED
+    const isMemoryEnabled = await readSetting(SETTINGS.MEMORY_ENABLED)
     // A per-chat system prompt override, when set, replaces the model's
     // configured prompt for this session only. Empty/whitespace is ignored, and
     // a failed read degrades to the model default rather than breaking the turn.
@@ -181,10 +168,7 @@ export const handleChatWithModel = withErrorContext(
           // Enforce the prompt-budget ceiling (same setting the client RAG path
           // uses) so a large set of recalled memories can't blow the model's
           // context window. `<= 0` means unlimited.
-          const maxRagChars =
-            (await plasmoGlobalStorage.get<number>(
-              STORAGE_KEYS.CHAT.MAX_RAG_CONTEXT_CHARS
-            )) ?? DEFAULT_MAX_RAG_CONTEXT_CHARS
+          const maxRagChars = await readSetting(SETTINGS.MAX_RAG_CONTEXT_CHARS)
           const truncationMarker = "\n\n[Context truncated due to length]"
           const cappedContext =
             maxRagChars > 0 && formattedContext.length > maxRagChars
@@ -303,10 +287,9 @@ export const handleChatWithModel = withErrorContext(
     try {
       if (resolvedTools && resolvedTools.tools.length > 0) {
         const { getToolRegistry } = await import("@/lib/tools")
-        const toolResultMaxChars =
-          (await plasmoGlobalStorage.get<number>(
-            STORAGE_KEYS.CHAT.MAX_TOOL_RESULT_CHARS
-          )) ?? undefined
+        const toolResultMaxChars = await readSetting(
+          SETTINGS.MAX_TOOL_RESULT_CHARS
+        )
         const ctx = {
           signal: ac.signal,
           sessionId: msg.payload.sessionId,

--- a/src/background/handlers/handle-embedding-download.ts
+++ b/src/background/handlers/handle-embedding-download.ts
@@ -13,15 +13,14 @@ import {
 } from "@/lib/constants"
 import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import {
-  plasmoGlobalStorage,
-  setPlasmoStoredValue
-} from "@/lib/plasmo-global-storage"
+import { setPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import {
   discoverProviderModels,
   type ModelCatalogVerdict
 } from "@/lib/providers/model-discovery"
+import { writeSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { DefaultProviderPullRequest } from "@/types"
 
 const abortError = (signal: AbortSignal): Error =>
@@ -54,10 +53,7 @@ const commitDownloadedEmbeddingModel = async (
   // abortable, so once this pair starts it must finish without observing
   // cancellation between writes. If the second write fails, the model may be
   // selected but the preparation is not falsely recorded as complete.
-  await plasmoGlobalStorage.set(
-    STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
-    modelName
-  )
+  await writeSetting(SETTINGS.EMBEDDING_SELECTED_MODEL, modelName)
   await setPlasmoStoredValue(STORAGE_KEYS.EMBEDDINGS.AUTO_DOWNLOADED, true)
 
   // Preserve cancellation semantics for the RPC caller after state is

--- a/src/background/handlers/handle-selection-action.ts
+++ b/src/background/handlers/handle-selection-action.ts
@@ -3,16 +3,13 @@ import type { SelectionActionMessage } from "@/application/selection-actions/typ
 import { setAbortController } from "@/background/lib/abort-controller-registry"
 import { normalizeError } from "@/background/lib/error-handler"
 import { safePostChatStreamEvent } from "@/background/lib/utils"
-import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import {
-  parseStoredModelConfigMap,
-  resolveModelConfig
-} from "@/lib/model-config-utils"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
-import { isSelectedModelRef } from "@/lib/providers/selected-model"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ChromePort, PortStatusFunction } from "@/types"
 
 export const handleSelectionAction = async (
@@ -20,19 +17,13 @@ export const handleSelectionAction = async (
   port: ChromePort,
   isPortClosed: PortStatusFunction
 ) => {
-  const selectedRef = await plasmoGlobalStorage.get<unknown>(
-    STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF
-  )
-  const fallbackModel = await plasmoGlobalStorage.get<string>(
-    STORAGE_KEYS.PROVIDER.SELECTED_MODEL
-  )
+  const selectedRef = await readSetting(SETTINGS.SELECTED_MODEL_REF)
+  const fallbackModel = await readSetting(SETTINGS.SELECTED_MODEL)
 
   const model =
-    msg.payload.model ||
-    (isSelectedModelRef(selectedRef) ? selectedRef.modelId : fallbackModel)
+    msg.payload.model || (selectedRef ? selectedRef.modelId : fallbackModel)
   const providerId =
-    msg.payload.providerId ||
-    (isSelectedModelRef(selectedRef) ? selectedRef.providerId : undefined)
+    msg.payload.providerId || (selectedRef ? selectedRef.providerId : undefined)
 
   if (!model) {
     safePostChatStreamEvent(port, {
@@ -53,11 +44,7 @@ export const handleSelectionAction = async (
   setAbortController(abortKey, ac)
 
   try {
-    const modelConfigMap = parseStoredModelConfigMap(
-      await plasmoGlobalStorage.get<unknown>(
-        STORAGE_KEYS.PROVIDER.MODEL_CONFIGS
-      )
-    )
+    const modelConfigMap = await readSetting(SETTINGS.MODEL_CONFIGS)
     const modelParams = resolveModelConfig(modelConfigMap[model])
     const provider = await ProviderFactory.getProviderForModel(
       model,

--- a/src/background/lib/__tests__/memory-manager.test.ts
+++ b/src/background/lib/__tests__/memory-manager.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/embeddings/vector-store", () => ({
 
 const mockGet = vi.fn()
 vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: mockGet,
   plasmoGlobalStorage: { get: mockGet }
 }))
 

--- a/src/background/lib/memory-manager.ts
+++ b/src/background/lib/memory-manager.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_MEMORY_ENABLED, STORAGE_KEYS } from "@/lib/constants"
 import { storeChatMessage } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 
 export interface ChatMemoryPayload {
   userMessage: string
@@ -22,9 +22,7 @@ export const memoryManager = {
     const { userMessage, aiResponse, sessionId, chatId } = payload
 
     // Check if memory is enabled
-    const isMemoryEnabled =
-      (await plasmoGlobalStorage.get<boolean>(STORAGE_KEYS.MEMORY.ENABLED)) ??
-      DEFAULT_MEMORY_ENABLED
+    const isMemoryEnabled = await readSetting(SETTINGS.MEMORY_ENABLED)
     if (!isMemoryEnabled) {
       return
     }

--- a/src/contents/__tests__/url-filter.test.ts
+++ b/src/contents/__tests__/url-filter.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_CONTENT_EXTRACTION_CONFIG } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 
 import {
   isExcludedUrl,
@@ -9,7 +9,7 @@ import {
   urlMatchesAny
 } from "../url-filter"
 
-const mockedGet = vi.mocked(plasmoGlobalStorage.get)
+const mockedGet = vi.mocked(getPlasmoStoredValue)
 const profileNeverRead = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/per-site-profiles", () => ({

--- a/src/contents/content-config.ts
+++ b/src/contents/content-config.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_CONTENT_EXTRACTION_CONFIG } from "@/lib/constants"
 import { getEffectiveConfig } from "@/lib/content-extractor"
+import { EXCLUDE_URL_PATTERNS_SETTING } from "@/lib/storage/content-policy-settings"
+import { CONTENT_SETTINGS } from "@/lib/storage/content-settings"
 import { readSetting, readStoredSetting } from "@/lib/storage/setting-access"
-import { SETTINGS } from "@/lib/storage/settings"
 import type { ContentExtractionConfig } from "@/types"
 
 export const resolveActiveConfig = async (
@@ -10,11 +11,13 @@ export const resolveActiveConfig = async (
   effectiveConfig: ContentExtractionConfig
   hasSiteOverride: boolean
 }> => {
-  const stored = await readStoredSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
+  const stored = await readStoredSetting(
+    CONTENT_SETTINGS.CONTENT_EXTRACTION_CONFIG
+  )
 
   let excludedUrlPatterns = stored?.excludedUrlPatterns
   if (!excludedUrlPatterns || excludedUrlPatterns.length === 0) {
-    const oldPatterns = await readSetting(SETTINGS.EXCLUDE_URL_PATTERNS)
+    const oldPatterns = await readSetting(EXCLUDE_URL_PATTERNS_SETTING)
     excludedUrlPatterns = oldPatterns
   }
 

--- a/src/contents/content-config.ts
+++ b/src/contents/content-config.ts
@@ -1,9 +1,7 @@
-import {
-  DEFAULT_CONTENT_EXTRACTION_CONFIG,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { DEFAULT_CONTENT_EXTRACTION_CONFIG } from "@/lib/constants"
 import { getEffectiveConfig } from "@/lib/content-extractor"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting, readStoredSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ContentExtractionConfig } from "@/types"
 
 export const resolveActiveConfig = async (
@@ -12,22 +10,16 @@ export const resolveActiveConfig = async (
   effectiveConfig: ContentExtractionConfig
   hasSiteOverride: boolean
 }> => {
-  const stored = await plasmoGlobalStorage.get<ContentExtractionConfig>(
-    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG
-  )
+  const stored = await readStoredSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
 
   let excludedUrlPatterns = stored?.excludedUrlPatterns
   if (!excludedUrlPatterns || excludedUrlPatterns.length === 0) {
-    const oldPatterns = await plasmoGlobalStorage.get<string[]>(
-      STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS
-    )
-    excludedUrlPatterns =
-      oldPatterns || DEFAULT_CONTENT_EXTRACTION_CONFIG.excludedUrlPatterns
+    const oldPatterns = await readSetting(SETTINGS.EXCLUDE_URL_PATTERNS)
+    excludedUrlPatterns = oldPatterns
   }
 
   const globalConfig: ContentExtractionConfig = stored
     ? {
-        ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
         ...stored,
         excludedUrlPatterns,
         siteOverrides: stored.siteOverrides || {}

--- a/src/contents/page-content-handler.ts
+++ b/src/contents/page-content-handler.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_TABS_ACCESS, STORAGE_KEYS } from "@/lib/constants"
 import { extractContentWithLoading } from "@/lib/content-extractor"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { TAB_ACCESS_SETTING } from "@/lib/storage/content-policy-settings"
+import { readSetting } from "@/lib/storage/setting-access"
 import { getTranscript } from "@/lib/transcript-extractor"
 import { getYouTubeVideoId } from "@/lib/youtube-url"
 import { resolveActiveConfig } from "./content-config"
@@ -93,10 +93,7 @@ const extractYouTubeMetadata = (currentUrl: string, pageTitle: string) => {
 export const handleGetPageContent = async (
   sendResponse: (response: unknown) => void
 ): Promise<void> => {
-  const storedTabAccess = await plasmoGlobalStorage.get<boolean>(
-    STORAGE_KEYS.BROWSER.TABS_ACCESS
-  )
-  const tabAccessEnabled = storedTabAccess ?? DEFAULT_TABS_ACCESS
+  const tabAccessEnabled = await readSetting(TAB_ACCESS_SETTING)
 
   if (!tabAccessEnabled) {
     contentDebugLog("[Content Script] Tab access is disabled")

--- a/src/contents/url-filter.ts
+++ b/src/contents/url-filter.ts
@@ -1,11 +1,7 @@
-import {
-  DEFAULT_CONTENT_EXTRACTION_CONFIG,
-  STORAGE_KEYS
-} from "@/lib/constants"
 import { isNeverReadUrl } from "@/lib/per-site-profiles"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting, readStoredSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import { matchesUserPattern } from "@/lib/url-pattern"
-import type { ContentExtractionConfig } from "@/types"
 
 /**
  * Resolve the active list of excluded URL patterns.
@@ -16,20 +12,18 @@ import type { ContentExtractionConfig } from "@/types"
  *   3. Defaults from DEFAULT_CONTENT_EXTRACTION_CONFIG
  */
 export const resolveExcludedUrlPatterns = async (): Promise<string[]> => {
-  const storedConfig = await plasmoGlobalStorage.get<ContentExtractionConfig>(
-    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG
+  const storedConfig = await readStoredSetting(
+    SETTINGS.CONTENT_EXTRACTION_CONFIG
   )
 
   if (storedConfig?.excludedUrlPatterns?.length) {
     return storedConfig.excludedUrlPatterns
   }
 
-  const legacy = await plasmoGlobalStorage.get<string[]>(
-    STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS
-  )
+  const legacy = await readSetting(SETTINGS.EXCLUDE_URL_PATTERNS)
   if (legacy?.length) return legacy
 
-  return DEFAULT_CONTENT_EXTRACTION_CONFIG.excludedUrlPatterns
+  return SETTINGS.CONTENT_EXTRACTION_CONFIG.defaultValue.excludedUrlPatterns
 }
 
 /**

--- a/src/contents/url-filter.ts
+++ b/src/contents/url-filter.ts
@@ -1,6 +1,7 @@
 import { isNeverReadUrl } from "@/lib/per-site-profiles"
+import { EXCLUDE_URL_PATTERNS_SETTING } from "@/lib/storage/content-policy-settings"
+import { CONTENT_SETTINGS } from "@/lib/storage/content-settings"
 import { readSetting, readStoredSetting } from "@/lib/storage/setting-access"
-import { SETTINGS } from "@/lib/storage/settings"
 import { matchesUserPattern } from "@/lib/url-pattern"
 
 /**
@@ -13,17 +14,18 @@ import { matchesUserPattern } from "@/lib/url-pattern"
  */
 export const resolveExcludedUrlPatterns = async (): Promise<string[]> => {
   const storedConfig = await readStoredSetting(
-    SETTINGS.CONTENT_EXTRACTION_CONFIG
+    CONTENT_SETTINGS.CONTENT_EXTRACTION_CONFIG
   )
 
   if (storedConfig?.excludedUrlPatterns?.length) {
     return storedConfig.excludedUrlPatterns
   }
 
-  const legacy = await readSetting(SETTINGS.EXCLUDE_URL_PATTERNS)
+  const legacy = await readSetting(EXCLUDE_URL_PATTERNS_SETTING)
   if (legacy?.length) return legacy
 
-  return SETTINGS.CONTENT_EXTRACTION_CONFIG.defaultValue.excludedUrlPatterns
+  return CONTENT_SETTINGS.CONTENT_EXTRACTION_CONFIG.defaultValue
+    .excludedUrlPatterns
 }
 
 /**

--- a/src/features/file-upload/hooks/__tests__/use-file-search.test.ts
+++ b/src/features/file-upload/hooks/__tests__/use-file-search.test.ts
@@ -12,19 +12,17 @@ vi.mock("@/lib/embeddings/vector-store", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    get: vi.fn()
-  }
+  getPlasmoStoredValue: vi.fn()
 }))
 
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { searchSimilarVectors } from "@/lib/embeddings/vector-store"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 
 describe("useFileSearch", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue({
       defaultSearchLimit: 10,
       defaultMinSimilarity: 0.5
     })

--- a/src/features/file-upload/hooks/use-file-search.ts
+++ b/src/features/file-upload/hooks/use-file-search.ts
@@ -1,14 +1,11 @@
 import { useCallback, useState } from "react"
-
-import type { EmbeddingConfig } from "@/lib/constants"
-import { STORAGE_KEYS } from "@/lib/constants"
+import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
 import { searchSimilarVectors } from "@/lib/embeddings/vector-store"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
 export interface FileSearchResult {
   result: SearchResult
@@ -46,9 +43,7 @@ export const useFileSearch = () => {
 
       try {
         // Get embedding config
-        const embeddingConfig = await plasmoGlobalStorage.get<EmbeddingConfig>(
-          STORAGE_KEYS.EMBEDDINGS.CONFIG
-        )
+        const embeddingConfig = await getEmbeddingConfig()
 
         // Generate embedding for query
         const embeddingResult = await generateEmbedding(query.trim())

--- a/src/features/model/hooks/use-model-capability-overrides.ts
+++ b/src/features/model/hooks/use-model-capability-overrides.ts
@@ -16,7 +16,7 @@ import {
   modelCapabilityOverrideKey,
   setModelCapabilityOverride
 } from "@/lib/providers/model-capability-overrides"
-import { SETTINGS } from "@/lib/storage/settings"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
 import type { ProviderModel } from "@/types"
 
 /**
@@ -26,8 +26,8 @@ import type { ProviderModel } from "@/types"
  * so the prune/merge rules stay in one place.
  */
 export const useModelCapabilityOverrides = () => {
-  const [overrides] = useSetting(SETTINGS.MODEL_CAPABILITY_OVERRIDES)
-  const [probes] = useSetting(SETTINGS.MODEL_CAPABILITY_PROBES)
+  const [overrides] = useSetting(POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES)
+  const [probes] = useSetting(POLICY_SETTINGS.MODEL_CAPABILITY_PROBES)
 
   const getOverride = useCallback(
     (providerId: string, modelName: string): ModelCapabilityOverride | null =>

--- a/src/features/permissions/components/approvals-card.tsx
+++ b/src/features/permissions/components/approvals-card.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { SettingsCard } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { useSetting } from "@/hooks/use-setting"
-import { SETTINGS } from "@/lib/storage/settings"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
 import {
   clearAllApprovalGrants,
   revokeApprovalGrant
@@ -18,7 +18,7 @@ import { getToolDisplayMeta } from "@/lib/tools/tool-display"
  */
 export const ApprovalsCard = () => {
   const { t, i18n } = useTranslation()
-  const [grants] = useSetting(SETTINGS.APPROVAL_GRANTS)
+  const [grants] = useSetting(POLICY_SETTINGS.APPROVAL_GRANTS)
 
   const entries = Object.entries(grants ?? {}).sort(
     ([, a], [, b]) => b.grantedAt - a.grantedAt

--- a/src/features/permissions/components/permissions-panel.tsx
+++ b/src/features/permissions/components/permissions-panel.tsx
@@ -10,24 +10,21 @@ import {
 import { Button } from "@/components/ui/button"
 import { ApprovalsCard } from "@/features/permissions/components/approvals-card"
 import { ModelToolsCard } from "@/features/permissions/components/model-tools-card"
+import { useSetting } from "@/hooks/use-setting"
 import { browser, supportsSessions, supportsTabGroups } from "@/lib/browser-api"
-import {
-  DEFAULT_TABS_ACCESS,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { MESSAGE_KEYS } from "@/lib/constants"
 import {
   hasPermission,
   type OptionalApiPermission,
   removePermission,
   requestPermission
 } from "@/lib/permissions"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import {
   getScheduledJobSettings,
   type ScheduledJobId,
   setScheduledJobEnabled
 } from "@/lib/scheduled-jobs"
+import { SETTINGS } from "@/lib/storage/settings"
 
 /**
  * Shared privacy / permissions surface. Reused in the Options "Permissions"
@@ -81,35 +78,14 @@ const SCHEDULED_JOB_LABELS: Record<
 
 const TabAccessSettings = () => {
   const { t } = useTranslation()
-  const [tabAccess, setTabAccess] = useState(DEFAULT_TABS_ACCESS)
-
-  useEffect(() => {
-    let active = true
-    plasmoGlobalStorage
-      .get<boolean>(STORAGE_KEYS.BROWSER.TABS_ACCESS)
-      .then((stored) => {
-        if (active) setTabAccess(stored ?? DEFAULT_TABS_ACCESS)
-      })
-      .catch(() => {
-        // Fall back to the default on a storage read error rather than
-        // leaving an unhandled rejection.
-      })
-    return () => {
-      active = false
-    }
-  }, [])
-
-  const onCheckedChange = async (next: boolean) => {
-    setTabAccess(next)
-    await plasmoGlobalStorage.set(STORAGE_KEYS.BROWSER.TABS_ACCESS, next)
-  }
+  const [tabAccess, setTabAccess] = useSetting(SETTINGS.TABS_ACCESS)
 
   return (
     <SettingsSwitch
       id="browser-tab-access"
       label={t("settings.presets.fields.tab_access")}
       checked={tabAccess}
-      onCheckedChange={onCheckedChange}
+      onCheckedChange={setTabAccess}
     />
   )
 }

--- a/src/features/selection-actions/__tests__/content-settings.test.ts
+++ b/src/features/selection-actions/__tests__/content-settings.test.ts
@@ -10,9 +10,7 @@ vi.mock("@/i18n/selection-config", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    get: mocks.getStoredValue
-  }
+  getPlasmoStoredValue: mocks.getStoredValue
 }))
 
 import { syncSelectionLanguage } from "@/features/selection-actions/content-settings"

--- a/src/features/selection-actions/__tests__/content-settings.test.ts
+++ b/src/features/selection-actions/__tests__/content-settings.test.ts
@@ -13,7 +13,58 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
   getPlasmoStoredValue: mocks.getStoredValue
 }))
 
-import { syncSelectionLanguage } from "@/features/selection-actions/content-settings"
+import {
+  createLatestSelectionConfigRefresh,
+  syncSelectionLanguage
+} from "@/features/selection-actions/content-settings"
+
+describe("createLatestSelectionConfigRefresh", () => {
+  it("ignores an older read that resolves after a newer read", async () => {
+    let resolveOld: (value: string) => void = () => undefined
+    let resolveNew: (value: string) => void = () => undefined
+    const oldRead = new Promise<string>((resolve) => {
+      resolveOld = resolve
+    })
+    const newRead = new Promise<string>((resolve) => {
+      resolveNew = resolve
+    })
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(oldRead)
+      .mockReturnValueOnce(newRead)
+    const apply = vi.fn()
+    const refresh = createLatestSelectionConfigRefresh(load, apply)
+
+    const oldRefresh = refresh.run()
+    const newRefresh = refresh.run()
+    resolveNew("new")
+    await newRefresh
+    resolveOld("old")
+    await oldRefresh
+
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(apply).toHaveBeenCalledWith("new")
+  })
+
+  it("does not apply a pending read after invalidation", async () => {
+    let resolveRead: (value: string) => void = () => undefined
+    const load = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve
+        })
+    )
+    const apply = vi.fn()
+    const refresh = createLatestSelectionConfigRefresh(load, apply)
+
+    const pending = refresh.run()
+    refresh.invalidate()
+    resolveRead("stale")
+    await pending
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+})
 
 describe("syncSelectionLanguage", () => {
   beforeEach(() => {

--- a/src/features/selection-actions/content-script.tsx
+++ b/src/features/selection-actions/content-script.tsx
@@ -17,13 +17,13 @@ import {
   DEFAULT_CONTENT_EXTRACTION_CONFIG,
   STORAGE_KEYS
 } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { plasmoSyncStorage } from "@/lib/plasmo-global-storage"
 import {
   SELECTION_OVERLAY_READY_EVENT,
   SELECTION_OVERLAY_REQUEST_ID_GLOBAL,
   type SelectionOverlayReadyDetail
 } from "@/protocol/content-messages"
-import type { ContentExtractionConfig, ProviderModel } from "@/types"
+import type { ProviderModel } from "@/types"
 
 export const createSelectionActionsContentScript = (appStyles: string) =>
   defineContentScript({
@@ -209,14 +209,11 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
             )
           }
         },
-        [STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG]: (change: {
-          newValue?: unknown
-        }) => {
-          configRef.current = {
-            ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
-            ...((change.newValue as Partial<ContentExtractionConfig>) ?? {})
-          }
-          if (!configRef.current.selectionActionsEnabled) hide()
+        [STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG]: () => {
+          void loadSelectionConfig().then((config) => {
+            configRef.current = config
+            if (!config.selectionActionsEnabled) hide()
+          })
         },
         [STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF]: () => {
           panelModelRef.current = ""
@@ -227,7 +224,7 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
           void syncPanelModel()
         }
       }
-      plasmoGlobalStorage.watch(storageWatchCallbacks)
+      plasmoSyncStorage.watch(storageWatchCallbacks)
 
       // ── DOM event listeners ──────────────────────────────────────────
       document.addEventListener("selectionchange", queueSelectionCheck, true)
@@ -248,7 +245,7 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
         document.removeEventListener("keyup", queueSelectionCheck, true)
         document.removeEventListener("keydown", handleEscape, true)
         chrome.storage.onChanged.removeListener(handleThemeChange)
-        plasmoGlobalStorage.unwatch(storageWatchCallbacks)
+        plasmoSyncStorage.unwatch(storageWatchCallbacks)
         root?.unmount()
         ui.remove()
       })

--- a/src/features/selection-actions/content-script.tsx
+++ b/src/features/selection-actions/content-script.tsx
@@ -3,6 +3,7 @@ import { createShadowRootUi } from "wxt/utils/content-script-ui/shadow-root"
 import { defineContentScript } from "wxt/utils/define-content-script"
 import {
   applyStoredTheme,
+  createLatestSelectionConfigRefresh,
   loadSelectedPanelModel,
   loadSelectionConfig,
   syncSelectionLanguage
@@ -95,9 +96,13 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
       })
 
       // ── Config / model helpers ───────────────────────────────────────
-      const updateConfig = async () => {
-        configRef.current = await loadSelectionConfig()
-      }
+      const configRefresh = createLatestSelectionConfigRefresh(
+        loadSelectionConfig,
+        (config) => {
+          configRef.current = config
+          if (!config.selectionActionsEnabled) hide()
+        }
+      )
       const syncPanelModel = async () => {
         const selected = await loadSelectedPanelModel(panelModelRef.current)
         panelModelRef.current = selected.model
@@ -184,7 +189,7 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
 
       // ── Bootstrap ────────────────────────────────────────────────────
       await Promise.all([
-        updateConfig(),
+        configRefresh.run(),
         syncPanelModel(),
         syncSelectionLanguage()
       ])
@@ -210,10 +215,7 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
           }
         },
         [STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG]: () => {
-          void loadSelectionConfig().then((config) => {
-            configRef.current = config
-            if (!config.selectionActionsEnabled) hide()
-          })
+          void configRefresh.run()
         },
         [STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF]: () => {
           panelModelRef.current = ""
@@ -235,6 +237,7 @@ export const createSelectionActionsContentScript = (appStyles: string) =>
       queueSelectionCheck()
 
       ctx.onInvalidated(() => {
+        configRefresh.invalidate()
         document.removeEventListener(
           "selectionchange",
           queueSelectionCheck,

--- a/src/features/selection-actions/content-settings.ts
+++ b/src/features/selection-actions/content-settings.ts
@@ -1,18 +1,14 @@
 import { isEmbeddingModel } from "@/features/model/lib/model-utils"
 import { setSelectionLanguage } from "@/i18n/selection-config"
 import { browser } from "@/lib/browser-api"
-import {
-  DEFAULT_CONTENT_EXTRACTION_CONFIG,
-  MESSAGE_KEYS,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
-import { isSelectedModelRef } from "@/lib/providers/selected-model"
+import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { sendRuntimeMessage } from "@/lib/runtime-messages"
-import type { ContentExtractionConfig, ProviderModel } from "@/types"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
+import type { ProviderModel } from "@/types"
 
 export async function syncSelectionLanguage() {
-  const stored = await plasmoGlobalStorage.get<string>(STORAGE_KEYS.LANGUAGE)
+  const stored = await readSetting(SETTINGS.LANGUAGE)
   const browserLanguage =
     chrome.i18n?.getUILanguage?.() ?? globalThis.navigator?.language
   try {
@@ -25,10 +21,7 @@ export async function syncSelectionLanguage() {
 }
 
 export async function loadSelectionConfig() {
-  const stored = await plasmoGlobalStorage.get<ContentExtractionConfig>(
-    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG
-  )
-  return { ...DEFAULT_CONTENT_EXTRACTION_CONFIG, ...(stored ?? {}) }
+  return readSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
 }
 
 export async function loadSelectedPanelModel(currentModel: string): Promise<{
@@ -37,14 +30,10 @@ export async function loadSelectedPanelModel(currentModel: string): Promise<{
 }> {
   if (currentModel) return { model: currentModel }
 
-  const ref = await plasmoGlobalStorage.get<unknown>(
-    STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF
-  )
-  const fallback = await plasmoGlobalStorage.get<string>(
-    STORAGE_KEYS.PROVIDER.SELECTED_MODEL
-  )
+  const ref = await readSetting(SETTINGS.SELECTED_MODEL_REF)
+  const fallback = await readSetting(SETTINGS.SELECTED_MODEL)
 
-  if (isSelectedModelRef(ref)) {
+  if (ref) {
     return { model: ref.modelId, providerId: ref.providerId }
   }
 

--- a/src/features/selection-actions/content-settings.ts
+++ b/src/features/selection-actions/content-settings.ts
@@ -7,6 +7,24 @@ import { SELECTION_ACTION_SETTINGS } from "@/lib/storage/selection-action-settin
 import { readSetting } from "@/lib/storage/setting-access"
 import type { ProviderModel } from "@/types"
 
+/** Apply only the newest completed async refresh; older reads become no-ops. */
+export const createLatestSelectionConfigRefresh = <T>(
+  load: () => Promise<T>,
+  apply: (value: T) => void
+) => {
+  let generation = 0
+  return {
+    run: async (): Promise<void> => {
+      const current = ++generation
+      const value = await load()
+      if (current === generation) apply(value)
+    },
+    invalidate: () => {
+      generation++
+    }
+  }
+}
+
 export async function syncSelectionLanguage() {
   const stored = await readSetting(SELECTION_ACTION_SETTINGS.LANGUAGE)
   const browserLanguage =

--- a/src/features/selection-actions/content-settings.ts
+++ b/src/features/selection-actions/content-settings.ts
@@ -3,12 +3,12 @@ import { setSelectionLanguage } from "@/i18n/selection-config"
 import { browser } from "@/lib/browser-api"
 import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { sendRuntimeMessage } from "@/lib/runtime-messages"
+import { SELECTION_ACTION_SETTINGS } from "@/lib/storage/selection-action-settings"
 import { readSetting } from "@/lib/storage/setting-access"
-import { SETTINGS } from "@/lib/storage/settings"
 import type { ProviderModel } from "@/types"
 
 export async function syncSelectionLanguage() {
-  const stored = await readSetting(SETTINGS.LANGUAGE)
+  const stored = await readSetting(SELECTION_ACTION_SETTINGS.LANGUAGE)
   const browserLanguage =
     chrome.i18n?.getUILanguage?.() ?? globalThis.navigator?.language
   try {
@@ -21,7 +21,7 @@ export async function syncSelectionLanguage() {
 }
 
 export async function loadSelectionConfig() {
-  return readSetting(SETTINGS.CONTENT_EXTRACTION_CONFIG)
+  return readSetting(SELECTION_ACTION_SETTINGS.CONTENT_EXTRACTION_CONFIG)
 }
 
 export async function loadSelectedPanelModel(currentModel: string): Promise<{
@@ -30,8 +30,8 @@ export async function loadSelectedPanelModel(currentModel: string): Promise<{
 }> {
   if (currentModel) return { model: currentModel }
 
-  const ref = await readSetting(SETTINGS.SELECTED_MODEL_REF)
-  const fallback = await readSetting(SETTINGS.SELECTED_MODEL)
+  const ref = await readSetting(SELECTION_ACTION_SETTINGS.SELECTED_MODEL_REF)
+  const fallback = await readSetting(SELECTION_ACTION_SETTINGS.SELECTED_MODEL)
 
   if (ref) {
     return { model: ref.modelId, providerId: ref.providerId }

--- a/src/features/settings/__tests__/apply-settings.test.ts
+++ b/src/features/settings/__tests__/apply-settings.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_EMBEDDING_CONFIG } from "@/lib/constants"
 
 const store = new Map<string, unknown>()
 vi.mock("@/lib/plasmo-global-storage", () => ({
@@ -23,16 +24,16 @@ describe("applyStorageWrites", () => {
     expect(store.get("chat-grounded-only-mode")).toBe(true)
   })
 
-  it("merges field writes into the existing config object, preserving siblings", async () => {
+  it("merges field writes into validated config and drops unknown fields", async () => {
     store.set("embeddings-config", { chunkSize: 500, batchSize: 5, keepMe: 1 })
     await applyStorageWrites([
       { storageKey: "embeddings-config", field: "chunkSize", value: 800 },
       { storageKey: "embeddings-config", field: "useReranking", value: false }
     ])
     expect(store.get("embeddings-config")).toEqual({
+      ...DEFAULT_EMBEDDING_CONFIG,
       chunkSize: 800,
       batchSize: 5,
-      keepMe: 1,
       useReranking: false
     })
   })
@@ -41,19 +42,35 @@ describe("applyStorageWrites", () => {
     await applyStorageWrites([
       { storageKey: "embeddings-config", field: "chunkSize", value: 200 }
     ])
-    expect(store.get("embeddings-config")).toEqual({ chunkSize: 200 })
+    expect(store.get("embeddings-config")).toEqual({
+      ...DEFAULT_EMBEDDING_CONFIG,
+      chunkSize: 200
+    })
   })
 
   it("groups writes so each key is written once", async () => {
     const { setPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     await applyStorageWrites([
       { storageKey: "a", value: 1 },
-      { storageKey: "embeddings-config", field: "x", value: 1 },
-      { storageKey: "embeddings-config", field: "y", value: 2 }
+      { storageKey: "embeddings-config", field: "chunkSize", value: 300 },
+      { storageKey: "embeddings-config", field: "batchSize", value: 2 }
     ])
     // one write for "a", one for "embeddings-config"
     expect(setPlasmoStoredValue).toHaveBeenCalledTimes(2)
-    expect(store.get("embeddings-config")).toEqual({ x: 1, y: 2 })
+    expect(store.get("embeddings-config")).toEqual({
+      ...DEFAULT_EMBEDDING_CONFIG,
+      chunkSize: 300,
+      batchSize: 2
+    })
+  })
+
+  it("rejects invalid descriptor-backed field writes", async () => {
+    await expect(
+      applyStorageWrites([
+        { storageKey: "embeddings-config", field: "chunkSize", value: -1 }
+      ])
+    ).rejects.toThrow(/Invalid value for setting embeddings-config/)
+    expect(store.has("embeddings-config")).toBe(false)
   })
 
   it("rejects mixed scalar and field writes for the same key", async () => {

--- a/src/features/settings/apply-settings.ts
+++ b/src/features/settings/apply-settings.ts
@@ -18,6 +18,8 @@ import {
   getPlasmoStoredValue,
   setPlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
+import { getSettingDescriptor } from "@/lib/storage/settings"
 
 export interface SettingWrite {
   /** The storage key to write. */
@@ -50,20 +52,31 @@ export const applyStorageWrites = async (
 
   await Promise.all(
     Array.from(byKey.entries()).map(async ([key, group]) => {
+      const descriptor = getSettingDescriptor(key)
       const fieldWrites = group.filter((w) => w.field)
       // Scalar key: a single fieldless write replaces the whole value.
       if (fieldWrites.length === 0) {
-        await setPlasmoStoredValue(key, group[group.length - 1].value)
+        const value = group[group.length - 1].value
+        if (descriptor) await writeSetting(descriptor, value)
+        else await setPlasmoStoredValue(key, value)
         return
       }
       // Config-object key: merge all field updates into the current object.
       const current =
-        (await getPlasmoStoredValue<Record<string, unknown>>(key)) ?? {}
+        (descriptor
+          ? await readSetting(descriptor)
+          : await getPlasmoStoredValue<Record<string, unknown>>(key)) ?? {}
+      if (typeof current !== "object" || Array.isArray(current)) {
+        throw new Error(
+          `Cannot apply field settings to non-object key "${key}"`
+        )
+      }
       const next: Record<string, unknown> = { ...current }
       for (const write of fieldWrites) {
         if (write.field) next[write.field] = write.value
       }
-      await setPlasmoStoredValue(key, next)
+      if (descriptor) await writeSetting(descriptor, next)
+      else await setPlasmoStoredValue(key, next)
     })
   )
 }

--- a/src/features/settings/apply-settings.ts
+++ b/src/features/settings/apply-settings.ts
@@ -19,7 +19,7 @@ import {
   setPlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
 import { readSetting, writeSetting } from "@/lib/storage/setting-access"
-import { getSettingDescriptor } from "@/lib/storage/settings"
+import { getSettingDescriptor } from "@/lib/storage/setting-registry"
 
 export interface SettingWrite {
   /** The storage key to write. */

--- a/src/lib/config/knowledge-config.ts
+++ b/src/lib/config/knowledge-config.ts
@@ -1,8 +1,5 @@
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
+import { DEFAULT_EMBEDDING_CONFIG } from "@/lib/constants"
+import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 
 export const KNOWLEDGE_CONFIG_KEYS = {
@@ -103,9 +100,7 @@ export class KnowledgeConfig {
   }
 
   async getMinSimilarity(): Promise<number> {
-    const config = await plasmoGlobalStorage.get<EmbeddingConfig>(
-      STORAGE_KEYS.EMBEDDINGS.CONFIG
-    )
+    const config = await getEmbeddingConfig()
     return (
       config?.defaultMinSimilarity ??
       DEFAULT_EMBEDDING_CONFIG.defaultMinSimilarity

--- a/src/lib/embeddings/__tests__/config.test.ts
+++ b/src/lib/embeddings/__tests__/config.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { getEmbeddingConfig } from "../config"
 
 describe("getEmbeddingConfig", () => {
   it("normalizes legacy backend values", async () => {
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValueOnce({
+    vi.mocked(getPlasmoStoredValue).mockResolvedValueOnce({
       annBackend: "wasm-hnsw",
       rerankerBackend: "transformers-js",
       useReranking: true
@@ -17,7 +17,7 @@ describe("getEmbeddingConfig", () => {
   })
 
   it("forces cosine when reranking is enabled", async () => {
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValueOnce({
+    vi.mocked(getPlasmoStoredValue).mockResolvedValueOnce({
       rerankerBackend: "none",
       useReranking: true
     } as unknown)

--- a/src/lib/embeddings/__tests__/embedding-client.test.ts
+++ b/src/lib/embeddings/__tests__/embedding-client.test.ts
@@ -15,6 +15,7 @@ const { mockEmbed } = vi.hoisted(() => ({
 
 // Mock plasmo storage
 vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: vi.fn().mockResolvedValue(undefined),
   plasmoGlobalStorage: {
     get: vi.fn().mockResolvedValue(undefined),
     set: vi.fn().mockResolvedValue(undefined)

--- a/src/lib/embeddings/__tests__/search-hybrid.test.ts
+++ b/src/lib/embeddings/__tests__/search-hybrid.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { searchHybrid, vectorDb } from "../vector-store"
 
 vi.mock("@/lib/embeddings/keyword-index", () => ({
@@ -33,10 +33,7 @@ vi.mock("@/lib/embeddings/hnsw-index", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    get: vi.fn(),
-    set: vi.fn()
-  }
+  getPlasmoStoredValue: vi.fn()
 }))
 
 // Disable search cache so each test sees the current DB state
@@ -92,7 +89,7 @@ const noKeywordResults = () =>
 beforeEach(async () => {
   await vectorDb.vectors.clear()
   vi.clearAllMocks()
-  vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({})
+  vi.mocked(getPlasmoStoredValue).mockResolvedValue({})
 })
 
 describe("searchHybrid — RRF fusion", () => {

--- a/src/lib/embeddings/__tests__/vector-store-advanced.test.ts
+++ b/src/lib/embeddings/__tests__/vector-store-advanced.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import {
   searchHybrid,
   searchSimilarVectors,
@@ -39,10 +39,7 @@ vi.mock("@/lib/embeddings/hnsw-index", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: {
-    get: vi.fn(),
-    set: vi.fn()
-  }
+  getPlasmoStoredValue: vi.fn()
 }))
 
 describe("Vector Store - Advanced Tests", () => {
@@ -51,7 +48,7 @@ describe("Vector Store - Advanced Tests", () => {
     vi.clearAllMocks()
 
     // Default config mock
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({})
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue({})
   })
 
   describe("searchHybrid", () => {
@@ -132,7 +129,7 @@ describe("Vector Store - Advanced Tests", () => {
   describe("Storage Limits & Cleanup", () => {
     it("should enforce maxEmbeddingsPerFile", async () => {
       // Mock config with limit
-      vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({
+      vi.mocked(getPlasmoStoredValue).mockResolvedValue({
         maxEmbeddingsPerFile: 2
       })
 
@@ -164,7 +161,7 @@ describe("Vector Store - Advanced Tests", () => {
 
     it("should auto-cleanup old vectors", async () => {
       // Mock config for cleanup
-      vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({
+      vi.mocked(getPlasmoStoredValue).mockResolvedValue({
         autoCleanup: true,
         cleanupDaysOld: 7
       })
@@ -214,7 +211,7 @@ describe("Vector Store - Advanced Tests", () => {
   describe("Internal Logic & Edge Cases", () => {
     it("should enforce maxStorageSize", async () => {
       // Mock config with very small storage limit (1KB)
-      vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({
+      vi.mocked(getPlasmoStoredValue).mockResolvedValue({
         maxStorageSize: 0.001 // 1KB approx
       })
 
@@ -410,7 +407,7 @@ describe("Vector Store - Advanced Tests", () => {
 
     it("should handle large cleanup batches with yielding", async () => {
       // Mock config to force cleanup
-      vi.mocked(plasmoGlobalStorage.get).mockResolvedValue({
+      vi.mocked(getPlasmoStoredValue).mockResolvedValue({
         maxStorageSize: 0.001 // 1KB
       })
 

--- a/src/lib/embeddings/__tests__/vector-store.test.ts
+++ b/src/lib/embeddings/__tests__/vector-store.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { hnswIndexManager } from "../hnsw-index"
 import { keywordIndexManager } from "../keyword-index"
 import {
@@ -16,7 +16,7 @@ describe("Vector Store - Baseline Tests", () => {
   beforeEach(async () => {
     // Clear database before each test
     await clearAllVectors()
-    vi.mocked(plasmoGlobalStorage.get).mockResolvedValue(undefined)
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue(undefined)
   })
 
   describe("storeVector", () => {
@@ -644,11 +644,11 @@ describe("Vector Store - Baseline Tests", () => {
 
 describe("Advanced Features", () => {
   it("should respect storage limits", async () => {
-    const { plasmoGlobalStorage } = await import("@/lib/plasmo-global-storage")
+    const { getPlasmoStoredValue } = await import("@/lib/plasmo-global-storage")
     const { STORAGE_KEYS } = await import("@/lib/constants")
 
     // Mock config with small storage limit (e.g., 0.001 MB = 1KB)
-    vi.spyOn(plasmoGlobalStorage, "get").mockImplementation(async (key) => {
+    vi.mocked(getPlasmoStoredValue).mockImplementation(async (key) => {
       if (key === STORAGE_KEYS.EMBEDDINGS.CONFIG) {
         return { maxStorageSize: 0.001, autoCleanup: true }
       }

--- a/src/lib/embeddings/config.ts
+++ b/src/lib/embeddings/config.ts
@@ -1,45 +1,10 @@
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import type { EmbeddingConfig } from "@/lib/constants"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 
 /**
  * Gets embedding configuration
  */
 export const getEmbeddingConfig = async (): Promise<EmbeddingConfig> => {
-  const stored = await plasmoGlobalStorage.get<EmbeddingConfig>(
-    STORAGE_KEYS.EMBEDDINGS.CONFIG
-  )
-  const merged: EmbeddingConfig = {
-    ...DEFAULT_EMBEDDING_CONFIG,
-    ...stored
-  }
-
-  const rawAnnBackend = merged.annBackend as string | undefined
-  const annBackend: EmbeddingConfig["annBackend"] =
-    rawAnnBackend === "bruteforce" ? "bruteforce" : "ts-hnsw"
-
-  // Migration shim: earlier builds experimented with a transformers.js /
-  // onnxruntime-web cross-encoder reranker, but MV3 CSP blocked it, so the only
-  // shipped backend is cosine re-scoring (see lib/embeddings/reranker.ts).
-  // Old stored configs may still hold those backend strings — collapse them to
-  // "cosine" rather than silently disabling reranking for those users.
-  const rawRerankerBackend = merged.rerankerBackend as string | undefined
-  const rerankerBackend: EmbeddingConfig["rerankerBackend"] =
-    rawRerankerBackend === "cosine" ||
-    rawRerankerBackend === "transformers-js" ||
-    rawRerankerBackend === "onnxruntime-web"
-      ? "cosine"
-      : "none"
-
-  return {
-    ...merged,
-    annBackend,
-    rerankerBackend:
-      merged.useReranking && rerankerBackend === "none"
-        ? "cosine"
-        : rerankerBackend
-  }
+  return readSetting(SETTINGS.EMBEDDING_CONFIG)
 }

--- a/src/lib/embeddings/embedding-client.ts
+++ b/src/lib/embeddings/embedding-client.ts
@@ -1,10 +1,7 @@
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  type EmbeddingConfig,
-  STORAGE_KEYS
-} from "@/lib/constants"
 import { getErrorMessage } from "@/lib/error-utils"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
+import { getEmbeddingConfig } from "./config"
 import {
   type EmbeddingStrategyCapabilities,
   type EmbeddingStrategyReadiness,
@@ -74,19 +71,6 @@ const cleanExpiredCache = (): void => {
   }
 }
 
-/**
- * Gets embedding configuration with defaults
- */
-const getEmbeddingConfig = async (): Promise<EmbeddingConfig> => {
-  const stored = await plasmoGlobalStorage.get<EmbeddingConfig>(
-    STORAGE_KEYS.EMBEDDINGS.CONFIG
-  )
-  return {
-    ...DEFAULT_EMBEDDING_CONFIG,
-    ...stored
-  }
-}
-
 const getCacheModelKey = async (modelName?: string): Promise<string> => {
   const config = await getEmbeddingConfig()
   const providerId = config.sharedEmbeddingProviderId || "default"
@@ -95,9 +79,7 @@ const getCacheModelKey = async (modelName?: string): Promise<string> => {
     return `${providerId}:${modelName}`
   }
 
-  const stored = await plasmoGlobalStorage.get<string>(
-    STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL
-  )
+  const stored = await readSetting(SETTINGS.EMBEDDING_SELECTED_MODEL)
   return `${providerId}:${stored || "default"}`
 }
 

--- a/src/lib/embeddings/embedding-strategy.ts
+++ b/src/lib/embeddings/embedding-strategy.ts
@@ -3,15 +3,15 @@ import {
   DEFAULT_EMBEDDING_MODEL,
   DEFAULT_PROVIDER_ID,
   DEFAULT_SHARED_EMBEDDING_PROVIDER_ID,
-  normalizeEmbeddingModelName,
-  STORAGE_KEYS
+  normalizeEmbeddingModelName
 } from "@/lib/constants"
 import { createAppError, getErrorMessage } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderManager } from "@/lib/providers/manager"
 import type { LLMProvider } from "@/lib/providers/types"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import { extensionRpcClient } from "@/protocol/extension-client"
 import { getEmbeddingConfig } from "./config"
 
@@ -74,10 +74,7 @@ const normalizeModelForProvider = (
 
 const getActiveProvider = async (): Promise<LLMProvider | null> => {
   try {
-    const selectedModelRef = await plasmoGlobalStorage.get<{
-      providerId?: string
-      modelId?: string
-    }>(STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF)
+    const selectedModelRef = await readSetting(SETTINGS.SELECTED_MODEL_REF)
     if (selectedModelRef?.modelId) {
       return await ProviderFactory.getProviderForModel(
         selectedModelRef.modelId,
@@ -85,9 +82,7 @@ const getActiveProvider = async (): Promise<LLMProvider | null> => {
       )
     }
 
-    const selectedChatModel = await plasmoGlobalStorage.get<string>(
-      STORAGE_KEYS.PROVIDER.SELECTED_MODEL
-    )
+    const selectedChatModel = await readSetting(SETTINGS.SELECTED_MODEL)
 
     if (!selectedChatModel) {
       return null
@@ -104,9 +99,7 @@ const getActiveProvider = async (): Promise<LLMProvider | null> => {
 
 const getStoredEmbeddingModel = async (): Promise<string> => {
   const config = await getEmbeddingConfig()
-  const stored = await plasmoGlobalStorage.get<string>(
-    STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL
-  )
+  const stored = await readSetting(SETTINGS.EMBEDDING_SELECTED_MODEL)
   const configModel = config.sharedEmbeddingModel
 
   if (

--- a/src/lib/per-site-profile-settings.ts
+++ b/src/lib/per-site-profile-settings.ts
@@ -1,0 +1,46 @@
+import { z } from "zod"
+
+export type PerSiteRuleMode = "inherit" | "always" | "never"
+
+export interface PerSiteProfile {
+  id: string
+  name: string
+  pattern: string
+  enabled: boolean
+  tabContext: PerSiteRuleMode
+  groundedOnly: PerSiteRuleMode
+}
+
+export interface PerSiteProfileSettings {
+  profiles: PerSiteProfile[]
+}
+
+const PerSiteRuleModeSchema = z.enum(["inherit", "always", "never"])
+
+export const PerSiteProfileSettingsSchema = z
+  .object({
+    profiles: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          name: z.string(),
+          pattern: z.string(),
+          enabled: z.boolean(),
+          tabContext: PerSiteRuleModeSchema,
+          groundedOnly: PerSiteRuleModeSchema
+        })
+        .strict()
+    )
+  })
+  .strict()
+
+export const DEFAULT_PER_SITE_PROFILE_SETTINGS: PerSiteProfileSettings = {
+  profiles: []
+}
+
+export const parsePerSiteProfileSettings = (
+  value: unknown
+): PerSiteProfileSettings => {
+  const parsed = PerSiteProfileSettingsSchema.safeParse(value)
+  return parsed.success ? parsed.data : DEFAULT_PER_SITE_PROFILE_SETTINGS
+}

--- a/src/lib/per-site-profile-settings.ts
+++ b/src/lib/per-site-profile-settings.ts
@@ -1,5 +1,3 @@
-import { z } from "zod"
-
 export type PerSiteRuleMode = "inherit" | "always" | "never"
 
 export interface PerSiteProfile {
@@ -15,27 +13,40 @@ export interface PerSiteProfileSettings {
   profiles: PerSiteProfile[]
 }
 
-const PerSiteRuleModeSchema = z.enum(["inherit", "always", "never"])
-
-export const PerSiteProfileSettingsSchema = z
-  .object({
-    profiles: z.array(
-      z
-        .object({
-          id: z.string().min(1),
-          name: z.string(),
-          pattern: z.string(),
-          enabled: z.boolean(),
-          tabContext: PerSiteRuleModeSchema,
-          groundedOnly: PerSiteRuleModeSchema
-        })
-        .strict()
-    )
-  })
-  .strict()
-
 export const DEFAULT_PER_SITE_PROFILE_SETTINGS: PerSiteProfileSettings = {
   profiles: []
+}
+
+const RULE_MODES: unknown[] = ["inherit", "always", "never"]
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isPerSiteProfile = (value: unknown): value is PerSiteProfile =>
+  isRecord(value) &&
+  Object.keys(value).length === 6 &&
+  typeof value.id === "string" &&
+  value.id.length > 0 &&
+  typeof value.name === "string" &&
+  typeof value.pattern === "string" &&
+  typeof value.enabled === "boolean" &&
+  RULE_MODES.includes(value.tabContext) &&
+  RULE_MODES.includes(value.groundedOnly)
+
+export const PerSiteProfileSettingsSchema = {
+  safeParse: (
+    value: unknown
+  ): { success: true; data: PerSiteProfileSettings } | { success: false } => {
+    if (
+      !isRecord(value) ||
+      Object.keys(value).some((key) => key !== "profiles") ||
+      !Array.isArray(value.profiles) ||
+      !value.profiles.every(isPerSiteProfile)
+    ) {
+      return { success: false }
+    }
+    return { success: true, data: { profiles: value.profiles } }
+  }
 }
 
 export const parsePerSiteProfileSettings = (

--- a/src/lib/per-site-profiles.ts
+++ b/src/lib/per-site-profiles.ts
@@ -6,8 +6,8 @@ import {
   type PerSiteRuleMode,
   parsePerSiteProfileSettings
 } from "@/lib/per-site-profile-settings"
+import { PER_SITE_PROFILE_SETTING } from "@/lib/storage/per-site-profile-setting"
 import { readSetting, writeSetting } from "@/lib/storage/setting-access"
-import { SETTINGS } from "@/lib/storage/settings"
 import { compileSafePattern } from "@/lib/url-pattern"
 
 export type { PerSiteProfile, PerSiteProfileSettings, PerSiteRuleMode }
@@ -19,13 +19,13 @@ export {
 
 export const getPerSiteProfileSettings =
   async (): Promise<PerSiteProfileSettings> => {
-    return readSetting(SETTINGS.PER_SITE_PROFILES)
+    return readSetting(PER_SITE_PROFILE_SETTING)
   }
 
 export const setPerSiteProfileSettings = async (
   settings: PerSiteProfileSettings
 ): Promise<void> => {
-  await writeSetting(SETTINGS.PER_SITE_PROFILES, {
+  await writeSetting(PER_SITE_PROFILE_SETTING, {
     profiles: normalizePerSiteProfiles(settings.profiles)
   })
 }

--- a/src/lib/per-site-profiles.ts
+++ b/src/lib/per-site-profiles.ts
@@ -1,68 +1,31 @@
-import { z } from "zod"
-import { STORAGE_KEYS } from "@/lib/constants"
 import {
-  getPlasmoStoredValue,
-  setPlasmoStoredValue
-} from "@/lib/plasmo-global-storage"
+  DEFAULT_PER_SITE_PROFILE_SETTINGS,
+  type PerSiteProfile,
+  type PerSiteProfileSettings,
+  PerSiteProfileSettingsSchema,
+  type PerSiteRuleMode,
+  parsePerSiteProfileSettings
+} from "@/lib/per-site-profile-settings"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import { compileSafePattern } from "@/lib/url-pattern"
 
-export type PerSiteRuleMode = "inherit" | "always" | "never"
-
-export interface PerSiteProfile {
-  id: string
-  name: string
-  pattern: string
-  enabled: boolean
-  tabContext: PerSiteRuleMode
-  groundedOnly: PerSiteRuleMode
-}
-
-export interface PerSiteProfileSettings {
-  profiles: PerSiteProfile[]
-}
-
-const PerSiteRuleModeSchema = z.enum(["inherit", "always", "never"])
-
-export const PerSiteProfileSettingsSchema = z
-  .object({
-    profiles: z.array(
-      z
-        .object({
-          id: z.string().min(1),
-          name: z.string(),
-          pattern: z.string(),
-          enabled: z.boolean(),
-          tabContext: PerSiteRuleModeSchema,
-          groundedOnly: PerSiteRuleModeSchema
-        })
-        .strict()
-    )
-  })
-  .strict()
-
-export const DEFAULT_PER_SITE_PROFILE_SETTINGS: PerSiteProfileSettings = {
-  profiles: []
-}
-
-export const parsePerSiteProfileSettings = (
-  value: unknown
-): PerSiteProfileSettings => {
-  const parsed = PerSiteProfileSettingsSchema.safeParse(value)
-  return parsed.success ? parsed.data : DEFAULT_PER_SITE_PROFILE_SETTINGS
+export type { PerSiteProfile, PerSiteProfileSettings, PerSiteRuleMode }
+export {
+  DEFAULT_PER_SITE_PROFILE_SETTINGS,
+  PerSiteProfileSettingsSchema,
+  parsePerSiteProfileSettings
 }
 
 export const getPerSiteProfileSettings =
   async (): Promise<PerSiteProfileSettings> => {
-    const stored = await getPlasmoStoredValue<unknown>(
-      STORAGE_KEYS.BROWSER.PER_SITE_PROFILES
-    )
-    return parsePerSiteProfileSettings(stored)
+    return readSetting(SETTINGS.PER_SITE_PROFILES)
   }
 
 export const setPerSiteProfileSettings = async (
   settings: PerSiteProfileSettings
 ): Promise<void> => {
-  await setPlasmoStoredValue(STORAGE_KEYS.BROWSER.PER_SITE_PROFILES, {
+  await writeSetting(SETTINGS.PER_SITE_PROFILES, {
     profiles: normalizePerSiteProfiles(settings.profiles)
   })
 }

--- a/src/lib/providers/__tests__/model-capability-overrides.test.ts
+++ b/src/lib/providers/__tests__/model-capability-overrides.test.ts
@@ -9,7 +9,9 @@ const storage = vi.hoisted(() => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: storage
+  plasmoGlobalStorage: storage,
+  getPlasmoStoredValue: storage.get,
+  setPlasmoStoredValue: storage.set
 }))
 
 import {
@@ -48,6 +50,14 @@ describe("model capability overrides", () => {
 
   it("returns null when no override exists", async () => {
     expect(await getModelCapabilityOverride("vllm", "absent")).toBeNull()
+  })
+
+  it("fails closed when the persisted override map is malformed", async () => {
+    store.set("model-capability-overrides", {
+      "vllm::unsafe": { vision: "yes" }
+    })
+
+    await expect(getAllModelCapabilityOverrides()).resolves.toEqual({})
   })
 
   it("drops undefined fields and removes a fully-empty override", async () => {

--- a/src/lib/providers/__tests__/model-rpc-service.test.ts
+++ b/src/lib/providers/__tests__/model-rpc-service.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/providers/manager", () => ({
   ProviderManager: { getProviderConfig: mocks.getProviderConfig }
 }))
 vi.mock("@/lib/plasmo-global-storage", () => ({
-  plasmoGlobalStorage: { get: mocks.storageGet }
+  getPlasmoStoredValue: mocks.storageGet
 }))
 vi.mock("@/lib/providers/provider-policy", () => ({
   assertProviderEnabled: mocks.assertProviderEnabled

--- a/src/lib/providers/capability-probe.ts
+++ b/src/lib/providers/capability-probe.ts
@@ -1,9 +1,6 @@
-import { STORAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import {
-  getPlasmoStoredValue,
-  setPlasmoStoredValue
-} from "@/lib/plasmo-global-storage"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
 import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
 import { runToolCallingProbe } from "./tool-calling-probe"
 import type { LLMProvider } from "./types"
@@ -50,8 +47,6 @@ export interface CapabilityProbeResult {
 
 export type CapabilityProbeMap = Record<string, CapabilityProbeResult>
 
-const STORAGE_KEY = STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_PROBES
-
 const PROBE_TIMEOUT_MS = 30_000
 export const TOOL_CALLING_PROBE_VERSION = 3
 
@@ -90,8 +85,7 @@ export const capabilityProbeKey = (
 ): string => `${providerId}::${modelName}`
 
 export const getAllCapabilityProbes = async (): Promise<CapabilityProbeMap> => {
-  const stored = await getPlasmoStoredValue<CapabilityProbeMap>(STORAGE_KEY)
-  return stored ?? {}
+  return { ...(await readSetting(POLICY_SETTINGS.MODEL_CAPABILITY_PROBES)) }
 }
 
 export const getCapabilityProbe = async (
@@ -142,7 +136,7 @@ export const setCapabilityProbe = (
             toolCallingProbeVersion: TOOL_CALLING_PROBE_VERSION
           }
     all[key] = { ...all[key], ...versionedResult }
-    await setPlasmoStoredValue(STORAGE_KEY, all)
+    await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_PROBES, all)
   })
 
 export const clearCapabilityProbe = (
@@ -154,7 +148,7 @@ export const clearCapabilityProbe = (
     const key = capabilityProbeKey(providerId, modelName)
     if (key in all) {
       delete all[key]
-      await setPlasmoStoredValue(STORAGE_KEY, all)
+      await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_PROBES, all)
     }
   })
 
@@ -175,7 +169,8 @@ export const clearCapabilityProbesForProvider = (
         changed = true
       }
     }
-    if (changed) await setPlasmoStoredValue(STORAGE_KEY, all)
+    if (changed)
+      await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_PROBES, all)
   })
 
 /**

--- a/src/lib/providers/model-capability-overrides.ts
+++ b/src/lib/providers/model-capability-overrides.ts
@@ -1,5 +1,5 @@
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
 import { withStorageWriteLock } from "@/lib/storage/storage-write-lock"
 import type { ModelCapabilityOverride } from "./capabilities"
 
@@ -11,8 +11,6 @@ import type { ModelCapabilityOverride } from "./capabilities"
  * for how an override is layered on top of detection.
  */
 export type ModelCapabilityOverrideMap = Record<string, ModelCapabilityOverride>
-
-const STORAGE_KEY = STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_OVERRIDES
 
 /**
  * Web Locks name serializing read-modify-write on the override map across every
@@ -35,11 +33,9 @@ export const modelCapabilityOverrideKey = (
 ): string => `${providerId}::${modelName}`
 
 export const getAllModelCapabilityOverrides =
-  async (): Promise<ModelCapabilityOverrideMap> => {
-    const stored =
-      await plasmoGlobalStorage.get<ModelCapabilityOverrideMap>(STORAGE_KEY)
-    return stored ?? {}
-  }
+  async (): Promise<ModelCapabilityOverrideMap> => ({
+    ...(await readSetting(POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES))
+  })
 
 export const getModelCapabilityOverride = async (
   providerId: string,
@@ -70,7 +66,7 @@ export const setModelCapabilityOverride = (
       delete all[key]
     }
 
-    await plasmoGlobalStorage.set(STORAGE_KEY, all)
+    await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES, all)
   })
 
 export const clearModelCapabilityOverride = (
@@ -82,7 +78,7 @@ export const clearModelCapabilityOverride = (
     const key = modelCapabilityOverrideKey(providerId, modelName)
     if (key in all) {
       delete all[key]
-      await plasmoGlobalStorage.set(STORAGE_KEY, all)
+      await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES, all)
     }
   })
 
@@ -100,7 +96,8 @@ export const clearModelCapabilityOverridesForProvider = (
         changed = true
       }
     }
-    if (changed) await plasmoGlobalStorage.set(STORAGE_KEY, all)
+    if (changed)
+      await writeSetting(POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES, all)
   })
 
 /** Drop undefined fields; return null if nothing meaningful remains. */

--- a/src/lib/providers/model-rpc-service.ts
+++ b/src/lib/providers/model-rpc-service.ts
@@ -13,19 +13,17 @@ import type {
   ModelsWarmupRequest,
   ModelsWarmupResult
 } from "@ollama-client/contracts/model-rpc"
-import { DEFAULT_MODEL_LIBRARY_BASE_URL, STORAGE_KEYS } from "@/lib/constants"
+import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import {
-  parseStoredModelConfigMap,
-  resolveModelConfig
-} from "@/lib/model-config-utils"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { resolveModelConfig } from "@/lib/model-config-utils"
 import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { ProviderManager } from "@/lib/providers/manager"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { ProviderId } from "@/lib/providers/types"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ProviderModelDetails } from "@/types"
 
 /**
@@ -144,9 +142,7 @@ const parseKeepAliveMs = (value?: string | number): number | undefined => {
 }
 
 const getModelConfig = async (model: string) => {
-  const configs = parseStoredModelConfigMap(
-    await plasmoGlobalStorage.get<unknown>(STORAGE_KEYS.PROVIDER.MODEL_CONFIGS)
-  )
+  const configs = await readSetting(SETTINGS.MODEL_CONFIGS)
   return resolveModelConfig(configs[model])
 }
 

--- a/src/lib/providers/selected-model.ts
+++ b/src/lib/providers/selected-model.ts
@@ -1,20 +1,22 @@
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { removeSetting, writeSetting } from "@/lib/storage/setting-access"
+import { SelectedModelRefSchema } from "@/lib/storage/setting-schemas"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ProviderModel, SelectedModelRef } from "@/types"
 
-export const isSelectedModelRef = (value: unknown): value is SelectedModelRef =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as SelectedModelRef).providerId === "string" &&
-  typeof (value as SelectedModelRef).modelId === "string"
+export const isSelectedModelRef = (
+  value: unknown
+): value is SelectedModelRef => {
+  const parsed = SelectedModelRefSchema.safeParse(value)
+  return parsed.success && parsed.data !== null
+}
 
 export const saveSelectedModelRef = async (
   ref: SelectedModelRef
 ): Promise<void> => {
   await Promise.all([
-    plasmoGlobalStorage.set(STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF, ref),
-    plasmoGlobalStorage.set(STORAGE_KEYS.PROVIDER.SELECTED_MODEL, ref.modelId),
-    plasmoGlobalStorage.remove(STORAGE_KEYS.PROVIDER.SELECTION_CONFLICT_MODEL)
+    writeSetting(SETTINGS.SELECTED_MODEL_REF, ref),
+    writeSetting(SETTINGS.SELECTED_MODEL, ref.modelId),
+    removeSetting(SETTINGS.SELECTION_CONFLICT_MODEL)
   ])
 }
 

--- a/src/lib/storage/__tests__/setting-access.test.ts
+++ b/src/lib/storage/__tests__/setting-access.test.ts
@@ -14,7 +14,12 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
   removePlasmoStoredValue: storage.remove
 }))
 
-import { readSetting, removeSetting, writeSetting } from "../setting-access"
+import {
+  readSetting,
+  readStoredSetting,
+  removeSetting,
+  writeSetting
+} from "../setting-access"
 import { defineSetting } from "../setting-descriptor"
 
 /** Trims and rejects blanks, so parse is observable in both directions. */
@@ -98,6 +103,29 @@ describe("readSetting", () => {
     storage.get.mockResolvedValue("  spaced  ")
 
     await expect(readSetting(descriptor)).resolves.toBe("  spaced  ")
+  })
+})
+
+describe("readStoredSetting", () => {
+  it("preserves absence for compatibility migrations", async () => {
+    const descriptor = defineSetting<string>(SYNC_KEY, {
+      defaultValue: "default"
+    })
+
+    storage.get.mockResolvedValue(undefined)
+    await expect(readStoredSetting(descriptor)).resolves.toBeUndefined()
+  })
+
+  it("validates stored data without substituting the default", async () => {
+    const descriptor = defineSetting<string>(SYNC_KEY, {
+      defaultValue: "default",
+      parser: trimmedString
+    })
+
+    storage.get.mockResolvedValue({ bad: true })
+    await expect(readStoredSetting(descriptor)).resolves.toBeUndefined()
+    storage.get.mockResolvedValue("  stored  ")
+    await expect(readStoredSetting(descriptor)).resolves.toBe("stored")
   })
 })
 

--- a/src/lib/storage/__tests__/setting-schemas.test.ts
+++ b/src/lib/storage/__tests__/setting-schemas.test.ts
@@ -7,6 +7,12 @@ import {
 import { ModelConfigMapSchema } from "@/lib/model-config-utils"
 import { PerSiteProfileSettingsSchema } from "@/lib/per-site-profile-settings"
 import {
+  ApprovalGrantMapSchema,
+  CapabilityProbeMapSchema,
+  ModelCapabilityOverrideMapSchema,
+  ToolModelOverrideMapSchema
+} from "../policy-setting-schemas"
+import {
   ContentExtractionConfigSchema,
   EmbeddingConfigSchema,
   FileUploadConfigSchema,
@@ -126,6 +132,68 @@ describe("structured setting schemas", () => {
     expect(
       PerSiteProfileSettingsSchema.safeParse({
         profiles: [{ id: "bad", pattern: 42 }]
+      }).success
+    ).toBe(false)
+  })
+
+  it("validates capability overrides and probe evidence", () => {
+    expect(
+      ModelCapabilityOverrideMapSchema.safeParse({
+        "ollama::qwen": { vision: true, contextLength: 8192 }
+      }).success
+    ).toBe(true)
+    expect(
+      ModelCapabilityOverrideMapSchema.safeParse({
+        "ollama::qwen": { vision: "yes" }
+      }).success
+    ).toBe(false)
+    expect(
+      CapabilityProbeMapSchema.safeParse({
+        "ollama::qwen": { toolCalling: true, probedAt: Date.now() }
+      }).success
+    ).toBe(true)
+    expect(
+      CapabilityProbeMapSchema.safeParse({
+        "ollama::qwen": { toolCalling: true, probedAt: "today" }
+      }).success
+    ).toBe(false)
+  })
+
+  it("rejects malformed or mismatched approval grants", () => {
+    expect(
+      ApprovalGrantMapSchema.safeParse({
+        "save_artifact::*": {
+          toolName: "save_artifact",
+          origin: "*",
+          grantedAt: Date.now()
+        }
+      }).success
+    ).toBe(true)
+    expect(
+      ApprovalGrantMapSchema.safeParse({
+        "different::*": {
+          toolName: "save_artifact",
+          origin: "*",
+          grantedAt: Date.now()
+        }
+      }).success
+    ).toBe(false)
+  })
+
+  it("rejects unknown or malformed tool-family overrides", () => {
+    expect(
+      ToolModelOverrideMapSchema.safeParse({
+        "ollama::qwen": { families: { browser: false } }
+      }).success
+    ).toBe(true)
+    expect(
+      ToolModelOverrideMapSchema.safeParse({
+        "ollama::qwen": { families: { browser: "no" } }
+      }).success
+    ).toBe(false)
+    expect(
+      ToolModelOverrideMapSchema.safeParse({
+        "ollama::qwen": { families: { unknown: true } }
       }).success
     ).toBe(false)
   })

--- a/src/lib/storage/__tests__/setting-schemas.test.ts
+++ b/src/lib/storage/__tests__/setting-schemas.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_CONTENT_EXTRACTION_CONFIG,
+  DEFAULT_EMBEDDING_CONFIG,
+  DEFAULT_FILE_UPLOAD_CONFIG
+} from "@/lib/constants"
+import { ModelConfigMapSchema } from "@/lib/model-config-utils"
+import { PerSiteProfileSettingsSchema } from "@/lib/per-site-profile-settings"
+import {
+  ContentExtractionConfigSchema,
+  EmbeddingConfigSchema,
+  FileUploadConfigSchema,
+  SelectedModelRefSchema
+} from "../setting-schemas"
+
+describe("structured setting schemas", () => {
+  it("normalizes partial content extraction config", () => {
+    expect(
+      ContentExtractionConfigSchema.parse({
+        enabled: false,
+        scrollDepth: 0.25,
+        unknown: "drop"
+      })
+    ).toEqual({
+      ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
+      enabled: false,
+      scrollDepth: 0.25
+    })
+  })
+
+  it("rejects unsafe content extraction limits", () => {
+    expect(
+      ContentExtractionConfigSchema.safeParse({ scrollDepth: 2 }).success
+    ).toBe(false)
+    expect(
+      ContentExtractionConfigSchema.safeParse({ maxWaitTime: Number.NaN })
+        .success
+    ).toBe(false)
+  })
+
+  it("validates nested content extraction overrides", () => {
+    const parsed = ContentExtractionConfigSchema.parse({
+      siteOverrides: {
+        "docs.example.com": { scrollStrategy: "none", scrollDepth: 0 }
+      }
+    })
+    expect(parsed.siteOverrides["docs.example.com"]).toEqual({
+      scrollStrategy: "none",
+      scrollDepth: 0
+    })
+    expect(
+      ContentExtractionConfigSchema.safeParse({
+        siteOverrides: { bad: { scrollStrategy: "teleport" } }
+      }).success
+    ).toBe(false)
+  })
+
+  it("normalizes partial embedding config", () => {
+    expect(EmbeddingConfigSchema.parse({ batchSize: 9 })).toEqual({
+      ...DEFAULT_EMBEDDING_CONFIG,
+      batchSize: 9
+    })
+  })
+
+  it("retains legacy embedding backend migrations", () => {
+    const parsed = EmbeddingConfigSchema.parse({
+      annBackend: "wasm-hnsw",
+      rerankerBackend: "transformers-js",
+      useReranking: true
+    })
+    expect(parsed.annBackend).toBe("ts-hnsw")
+    expect(parsed.rerankerBackend).toBe("cosine")
+  })
+
+  it("forces cosine when reranking remains enabled", () => {
+    expect(
+      EmbeddingConfigSchema.parse({
+        useReranking: true,
+        rerankerBackend: "none"
+      }).rerankerBackend
+    ).toBe("cosine")
+  })
+
+  it("rejects invalid embedding bounds", () => {
+    expect(EmbeddingConfigSchema.safeParse({ chunkSize: 0 }).success).toBe(
+      false
+    )
+    expect(
+      EmbeddingConfigSchema.safeParse({ defaultMinSimilarity: 1.1 }).success
+    ).toBe(false)
+    expect(EmbeddingConfigSchema.safeParse({ batchSize: 1.5 }).success).toBe(
+      false
+    )
+  })
+
+  it("normalizes and validates file upload config", () => {
+    expect(FileUploadConfigSchema.parse({ embeddingBatchSize: 7 })).toEqual({
+      ...DEFAULT_FILE_UPLOAD_CONFIG,
+      embeddingBatchSize: 7
+    })
+    expect(FileUploadConfigSchema.safeParse({ maxFileSize: 0 }).success).toBe(
+      false
+    )
+  })
+
+  it("requires complete provider-qualified model refs", () => {
+    expect(
+      SelectedModelRefSchema.safeParse({
+        providerId: "ollama",
+        modelId: "qwen"
+      }).success
+    ).toBe(true)
+    expect(
+      SelectedModelRefSchema.safeParse({ providerId: "", modelId: "qwen" })
+        .success
+    ).toBe(false)
+    expect(
+      SelectedModelRefSchema.safeParse({ providerId: "ollama" }).success
+    ).toBe(false)
+  })
+
+  it("rejects malformed model configs and per-site profiles", () => {
+    expect(
+      ModelConfigMapSchema.safeParse({ qwen: { temperature: "hot" } }).success
+    ).toBe(false)
+    expect(
+      PerSiteProfileSettingsSchema.safeParse({
+        profiles: [{ id: "bad", pattern: 42 }]
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/lib/storage/__tests__/storage-api-boundary.test.ts
+++ b/src/lib/storage/__tests__/storage-api-boundary.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 import { describe, expect, it } from "vitest"
+import { SETTINGS } from "@/lib/storage/settings"
 
 const ROOT = process.cwd()
 const SOURCE_ROOT = join(ROOT, "src")
@@ -16,6 +17,21 @@ const SCOPE_AWARE_UI = [
   "src/features/model/hooks/use-model-capability-overrides.ts",
   "src/features/permissions/components/approvals-card.tsx",
   "src/features/web-search/stores/web-search-config-store.ts"
+]
+
+const VALIDATED_STRUCTURED_CONSUMERS = [
+  "src/background/handlers/handle-chat-with-model.ts",
+  "src/background/handlers/handle-selection-action.ts",
+  "src/contents/content-config.ts",
+  "src/contents/url-filter.ts",
+  "src/features/file-upload/hooks/use-file-search.ts",
+  "src/features/selection-actions/content-settings.ts",
+  "src/lib/embeddings/config.ts",
+  "src/lib/embeddings/embedding-client.ts",
+  "src/lib/embeddings/embedding-strategy.ts",
+  "src/lib/per-site-profiles.ts",
+  "src/lib/providers/model-rpc-service.ts",
+  "src/lib/providers/selected-model.ts"
 ]
 
 describe("storage API boundary", () => {
@@ -46,6 +62,26 @@ describe("storage API boundary", () => {
       expect(source, file).not.toContain("@plasmohq/storage/hook")
       expect(source, file).not.toContain("plasmoGlobalStorage")
       expect(source, file).not.toContain("getPlasmoStorageForKey")
+    }
+  })
+
+  it("gives high-risk structured settings runtime parsers", () => {
+    for (const descriptor of [
+      SETTINGS.SELECTED_MODEL_REF,
+      SETTINGS.MODEL_CONFIGS,
+      SETTINGS.CONTENT_EXTRACTION_CONFIG,
+      SETTINGS.PER_SITE_PROFILES,
+      SETTINGS.EMBEDDING_CONFIG,
+      SETTINGS.FILE_UPLOAD_CONFIG
+    ]) {
+      expect(descriptor.parser, descriptor.key).toBeDefined()
+    }
+  })
+
+  it("keeps migrated structured consumers off the deprecated sync alias", () => {
+    for (const file of VALIDATED_STRUCTURED_CONSUMERS) {
+      const source = readFileSync(join(ROOT, file), "utf8")
+      expect(source, file).not.toContain("plasmoGlobalStorage")
     }
   })
 

--- a/src/lib/storage/__tests__/storage-api-boundary.test.ts
+++ b/src/lib/storage/__tests__/storage-api-boundary.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 import { describe, expect, it } from "vitest"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
 import { SETTINGS } from "@/lib/storage/settings"
 
 const ROOT = process.cwd()
@@ -31,7 +32,11 @@ const VALIDATED_STRUCTURED_CONSUMERS = [
   "src/lib/embeddings/embedding-strategy.ts",
   "src/lib/per-site-profiles.ts",
   "src/lib/providers/model-rpc-service.ts",
-  "src/lib/providers/selected-model.ts"
+  "src/lib/providers/selected-model.ts",
+  "src/lib/providers/capability-probe.ts",
+  "src/lib/providers/model-capability-overrides.ts",
+  "src/lib/tools/approval/approval-grants.ts",
+  "src/lib/tools/tool-model-overrides.ts"
 ]
 
 describe("storage API boundary", () => {
@@ -72,7 +77,11 @@ describe("storage API boundary", () => {
       SETTINGS.CONTENT_EXTRACTION_CONFIG,
       SETTINGS.PER_SITE_PROFILES,
       SETTINGS.EMBEDDING_CONFIG,
-      SETTINGS.FILE_UPLOAD_CONFIG
+      SETTINGS.FILE_UPLOAD_CONFIG,
+      POLICY_SETTINGS.MODEL_CAPABILITY_OVERRIDES,
+      POLICY_SETTINGS.MODEL_CAPABILITY_PROBES,
+      POLICY_SETTINGS.APPROVAL_GRANTS,
+      POLICY_SETTINGS.TOOL_MODEL_OVERRIDES
     ]) {
       expect(descriptor.parser, descriptor.key).toBeDefined()
     }

--- a/src/lib/storage/content-policy-settings.ts
+++ b/src/lib/storage/content-policy-settings.ts
@@ -1,0 +1,23 @@
+import {
+  DEFAULT_EXCLUDE_URLS,
+  DEFAULT_TABS_ACCESS,
+  STORAGE_KEYS
+} from "@/lib/constants"
+import { defineSetting } from "./setting-descriptor"
+
+const BooleanParser = {
+  safeParse: (value: unknown) =>
+    typeof value === "boolean"
+      ? { success: true as const, data: value }
+      : { success: false as const }
+}
+
+export const TAB_ACCESS_SETTING = defineSetting<boolean>(
+  STORAGE_KEYS.BROWSER.TABS_ACCESS,
+  { defaultValue: DEFAULT_TABS_ACCESS, parser: BooleanParser }
+)
+
+export const EXCLUDE_URL_PATTERNS_SETTING = defineSetting<string[]>(
+  STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS,
+  { defaultValue: DEFAULT_EXCLUDE_URLS }
+)

--- a/src/lib/storage/content-settings.ts
+++ b/src/lib/storage/content-settings.ts
@@ -1,0 +1,129 @@
+import {
+  DEFAULT_CONTENT_EXTRACTION_CONFIG,
+  STORAGE_KEYS
+} from "@/lib/constants"
+import type { ContentExtractionConfig, SelectedModelRef } from "@/types"
+import { defineSetting } from "./setting-descriptor"
+
+const failed = { success: false as const }
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+const finite = (value: unknown): value is number =>
+  Number.isFinite(value as number)
+const nonNegative = (value: unknown): value is number =>
+  finite(value) && value >= 0
+
+const BOOLEAN_FIELDS = [
+  "enabled",
+  "showSelectionButton",
+  "selectionActionsEnabled"
+] as const
+const NON_NEGATIVE_FIELDS = [
+  "scrollDelay",
+  "mutationObserverTimeout",
+  "networkIdleTimeout",
+  "maxWaitTime"
+] as const
+const SCRAPERS: unknown[] = ["auto", "defuddle", "readability"]
+const SCROLL_STRATEGIES: unknown[] = ["none", "gradual", "instant", "smart"]
+
+const parseExtractionOverride = (
+  value: Record<string, unknown>
+): Record<string, unknown> | undefined => {
+  const parsed: Record<string, unknown> = {}
+  for (const [key, field] of Object.entries(value)) {
+    let valid: boolean
+    if (BOOLEAN_FIELDS.includes(key as (typeof BOOLEAN_FIELDS)[number])) {
+      valid = typeof field === "boolean"
+    } else if (
+      NON_NEGATIVE_FIELDS.includes(key as (typeof NON_NEGATIVE_FIELDS)[number])
+    ) {
+      valid = nonNegative(field)
+    } else if (key === "selectionActionsMinChars") {
+      valid = nonNegative(field) && Number.isInteger(field)
+    } else if (
+      key === "selectionActionsEnabledIds" ||
+      key === "excludedUrlPatterns"
+    ) {
+      valid =
+        Array.isArray(field) && field.every((item) => typeof item === "string")
+    } else if (key === "contentScraper") {
+      valid = SCRAPERS.includes(field)
+    } else if (key === "scrollStrategy") {
+      valid = SCROLL_STRATEGIES.includes(field)
+    } else if (key === "scrollDepth") {
+      valid = finite(field) && field >= 0 && field <= 1
+    } else continue
+    if (!valid) return undefined
+    parsed[key] = field
+  }
+  return parsed
+}
+
+const ContentExtractionParser = {
+  safeParse: (value: unknown) => {
+    if (!isRecord(value)) return failed
+    const stored = parseExtractionOverride(value)
+    if (!stored) return failed
+    let siteOverrides = DEFAULT_CONTENT_EXTRACTION_CONFIG.siteOverrides
+    if ("siteOverrides" in value) {
+      if (!isRecord(value.siteOverrides)) return failed
+      const parsedOverrides: Record<string, Record<string, unknown>> = {}
+      for (const [pattern, override] of Object.entries(value.siteOverrides)) {
+        if (!isRecord(override)) return failed
+        const parsed = parseExtractionOverride(override)
+        if (!parsed) return failed
+        parsedOverrides[pattern] = parsed
+      }
+      siteOverrides = parsedOverrides
+    }
+    return {
+      success: true as const,
+      data: {
+        ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
+        ...stored,
+        siteOverrides
+      } as ContentExtractionConfig
+    }
+  }
+}
+
+const SelectedModelRefParser = {
+  safeParse: (value: unknown) => {
+    if (value === null) return { success: true as const, data: null }
+    if (
+      !isRecord(value) ||
+      typeof value.providerId !== "string" ||
+      !value.providerId ||
+      typeof value.modelId !== "string" ||
+      !value.modelId
+    ) {
+      return failed
+    }
+    return {
+      success: true as const,
+      data: { providerId: value.providerId, modelId: value.modelId }
+    }
+  }
+}
+
+/** Lightweight descriptors shared by content scripts and extension pages. */
+export const CONTENT_SETTINGS = {
+  LANGUAGE: defineSetting<string>(STORAGE_KEYS.LANGUAGE, {
+    defaultValue: "en"
+  }),
+  SELECTED_MODEL: defineSetting<string>(STORAGE_KEYS.PROVIDER.SELECTED_MODEL, {
+    defaultValue: ""
+  }),
+  SELECTED_MODEL_REF: defineSetting<SelectedModelRef | null>(
+    STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
+    { defaultValue: null, parser: SelectedModelRefParser }
+  ),
+  CONTENT_EXTRACTION_CONFIG: defineSetting<ContentExtractionConfig>(
+    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
+    {
+      defaultValue: DEFAULT_CONTENT_EXTRACTION_CONFIG,
+      parser: ContentExtractionParser
+    }
+  )
+}

--- a/src/lib/storage/per-site-profile-setting.ts
+++ b/src/lib/storage/per-site-profile-setting.ts
@@ -1,0 +1,15 @@
+import { STORAGE_KEYS } from "@/lib/constants"
+import {
+  DEFAULT_PER_SITE_PROFILE_SETTINGS,
+  type PerSiteProfileSettings,
+  PerSiteProfileSettingsSchema
+} from "@/lib/per-site-profile-settings"
+import { defineSetting } from "./setting-descriptor"
+
+export const PER_SITE_PROFILE_SETTING = defineSetting<PerSiteProfileSettings>(
+  STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
+  {
+    defaultValue: DEFAULT_PER_SITE_PROFILE_SETTINGS,
+    parser: PerSiteProfileSettingsSchema
+  }
+)

--- a/src/lib/storage/policy-setting-schemas.ts
+++ b/src/lib/storage/policy-setting-schemas.ts
@@ -1,0 +1,80 @@
+import { z } from "zod"
+import { approvalGrantKey } from "@/lib/tools/approval/approval-policy"
+import { TOOL_FAMILIES } from "@/lib/tools/tool-families"
+
+const ModelCapabilityOverrideSchema = z
+  .object({
+    text: z.boolean().optional(),
+    vision: z.boolean().optional(),
+    embeddings: z.boolean().optional(),
+    toolCalling: z.boolean().optional(),
+    reasoning: z.boolean().optional(),
+    contextLength: z.number().int().positive().optional()
+  })
+  .strict()
+
+export const ModelCapabilityOverrideMapSchema = z.record(
+  z.string(),
+  ModelCapabilityOverrideSchema
+)
+
+const CapabilityProbeResultSchema = z
+  .object({
+    toolCalling: z.boolean().optional(),
+    toolCallingMode: z.enum(["native", "native-user-results"]).optional(),
+    toolCallingProbeVersion: z.number().int().positive().optional(),
+    reasoning: z.boolean().optional(),
+    vision: z.boolean().optional(),
+    incomplete: z
+      .array(z.enum(["toolCalling", "reasoning", "vision"]))
+      .optional(),
+    probedAt: z.number().finite().nonnegative()
+  })
+  .strict()
+
+export const CapabilityProbeMapSchema = z.record(
+  z.string(),
+  CapabilityProbeResultSchema
+)
+
+const ApprovalGrantSchema = z
+  .object({
+    toolName: z.string().min(1),
+    origin: z.string().min(1),
+    grantedAt: z.number().finite().nonnegative()
+  })
+  .strict()
+
+export const ApprovalGrantMapSchema = z
+  .record(z.string(), ApprovalGrantSchema)
+  .superRefine((grants, context) => {
+    for (const [key, grant] of Object.entries(grants)) {
+      if (key !== approvalGrantKey(grant.toolName, grant.origin)) {
+        context.addIssue({
+          code: "custom",
+          path: [key],
+          message: "Grant key does not match its tool and origin"
+        })
+      }
+    }
+  })
+
+const ToolFamilySchema = z.enum(
+  TOOL_FAMILIES as [
+    (typeof TOOL_FAMILIES)[number],
+    ...(typeof TOOL_FAMILIES)[number][]
+  ]
+)
+
+const ToolFamilyOverrideSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    families: z.partialRecord(ToolFamilySchema, z.boolean()).optional(),
+    nonNativeToolFallback: z.boolean().optional()
+  })
+  .strict()
+
+export const ToolModelOverrideMapSchema = z.record(
+  z.string(),
+  ToolFamilyOverrideSchema
+)

--- a/src/lib/storage/policy-settings.ts
+++ b/src/lib/storage/policy-settings.ts
@@ -1,0 +1,31 @@
+import { STORAGE_KEYS } from "@/lib/constants"
+import type { CapabilityProbeMap } from "@/lib/providers/capability-probe"
+import type { ModelCapabilityOverrideMap } from "@/lib/providers/model-capability-overrides"
+import type { ApprovalGrantMap } from "@/lib/tools/approval/approval-grants"
+import type { ToolModelOverrideMap } from "@/lib/tools/tool-model-overrides"
+import {
+  ApprovalGrantMapSchema,
+  CapabilityProbeMapSchema,
+  ModelCapabilityOverrideMapSchema,
+  ToolModelOverrideMapSchema
+} from "./policy-setting-schemas"
+import { defineSetting } from "./setting-descriptor"
+
+export const POLICY_SETTINGS = {
+  MODEL_CAPABILITY_OVERRIDES: defineSetting<ModelCapabilityOverrideMap>(
+    STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_OVERRIDES,
+    { defaultValue: {}, parser: ModelCapabilityOverrideMapSchema }
+  ),
+  MODEL_CAPABILITY_PROBES: defineSetting<CapabilityProbeMap>(
+    STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_PROBES,
+    { defaultValue: {}, parser: CapabilityProbeMapSchema }
+  ),
+  APPROVAL_GRANTS: defineSetting<ApprovalGrantMap>(
+    STORAGE_KEYS.TOOLS.APPROVAL_GRANTS,
+    { defaultValue: {}, parser: ApprovalGrantMapSchema }
+  ),
+  TOOL_MODEL_OVERRIDES: defineSetting<ToolModelOverrideMap>(
+    STORAGE_KEYS.TOOLS.MODEL_OVERRIDES,
+    { defaultValue: {}, parser: ToolModelOverrideMapSchema }
+  )
+}

--- a/src/lib/storage/selection-action-settings.ts
+++ b/src/lib/storage/selection-action-settings.ts
@@ -1,0 +1,81 @@
+import {
+  DEFAULT_CONTENT_EXTRACTION_CONFIG,
+  STORAGE_KEYS
+} from "@/lib/constants"
+import type { ContentExtractionConfig, SelectedModelRef } from "@/types"
+import { defineSetting } from "./setting-descriptor"
+
+const failed = { success: false as const }
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const SelectedModelRefParser = {
+  safeParse: (value: unknown) => {
+    if (value === null) return { success: true as const, data: null }
+    if (
+      !isRecord(value) ||
+      typeof value.providerId !== "string" ||
+      !value.providerId ||
+      typeof value.modelId !== "string" ||
+      !value.modelId
+    ) {
+      return failed
+    }
+    return {
+      success: true as const,
+      data: { providerId: value.providerId, modelId: value.modelId }
+    }
+  }
+}
+
+const SelectionConfigParser = {
+  safeParse: (value: unknown) => {
+    if (!isRecord(value)) return failed
+    const enabled = value.selectionActionsEnabled
+    const minChars = value.selectionActionsMinChars
+    const enabledIds = value.selectionActionsEnabledIds
+    if (
+      (enabled !== undefined && typeof enabled !== "boolean") ||
+      (minChars !== undefined &&
+        (!Number.isInteger(minChars) || (minChars as number) < 0)) ||
+      (enabledIds !== undefined &&
+        (!Array.isArray(enabledIds) ||
+          !enabledIds.every((item) => typeof item === "string")))
+    ) {
+      return failed
+    }
+    return {
+      success: true as const,
+      data: {
+        ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
+        ...(enabled === undefined ? {} : { selectionActionsEnabled: enabled }),
+        ...(minChars === undefined
+          ? {}
+          : { selectionActionsMinChars: minChars }),
+        ...(enabledIds === undefined
+          ? {}
+          : { selectionActionsEnabledIds: enabledIds })
+      } as ContentExtractionConfig
+    }
+  }
+}
+
+export const SELECTION_ACTION_SETTINGS = {
+  LANGUAGE: defineSetting<string>(STORAGE_KEYS.LANGUAGE, {
+    defaultValue: "en"
+  }),
+  SELECTED_MODEL: defineSetting<string>(STORAGE_KEYS.PROVIDER.SELECTED_MODEL, {
+    defaultValue: ""
+  }),
+  SELECTED_MODEL_REF: defineSetting<SelectedModelRef | null>(
+    STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
+    { defaultValue: null, parser: SelectedModelRefParser }
+  ),
+  CONTENT_EXTRACTION_CONFIG: defineSetting<ContentExtractionConfig>(
+    STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
+    {
+      defaultValue: DEFAULT_CONTENT_EXTRACTION_CONFIG,
+      parser: SelectionConfigParser
+    }
+  )
+}

--- a/src/lib/storage/setting-access.ts
+++ b/src/lib/storage/setting-access.ts
@@ -3,22 +3,41 @@ import {
   removePlasmoStoredValue,
   setPlasmoStoredValue
 } from "@/lib/plasmo-global-storage"
-import type { SettingDescriptor } from "./setting-descriptor"
+import type {
+  RequiredSettingDescriptor,
+  SettingDescriptor
+} from "./setting-descriptor"
 
-const parse = <T>(
+const parseStored = <T>(
   descriptor: SettingDescriptor<T>,
   value: unknown
 ): T | undefined => {
-  if (value === undefined || value === null) return descriptor.defaultValue
+  if (value === undefined || value === null) return undefined
   if (!descriptor.parser) return value as T
   const parsed = descriptor.parser.safeParse(value)
-  return parsed.success ? parsed.data : descriptor.defaultValue
+  return parsed.success ? parsed.data : undefined
 }
 
-export const readSetting = async <T>(
+/**
+ * Read and validate only a persisted value. Migration callers use this when
+ * absence must remain distinguishable from a descriptor default.
+ */
+export const readStoredSetting = async <T>(
   descriptor: SettingDescriptor<T>
 ): Promise<T | undefined> =>
-  parse(descriptor, await getPlasmoStoredValue<unknown>(descriptor.key))
+  parseStored(descriptor, await getPlasmoStoredValue<unknown>(descriptor.key))
+
+export function readSetting<T>(
+  descriptor: RequiredSettingDescriptor<T>
+): Promise<T>
+export function readSetting<T>(
+  descriptor: SettingDescriptor<T>
+): Promise<T | undefined>
+export async function readSetting<T>(
+  descriptor: SettingDescriptor<T>
+): Promise<T | undefined> {
+  return (await readStoredSetting(descriptor)) ?? descriptor.defaultValue
+}
 
 export const writeSetting = async <T>(
   descriptor: SettingDescriptor<T>,

--- a/src/lib/storage/setting-descriptor.ts
+++ b/src/lib/storage/setting-descriptor.ts
@@ -4,7 +4,7 @@ import { getStorageKeyMetadata } from "./storage-key-registry"
 export interface ValueParser<T> {
   safeParse: (
     value: unknown
-  ) => { success: true; data: T } | { success: false; error: unknown }
+  ) => { success: true; data: T } | { success: false; error?: unknown }
 }
 
 export interface SettingDescriptor<T> {

--- a/src/lib/storage/setting-registry.ts
+++ b/src/lib/storage/setting-registry.ts
@@ -1,0 +1,14 @@
+import { POLICY_SETTINGS } from "./policy-settings"
+import type { SettingDescriptor } from "./setting-descriptor"
+import { SETTINGS } from "./settings"
+
+const SETTINGS_BY_KEY = new Map<string, SettingDescriptor<unknown>>(
+  [...Object.values(SETTINGS), ...Object.values(POLICY_SETTINGS)].map(
+    (descriptor) => [descriptor.key, descriptor as SettingDescriptor<unknown>]
+  )
+)
+
+/** Descriptor lookup for generic settings workflows such as presets/reset. */
+export const getSettingDescriptor = (
+  key: string
+): SettingDescriptor<unknown> | undefined => SETTINGS_BY_KEY.get(key)

--- a/src/lib/storage/setting-schemas.ts
+++ b/src/lib/storage/setting-schemas.ts
@@ -1,0 +1,151 @@
+import { z } from "zod"
+import {
+  DEFAULT_CONTENT_EXTRACTION_CONFIG,
+  DEFAULT_EMBEDDING_CONFIG,
+  DEFAULT_FILE_UPLOAD_CONFIG,
+  type EmbeddingConfig
+} from "@/lib/constants"
+import type { ContentExtractionConfig, FileUploadConfig } from "@/types"
+
+const finite = z.number().finite()
+const nonNegative = finite.nonnegative()
+const positive = finite.positive()
+const nonNegativeInteger = z.number().int().nonnegative()
+const positiveInteger = z.number().int().positive()
+const unitInterval = finite.min(0).max(1)
+
+const ContentExtractionOverrideSchema = z
+  .object({
+    enabled: z.boolean(),
+    showSelectionButton: z.boolean(),
+    selectionActionsEnabled: z.boolean(),
+    selectionActionsMinChars: nonNegativeInteger,
+    selectionActionsEnabledIds: z.array(z.string()),
+    contentScraper: z.enum(["auto", "defuddle", "readability"]),
+    excludedUrlPatterns: z.array(z.string()),
+    scrollStrategy: z.enum(["none", "gradual", "instant", "smart"]),
+    scrollDepth: unitInterval,
+    scrollDelay: nonNegative,
+    mutationObserverTimeout: nonNegative,
+    networkIdleTimeout: nonNegative,
+    maxWaitTime: nonNegative
+  })
+  .partial()
+
+/**
+ * Accepts partial values written by older releases, drops unknown fields, and
+ * returns one complete config. A malformed known field rejects the stored
+ * object so callers receive the descriptor default instead of mixed bad data.
+ */
+export const ContentExtractionConfigSchema = z
+  .object({
+    ...ContentExtractionOverrideSchema.shape,
+    siteOverrides: z.record(z.string(), ContentExtractionOverrideSchema)
+  })
+  .partial()
+  .transform(
+    (stored): ContentExtractionConfig => ({
+      ...DEFAULT_CONTENT_EXTRACTION_CONFIG,
+      ...stored,
+      siteOverrides:
+        stored.siteOverrides ?? DEFAULT_CONTENT_EXTRACTION_CONFIG.siteOverrides
+    })
+  )
+
+const storedRerankerBackend = z
+  .enum(["none", "cosine", "transformers-js", "onnxruntime-web"])
+  .transform<EmbeddingConfig["rerankerBackend"]>((value) =>
+    value === "none" ? "none" : "cosine"
+  )
+
+const storedAnnBackend = z
+  .string()
+  .transform<EmbeddingConfig["annBackend"]>((value) =>
+    value === "bruteforce" ? "bruteforce" : "ts-hnsw"
+  )
+
+/** Runtime contract for synced embedding configuration. */
+export const EmbeddingConfigSchema = z
+  .object({
+    chunkSize: positiveInteger,
+    chunkOverlap: nonNegativeInteger,
+    chunkingStrategy: z.enum(["fixed", "semantic", "hybrid", "markdown"]),
+    useEnhancedChunking: z.boolean(),
+    batchSize: positiveInteger,
+    maxEmbeddingsPerFile: nonNegativeInteger,
+    embeddingStrategy: z.enum([
+      "auto",
+      "provider-native",
+      "shared-model",
+      "default-provider-only",
+      "ollama-only"
+    ]),
+    sharedEmbeddingModel: z.string(),
+    sharedEmbeddingProviderId: z.string(),
+    warmupEmbeddingsInBackground: z.boolean(),
+    showAdvancedEmbeddingModels: z.boolean(),
+    enableCaching: z.boolean(),
+    defaultSearchLimit: positiveInteger,
+    defaultMinSimilarity: unitInterval,
+    searchCacheTTL: nonNegative,
+    searchCacheMaxSize: nonNegativeInteger,
+    annBackend: storedAnnBackend,
+    annMinVectors: nonNegativeInteger,
+    maxStorageSize: nonNegative,
+    autoCleanup: z.boolean(),
+    cleanupDaysOld: nonNegative,
+    useHNSW: z.boolean(),
+    hnswM: positiveInteger,
+    hnswEfConstruction: positiveInteger,
+    hnswEfSearch: positiveInteger,
+    hnswMinVectors: nonNegativeInteger,
+    hnswAutoRebuild: z.boolean(),
+    useReranking: z.boolean(),
+    useHybridSearch: z.boolean(),
+    keywordWeight: unitInterval,
+    semanticWeight: unitInterval,
+    minQualityScore: unitInterval,
+    excludeGreetings: z.boolean(),
+    diversityEnabled: z.boolean(),
+    diversityLambda: unitInterval,
+    minRerankScore: unitInterval,
+    rerankerBackend: storedRerankerBackend,
+    feedbackEnabled: z.boolean(),
+    showRetrievedChunks: z.boolean(),
+    feedbackBlendWeight: unitInterval
+  })
+  .partial()
+  .transform((stored): EmbeddingConfig => {
+    const merged = { ...DEFAULT_EMBEDDING_CONFIG, ...stored }
+    return {
+      ...merged,
+      rerankerBackend:
+        merged.useReranking && merged.rerankerBackend === "none"
+          ? "cosine"
+          : merged.rerankerBackend
+    }
+  })
+
+/** Runtime contract for upload limits and embedding behavior. */
+export const FileUploadConfigSchema = z
+  .object({
+    maxFileSize: positive,
+    autoEmbedFiles: z.boolean(),
+    showEmbeddingProgress: z.boolean(),
+    embeddingBatchSize: positiveInteger
+  })
+  .partial()
+  .transform(
+    (stored): FileUploadConfig => ({
+      ...DEFAULT_FILE_UPLOAD_CONFIG,
+      ...stored
+    })
+  )
+
+export const SelectedModelRefSchema = z
+  .object({
+    providerId: z.string().min(1),
+    modelId: z.string().min(1)
+  })
+  .strict()
+  .nullable()

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -18,11 +18,15 @@ import {
   type EmbeddingConfig,
   STORAGE_KEYS
 } from "@/lib/constants"
-import type { StoredModelConfigMap } from "@/lib/model-config-utils"
+import {
+  ModelConfigMapSchema,
+  type StoredModelConfigMap
+} from "@/lib/model-config-utils"
 import {
   DEFAULT_PER_SITE_PROFILE_SETTINGS,
-  type PerSiteProfileSettings
-} from "@/lib/per-site-profiles"
+  type PerSiteProfileSettings,
+  PerSiteProfileSettingsSchema
+} from "@/lib/per-site-profile-settings"
 import type { CapabilityProbeMap } from "@/lib/providers/capability-probe"
 import type { ModelCapabilityOverrideMap } from "@/lib/providers/model-capability-overrides"
 import type { ApprovalGrantMap } from "@/lib/tools/approval/approval-grants"
@@ -36,7 +40,14 @@ import type {
   FileUploadConfig,
   SelectedModelRef
 } from "@/types"
+import type { SettingDescriptor } from "./setting-descriptor"
 import { defineSetting } from "./setting-descriptor"
+import {
+  ContentExtractionConfigSchema,
+  EmbeddingConfigSchema,
+  FileUploadConfigSchema,
+  SelectedModelRefSchema
+} from "./setting-schemas"
 
 export const SETTINGS = {
   LANGUAGE: defineSetting<string>(STORAGE_KEYS.LANGUAGE, {
@@ -47,7 +58,7 @@ export const SETTINGS = {
   }),
   SELECTED_MODEL_REF: defineSetting<SelectedModelRef | null>(
     STORAGE_KEYS.PROVIDER.SELECTED_MODEL_REF,
-    { defaultValue: null }
+    { defaultValue: null, parser: SelectedModelRefSchema }
   ),
   SELECTION_CONFLICT_MODEL: defineSetting<string | null>(
     STORAGE_KEYS.PROVIDER.SELECTION_CONFLICT_MODEL,
@@ -55,7 +66,7 @@ export const SETTINGS = {
   ),
   MODEL_CONFIGS: defineSetting<StoredModelConfigMap>(
     STORAGE_KEYS.PROVIDER.MODEL_CONFIGS,
-    { defaultValue: {} }
+    { defaultValue: {}, parser: ModelConfigMapSchema }
   ),
   PROVIDER_FAVICON_LOOKUP: defineSetting<boolean>(
     STORAGE_KEYS.PROVIDER.FAVICON_LOOKUP,
@@ -70,7 +81,10 @@ export const SETTINGS = {
   }),
   CONTENT_EXTRACTION_CONFIG: defineSetting<ContentExtractionConfig>(
     STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
-    { defaultValue: DEFAULT_CONTENT_EXTRACTION_CONFIG }
+    {
+      defaultValue: DEFAULT_CONTENT_EXTRACTION_CONFIG,
+      parser: ContentExtractionConfigSchema
+    }
   ),
   EXCLUDE_URL_PATTERNS: defineSetting<string[]>(
     STORAGE_KEYS.BROWSER.EXCLUDE_URL_PATTERNS,
@@ -78,7 +92,10 @@ export const SETTINGS = {
   ),
   PER_SITE_PROFILES: defineSetting<PerSiteProfileSettings>(
     STORAGE_KEYS.BROWSER.PER_SITE_PROFILES,
-    { defaultValue: DEFAULT_PER_SITE_PROFILE_SETTINGS }
+    {
+      defaultValue: DEFAULT_PER_SITE_PROFILE_SETTINGS,
+      parser: PerSiteProfileSettingsSchema
+    }
   ),
   MAX_RESTORE_SESSIONS: defineSetting<number>(
     STORAGE_KEYS.BROWSER.MAX_RESTORE_SESSIONS,
@@ -90,7 +107,7 @@ export const SETTINGS = {
   ),
   EMBEDDING_CONFIG: defineSetting<EmbeddingConfig>(
     STORAGE_KEYS.EMBEDDINGS.CONFIG,
-    { defaultValue: DEFAULT_EMBEDDING_CONFIG }
+    { defaultValue: DEFAULT_EMBEDDING_CONFIG, parser: EmbeddingConfigSchema }
   ),
   USE_RAG: defineSetting<boolean>(STORAGE_KEYS.EMBEDDINGS.USE_RAG, {
     defaultValue: true
@@ -100,7 +117,7 @@ export const SETTINGS = {
   }),
   FILE_UPLOAD_CONFIG: defineSetting<FileUploadConfig>(
     STORAGE_KEYS.FILE_UPLOAD.CONFIG,
-    { defaultValue: DEFAULT_FILE_UPLOAD_CONFIG }
+    { defaultValue: DEFAULT_FILE_UPLOAD_CONFIG, parser: FileUploadConfigSchema }
   ),
   MAX_IMAGE_SIZE_MB: defineSetting<number>(STORAGE_KEYS.IMAGES.MAX_SIZE_MB, {
     defaultValue: DEFAULT_MAX_IMAGE_SIZE_MB
@@ -168,3 +185,15 @@ export const SETTINGS = {
     }
   )
 }
+
+const SETTINGS_BY_KEY = new Map<string, SettingDescriptor<unknown>>(
+  Object.values(SETTINGS).map((descriptor) => [
+    descriptor.key,
+    descriptor as SettingDescriptor<unknown>
+  ])
+)
+
+/** Descriptor lookup for generic settings workflows such as presets/reset. */
+export const getSettingDescriptor = (
+  key: string
+): SettingDescriptor<unknown> | undefined => SETTINGS_BY_KEY.get(key)

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -16,6 +16,8 @@ import {
   DEFAULT_PROVIDER_CATALOG_REFRESH_MS,
   DEFAULT_TABS_ACCESS,
   type EmbeddingConfig,
+  MAX_MAX_RESTORE_SESSIONS,
+  MIN_MAX_RESTORE_SESSIONS,
   STORAGE_KEYS
 } from "@/lib/constants"
 import {
@@ -27,9 +29,6 @@ import {
   type PerSiteProfileSettings,
   PerSiteProfileSettingsSchema
 } from "@/lib/per-site-profile-settings"
-import type { CapabilityProbeMap } from "@/lib/providers/capability-probe"
-import type { ModelCapabilityOverrideMap } from "@/lib/providers/model-capability-overrides"
-import type { ApprovalGrantMap } from "@/lib/tools/approval/approval-grants"
 import {
   DEFAULT_WEB_SEARCH_CONFIG,
   type WebSearchProviderConfig,
@@ -40,7 +39,6 @@ import type {
   FileUploadConfig,
   SelectedModelRef
 } from "@/types"
-import type { SettingDescriptor } from "./setting-descriptor"
 import { defineSetting } from "./setting-descriptor"
 import {
   ContentExtractionConfigSchema,
@@ -77,7 +75,8 @@ export const SETTINGS = {
     { defaultValue: DEFAULT_PROVIDER_CATALOG_REFRESH_MS }
   ),
   TABS_ACCESS: defineSetting<boolean>(STORAGE_KEYS.BROWSER.TABS_ACCESS, {
-    defaultValue: DEFAULT_TABS_ACCESS
+    defaultValue: DEFAULT_TABS_ACCESS,
+    parser: z.boolean()
   }),
   CONTENT_EXTRACTION_CONFIG: defineSetting<ContentExtractionConfig>(
     STORAGE_KEYS.BROWSER.CONTENT_EXTRACTION_CONFIG,
@@ -99,7 +98,18 @@ export const SETTINGS = {
   ),
   MAX_RESTORE_SESSIONS: defineSetting<number>(
     STORAGE_KEYS.BROWSER.MAX_RESTORE_SESSIONS,
-    { defaultValue: DEFAULT_MAX_RESTORE_SESSIONS }
+    {
+      defaultValue: DEFAULT_MAX_RESTORE_SESSIONS,
+      parser: z
+        .number()
+        .finite()
+        .transform((value) =>
+          Math.max(
+            MIN_MAX_RESTORE_SESSIONS,
+            Math.min(MAX_MAX_RESTORE_SESSIONS, Math.floor(value))
+          )
+        )
+    }
   ),
   EMBEDDING_SELECTED_MODEL: defineSetting<string>(
     STORAGE_KEYS.EMBEDDINGS.SELECTED_MODEL,
@@ -110,10 +120,12 @@ export const SETTINGS = {
     { defaultValue: DEFAULT_EMBEDDING_CONFIG, parser: EmbeddingConfigSchema }
   ),
   USE_RAG: defineSetting<boolean>(STORAGE_KEYS.EMBEDDINGS.USE_RAG, {
-    defaultValue: true
+    defaultValue: true,
+    parser: z.boolean()
   }),
   MEMORY_ENABLED: defineSetting<boolean>(STORAGE_KEYS.MEMORY.ENABLED, {
-    defaultValue: DEFAULT_MEMORY_ENABLED
+    defaultValue: DEFAULT_MEMORY_ENABLED,
+    parser: z.boolean()
   }),
   FILE_UPLOAD_CONFIG: defineSetting<FileUploadConfig>(
     STORAGE_KEYS.FILE_UPLOAD.CONFIG,
@@ -161,17 +173,12 @@ export const SETTINGS = {
   TTS_VOICE_URI: defineSetting<string>(STORAGE_KEYS.TTS.VOICE_URI, {
     defaultValue: ""
   }),
-  MODEL_CAPABILITY_OVERRIDES: defineSetting<ModelCapabilityOverrideMap>(
-    STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_OVERRIDES,
-    { defaultValue: {} }
-  ),
-  MODEL_CAPABILITY_PROBES: defineSetting<CapabilityProbeMap>(
-    STORAGE_KEYS.PROVIDER.MODEL_CAPABILITY_PROBES,
-    { defaultValue: {} }
-  ),
-  APPROVAL_GRANTS: defineSetting<ApprovalGrantMap>(
-    STORAGE_KEYS.TOOLS.APPROVAL_GRANTS,
-    { defaultValue: {} }
+  SETTINGS_LEVEL: defineSetting<"basic" | "power" | "advanced">(
+    STORAGE_KEYS.UI.SETTINGS_LEVEL,
+    {
+      defaultValue: "basic",
+      parser: z.enum(["basic", "power", "advanced"])
+    }
   ),
   WEB_SEARCH_ACTIVE: defineSetting<boolean>(STORAGE_KEYS.WEB_SEARCH.ACTIVE, {
     defaultValue: true,
@@ -185,15 +192,3 @@ export const SETTINGS = {
     }
   )
 }
-
-const SETTINGS_BY_KEY = new Map<string, SettingDescriptor<unknown>>(
-  Object.values(SETTINGS).map((descriptor) => [
-    descriptor.key,
-    descriptor as SettingDescriptor<unknown>
-  ])
-)
-
-/** Descriptor lookup for generic settings workflows such as presets/reset. */
-export const getSettingDescriptor = (
-  key: string
-): SettingDescriptor<unknown> | undefined => SETTINGS_BY_KEY.get(key)

--- a/src/lib/tools/__tests__/tool-model-overrides.test.ts
+++ b/src/lib/tools/__tests__/tool-model-overrides.test.ts
@@ -8,6 +8,10 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
     set: async (key: string, value: unknown) => {
       store.set(key, value)
     }
+  },
+  getPlasmoStoredValue: async (key: string) => store.get(key),
+  setPlasmoStoredValue: async (key: string, value: unknown) => {
+    store.set(key, value)
   }
 }))
 
@@ -47,6 +51,12 @@ describe("tool-model-overrides", () => {
   it("returns global settings when a model has no override", async () => {
     const effective = await getEffectiveToolFamilySettings("ollama", "qwen")
     expect(effective).toEqual(globalSettings)
+  })
+
+  it("fails closed when a persisted family value is malformed", async () => {
+    store.set(KEY, { "ollama::qwen": { families: { browser: "yes" } } })
+
+    await expect(getToolModelOverride("ollama", "qwen")).resolves.toBeNull()
   })
 
   it("layers a partial override over global, per field", async () => {

--- a/src/lib/tools/approval/approval-grants.ts
+++ b/src/lib/tools/approval/approval-grants.ts
@@ -1,8 +1,5 @@
-import { STORAGE_KEYS } from "@/lib/constants"
-import {
-  getPlasmoStoredValue,
-  setPlasmoStoredValue
-} from "@/lib/plasmo-global-storage"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
 import { approvalGrantKey } from "./approval-policy"
 
 /**
@@ -20,11 +17,8 @@ export interface ApprovalGrant {
 
 export type ApprovalGrantMap = Record<string, ApprovalGrant>
 
-const STORAGE_KEY = STORAGE_KEYS.TOOLS.APPROVAL_GRANTS
-
 export const getAllApprovalGrants = async (): Promise<ApprovalGrantMap> => {
-  const stored = await getPlasmoStoredValue<ApprovalGrantMap>(STORAGE_KEY)
-  return stored ?? {}
+  return { ...(await readSetting(POLICY_SETTINGS.APPROVAL_GRANTS)) }
 }
 
 export const hasAlwaysGrant = async (
@@ -46,17 +40,17 @@ export const addAlwaysGrant = async (
     origin: origin || "*",
     grantedAt: Date.now()
   }
-  await setPlasmoStoredValue(STORAGE_KEY, all)
+  await writeSetting(POLICY_SETTINGS.APPROVAL_GRANTS, all)
 }
 
 export const revokeApprovalGrant = async (key: string): Promise<void> => {
   const all = await getAllApprovalGrants()
   if (key in all) {
     delete all[key]
-    await setPlasmoStoredValue(STORAGE_KEY, all)
+    await writeSetting(POLICY_SETTINGS.APPROVAL_GRANTS, all)
   }
 }
 
 export const clearAllApprovalGrants = async (): Promise<void> => {
-  await setPlasmoStoredValue(STORAGE_KEY, {})
+  await writeSetting(POLICY_SETTINGS.APPROVAL_GRANTS, {})
 }

--- a/src/lib/tools/internal/__tests__/browser-session-tools.test.ts
+++ b/src/lib/tools/internal/__tests__/browser-session-tools.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/browser-sessions", () => ({
 }))
 
 vi.mock("@/lib/plasmo-global-storage", () => ({
+  getPlasmoStoredValue: mocks.storageGet,
   plasmoGlobalStorage: { get: mocks.storageGet }
 }))
 

--- a/src/lib/tools/internal/browser-session-tools.ts
+++ b/src/lib/tools/internal/browser-session-tools.ts
@@ -5,28 +5,13 @@ import {
   type ReadableBrowserSession,
   restoreBrowserSession
 } from "@/lib/browser-sessions"
-import {
-  DEFAULT_MAX_RESTORE_SESSIONS,
-  MAX_MAX_RESTORE_SESSIONS,
-  MIN_MAX_RESTORE_SESSIONS
-} from "@/lib/constants/config"
-import { STORAGE_KEYS } from "@/lib/constants/keys"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import type { ToolContext, ToolDefinition, ToolResult } from "../types"
 
 /** Read the user-configured cap on how many tabs restore_session reopens. */
-const getMaxRestoreSessions = async (): Promise<number> => {
-  const stored = await plasmoGlobalStorage.get<number>(
-    STORAGE_KEYS.BROWSER.MAX_RESTORE_SESSIONS
-  )
-  if (typeof stored !== "number" || !Number.isFinite(stored)) {
-    return DEFAULT_MAX_RESTORE_SESSIONS
-  }
-  return Math.max(
-    MIN_MAX_RESTORE_SESSIONS,
-    Math.min(MAX_MAX_RESTORE_SESSIONS, Math.floor(stored))
-  )
-}
+const getMaxRestoreSessions = async (): Promise<number> =>
+  readSetting(SETTINGS.MAX_RESTORE_SESSIONS)
 
 const clampLimit = (value: unknown, fallback = 10): number => {
   const parsed = typeof value === "number" ? value : Number(value)

--- a/src/lib/tools/tool-model-overrides.ts
+++ b/src/lib/tools/tool-model-overrides.ts
@@ -1,5 +1,5 @@
-import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { POLICY_SETTINGS } from "@/lib/storage/policy-settings"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
 import { TOOL_FAMILIES, type ToolFamily } from "./tool-families"
 import { getToolFamilySettings, type ToolFamilySettings } from "./tool-settings"
 
@@ -26,19 +26,15 @@ export interface ToolFamilyOverride {
 
 export type ToolModelOverrideMap = Record<string, ToolFamilyOverride>
 
-const STORAGE_KEY = STORAGE_KEYS.TOOLS.MODEL_OVERRIDES
-
 export const toolModelOverrideKey = (
   providerId: string,
   modelName: string
 ): string => `${providerId}::${modelName}`
 
 export const getAllToolModelOverrides =
-  async (): Promise<ToolModelOverrideMap> => {
-    const stored =
-      await plasmoGlobalStorage.get<ToolModelOverrideMap>(STORAGE_KEY)
-    return stored ?? {}
-  }
+  async (): Promise<ToolModelOverrideMap> => ({
+    ...(await readSetting(POLICY_SETTINGS.TOOL_MODEL_OVERRIDES))
+  })
 
 export const getToolModelOverride = async (
   providerId: string,
@@ -130,7 +126,7 @@ export const setToolModelOverride = (
     } else {
       delete all[key]
     }
-    await plasmoGlobalStorage.set(STORAGE_KEY, all)
+    await writeSetting(POLICY_SETTINGS.TOOL_MODEL_OVERRIDES, all)
   })
 
 /**
@@ -164,7 +160,7 @@ export const patchToolModelOverride = (
     } else {
       delete all[key]
     }
-    await plasmoGlobalStorage.set(STORAGE_KEY, all)
+    await writeSetting(POLICY_SETTINGS.TOOL_MODEL_OVERRIDES, all)
   })
 
 export const clearToolModelOverride = (
@@ -176,6 +172,6 @@ export const clearToolModelOverride = (
     const key = toolModelOverrideKey(providerId, modelName)
     if (key in all) {
       delete all[key]
-      await plasmoGlobalStorage.set(STORAGE_KEY, all)
+      await writeSetting(POLICY_SETTINGS.TOOL_MODEL_OVERRIDES, all)
     }
   })

--- a/src/options/components/__tests__/settings-page.test.tsx
+++ b/src/options/components/__tests__/settings-page.test.tsx
@@ -7,7 +7,10 @@ import {
 } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { STORAGE_KEYS } from "@/lib/constants"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import {
+  getPlasmoStoredValue,
+  setPlasmoStoredValue
+} from "@/lib/plasmo-global-storage"
 import { SettingsPage } from "../settings-page"
 
 vi.mock("react-i18next", () => ({
@@ -174,7 +177,7 @@ describe("SettingsPage", () => {
 
   it("does not let a late storage read undo a user selection", async () => {
     let resolveStoredLevel: (value: "basic") => void = () => undefined
-    vi.mocked(plasmoGlobalStorage.get).mockReturnValueOnce(
+    vi.mocked(getPlasmoStoredValue).mockReturnValueOnce(
       new Promise((resolve) => {
         resolveStoredLevel = resolve
       })
@@ -195,7 +198,7 @@ describe("SettingsPage", () => {
 
   it("does not let deep-link promotion downgrade a stored level", async () => {
     let resolveStoredLevel: (value: "advanced") => void = () => undefined
-    vi.mocked(plasmoGlobalStorage.get).mockReturnValueOnce(
+    vi.mocked(getPlasmoStoredValue).mockReturnValueOnce(
       new Promise((resolve) => {
         resolveStoredLevel = resolve
       })
@@ -219,7 +222,7 @@ describe("SettingsPage", () => {
         })
       ).toHaveAttribute("aria-selected", "true")
     })
-    expect(plasmoGlobalStorage.set).not.toHaveBeenCalledWith(
+    expect(setPlasmoStoredValue).not.toHaveBeenCalledWith(
       STORAGE_KEYS.UI.SETTINGS_LEVEL,
       "power"
     )

--- a/src/options/components/settings-page.tsx
+++ b/src/options/components/settings-page.tsx
@@ -41,9 +41,10 @@ import {
   settingsLevelIncludes
 } from "@/features/settings/settings-registry"
 import type { SettingsSearchRecord } from "@/features/settings/settings-search-index"
-import { HIGHLIGHT_FOCUS_DELAY_MS, STORAGE_KEYS } from "@/lib/constants"
+import { HIGHLIGHT_FOCUS_DELAY_MS } from "@/lib/constants"
 import { SOCIAL_LINKS } from "@/lib/constants-ui"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { readSetting, writeSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import GeneralSettingsTab from "@/options/components/tabs/general-settings-tab"
 
 const ModelsSettingsTab = lazy(
@@ -89,8 +90,7 @@ export const SettingsPage = () => {
 
   useEffect(() => {
     let active = true
-    plasmoGlobalStorage
-      .get<SettingsLevel>(STORAGE_KEYS.UI.SETTINGS_LEVEL)
+    readSetting(SETTINGS.SETTINGS_LEVEL)
       .then((stored) => {
         if (!active) return
         hydratedLevelRef.current = true
@@ -103,10 +103,7 @@ export const SettingsPage = () => {
         )
         setSettingsLevel(reconciledLevel)
         if (reconciledLevel !== storedLevel) {
-          void plasmoGlobalStorage.set(
-            STORAGE_KEYS.UI.SETTINGS_LEVEL,
-            reconciledLevel
-          )
+          void writeSetting(SETTINGS.SETTINGS_LEVEL, reconciledLevel)
         }
       })
       .catch(() => {
@@ -120,7 +117,7 @@ export const SettingsPage = () => {
   const updateSettingsLevel = useCallback((next: SettingsLevel) => {
     userSelectedLevelRef.current = true
     setSettingsLevel(next)
-    void plasmoGlobalStorage.set(STORAGE_KEYS.UI.SETTINGS_LEVEL, next)
+    void writeSetting(SETTINGS.SETTINGS_LEVEL, next)
   }, [])
 
   const revealSetting = useCallback(
@@ -134,7 +131,7 @@ export const SettingsPage = () => {
         )
         setSettingsLevel(promoted)
         if (hydratedLevelRef.current) {
-          void plasmoGlobalStorage.set(STORAGE_KEYS.UI.SETTINGS_LEVEL, promoted)
+          void writeSetting(SETTINGS.SETTINGS_LEVEL, promoted)
         }
       }
     },


### PR DESCRIPTION
## What changed

- add runtime schemas and typed descriptors for structured model, embedding, upload, extraction, and per-site settings
- validate approval grants, capability overrides/probes, and per-model tool policy maps with fail-closed behavior
- route background, content-script, model, permission, and settings-level consumers through descriptor-backed storage access
- centralize generic descriptor lookup for preset application and reject malformed preset values
- split content, selection, per-site, and policy descriptors so content scripts only ship the validators they use
- add malformed-data, boundary, migration, and storage behavior coverage

## Why

The deprecated global storage alias returned persisted values as trusted TypeScript types. Corrupt, stale, or imported values could therefore cross runtime boundaries unchecked, and consumers duplicated defaults and scope decisions. Security-sensitive maps such as persistent tool approvals also needed conservative validation.

This change makes descriptors the runtime contract, defaults invalid data safely, and keeps sync/local routing centralized. Approval, capability, probe, and tool-policy maps fail closed. The content-specific split preserves those guarantees without increasing the selection overlay beyond its bundle budget.

## Impact

Existing valid settings continue to load. Partial legacy extraction, embedding, and upload settings are normalized onto current defaults. Invalid structured values fall back safely instead of reaching runtime consumers. No chat-history or provider-secret storage is changed.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 342 files, 2,885 tests
- pre-push i18n drift and docs build
- Chrome production package build
- bundle-size gate, including selection overlay at 235,805 / 236,000 gzip bytes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces descriptor-backed validation for persisted settings and migrates consumers across background, content-script, model, permission, and settings paths.
- Adds runtime schemas, typed descriptors, defaults, and sync/local routing for structured settings.
- Makes approval, capability, probe, and model-tool policy data fail closed when malformed.
- Fixes the previously reported selection-configuration race by applying only the newest asynchronous refresh and invalidating pending refreshes during teardown.
- Adds validation, migration, malformed-data, storage-boundary, and race coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported out-of-order selection configuration overwrite is prevented by generation-tagged refreshes, and no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/selection-actions/content-script.tsx | Replaces overlapping direct configuration updates with generation-gated refreshes and invalidates pending work during content-script teardown. |
| src/features/selection-actions/content-settings.ts | Adds the latest-only refresh helper and routes selection settings through validated descriptors. |
| src/lib/storage/setting-access.ts | Centralizes descriptor-backed stored-value reads, validated defaults, and writes. |
| src/lib/storage/setting-schemas.ts | Defines runtime validation and normalization contracts for structured persisted settings. |
| src/lib/storage/settings.ts | Collects general typed setting descriptors while policy and content-script descriptors remain separately scoped. |
| src/lib/storage/policy-setting-schemas.ts | Adds conservative validation for security-sensitive approval, capability, probe, and tool-policy maps. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Persisted["Persisted browser setting"] --> Descriptor["Typed setting descriptor"]
  Descriptor --> Validation{"Runtime validation"}
  Validation -->|Valid| Consumer["Background / UI / content consumer"]
  Validation -->|Invalid| Default["Safe default or fail-closed value"]
  Default --> Consumer
  Change["Selection config change"] --> Refresh["Generation-tagged async refresh"]
  Refresh --> Latest{"Still latest?"}
  Latest -->|Yes| Apply["Apply config to overlay"]
  Latest -->|No| Ignore["Ignore stale result"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(selection): ignore stale config read..."](https://github.com/shishir435/ollama-client/commit/33aa3edf7b19cb42be7104bea7c8946e0bcd0249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52660020)</sub>

**Context used:**

- Knowledge Base — [Tool-Calling and Browser Context Access](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/tools-context.md)

<!-- /greptile_comment -->