### PR TITLE
refactor(providers): add lifecycle capability ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ connect through package ports.
 | `manager.ts` | config + model mappings via `ProviderStorageKey` |
 | `selected-model.ts` | active model state |
 | `capabilities.ts` | capability detection and per-flag attribution |
+| `model-lifecycle.ts` | shared lifecycle result normalization and safe provider errors |
 | `ollama.ts`, `lm-studio.ts`, `llama-cpp.ts` | verified built-ins |
 | `openai-compatible.ts` | custom OpenAI-compatible endpoints |
 | `anthropic.ts` | native Claude Messages API |
@@ -125,6 +126,8 @@ The default provider's embedding check is the one remaining direct `/api/tags` f
 The filter reads hostnames, so a public name resolving to a private address still passes, and no extension API closes that — `chrome.dns` is dev-channel only, and resolving before fetching is TOCTOU because `fetch` looks up again. What bounds it is that the response never leaves the device: no credentials are sent, non-image bytes are discarded, and it takes a provider the user already trusts with their prompts. Do not "fix" it by adding a resolve step; the honest mitigation is the off switch. Users can turn the lookup off; doing so also drops what was already fetched.
 
 **Capability detection** resolves in this order, highest first: user override → empirical probe (`capability-probe.ts`) → model metadata → provider default. An unknown capability resolves to `false`; only an override may flip it on. Never enable vision or tool calling on a guess.
+
+**Model lifecycle wires stay in provider adapters.** `LLMProvider.modelLifecycle` is an optional port for loaded-model listing, unload, and warmup. `ModelRpcService` owns RPC policy and warmup cooldowns, but never constructs vendor lifecycle URLs or branches on provider ids. A capability flag and its optional operation must agree; providers without an operation return an unsupported/no-op result rather than receiving an Ollama-shaped request.
 
 Metadata evidence, strongest first:
 

--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -222,6 +222,13 @@ The provider, model, embedding, and diagnostics request/response migration is
 complete. New request/response work is added as an `RpcMethod`; it must not add
 another runtime message key.
 
+Model lifecycle RPC coordinates policy through an optional provider-owned
+`modelLifecycle` port. Ollama owns `/api/ps`, keep-alive eviction, and no-op
+generation warmup; LM Studio owns its loaded-model and unload routes. The RPC
+service applies warmup settings and cooldowns but does not branch on provider
+ids or construct vendor URLs. Providers without the corresponding operation
+return an unsupported/no-op result instead of receiving an Ollama-shaped call.
+
 Streaming ports, one-way browser/app events, and the content-script-reachable
 `PROVIDER.GET_MODELS` read intentionally remain outside RPC. RPC envelopes are
 extension-page-only, while the model read is needed by the selection overlay.

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -358,6 +358,18 @@ describe("architecture import boundaries", () => {
     expect(offenders).toEqual([])
   })
 
