### PR TITLE
refactor(providers): split manager internals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,10 @@ connect through package ports.
 | `types.ts` | `LLMProvider`, `ProviderConfig`, `ProviderType`/`ProviderId` enums |
 | `registry.ts` | static metadata for built-in providers |
 | `factory.ts` | `ProviderFactory.getProviderForModel()` |
-| `manager.ts` | config + model mappings via `ProviderStorageKey` |
+| `manager.ts` | stable provider CRUD/routing facade |
+| `provider-config-repository.ts` | locked config recovery, hydration, defaults, and legacy URL adoption |
+| `provider-mapping-repository.ts` | scoped model mapping migration and CRUD |
+| `provider-compat-migration.ts` | removed-beta remapping, sanitization, and duplicate retention |
 | `selected-model.ts` | active model state |
 | `capabilities.ts` | capability detection and per-flag attribution |
 | `ollama.ts`, `lm-studio.ts`, `llama-cpp.ts` | verified built-ins |

--- a/RELEASE_ROADMAP.md
+++ b/RELEASE_ROADMAP.md
@@ -164,16 +164,17 @@ descriptors cover only part of the settings surface.
 - Preserve sync-versus-local ownership from `storage-key-registry.ts`.
 - Move simple values opportunistically; do not use a flag-day migration.
 
-### Provider manager decomposition
+### Provider manager decomposition — landed
 
-`src/lib/providers/manager.ts` still combines compatibility migration,
-validation, secret recovery, provider CRUD, and model mappings.
+`src/lib/providers/manager.ts` remains the public CRUD/routing facade while
+config recovery, mapping persistence, and compatibility migration live in
+private collaborators.
 
-- Preserve the public `ProviderManager` facade.
-- Extract private mapping and migration collaborators only behind existing
-  characterization coverage.
-- Keep unknown-field preservation, journal recovery, and secret handling
-  behavior unchanged.
+- Existing characterization coverage still drives the facade end to end.
+- An architecture guard prevents raw storage and compatibility-key logic from
+  returning to the manager.
+- Unknown-field preservation, journal recovery, and secret handling remain
+  unchanged.
 
 ### Message router decomposition
 

--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -355,7 +355,11 @@ Images reuse the existing file metadata path for local persistence and preview d
 
 - The selected model key is persisted under the provider key path (`STORAGE_KEYS.PROVIDER.SELECTED_MODEL`) with legacy reads.
 - The model list is built by querying all enabled providers in `useProviderModels`.
-- Provider configs are persisted via `ProviderManager` (`ProviderStorageKey.CONFIG`).
+- Provider CRUD and routing stay behind the stable `ProviderManager` facade.
+  Locked configuration recovery, hydration, defaults, and legacy URL adoption
+  live in `provider-config-repository.ts`; scoped model mappings live in
+  `provider-mapping-repository.ts`; removed-beta remapping and duplicate
+  retention live in `provider-compat-migration.ts`.
 - Built-in profiles: Ollama, LM Studio, and llama.cpp. User-added configs keep wire protocol separate from service profile, so OpenRouter uses the OpenAI-compatible wire without being identified as OpenAI, and generic Anthropic-compatible endpoints avoid Anthropic-hosted credential/header assumptions.
 - Per-model provider routing is stored via `ProviderStorageKey.MODEL_MAPPINGS`.
 - Background routing is performed by `ProviderFactory.getProviderForModel(modelId)`.

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -358,6 +358,25 @@ describe("architecture import boundaries", () => {
     expect(offenders).toEqual([])
   })
 
+  it("keeps ProviderManager as a facade over config and mapping storage", () => {
+    const source = readFileSync(
+      join(sourceRoot, "lib/providers/manager.ts"),
+      "utf8"
+    )
+    const forbidden = referencedModules(source).filter((module) =>
+      [
+        "@/lib/plasmo-global-storage",
+        "@/lib/constants",
+        "./provider-config-schema"
+      ].includes(module)
+    )
+
+    expect(forbidden).toEqual([])
+    expect(withoutComments(source)).not.toMatch(
+      /ProviderStorageKey|LEGACY_STORAGE_KEYS|MODEL_MAPPINGS/
+    )
+  })
+
   /**
    * The observer registry is in-memory delivery state and nothing else.
    *

--- a/src/lib/providers/manager.ts
+++ b/src/lib/providers/manager.ts
@@ -1,18 +1,17 @@
-import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
 import { clearCapabilityProbesForProvider } from "./capability-probe"
 import { clearModelCapabilityOverridesForProvider } from "./model-capability-overrides"
 import { clearModelCatalogSupport } from "./model-catalog-support"
-import { parseStoredProviderConfigs } from "./provider-config-schema"
+import { getProviderConfigsUnlocked } from "./provider-config-repository"
 import {
-  containsLegacySyncedSecrets,
-  hydrateProviderSecrets,
+  removeModelMappingsForProvider as deleteModelMappingsForProvider,
+  getMappedProviderIds,
+  setModelMapping as persistModelMapping
+} from "./provider-mapping-repository"
+import {
   persistProviderConfigs,
   persistProviderConfigsUnlocked,
-  recoverProviderPersistenceUnlocked,
-  recoverProviderResetUnlocked,
   withProviderPersistenceLock
 } from "./provider-secret-store"
 import {
@@ -24,64 +23,12 @@ import {
   isCustomProviderId,
   makeCustomProviderId,
   type ProviderConfig,
-  ProviderId,
   ProviderServiceProfile,
-  ProviderStorageKey,
   ProviderType
 } from "./types"
 
-export const DEFAULT_PROVIDERS: ProviderConfig[] = [
-  {
-    id: ProviderId.OLLAMA,
-    type: ProviderType.OLLAMA,
-    name: "Ollama",
-    enabled: true,
-    baseUrl: "http://localhost:11434"
-  },
-  {
-    id: ProviderId.LM_STUDIO,
-    type: ProviderType.OPENAI,
-    name: "LM Studio",
-    enabled: false,
-    baseUrl: "http://localhost:1234/v1"
-  },
-  {
-    id: ProviderId.LLAMA_CPP,
-    type: ProviderType.OPENAI,
-    name: "llama.cpp",
-    enabled: false,
-    baseUrl: "http://localhost:8000/v1"
-  }
-]
-
-const DEFAULT_PROVIDER_IDS = new Set(DEFAULT_PROVIDERS.map((p) => p.id))
-const REMOVED_BETA_DEFAULTS: Record<
-  string,
-  { baseUrl: string; name: string; customId: string }
-> = {
-  [ProviderId.VLLM]: {
-    baseUrl: "http://localhost:8001/v1",
-    name: "vLLM",
-    customId: "custom:openai:legacy-vllm"
-  },
-  [ProviderId.LOCALAI]: {
-    baseUrl: "http://localhost:8080/v1",
-    name: "LocalAI",
-    customId: "custom:openai:legacy-localai"
-  },
-  [ProviderId.KOBOLDCPP]: {
-    baseUrl: "http://localhost:5001/v1",
-    name: "KoboldCpp",
-    customId: "custom:openai:legacy-koboldcpp"
-  }
-}
-
-/**
- * Built-in ids and user-added `custom:` ids survive; anything else is stale
- * data from an old version and gets dropped.
- */
-const isKnownProviderId = (id: string): boolean =>
-  DEFAULT_PROVIDER_IDS.has(id as ProviderId) || isCustomProviderId(id)
+export { DEFAULT_PROVIDERS } from "./provider-defaults"
+export { scopedModelKey } from "./provider-mapping-repository"
 
 const validateHostedProfileConfig = (config: ProviderConfig): void => {
   const profile = resolveProviderServiceProfile(config)
@@ -111,155 +58,6 @@ const validateHostedProfileConfig = (config: ProviderConfig): void => {
   }
 }
 