+  it("keeps provider lifecycle wires inside provider adapters", () => {
+    const source = withoutComments(
+      readFileSync(
+        join(sourceRoot, "lib/providers/model-rpc-service.ts"),
+        "utf8"
+      )
+    )
+
+    expect(source).not.toMatch(/provider\.id\s*===\s*ProviderId\./)
+    expect(source).not.toMatch(/\/api\/(?:ps|generate|chat|v1\/models)/)
+  })
+
   /**
    * The observer registry is in-memory delivery state and nothing else.
    *

--- a/src/lib/providers/__tests__/lm-studio.test.ts
+++ b/src/lib/providers/__tests__/lm-studio.test.ts
@@ -162,3 +162,60 @@ describe("LMStudioProvider.getModels", () => {
     )
   })
 })
+
+describe("LMStudioProvider.modelLifecycle", () => {
+  it("normalizes the loaded-model endpoint inside the adapter", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "qwen3-8b", arch: "qwen3", quantization: "Q4_K_M" }]
+      })
+    } as Response)
+
+    await expect(
+      makeProvider().modelLifecycle.listLoadedModels()
+    ).resolves.toEqual([
+      {
+        name: "qwen3-8b",
+        sizeBytes: 0,
+        family: "qwen3",
+        parameterSize: "",
+        quantizationLevel: "Q4_K_M"
+      }
+    ])
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
+      "http://localhost:1234/api/v1/models"
+    )
+  })
+
+  it("owns the LM Studio unload wire format", async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+
+    await expect(
+      makeProvider().modelLifecycle.unloadModel("qwen3-8b")
+    ).resolves.toBe(true)
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:1234/api/v1/models/unload",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ model: "qwen3-8b" })
+      })
+    )
+  })
+
+  it("classifies lifecycle request failures inside the adapter", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Unavailable"
+    } as Response)
+
+    await expect(
+      makeProvider().modelLifecycle.listLoadedModels()
+    ).rejects.toMatchObject({
+      status: 503,
+      providerId: ProviderId.LM_STUDIO,
+      retryable: true
+    })
+  })
+})

--- a/src/lib/providers/__tests__/model-rpc-service.test.ts
+++ b/src/lib/providers/__tests__/model-rpc-service.test.ts
@@ -29,14 +29,23 @@ import { ModelRpcService } from "../model-rpc-service"
 const ollama = {
   id: "ollama",
   config: { id: "ollama", baseUrl: "http://localhost:11434" },
-  capabilities: { modelDetails: true },
-  getModelDetails: vi.fn()
+  capabilities: { modelDetails: true, modelUnload: true },
+  getModelDetails: vi.fn(),
+  modelLifecycle: {
+    listLoadedModels: vi.fn(),
+    unloadModel: vi.fn(),
+    warmModel: vi.fn()
+  }
 }
 
 const lmStudio = {
   id: "lm studio",
   config: { id: "lm studio", baseUrl: "http://localhost:1234/v1" },
-  capabilities: { modelDetails: false }
+  capabilities: { modelDetails: false, modelUnload: true },
+  modelLifecycle: {
+    listLoadedModels: vi.fn(),
+    unloadModel: vi.fn()
+  }
 }
 
 const jsonResponse = (body: unknown, ok = true, status = 200) =>
@@ -51,6 +60,11 @@ const jsonResponse = (body: unknown, ok = true, status = 200) =>
 beforeEach(() => {
   vi.clearAllMocks()
   ollama.getModelDetails = vi.fn()
+  ollama.modelLifecycle.listLoadedModels.mockResolvedValue([])
+  ollama.modelLifecycle.unloadModel.mockResolvedValue(true)
+  ollama.modelLifecycle.warmModel.mockResolvedValue(undefined)
+  lmStudio.modelLifecycle.listLoadedModels.mockResolvedValue([])
+  lmStudio.modelLifecycle.unloadModel.mockResolvedValue(true)
   mocks.getProvider.mockResolvedValue(ollama)
   mocks.getProviderForModel.mockResolvedValue(ollama)
   mocks.getProviderConfig.mockResolvedValue(ollama.config)
@@ -91,22 +105,16 @@ describe("ModelRpcService.getDetails", () => {
 })
 
 describe("ModelRpcService.listLoaded", () => {
-  it("normalizes Ollama's /api/ps shape", async () => {
-    vi.mocked(fetch).mockResolvedValue(
-      jsonResponse({
-        models: [
-          {
-            name: "llama3:8b",
-            size: 1024,
-            details: {
-              family: "llama",
-              parameter_size: "8B",
-              quantization_level: "Q4_0"
-            }
-          }
-        ]
-      })
-    )
+  it("delegates loaded-model listing to the provider lifecycle port", async () => {
+    ollama.modelLifecycle.listLoadedModels.mockResolvedValue([
+      {
+        name: "llama3:8b",
+        sizeBytes: 1024,
+        family: "llama",
+        parameterSize: "8B",
+        quantizationLevel: "Q4_0"
+      }
+    ])
 
     await expect(ModelRpcService.listLoaded({})).resolves.toEqual({
       models: [
@@ -119,17 +127,20 @@ describe("ModelRpcService.listLoaded", () => {
         }
       ]
     })
+    expect(ollama.modelLifecycle.listLoadedModels).toHaveBeenCalledOnce()
   })
 
-  it("normalizes LM Studio's differently named fields", async () => {
-    // The old handler passed LM Studio's entries through untouched, so the card
-    // rendered `undefined` for family, size, and quantization.
+  it("uses the requested provider's lifecycle port", async () => {
     mocks.getProvider.mockResolvedValue(lmStudio)
-    vi.mocked(fetch).mockResolvedValue(
-      jsonResponse({
-        data: [{ id: "qwen3-8b", arch: "qwen3", quantization: "Q4_K_M" }]
-      })
-    )
+    lmStudio.modelLifecycle.listLoadedModels.mockResolvedValue([
+      {
+        name: "qwen3-8b",
+        sizeBytes: 0,
+        family: "qwen3",
+        parameterSize: "",
+        quantizationLevel: "Q4_K_M"
+      }
+    ])
 
     await expect(
       ModelRpcService.listLoaded({ providerId: "lm studio" })
@@ -144,32 +155,35 @@ describe("ModelRpcService.listLoaded", () => {
         }
       ]
     })
-    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
-      "http://localhost:1234/api/v1/models"
-    )
+    expect(lmStudio.modelLifecycle.listLoadedModels).toHaveBeenCalledOnce()
   })
 
-  it("throws an AppError the RPC server can classify", async () => {
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({}, false, 503))
+  it("returns an empty list when the provider has no lifecycle port", async () => {
+    mocks.getProvider.mockResolvedValue({
+      ...lmStudio,
+      modelLifecycle: undefined
+    })
 
-    await expect(ModelRpcService.listLoaded({})).rejects.toMatchObject({
-      status: 503,
-      retryable: true
+    await expect(ModelRpcService.listLoaded({})).resolves.toEqual({
+      models: []
     })
   })
 })
 
 describe("ModelRpcService.unload", () => {
-  it("reports whether the keep-alive eviction actually took", async () => {
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({ done_reason: "unload" }))
+  it("delegates unload and preserves the provider's result", async () => {
     await expect(ModelRpcService.unload({ model: "llama3" })).resolves.toEqual({
       unloaded: true
     })
 
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({ done_reason: "stop" }))
+    ollama.modelLifecycle.unloadModel.mockResolvedValue(false)
     await expect(ModelRpcService.unload({ model: "llama3" })).resolves.toEqual({
       unloaded: false
     })
+    expect(ollama.modelLifecycle.unloadModel).toHaveBeenCalledWith(
+      "llama3",
+      undefined
+    )
   })
 })
 
@@ -181,21 +195,19 @@ describe("ModelRpcService.warmup", () => {
       warmed: false,
       unloadedPrevious: false
     })
-    expect(fetch).not.toHaveBeenCalled()
+    expect(ollama.modelLifecycle.warmModel).not.toHaveBeenCalled()
   })
 
   it("warms once and then respects the cooldown", async () => {
     mocks.storageGet.mockResolvedValue({
       "cooldown-model": { warm_on_select: true, keep_alive: "10m" }
     })
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({}))
-
     const first = await ModelRpcService.warmup({ model: "cooldown-model" })
     const second = await ModelRpcService.warmup({ model: "cooldown-model" })
 
     expect(first.warmed).toBe(true)
     expect(second.warmed).toBe(false)
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(ollama.modelLifecycle.warmModel).toHaveBeenCalledTimes(1)
   })
 
   it("releases the previous model when it is configured to unload on switch", async () => {
@@ -203,16 +215,15 @@ describe("ModelRpcService.warmup", () => {
       "new-model": { warm_on_select: false },
       "old-model": { unload_on_switch: true }
     })
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({}))
-
     const result = await ModelRpcService.warmup({
       model: "new-model",
       previousModel: "old-model"
     })
 
     expect(result).toEqual({ warmed: false, unloadedPrevious: true })
-    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
-      "http://localhost:11434/api/chat"
+    expect(ollama.modelLifecycle.unloadModel).toHaveBeenCalledWith(
+      "old-model",
+      undefined
     )
   })
 
@@ -227,7 +238,7 @@ describe("ModelRpcService.warmup", () => {
     await expect(
       ModelRpcService.warmup({ model: "blocked-model" })
     ).rejects.toThrow("provider disabled")
-    expect(fetch).not.toHaveBeenCalled()
+    expect(ollama.modelLifecycle.warmModel).not.toHaveBeenCalled()
   })
 })
 

--- a/src/lib/providers/__tests__/ollama-model-lifecycle.test.ts
+++ b/src/lib/providers/__tests__/ollama-model-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { OllamaProvider } from "../ollama"
+import { ProviderId, ProviderType } from "../types"
+
+const makeProvider = () =>
+  new OllamaProvider({
+    id: ProviderId.OLLAMA,
+    type: ProviderType.OLLAMA,
+    name: "Ollama",
+    baseUrl: "http://localhost:11434",
+    enabled: true
+  })
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("OllamaProvider.modelLifecycle", () => {
+  it("normalizes /api/ps entries inside the adapter", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          {
+            name: "llama3:8b",
+            size: 1024,
+            details: {
+              family: "llama",
+              parameter_size: "8B",
+              quantization_level: "Q4_0"
+            }
+          }
+        ]
+      })
+    } as Response)
+
+    await expect(
+      makeProvider().modelLifecycle.listLoadedModels()
+    ).resolves.toEqual([
+      {
+        name: "llama3:8b",
+        sizeBytes: 1024,
+        family: "llama",
+        parameterSize: "8B",
+        quantizationLevel: "Q4_0"
+      }
+    ])
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
+      "http://localhost:11434/api/ps"
+    )
+  })
+
+  it("owns keep-alive eviction and reports whether it took", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ done_reason: "unload" })
+    } as Response)
+
+    await expect(
+      makeProvider().modelLifecycle.unloadModel("llama3")
+    ).resolves.toBe(true)
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:11434/api/chat",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "llama3",
+          messages: [],
+          keep_alive: 0
+        })
+      })
+    )
+  })
+
+  it("owns the no-op generate warmup wire format", async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+
+    await makeProvider().modelLifecycle.warmModel("llama3", "10m")
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:11434/api/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "llama3",
+          prompt: "",
+          stream: false,
+          keep_alive: "10m"
+        })
+      })
+    )
+  })
+})

--- a/src/lib/providers/lm-studio.ts
+++ b/src/lib/providers/lm-studio.ts
@@ -2,6 +2,11 @@ import { logger } from "@/lib/logger"
 import type { ProviderModel } from "@/types"
 import { resolveProviderBaseUrl } from "./base-url"
 import { parameterSizeFromModelId } from "./model-id-metadata"
+import {
+  lifecycleRequestFailed,
+  lmStudioApiRoot,
+  normalizeLmStudioLoadedModel
+} from "./model-lifecycle"
 import { OpenAICompatibleProvider } from "./openai-compatible"
 import { type EmbeddingSupport, type ProviderConfig, ProviderId } from "./types"
 
@@ -19,6 +24,36 @@ export class LMStudioProvider extends OpenAICompatibleProvider {
       modelUnload: true,
       providerVersion: false,
       toolCalling: true
+    }
+  }
+
+  modelLifecycle = {
+    listLoadedModels: async (signal?: AbortSignal) => {
+      const response = await fetch(
+        `${lmStudioApiRoot(resolveProviderBaseUrl(this.config))}/api/v1/models`,
+        signal ? { signal } : undefined
+      )
+      if (!response.ok) {
+        throw lifecycleRequestFailed("loaded model list", response, this.id)
+      }
+      const data = await response.json()
+      const models = Array.isArray(data?.data) ? data.data : []
+      return models.map(normalizeLmStudioLoadedModel)
+    },
+    unloadModel: async (model: string, signal?: AbortSignal) => {
+      const response = await fetch(
+        `${lmStudioApiRoot(resolveProviderBaseUrl(this.config))}/api/v1/models/unload`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model }),
+          signal
+        }
+      )
+      if (!response.ok) {
+        throw lifecycleRequestFailed("unload", response, this.id)
+      }
+      return true
     }
   }
 

--- a/src/lib/providers/model-lifecycle.ts
+++ b/src/lib/providers/model-lifecycle.ts
@@ -1,0 +1,56 @@
+import type { LoadedModel } from "@ollama-client/contracts/model-rpc"
+import { createAppError } from "@/lib/error-utils"
+
+export const lifecycleRequestFailed = (
+  operation: string,
+  response: Response,
+  providerId: string
+) =>
+  createAppError(`${operation} failed with ${response.status}`, {
+    kind: "provider",
+    status: response.status,
+    userMessage:
+      response.statusText || `The provider rejected the ${operation} request`,
+    providerId,
+    retryable: response.status >= 500
+  })
+
+interface OllamaPsModel {
+  name?: string
+  model?: string
+  size?: number
+  details?: {
+    family?: string
+    parameter_size?: string
+    quantization_level?: string
+  }
+}
+
+export const normalizeOllamaLoadedModel = (
+  model: OllamaPsModel
+): LoadedModel => ({
+  name: model.name ?? model.model ?? "",
+  sizeBytes: model.size ?? 0,
+  family: model.details?.family ?? "",
+  parameterSize: model.details?.parameter_size ?? "",
+  quantizationLevel: model.details?.quantization_level ?? ""
+})
+
+interface LmStudioModel {
+  id?: string
+  arch?: string
+  quantization?: string
+}
+
+export const normalizeLmStudioLoadedModel = (
+  model: LmStudioModel
+): LoadedModel => ({
+  name: model.id ?? "",
+  sizeBytes: 0,
+  family: model.arch ?? "",
+  parameterSize: "",
+  quantizationLevel: model.quantization ?? ""
+})
+
+export const lmStudioApiRoot = (baseUrl: string): string =>
+  baseUrl.replace(/\/v1\/?$/, "")

--- a/src/lib/providers/model-rpc-service.ts
+++ b/src/lib/providers/model-rpc-service.ts
@@ -1,5 +1,4 @@
 import type {
-  LoadedModel,
   ModelsGetDetailsRequest,
   ModelsGetDetailsResult,
   ModelsGetLibraryVariantsRequest,
@@ -17,9 +16,7 @@ import { DEFAULT_MODEL_LIBRARY_BASE_URL } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { resolveModelConfig } from "@/lib/model-config-utils"
-import { resolveProviderBaseUrl } from "@/lib/providers/base-url"
 import { ProviderFactory } from "@/lib/providers/factory"
-import { ProviderManager } from "@/lib/providers/manager"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { ProviderId } from "@/lib/providers/types"
 import { readSetting } from "@/lib/storage/setting-access"
@@ -50,17 +47,6 @@ const providerRequestFailed = (
     retryable: status >= 500
   })
 
-const resolveDefaultBaseUrl = async (): Promise<string> => {
-  const config = await ProviderManager.getProviderConfig(ProviderId.OLLAMA)
-  if (!config) {
-    throw createAppError("Built-in Ollama provider configuration is missing", {
-      kind: "validation",
-      providerId: ProviderId.OLLAMA
-    })
-  }
-  return resolveProviderBaseUrl(config)
-}
-
 /**
  * `/api/show` may include large license, tensor, template, and Modelfile
  * fields. Only these three are consumed; keeping the rest out keeps the RPC
@@ -76,45 +62,6 @@ const compactModelDetails = (
     ...(data.capabilities && { capabilities: data.capabilities })
   }
 }
-
-const lmStudioRoot = (baseUrl: string) => baseUrl.replace(/\/v1\/?$/, "")
-
-/** Ollama `/api/ps` entry. */
-interface OllamaPsModel {
-  name?: string
-  model?: string
-  size?: number
-  details?: {
-    family?: string
-    parameter_size?: string
-    quantization_level?: string
-  }
-}
-
-/** LM Studio model-list entry; field names differ from Ollama's. */
-interface LmStudioModel {
-  id?: string
-  arch?: string
-  quantization?: string
-  state?: string
-}
-
-const normalizeOllamaLoaded = (model: OllamaPsModel): LoadedModel => ({
-  name: model.name ?? model.model ?? "",
-  sizeBytes: model.size ?? 0,
-  family: model.details?.family ?? "",
-  parameterSize: model.details?.parameter_size ?? "",
-  quantizationLevel: model.details?.quantization_level ?? ""
-})
-
-const normalizeLmStudioLoaded = (model: LmStudioModel): LoadedModel => ({
-  name: model.id ?? "",
-  // LM Studio's list does not report resident bytes.
-  sizeBytes: 0,
-  family: model.arch ?? "",
-  parameterSize: "",
-  quantizationLevel: model.quantization ?? ""
-})
 
 /** Warmup */
 