-/**
- * Which of two configs sharing an id survives.
- *
- * Array order is not a reason. The entry carrying credentials or user-added
- * models is the one whose loss the user would actually notice, so rank by what
- * is expensive to retype and break ties toward the earlier entry — the one a
- * lookup would already have been returning.
- */
-const duplicateRetentionScore = (config: ProviderConfig): number =>
-  (config.apiKey?.trim() ? 4 : 0) +
-  ((config.customModels?.length ?? 0) > 0 ? 2 : 0) +
-  (config.enabled ? 1 : 0)
-
-const sanitizeStoredProviders = (
-  providers: ProviderConfig[]
-): {
-  providers: ProviderConfig[]
-  removed: ProviderConfig[]
-  migrated: Array<{ from: string; to: string }>
-  duplicates: string[]
-} => {
-  const kept: ProviderConfig[] = []
-  const removed: ProviderConfig[] = []
-  const migrated: Array<{ from: string; to: string }> = []
-
-  for (const provider of providers) {
-    const id = String(provider.id)
-    if (isKnownProviderId(id)) {
-      kept.push(provider)
-      continue
-    }
-
-    const legacy = REMOVED_BETA_DEFAULTS[id]
-    const wasConfigured =
-      legacy &&
-      (provider.enabled ||
-        Boolean(provider.apiKey?.trim()) ||
-        Boolean(provider.customModels?.length) ||
-        provider.baseUrl !== legacy.baseUrl ||
-        provider.name !== legacy.name)
-    if (legacy && wasConfigured) {
-      kept.push({
-        ...provider,
-        id: legacy.customId,
-        type: ProviderType.OPENAI
-      })
-      migrated.push({ from: id, to: legacy.customId })
-      continue
-    }
-
-    removed.push(provider)
-  }
-
-  /*
-   * Two entries can end up sharing an id: a backup import (the backup schema
-   * validates shape, not uniqueness), a legacy beta migration onto a fixed
-   * `custom:openai:legacy-*` id that is already present, or — vanishingly
-   * rarely — a random suffix collision. Duplicates used to be reported as "no
-   * change", so both survived and `getProviderConfig`'s `find` silently
-   * shadowed the second: it stayed in the provider grid and in model discovery
-   * while being unreachable by id.
-   */
-  const byId = new Map<string, ProviderConfig>()
-  const duplicates: string[] = []
-  for (const provider of kept) {
-    const id = String(provider.id)
-    const incumbent = byId.get(id)
-    if (!incumbent) {
-      byId.set(id, provider)
-      continue
-    }
-    duplicates.push(id)
-    if (
-      duplicateRetentionScore(provider) > duplicateRetentionScore(incumbent)
-    ) {
-      byId.set(id, provider)
-    }
-  }
-
-  return {
-    providers: [...byId.values()],
-    removed,
-    migrated,
-    duplicates
-  }
-}
-
-export const scopedModelKey = (providerId: string, modelId: string): string =>
-  `${providerId}::${modelId}`
-
-/**
- * Read the scoped model→provider map, lazily migrating the legacy flat map
- * (`modelName → providerId`, collision-lossy) into scoped keys on first read.
- * The legacy key is deleted after migration so this branch runs once.
- */
-const readScopedModelMappings = async (): Promise<Record<string, string>> => {
-  const v2 = await plasmoGlobalStorage.get<Record<string, string>>(
-    ProviderStorageKey.MODEL_MAPPINGS_V2
-  )
-  if (v2) {
-    const normalized: Record<string, string> = {}
-    let changed = false
-    for (const [key, providerId] of Object.entries(v2)) {
-      const targetProviderId =
-        REMOVED_BETA_DEFAULTS[providerId]?.customId ?? providerId
-      const separator = key.indexOf("::")
-      const modelId = separator >= 0 ? key.slice(separator + 2) : key
-      const targetKey = scopedModelKey(targetProviderId, modelId)
-      normalized[targetKey] = targetProviderId
-      if (targetKey !== key || targetProviderId !== providerId) changed = true
-    }
-    if (changed) {
-      await plasmoGlobalStorage.set(
-        ProviderStorageKey.MODEL_MAPPINGS_V2,
-        normalized
-      )
-    }
-    return normalized
-  }
-
-  const legacy = await plasmoGlobalStorage.get<Record<string, string>>(
-    ProviderStorageKey.MODEL_MAPPINGS
-  )
-  const migrated: Record<string, string> = {}
-  if (legacy) {
-    for (const [modelId, providerId] of Object.entries(legacy)) {
-      if (typeof providerId === "string" && providerId) {
-        const targetProviderId =
-          REMOVED_BETA_DEFAULTS[providerId]?.customId ?? providerId
-        migrated[scopedModelKey(targetProviderId, modelId)] = targetProviderId
-      }
-    }
-    await plasmoGlobalStorage.set(
-      ProviderStorageKey.MODEL_MAPPINGS_V2,
-      migrated
-    )
-    await plasmoGlobalStorage.remove(ProviderStorageKey.MODEL_MAPPINGS)
-    logger.info("Migrated model mappings to scoped keys", "ProviderManager", {
-      count: Object.keys(migrated).length
-    })
-  } else {
-    await plasmoGlobalStorage.set(
-      ProviderStorageKey.MODEL_MAPPINGS_V2,
-      migrated
-    )
-  }
-  return migrated
-}
-
 const validateProviderBaseUrl = (baseUrl?: string): void => {
   if (!baseUrl) return
   let parsed: URL
@@ -284,127 +82,12 @@ const validateProviderBaseUrl = (baseUrl?: string): void => {
   }
 }
 
-/** Caller must hold the provider-persistence lock. */
-const getProvidersUnlocked = async (): Promise<ProviderConfig[]> => {
-  await recoverProviderResetUnlocked()
-  await recoverProviderPersistenceUnlocked()
-  const rawStored = await plasmoGlobalStorage.get<unknown>(
-    ProviderStorageKey.CONFIG
-  )
-  const parsedStored = parseStoredProviderConfigs(rawStored)
-  let stored = parsedStored.providers
-  if (stored.length === 0) {
-    stored = [...DEFAULT_PROVIDERS]
-    await persistProviderConfigsUnlocked(stored)
-  }
-
-  const containsLegacySecrets = containsLegacySyncedSecrets(stored)
-  stored = await hydrateProviderSecrets(stored)
-  if (containsLegacySecrets) {
-    // Idempotent migration: local credentials are written first, then the
-    // legacy secret-bearing sync payload is replaced with public config.
-    await persistProviderConfigsUnlocked(stored)
-  }
-
-  const sanitized = sanitizeStoredProviders(stored)
-  // Deliberately includes `duplicates`: collapsing them used to be conditional
-  // on some *other* anomaly being present in the same read, which meant the
-  // surviving entry depended on an unrelated condition.
-  const sanitizationChanged =
-    parsedStored.normalized ||
-    sanitized.removed.length > 0 ||
-    sanitized.migrated.length > 0 ||
-    sanitized.duplicates.length > 0
-  if (sanitizationChanged) {
-    logger.info(
-      "Sanitized provider configs not present in the built-in provider UI",
-      "ProviderManager",
-      {
-        removed: sanitized.removed.map((provider) => provider.id),
-        migrated: sanitized.migrated,
-        // Ids only. A duplicate is a config the user cannot see collapsing, so
-        // it has to leave a trace, but provider names are user text.
-        duplicates: sanitized.duplicates,
-        rejectedMalformedEntries: parsedStored.rejected
-      }
-    )
-    stored = sanitized.providers
-  }
-
-  // Merge new defaults if they are missing from stored config
-  const currentStored = stored ?? []
-  const missing = DEFAULT_PROVIDERS.filter(
-    (d) => !currentStored.find((s) => s.id === d.id)
-  )
-
-  // One-time migration of the pre-provider-config Ollama base URL: adopt
-  // it into the stored config, persist, and delete the legacy key so this
-  // read stops happening on every getProviders call.
-  try {
-    const legacyStoredUrl = await plasmoGlobalStorage.get<string>(
-      LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL
-    )
-    const globalStoredUrl = await plasmoGlobalStorage.get<string>(
-      STORAGE_KEYS.PROVIDER.BASE_URL
-    )
-    const legacyUrl = legacyStoredUrl?.trim()
-      ? legacyStoredUrl
-      : globalStoredUrl?.trim()
-        ? globalStoredUrl
-        : undefined
-
-    if (legacyUrl) {
-      const defaultProviderIndex = stored.findIndex(
-        (p) => p.id === ProviderId.OLLAMA
-      )
-      const currentBaseUrl = stored[defaultProviderIndex]?.baseUrl
-      const defaultBaseUrl = DEFAULT_PROVIDERS.find(
-        (provider) => provider.id === ProviderId.OLLAMA
-      )?.baseUrl
-      if (
-        defaultProviderIndex !== -1 &&
-        legacyUrl !== currentBaseUrl &&
-        (!currentBaseUrl || currentBaseUrl === defaultBaseUrl)
-      ) {
-        stored = [...stored]
-        stored[defaultProviderIndex] = {
-          ...stored[defaultProviderIndex],
-          baseUrl: legacyUrl
-        }
-        await persistProviderConfigsUnlocked(stored)
-      }
-    }
-    if (legacyStoredUrl !== undefined || globalStoredUrl !== undefined) {
-      await plasmoGlobalStorage.remove(LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL)
-      await plasmoGlobalStorage.remove(STORAGE_KEYS.PROVIDER.BASE_URL)
-    }
-  } catch (e) {
-    logger.warn(
-      "Failed to migrate legacy provider URL in getProviders",
-      "ProviderManager",
-      { error: e }
-    )
-  }
-
-  if (missing.length > 0) {
-    const merged = [...stored, ...missing]
-    await persistProviderConfigsUnlocked(merged)
-    return merged
-  }
-
-  if (sanitizationChanged) {
-    await persistProviderConfigsUnlocked(stored)
-  }
-
-  return stored
-}
-
 /**
  * Manages persistence and retrieval of provider configurations.
  */
 export const ProviderManager = {
   async getProviders(): Promise<ProviderConfig[]> {
-    return withProviderPersistenceLock(getProvidersUnlocked)
+    return withProviderPersistenceLock(getProviderConfigsUnlocked)
   },
 
   async getProviderConfig(id: string): Promise<ProviderConfig | undefined> {
@@ -430,7 +113,7 @@ export const ProviderManager = {
     let updated = false
 
     await withProviderPersistenceLock(async () => {
-      const providers = await getProvidersUnlocked()
+      const providers = await getProviderConfigsUnlocked()
       const index = providers.findIndex((p) => p.id === id)
       if (index === -1) return
 
@@ -467,12 +150,7 @@ export const ProviderManager = {
   async getModelMapping(
     modelId: string
   ): Promise<{ providerId: string } | null> {
-    const mappings = await readScopedModelMappings()
-    const candidates = Object.entries(mappings)
-      .filter(
-        ([key, providerId]) => key === scopedModelKey(providerId, modelId)
-      )
-      .map(([, providerId]) => providerId)
+    const candidates = await getMappedProviderIds(modelId)
     if (candidates.length === 0) return null
     if (candidates.length === 1) return { providerId: candidates[0] }
 
@@ -484,40 +162,17 @@ export const ProviderManager = {
   },
 
   async setModelMapping(modelId: string, providerId: string): Promise<void> {
-    const mappings = await readScopedModelMappings()
-    mappings[scopedModelKey(providerId, modelId)] = providerId
-    await plasmoGlobalStorage.set(
-      ProviderStorageKey.MODEL_MAPPINGS_V2,
-      mappings
-    )
+    await persistModelMapping(modelId, providerId)
   },
 
   /** All providers known to serve `modelId` (for disambiguation UI). */
   async getModelProviders(modelId: string): Promise<string[]> {
-    const mappings = await readScopedModelMappings()
-    return Object.entries(mappings)
-      .filter(
-        ([key, providerId]) => key === scopedModelKey(providerId, modelId)
-      )
-      .map(([, providerId]) => providerId)
+    return getMappedProviderIds(modelId)
   },
 
   /** Drop all mappings pointing at `providerId` (provider removed). */
   async removeModelMappingsForProvider(providerId: string): Promise<void> {
-    const mappings = await readScopedModelMappings()
-    let changed = false
-    for (const [key, value] of Object.entries(mappings)) {
-      if (value === providerId) {
-        delete mappings[key]
-        changed = true
-      }
-    }
-    if (changed) {
-      await plasmoGlobalStorage.set(
-        ProviderStorageKey.MODEL_MAPPINGS_V2,
-        mappings
-      )
-    }
+    await deleteModelMappingsForProvider(providerId)
   },
 
   /**
@@ -566,7 +221,7 @@ export const ProviderManager = {
     validateHostedProfileConfig(config)
 
     await withProviderPersistenceLock(async () => {
-      const providers = await getProvidersUnlocked()
+      const providers = await getProviderConfigsUnlocked()
       /*
        * The suffix carries 32 bits, so a collision is vanishingly unlikely —
        * but unlikely is not a guarantee, and the failure mode is bad out of
@@ -598,7 +253,7 @@ export const ProviderManager = {
       })
     }
     await withProviderPersistenceLock(async () => {
-      const providers = await getProvidersUnlocked()
+      const providers = await getProviderConfigsUnlocked()
       await persistProviderConfigsUnlocked(
         providers.filter((p) => String(p.id) !== id)
       )

--- a/src/lib/providers/provider-compat-migration.ts
+++ b/src/lib/providers/provider-compat-migration.ts
@@ -1,0 +1,87 @@
+import { DEFAULT_PROVIDERS, REMOVED_BETA_DEFAULTS } from "./provider-defaults"
+import {
+  isCustomProviderId,
+  type ProviderConfig,
+  type ProviderId,
+  ProviderType
+} from "./types"
+
+const DEFAULT_PROVIDER_IDS = new Set(DEFAULT_PROVIDERS.map((p) => p.id))
+
+const isKnownProviderId = (id: string): boolean =>
+  DEFAULT_PROVIDER_IDS.has(id as ProviderId) || isCustomProviderId(id)
+
+const duplicateRetentionScore = (config: ProviderConfig): number =>
+  (config.apiKey?.trim() ? 4 : 0) +
+  ((config.customModels?.length ?? 0) > 0 ? 2 : 0) +
+  (config.enabled ? 1 : 0)
+
+export const remapLegacyProviderId = (providerId: string): string =>
+  REMOVED_BETA_DEFAULTS[providerId]?.customId ?? providerId
+
+export interface SanitizedProviderConfigs {
+  providers: ProviderConfig[]
+  removed: ProviderConfig[]
+  migrated: Array<{ from: string; to: string }>
+  duplicates: string[]
+}
+
+export const sanitizeStoredProviders = (
+  providers: ProviderConfig[]
+): SanitizedProviderConfigs => {
+  const kept: ProviderConfig[] = []
+  const removed: ProviderConfig[] = []
+  const migrated: Array<{ from: string; to: string }> = []
+
+  for (const provider of providers) {
+    const id = String(provider.id)
+    if (isKnownProviderId(id)) {
+      kept.push(provider)
+      continue
+    }
+
+    const legacy = REMOVED_BETA_DEFAULTS[id]
+    const wasConfigured =
+      legacy &&
+      (provider.enabled ||
+        Boolean(provider.apiKey?.trim()) ||
+        Boolean(provider.customModels?.length) ||
+        provider.baseUrl !== legacy.baseUrl ||
+        provider.name !== legacy.name)
+    if (legacy && wasConfigured) {
+      kept.push({
+        ...provider,
+        id: legacy.customId,
+        type: ProviderType.OPENAI
+      })
+      migrated.push({ from: id, to: legacy.customId })
+      continue
+    }
+
+    removed.push(provider)
+  }
+
+  const byId = new Map<string, ProviderConfig>()
+  const duplicates: string[] = []
+  for (const provider of kept) {
+    const id = String(provider.id)
+    const incumbent = byId.get(id)
+    if (!incumbent) {
+      byId.set(id, provider)
+      continue
+    }
+    duplicates.push(id)
+    if (
+      duplicateRetentionScore(provider) > duplicateRetentionScore(incumbent)
+    ) {
+      byId.set(id, provider)
+    }
+  }
+
+  return {
+    providers: [...byId.values()],
+    removed,
+    migrated,
+    duplicates
+  }
+}

--- a/src/lib/providers/provider-config-repository.ts
+++ b/src/lib/providers/provider-config-repository.ts
@@ -1,0 +1,127 @@
+import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { logger } from "@/lib/logger"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { sanitizeStoredProviders } from "./provider-compat-migration"
+import { parseStoredProviderConfigs } from "./provider-config-schema"
+import { DEFAULT_PROVIDERS } from "./provider-defaults"
+import {
+  containsLegacySyncedSecrets,
+  hydrateProviderSecrets,
+  persistProviderConfigsUnlocked,
+  recoverProviderPersistenceUnlocked,
+  recoverProviderResetUnlocked
+} from "./provider-secret-store"
+import { type ProviderConfig, ProviderId, ProviderStorageKey } from "./types"
+
+const migrateLegacyOllamaUrl = async (
+  providers: ProviderConfig[]
+): Promise<ProviderConfig[]> => {
+  let stored = providers
+  try {
+    const legacyStoredUrl = await plasmoGlobalStorage.get<string>(
+      LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL
+    )
+    const globalStoredUrl = await plasmoGlobalStorage.get<string>(
+      STORAGE_KEYS.PROVIDER.BASE_URL
+    )
+    const legacyUrl = legacyStoredUrl?.trim()
+      ? legacyStoredUrl
+      : globalStoredUrl?.trim()
+        ? globalStoredUrl
+        : undefined
+
+    if (legacyUrl) {
+      const defaultProviderIndex = stored.findIndex(
+        (provider) => provider.id === ProviderId.OLLAMA
+      )
+      const currentBaseUrl = stored[defaultProviderIndex]?.baseUrl
+      const defaultBaseUrl = DEFAULT_PROVIDERS.find(
+        (provider) => provider.id === ProviderId.OLLAMA
+      )?.baseUrl
+      if (
+        defaultProviderIndex !== -1 &&
+        legacyUrl !== currentBaseUrl &&
+        (!currentBaseUrl || currentBaseUrl === defaultBaseUrl)
+      ) {
+        stored = [...stored]
+        stored[defaultProviderIndex] = {
+          ...stored[defaultProviderIndex],
+          baseUrl: legacyUrl
+        }
+        await persistProviderConfigsUnlocked(stored)
+      }
+    }
+    if (legacyStoredUrl !== undefined || globalStoredUrl !== undefined) {
+      await plasmoGlobalStorage.remove(LEGACY_STORAGE_KEYS.OLLAMA.BASE_URL)
+      await plasmoGlobalStorage.remove(STORAGE_KEYS.PROVIDER.BASE_URL)
+    }
+  } catch (error) {
+    logger.warn(
+      "Failed to migrate legacy provider URL in getProviders",
+      "ProviderManager",
+      { error }
+    )
+  }
+  return stored
+}
+
+/** Caller must hold the provider-persistence lock. */
+export const getProviderConfigsUnlocked = async (): Promise<
+  ProviderConfig[]
+> => {
+  await recoverProviderResetUnlocked()
+  await recoverProviderPersistenceUnlocked()
+  const rawStored = await plasmoGlobalStorage.get<unknown>(
+    ProviderStorageKey.CONFIG
+  )
+  const parsedStored = parseStoredProviderConfigs(rawStored)
+  let stored = parsedStored.providers
+  if (stored.length === 0) {
+    stored = [...DEFAULT_PROVIDERS]
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  const containsLegacySecrets = containsLegacySyncedSecrets(stored)
+  stored = await hydrateProviderSecrets(stored)
+  if (containsLegacySecrets) {
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  const sanitized = sanitizeStoredProviders(stored)
+  const sanitizationChanged =
+    parsedStored.normalized ||
+    sanitized.removed.length > 0 ||
+    sanitized.migrated.length > 0 ||
+    sanitized.duplicates.length > 0
+  if (sanitizationChanged) {
+    logger.info(
+      "Sanitized provider configs not present in the built-in provider UI",
+      "ProviderManager",
+      {
+        removed: sanitized.removed.map((provider) => provider.id),
+        migrated: sanitized.migrated,
+        duplicates: sanitized.duplicates,
+        rejectedMalformedEntries: parsedStored.rejected
+      }
+    )
+    stored = sanitized.providers
+  }
+
+  const missing = DEFAULT_PROVIDERS.filter(
+    (candidate) => !stored.find((provider) => provider.id === candidate.id)
+  )
+
+  stored = await migrateLegacyOllamaUrl(stored)
+
+  if (missing.length > 0) {
+    const merged = [...stored, ...missing]
+    await persistProviderConfigsUnlocked(merged)
+    return merged
+  }
+
+  if (sanitizationChanged) {
+    await persistProviderConfigsUnlocked(stored)
+  }
+
+  return stored
+}

--- a/src/lib/providers/provider-defaults.ts
+++ b/src/lib/providers/provider-defaults.ts
@@ -1,0 +1,46 @@
+import { type ProviderConfig, ProviderId, ProviderType } from "./types"
+
+export const DEFAULT_PROVIDERS: ProviderConfig[] = [
+  {
+    id: ProviderId.OLLAMA,
+    type: ProviderType.OLLAMA,
+    name: "Ollama",
+    enabled: true,
+    baseUrl: "http://localhost:11434"
+  },
+  {
+    id: ProviderId.LM_STUDIO,
+    type: ProviderType.OPENAI,
+    name: "LM Studio",
+    enabled: false,
+    baseUrl: "http://localhost:1234/v1"
+  },
+  {
+    id: ProviderId.LLAMA_CPP,
+    type: ProviderType.OPENAI,
+    name: "llama.cpp",
+    enabled: false,
+    baseUrl: "http://localhost:8000/v1"
+  }
+]
+
+export const REMOVED_BETA_DEFAULTS: Record<
+  string,
+  { baseUrl: string; name: string; customId: string }
+> = {
+  [ProviderId.VLLM]: {
+    baseUrl: "http://localhost:8001/v1",
+    name: "vLLM",
+    customId: "custom:openai:legacy-vllm"
+  },
+  [ProviderId.LOCALAI]: {
+    baseUrl: "http://localhost:8080/v1",
+    name: "LocalAI",
+    customId: "custom:openai:legacy-localai"
+  },
+  [ProviderId.KOBOLDCPP]: {
+    baseUrl: "http://localhost:5001/v1",
+    name: "KoboldCpp",
+    customId: "custom:openai:legacy-koboldcpp"
+  }
+}

--- a/src/lib/providers/provider-mapping-repository.ts
+++ b/src/lib/providers/provider-mapping-repository.ts
@@ -1,0 +1,96 @@
+import { logger } from "@/lib/logger"
+import { plasmoGlobalStorage } from "@/lib/plasmo-global-storage"
+import { remapLegacyProviderId } from "./provider-compat-migration"
+import { ProviderStorageKey } from "./types"
+
+export const scopedModelKey = (providerId: string, modelId: string): string =>
+  `${providerId}::${modelId}`
+
+const readScopedModelMappings = async (): Promise<Record<string, string>> => {
+  const v2 = await plasmoGlobalStorage.get<Record<string, string>>(
+    ProviderStorageKey.MODEL_MAPPINGS_V2
+  )
+  if (v2) {
+    const normalized: Record<string, string> = {}
+    let changed = false
+    for (const [key, providerId] of Object.entries(v2)) {
+      const targetProviderId = remapLegacyProviderId(providerId)
+      const separator = key.indexOf("::")
+      const modelId = separator >= 0 ? key.slice(separator + 2) : key
+      const targetKey = scopedModelKey(targetProviderId, modelId)
+      normalized[targetKey] = targetProviderId
+      if (targetKey !== key || targetProviderId !== providerId) changed = true
+    }
+    if (changed) {
+      await plasmoGlobalStorage.set(
+        ProviderStorageKey.MODEL_MAPPINGS_V2,
+        normalized
+      )
+    }
+    return normalized
+  }
+
+  const legacy = await plasmoGlobalStorage.get<Record<string, string>>(
+    ProviderStorageKey.MODEL_MAPPINGS
+  )
+  const migrated: Record<string, string> = {}
+  if (legacy) {
+    for (const [modelId, providerId] of Object.entries(legacy)) {
+      if (typeof providerId === "string" && providerId) {
+        const targetProviderId = remapLegacyProviderId(providerId)
+        migrated[scopedModelKey(targetProviderId, modelId)] = targetProviderId
+      }
+    }
+    await plasmoGlobalStorage.set(
+      ProviderStorageKey.MODEL_MAPPINGS_V2,
+      migrated
+    )
+    await plasmoGlobalStorage.remove(ProviderStorageKey.MODEL_MAPPINGS)
+    logger.info("Migrated model mappings to scoped keys", "ProviderManager", {
+      count: Object.keys(migrated).length
+    })
+  } else {
+    await plasmoGlobalStorage.set(
+      ProviderStorageKey.MODEL_MAPPINGS_V2,
+      migrated
+    )
+  }
+  return migrated
+}
+
+export const getMappedProviderIds = async (
+  modelId: string
+): Promise<string[]> => {
+  const mappings = await readScopedModelMappings()
+  return Object.entries(mappings)
+    .filter(([key, providerId]) => key === scopedModelKey(providerId, modelId))
+    .map(([, providerId]) => providerId)
+}
+
+export const setModelMapping = async (
+  modelId: string,
+  providerId: string
+): Promise<void> => {
+  const mappings = await readScopedModelMappings()
+  mappings[scopedModelKey(providerId, modelId)] = providerId
+  await plasmoGlobalStorage.set(ProviderStorageKey.MODEL_MAPPINGS_V2, mappings)
+}
+
+export const removeModelMappingsForProvider = async (
+  providerId: string
+): Promise<void> => {
+  const mappings = await readScopedModelMappings()
+  let changed = false
+  for (const [key, value] of Object.entries(mappings)) {
+    if (value === providerId) {
+      delete mappings[key]
+      changed = true
+    }
+  }
+  if (changed) {
+    await plasmoGlobalStorage.set(
+      ProviderStorageKey.MODEL_MAPPINGS_V2,
+      mappings
+    )
+  }
+}


### PR DESCRIPTION
## What changed

- keep `ProviderManager` as the stable public CRUD and routing facade
- extract locked config recovery, secret hydration, defaults, sanitization, and legacy URL adoption into `provider-config-repository.ts`
- extract scoped model-mapping migration and CRUD into `provider-mapping-repository.ts`
- extract removed-beta remapping and duplicate-retention policy into `provider-compat-migration.ts`
- move provider defaults into a focused module while preserving the manager re-export
- add an architecture guard preventing raw storage and compatibility-key logic from returning to the facade

## Why

The manager combined provider CRUD with secret recovery, compatibility migration, raw storage keys, duplicate policy, default merging, and mapping migration. Unrelated changes therefore shared one mutable seam and could accidentally alter recovery or compatibility behavior.

## Compatibility

The public `ProviderManager`, `DEFAULT_PROVIDERS`, and `scopedModelKey` exports are preserved. Existing manager characterization tests continue to exercise journal recovery, unknown-field preservation, secrets, migrations, collisions, duplicate retention, and mapping behavior end to end.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` (343 files, 2,897 tests)
- 47 existing ProviderManager characterization tests
- architecture boundary regression test
- `pnpm docs:build`
- `pnpm generate:resources`
- Chrome production package and bundle budgets via pre-push gates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves `ProviderManager` as the public facade while extracting provider configuration recovery, compatibility migration, defaults, and scoped model mappings into focused repositories.

- Moves locked configuration loading, secret hydration, sanitization, default merging, and legacy URL adoption into `provider-config-repository.ts`.
- Moves scoped mapping migration and CRUD into `provider-mapping-repository.ts`.
- Moves removed-beta remapping and duplicate-retention policy into dedicated compatibility/default modules.
- Adds an architecture boundary test preventing raw storage concerns from returning to the facade.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/providers/manager.ts | Retains the public provider CRUD and routing API while delegating persistence and mapping internals. |
| src/lib/providers/provider-config-repository.ts | Extracts the existing locked recovery, hydration, sanitization, defaults, and legacy URL pipeline. |
| src/lib/providers/provider-mapping-repository.ts | Extracts scoped mapping migration and CRUD while preserving the manager re-exports. |
| src/lib/providers/provider-compat-migration.ts | Centralizes removed-beta remapping, stale-provider sanitization, and duplicate-retention behavior. |
| src/lib/providers/provider-defaults.ts | Moves built-in and removed-beta provider defaults into a dependency-light module. |
| src/lib/__tests__/architecture-boundaries.test.ts | Adds a regression guard keeping raw storage and compatibility-key logic outside the manager facade. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Callers["Provider callers"] --> Manager["ProviderManager facade"]
  Manager --> Config["provider-config-repository"]
  Manager --> Mapping["provider-mapping-repository"]
  Config --> Compat["provider-compat-migration"]
  Config --> Defaults["provider-defaults"]
  Mapping --> Compat
  Config --> Storage["Provider configuration storage"]
  Mapping --> MappingStorage["Scoped model-mapping storage"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: merge release/0.13.1"](https://github.com/shishir435/ollama-client/commit/13d60a228df4e09046d21b4fc97561df4fa90022) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52690624)</sub>

**Context used:**

- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)

<!-- /greptile_comment -->