@@ -157,22 +104,6 @@ const shouldWarmup = (historyKey: string, keepAliveMs?: number) => {
   return Date.now() - last > windowMs / 2
 }
 
-/**
- * Keep-alive 0 evicts the model. Used both to warm the newly selected model and
- * to release the one being switched away from.
- */
-const unloadViaKeepAlive = async (
-  baseUrl: string,
-  model: string,
-  signal?: AbortSignal
-) =>
-  fetch(`${baseUrl}/api/chat`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ model, messages: [], keep_alive: 0 }),
-    signal
-  })
-
 export const ModelRpcService = {
   async getDetails(
     request: ModelsGetDetailsRequest
@@ -204,34 +135,8 @@ export const ModelRpcService = {
     const provider = await ProviderFactory.getProvider(
       request.providerId ?? ProviderId.OLLAMA
     )
-    const baseUrl = request.providerId
-      ? resolveProviderBaseUrl(provider.config)
-      : await resolveDefaultBaseUrl()
-
-    const isLmStudio = provider.id === ProviderId.LM_STUDIO
-    const endpoint = isLmStudio
-      ? `${lmStudioRoot(baseUrl)}/api/v1/models`
-      : `${baseUrl}/api/ps`
-
-    const res = await fetch(endpoint, { signal })
-    if (!res.ok) {
-      throw providerRequestFailed(
-        "loaded model list",
-        res.status,
-        res.statusText,
-        provider.id
-      )
-    }
-
-    const data = await res.json()
-    if (isLmStudio) {
-      const models: LmStudioModel[] = Array.isArray(data?.data) ? data.data : []
-      return { models: models.map(normalizeLmStudioLoaded) }
-    }
-    const models: OllamaPsModel[] = Array.isArray(data?.models)
-      ? data.models
-      : []
-    return { models: models.map(normalizeOllamaLoaded) }
+    const listLoadedModels = provider.modelLifecycle?.listLoadedModels
+    return { models: listLoadedModels ? await listLoadedModels(signal) : [] }
   },
 
   async unload(
@@ -242,37 +147,11 @@ export const ModelRpcService = {
       request.model,
       request.providerId
     )
-    const baseUrl = resolveProviderBaseUrl(provider.config)
-
-    if (provider.id === ProviderId.LM_STUDIO) {
-      const res = await fetch(`${lmStudioRoot(baseUrl)}/api/v1/models/unload`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: request.model }),
-        signal
-      })
-      if (!res.ok) {
-        throw providerRequestFailed(
-          "unload",
-          res.status,
-          res.statusText,
-          provider.id
-        )
-      }
-      return { unloaded: true }
+    const unloadModel = provider.modelLifecycle?.unloadModel
+    if (!provider.capabilities.modelUnload || !unloadModel) {
+      return { unloaded: false }
     }
-
-    const res = await unloadViaKeepAlive(baseUrl, request.model, signal)
-    if (!res.ok) {
-      throw providerRequestFailed(
-        "unload",
-        res.status,
-        res.statusText,
-        provider.id
-      )
-    }
-    const data = await res.json()
-    return { unloaded: data?.done_reason === "unload" }
+    return { unloaded: await unloadModel(request.model, signal) }
   },
 
   async warmup(
@@ -290,19 +169,9 @@ export const ModelRpcService = {
         request.providerId
       )
       assertProviderEnabled(provider, request.model)
-      // Only Ollama exposes a no-op generate that parks a model in memory.
-      if (provider.id === ProviderId.OLLAMA) {
-        await fetch(`${resolveProviderBaseUrl(provider.config)}/api/generate`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: request.model,
-            prompt: "",
-            stream: false,
-            keep_alive: config.keep_alive
-          }),
-          signal
-        })
+      const warmModel = provider.modelLifecycle?.warmModel
+      if (warmModel) {
+        await warmModel(request.model, config.keep_alive, signal)
         warmupHistory.set(warmupKey, Date.now())
         warmed = true
         logger.info("Model warmup triggered", "ModelRpcService", {
@@ -319,13 +188,9 @@ export const ModelRpcService = {
           request.previousModel,
           request.previousProviderId
         )
-        if (previous.id === ProviderId.OLLAMA) {
-          await unloadViaKeepAlive(
-            resolveProviderBaseUrl(previous.config),
-            request.previousModel,
-            signal
-          )
-          unloadedPrevious = true
+        const unloadModel = previous.modelLifecycle?.unloadModel
+        if (previous.capabilities.modelUnload && unloadModel) {
+          unloadedPrevious = await unloadModel(request.previousModel, signal)
           logger.info("Model unloaded on switch", "ModelRpcService", {
             model: request.previousModel
           })

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -18,6 +18,10 @@ import type {
 import { resolveProviderBaseUrl } from "./base-url"
 import { PROVIDER_CAPABILITIES } from "./capabilities"
 import {
+  lifecycleRequestFailed,
+  normalizeOllamaLoadedModel
+} from "./model-lifecycle"
+import {
   type ChatRequest,
   type EmbeddingSupport,
   type LLMProvider,
@@ -90,6 +94,54 @@ export class OllamaProvider implements LLMProvider {
   capabilities = { ...PROVIDER_CAPABILITIES[ProviderId.OLLAMA] }
 
   constructor(public config: ProviderConfig) {}
+
+  modelLifecycle = {
+    listLoadedModels: async (signal?: AbortSignal) => {
+      const response = await fetch(
+        `${resolveProviderBaseUrl(this.config)}/api/ps`,
+        signal ? { signal } : undefined
+      )
+      if (!response.ok) {
+        throw lifecycleRequestFailed("loaded model list", response, this.id)
+      }
+      const data = await response.json()
+      const models = Array.isArray(data?.models) ? data.models : []
+      return models.map(normalizeOllamaLoadedModel)
+    },
+    unloadModel: async (model: string, signal?: AbortSignal) => {
+      const response = await fetch(
+        `${resolveProviderBaseUrl(this.config)}/api/chat`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model, messages: [], keep_alive: 0 }),
+          signal
+        }
+      )
+      if (!response.ok) {
+        throw lifecycleRequestFailed("unload", response, this.id)
+      }
+      const data = await response.json()
+      return data?.done_reason === "unload"
+    },
+    warmModel: async (
+      model: string,
+      keepAlive?: string | number,
+      signal?: AbortSignal
+    ) => {
+      await fetch(`${resolveProviderBaseUrl(this.config)}/api/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model,
+          prompt: "",
+          stream: false,
+          keep_alive: keepAlive
+        }),
+        signal
+      })
+    }
+  }
 
   async getModels(signal?: AbortSignal): Promise<ProviderModel[]> {
     try {

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,3 +1,4 @@
+import type { LoadedModel } from "@ollama-client/contracts/model-rpc"
 import type { ToolDefinition } from "@/lib/tools/types"
 import type {
   ChatMessage,
@@ -149,10 +150,21 @@ export interface ProviderCapabilities {
   toolCalling: boolean
 }
 
+export interface ProviderModelLifecycle {
+  listLoadedModels?(signal?: AbortSignal): Promise<LoadedModel[]>
+  unloadModel?(model: string, signal?: AbortSignal): Promise<boolean>
+  warmModel?(
+    model: string,
+    keepAlive?: string | number,
+    signal?: AbortSignal
+  ): Promise<void>
+}
+
 export interface LLMProvider {
   id: string
   config: ProviderConfig
   capabilities: ProviderCapabilities
+  modelLifecycle?: ProviderModelLifecycle
 
   streamChat(
     request: ChatRequest,


### PR DESCRIPTION
## What changed

- add an optional provider-owned `modelLifecycle` port
- move Ollama loaded-model, unload, and warmup wires into `OllamaProvider`
- move LM Studio loaded-model and unload wires into `LMStudioProvider`
- keep warmup settings and cooldown coordination in `ModelRpcService`
- return unsupported/no-op results when a provider has no matching operation
- add an architecture guard preventing vendor lifecycle URLs and provider-id branches in the RPC service

## Why

`ModelRpcService` declared provider capabilities but bypassed the provider abstraction to construct Ollama and LM Studio requests itself. Capability flags and implementations could diverge, and adding another lifecycle-capable provider required extending a central vendor switch.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` (344 files, 2,903 tests)
- adapter wire-format, normalization, error, and service-delegation tests
- `pnpm docs:build`
- `pnpm generate:resources`
- Chrome production package and bundle budgets via pre-push gates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves provider-specific loaded-model, unload, and warmup requests behind an optional provider lifecycle port while retaining cooldown and RPC policy in `ModelRpcService`.
- Adds lifecycle operations to the Ollama and LM Studio adapters.
- Centralizes loaded-model normalization and provider error construction.
- Makes unsupported lifecycle operations return empty or false results.
- Adds adapter tests, delegation tests, architecture guards, and documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regression identified.

The lifecycle-bearing providers are constructed with aligned capability flags and operations, delegation preserves the existing provider resolution and wire behavior, and unsupported providers follow the explicitly documented no-op contract.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/providers/model-rpc-service.ts | Replaces vendor-specific URL and response handling with optional lifecycle-port delegation while preserving warmup policy and cooldown ownership. |
| src/lib/providers/ollama.ts | Adds provider-owned loaded-model listing, keep-alive unload, and no-op generation warmup operations using the existing Ollama wire formats. |
| src/lib/providers/lm-studio.ts | Adds provider-owned loaded-model listing and unload operations with LM Studio URL normalization and classified failures. |
| src/lib/providers/model-lifecycle.ts | Introduces shared loaded-model normalization and safe lifecycle request error construction. |
| src/lib/providers/types.ts | Extends the provider contract with an optional lifecycle capability port. |
| src/lib/__tests__/architecture-boundaries.test.ts | Guards against reintroducing provider-id branches or vendor lifecycle URLs in the RPC service. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as Extension client
  participant RPC as ModelRpcService
  participant Factory as ProviderFactory
  participant Port as Provider modelLifecycle
  participant Server as Provider server
  Client->>RPC: lifecycle RPC request
  RPC->>Factory: resolve provider
  Factory-->>RPC: LLMProvider
  alt Operation is supported
    RPC->>Port: lifecycle operation
    Port->>Server: provider-specific request
    Server-->>Port: provider response
    Port-->>RPC: normalized result
  else Port or operation is absent
    RPC-->>Client: empty / false result
  end
  RPC-->>Client: typed RPC result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(providers): add lifecycle ports"](https://github.com/shishir435/ollama-client/commit/fac182fe92b499cbee4cd43b3bc065a194dc3dd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52689617)</sub>

**Context used:**

- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)

<!-- /greptile_comment -->