### PR TITLE
refactor(chat): extract stream session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,11 +454,6 @@ What these files are *now*, so you neither go looking for a god-object that was 
 
 **Do not restructure incrementally:**
 
-- `src/features/chat/hooks/use-chat-stream.ts` — owns port lifecycle, reconnect,
-  stop/finalization, stream presentation, and error UI. Its staged extraction is
-  tracked in `RELEASE_ROADMAP.md`; keep edits minimal and preserve the pure
-  `chat-stream-reducer.ts` seam.
-
 - `src/features/chat/hooks/use-chat-turn-controller.ts` — owns UI submission
   preconditions, session/message preparation, and durable turn command
   construction. Its boundary cleanup is tracked in `RELEASE_ROADMAP.md`. Keep
@@ -470,6 +465,7 @@ What these files are *now*, so you neither go looking for a god-object that was 
 
 **Already restructured — match the existing shape rather than reverting to props or god-objects:**
 
+- `src/features/chat/hooks/use-chat-stream.ts` is the React, i18n and browser-effects adapter over `src/application/turns/chat-stream-session.ts`. `ChatStreamSession` owns single-flight admission, the active request and port, schema parsing, reducer transitions, reconnects, snapshots and cancellation; keep those lifecycle concerns out of the hook. Keep translated errors, issue navigation and React state in the hook, and preserve the pure `chat-stream-reducer.ts` seam.
 - `src/features/selection-actions/` reads view state from `selection-overlay-context.tsx`, not props. `SelectionOverlayApp` alone knows about the reducer, the capture, and the content script's refs; `SelectionActionsOverlay`, `SelectionPanel`, `SelectionToolbar`, `PanelHeader`, `PanelFooter` take no props. Add a control to the context value and read it where it renders. `PanelMarkdown` and `PanelThinking` stay prop-driven — leaf presentational, own tests.
 - `src/features/chat/components/chat-input/context-settings-menu.tsx` is the sheet shell and view switch (~205 LOC). Settings in `hooks/use-context-settings.ts`, tab list and its reconciliation effects in `hooks/use-context-tab-options.ts`, summary in `context-summary.ts`, views in `context-main-view.tsx` / `context-sub-view.tsx`. New context controls go in the hook and the main view, not the shell.
 - `src/features/sessions/stores/chat-session-store.ts` is a ~19-LOC barrel over extracted slices; persistence reads via `chat-history.ts`. The old ~485-LOC store is gone.

--- a/src/application/turns/__tests__/chat-stream-session.test.ts
+++ b/src/application/turns/__tests__/chat-stream-session.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  type ChatStreamPort,
+  ChatStreamSession,
+  type ChatStreamSessionCallbacks
+} from "@/application/turns/chat-stream-session"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import type { ChatMessage } from "@/types"
+
+class FakePort implements ChatStreamPort {
+  readonly posted: unknown[] = []
+  readonly messageListeners = new Set<(message: unknown) => void>()
+  readonly disconnectListeners = new Set<() => void>()
+  disconnect = vi.fn()
+
+  postMessage(message: never) {
+    this.posted.push(message)
+  }
+
+  addMessageListener(listener: (message: unknown) => void) {
+    this.messageListeners.add(listener)
+  }
+
+  removeMessageListener(listener: (message: unknown) => void) {
+    this.messageListeners.delete(listener)
+  }
+
+  addDisconnectListener(listener: () => void) {
+    this.disconnectListeners.add(listener)
+  }
+
+  removeDisconnectListener(listener: () => void) {
+    this.disconnectListeners.delete(listener)
+  }
+
+  emit(message: unknown) {
+    for (const listener of [...this.messageListeners]) listener(message)
+  }
+
+  drop() {
+    for (const listener of [...this.disconnectListeners]) listener()
+  }
+}
+
+const startOptions = {
+  model: "llama3",
+  messages: [{ role: "user" as const, content: "Hello" }]
+}
+
+describe("ChatStreamSession", () => {
+  let ports: FakePort[]
+  let callbacks: ChatStreamSessionCallbacks
+  let rendered: ChatMessage[]
+
+  beforeEach(() => {
+    ports = []
+    rendered = []
+    callbacks = {
+      onAssistant: (assistant) => {
+        rendered.push(assistant)
+      },
+      onStartRejected: vi.fn(),
+      onTerminal: vi.fn()
+    }
+  })
+
+  const createSession = () =>
+    new ChatStreamSession(
+      {
+        connectPort: () => {
+          const port = new FakePort()
+          ports.push(port)
+          return port
+        },
+        schedule: (callback) => callback(),
+        createRequestId: () => "request-1"
+      },
+      callbacks
+    )
+
+  it("enforces single-flight before and after a port is opened", () => {
+    const session = createSession()
+    const claim = session.claimStream()
+
+    expect(claim).not.toBeNull()
+    expect(session.claimStream()).toBeNull()
+    expect(session.start(startOptions, claim ?? undefined)).toBe(true)
+    expect(session.start({ ...startOptions, model: "other" })).toBe(false)
+    expect(ports).toHaveLength(1)
+    expect(callbacks.onStartRejected).toHaveBeenCalledWith("request-1")
+  })
+
+  it("parses and reduces stream events without React", () => {
+    const session = createSession()
+    expect(session.start(startOptions)).toBe(true)
+
+    ports[0].emit({ seq: 0, delta: "Hello" })
+    ports[0].emit({ seq: 1, delta: " world", done: true })
+
+    expect(rendered.at(-1)).toMatchObject({ content: "Hello" })
+    expect(callbacks.onTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        message: expect.objectContaining({
+          content: "Hello world",
+          done: true
+        })
+      }),
+      startOptions
+    )
+    expect(ports[0].disconnect).toHaveBeenCalledOnce()
+  })
+
+  it("reconnects a durable stream and ignores the replaced port", () => {
+    const session = createSession()
+    const durableTurn = {
+      submission: {
+        id: "turn-1",
+        sessionId: "session-1",
+        mode: "new" as const,
+        model: "llama3",
+        request: {
+          version: 1 as const,
+          context: {
+            rawInput: "Hello",
+            messages: [],
+            hasTabContext: false,
+            contextText: "",
+            tabDocuments: [],
+            memoryEnabled: false,
+            maxTabContextChars: 1000,
+            maxRagContextChars: 1000,
+            groundedOnlyMode: false,
+            selectedModel: "llama3",
+            selectedModelRef: null
+          },
+          userMessage: { role: "user" as const, content: "Hello" }
+        },
+        createdAt: 1
+      },
+      userMessageId: 1,
+      assistantMessageId: 2
+    }
+    session.start({ ...startOptions, durableTurn })
+    const firstPort = ports[0]
+    firstPort.emit({ seq: 3, delta: "partial" })
+    firstPort.drop()
+
+    expect(ports).toHaveLength(2)
+    expect(ports[1].posted.at(-1)).toEqual({
+      version: 1,
+      type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
+      payload: { requestId: "turn-1", afterSeq: 3 }
+    })
+    expect(firstPort.messageListeners.size).toBe(0)
+
+    firstPort.emit({ seq: 4, delta: " stale" })
+    ports[1].emit({ seq: 4, delta: " resumed", done: true })
+    expect(callbacks.onTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "partial resumed" })
+      }),
+      expect.anything()
+    )
+  })
+
+  it("cancels with the active request id and cleanly finalizes the partial", () => {
+    const session = createSession()
+    session.start(startOptions)
+    ports[0].emit({ delta: "partial" })
+
+    expect(session.stop()).toBe(true)
+    expect(ports[0].posted.at(-1)).toEqual({
+      version: 1,
+      type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION,
+      payload: { requestId: "request-1" }
+    })
+    expect(rendered.at(-1)).toMatchObject({
+      content: "partial",
+      done: true
+    })
+    expect(rendered.at(-1)?.metrics?.interrupted).toBeUndefined()
+  })
+})

--- a/src/application/turns/chat-stream-session.ts
+++ b/src/application/turns/chat-stream-session.ts
@@ -1,0 +1,380 @@
+import {
+  makeStreamReducerState,
+  reduceStreamEvent,
+  type StreamReducerState,
+  type StreamReduction,
+  type StreamTerminal
+} from "@ollama-client/runtime-core/chat-stream-reducer"
+import type { DurableTurnStart } from "@/application/turns/turn-contract"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import {
+  CHAT_STREAM_EVENT_TYPES,
+  type ChatStreamClientEvent,
+  type ChatStreamServerEvent,
+  parseChatStreamServerEvent,
+  STREAM_PROTOCOL_VERSION
+} from "@/protocol/streams"
+import type { ChatMessage } from "@/types"
+
+export type ChatStreamClaim = symbol
+
+export interface ChatStreamStartOptions {
+  model: string
+  providerId?: string
+  messages: ChatMessage[]
+  sessionId?: string
+  generatedMessage?: ChatMessage
+  /** See {@link import("@/types/messaging").ChatWithModelMessage}. */
+  clientContextPrepared?: boolean
+  durableTurn?: DurableTurnStart & { assistantMessageId: number }
+}
+
+export interface ChatStreamPort {
+  postMessage(message: ChatStreamClientEvent): void
+  disconnect(): void
+  addMessageListener(listener: (message: unknown) => void): void
+  removeMessageListener(listener: (message: unknown) => void): void
+  addDisconnectListener(listener: () => void): void
+  removeDisconnectListener(listener: () => void): void
+}
+
+export interface ChatStreamSessionCallbacks {
+  onAssistant?: (
+    assistant: ChatMessage,
+    options: ChatStreamStartOptions
+  ) => void | Promise<void>
+  onActivityChange?: (activity: {
+    loading: boolean
+    streaming: boolean
+  }) => void
+  onToken?: (token: string) => void
+  onTerminal?: (
+    terminal: StreamTerminal<ChatMessage>,
+    options: ChatStreamStartOptions
+  ) => void
+  onWarning?: (
+    warning: Extract<
+      ChatStreamServerEvent,
+      { type: typeof CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING }
+    >["payload"]
+  ) => void
+  onInvalidEvent?: (issueCount: number) => void
+  onStartRejected?: (requestId: string | null) => void
+  onStopWithoutActiveStream?: () => void
+  onStopError?: (error: unknown) => void
+  onDisconnectError?: (message: string) => void
+}
+
+export interface ChatStreamSessionDependencies {
+  connectPort: () => ChatStreamPort
+  schedule: (callback: () => void, delayMs: number) => unknown
+  createRequestId: () => string
+  getLastDisconnectError?: () => string | undefined
+}
+
+interface ActiveStream {
+  requestId: string
+  options: ChatStreamStartOptions
+  requestMessage: ChatStreamClientEvent
+  port: ChatStreamPort
+  state: StreamReducerState<ChatMessage>
+  settled: boolean
+  resumeAttempts: number
+  messageListener?: (message: unknown) => void
+  disconnectListener?: () => void
+}
+
+const isSettledSnapshot = (
+  event: Extract<
+    ChatStreamServerEvent,
+    { type: typeof CHAT_STREAM_EVENT_TYPES.SNAPSHOT }
+  >
+) =>
+  event.assistant?.done ||
+  event.status === "completed" ||
+  event.status === "failed" ||
+  event.status === "cancelled"
+
+/**
+ * Framework-independent owner of one chat stream lifecycle.
+ *
+ * React supplies effects through callbacks, while this class exclusively owns
+ * single-flight admission, ports, protocol parsing, reduction, reconnects and
+ * cancellation. A stale port can never mutate the stream that replaced it.
+ */
+export class ChatStreamSession {
+  private callbacks: ChatStreamSessionCallbacks
+  private claim: ChatStreamClaim | null = null
+  private active: ActiveStream | null = null
+
+  constructor(
+    private readonly dependencies: ChatStreamSessionDependencies,
+    callbacks: ChatStreamSessionCallbacks = {}
+  ) {
+    this.callbacks = callbacks
+  }
+
+  updateCallbacks(callbacks: ChatStreamSessionCallbacks) {
+    this.callbacks = callbacks
+  }
+
+  claimStream(): ChatStreamClaim | null {
+    if (this.active || this.claim) return null
+    this.claim = Symbol("chat-stream-claim")
+    return this.claim
+  }
+
+  releaseStreamClaim(claim: ChatStreamClaim) {
+    if (this.claim === claim) this.claim = null
+  }
+
+  start(
+    options: ChatStreamStartOptions,
+    suppliedClaim?: ChatStreamClaim
+  ): boolean {
+    if (this.active) {
+      if (suppliedClaim) this.releaseStreamClaim(suppliedClaim)
+      this.callbacks.onStartRejected?.(this.active.requestId)
+      return false
+    }
+
+    const claim = suppliedClaim ?? this.claimStream()
+    if (!claim || this.claim !== claim) {
+      this.callbacks.onStartRejected?.(null)
+      return false
+    }
+    this.claim = null
+
+    const requestId =
+      options.durableTurn?.submission.id || this.dependencies.createRequestId()
+    const requestMessage: ChatStreamClientEvent = options.durableTurn
+      ? {
+          version: STREAM_PROTOCOL_VERSION,
+          type: MESSAGE_KEYS.PROVIDER.START_TURN,
+          payload: {
+            start: {
+              submission: options.durableTurn.submission,
+              userMessageId: options.durableTurn.userMessageId
+            },
+            assistantMessageId: options.durableTurn.assistantMessageId
+          }
+        }
+      : {
+          version: STREAM_PROTOCOL_VERSION,
+          type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
+          payload: {
+            model: options.model,
+            providerId: options.providerId,
+            messages: options.messages,
+            sessionId: options.sessionId,
+            requestId,
+            clientContextPrepared: options.clientContextPrepared
+          }
+        }
+    const assistant = options.generatedMessage || {
+      role: "assistant" as const,
+      content: "",
+      model: options.model
+    }
+    const active: ActiveStream = {
+      requestId,
+      options,
+      requestMessage,
+      port: this.dependencies.connectPort(),
+      state: makeStreamReducerState(assistant),
+      settled: false,
+      resumeAttempts: 0
+    }
+    this.active = active
+    this.callbacks.onActivityChange?.({ loading: true, streaming: false })
+    this.callbacks.onAssistant?.(assistant, options)
+    this.attach(active, active.port)
+    active.port.postMessage(requestMessage)
+    return true
+  }
+
+  stop(): boolean {
+    const active = this.active
+    if (!active) {
+      this.callbacks.onStopWithoutActiveStream?.()
+      this.callbacks.onActivityChange?.({ loading: false, streaming: false })
+      return false
+    }
+
+    try {
+      if (!active.state.assistant.done) {
+        active.state = {
+          ...active.state,
+          assistant: { ...active.state.assistant, done: true }
+        }
+        this.callbacks.onAssistant?.(active.state.assistant, active.options)
+      }
+      active.port.postMessage({
+        version: STREAM_PROTOCOL_VERSION,
+        type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION,
+        payload: { requestId: active.requestId }
+      })
+      this.finish(active)
+      return true
+    } catch (error) {
+      this.callbacks.onStopError?.(error)
+      this.finish(active)
+      return false
+    }
+  }
+
+  private readonly handleMessage = (active: ActiveStream, raw: unknown) => {
+    if (!this.isCurrent(active)) return
+    const parsed = parseChatStreamServerEvent(raw)
+    if (!parsed.success) {
+      this.callbacks.onInvalidEvent?.(parsed.error.issues.length)
+      return
+    }
+    const event = parsed.data
+
+    if (event.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING) {
+      this.callbacks.onWarning?.(event.payload)
+      return
+    }
+    if (
+      event.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS ||
+      event.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT ||
+      event.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR ||
+      event.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK ||
+      event.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE ||
+      event.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR
+    ) {
+      return
+    }
+    if (event.type === CHAT_STREAM_EVENT_TYPES.SNAPSHOT) {
+      if (!event.sequenceReset && event.seq < active.state.lastSeq) return
+      if (event.assistant) {
+        active.state = {
+          ...makeStreamReducerState(event.assistant),
+          ...(event.thinkingState
+            ? { thinkingState: event.thinkingState }
+            : {}),
+          lastSeq: event.seq,
+          started: Boolean(event.assistant.content || event.assistant.thinking)
+        }
+        this.callbacks.onAssistant?.(event.assistant, active.options)
+      } else {
+        active.state = { ...active.state, lastSeq: event.seq }
+      }
+      if (isSettledSnapshot(event)) this.finish(active)
+      return
+    }
+
+    const result: StreamReduction<ChatMessage> = reduceStreamEvent(
+      active.state,
+      event
+    )
+    active.state = result.state
+    if (result.dropped) return
+    if (result.justStarted) {
+      this.callbacks.onActivityChange?.({ loading: true, streaming: true })
+    }
+    for (const token of result.tokens) this.callbacks.onToken?.(token)
+    if (result.terminal) {
+      this.callbacks.onTerminal?.(result.terminal, active.options)
+      this.finish(active)
+      return
+    }
+    if (result.changed) {
+      this.callbacks.onAssistant?.(active.state.assistant, active.options)
+    }
+  }
+
+  private readonly handleDisconnect = (
+    active: ActiveStream,
+    disconnectedPort: ChatStreamPort
+  ) => {
+    if (!this.isCurrent(active) || active.port !== disconnectedPort) return
+    const disconnectError = this.dependencies.getLastDisconnectError?.()
+    if (disconnectError) this.callbacks.onDisconnectError?.(disconnectError)
+
+    const awaitingConfirmation =
+      active.state.assistant.metrics?.toolRuns?.some(
+        (run) => run.status === "awaiting-confirmation"
+      ) ?? false
+    if (
+      !active.state.assistant.done &&
+      (active.options.durableTurn !== undefined || awaitingConfirmation) &&
+      active.resumeAttempts < 3
+    ) {
+      active.resumeAttempts += 1
+      this.detach(active, disconnectedPort)
+      this.dependencies.schedule(() => this.reconnect(active), 250)
+      return
+    }
+
+    if (!active.state.assistant.done) {
+      active.state = {
+        ...active.state,
+        assistant: {
+          ...active.state.assistant,
+          done: true,
+          metrics: { ...active.state.assistant.metrics, interrupted: true }
+        }
+      }
+      this.callbacks.onAssistant?.(active.state.assistant, active.options)
+    }
+    this.finish(active, false)
+  }
+
+  private reconnect(active: ActiveStream) {
+    if (!this.isCurrent(active) || active.state.assistant.done) return
+    if (!active.options.durableTurn) {
+      active.state = { ...active.state, lastSeq: -1 }
+    }
+    const port = this.dependencies.connectPort()
+    active.port = port
+    this.attach(active, port)
+    port.postMessage(
+      active.options.durableTurn
+        ? {
+            version: STREAM_PROTOCOL_VERSION,
+            type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
+            payload: {
+              requestId: active.requestId,
+              afterSeq: active.state.lastSeq
+            }
+          }
+        : active.requestMessage
+    )
+  }
+
+  private attach(active: ActiveStream, port: ChatStreamPort) {
+    const messageListener = (message: unknown) =>
+      this.handleMessage(active, message)
+    active.messageListener = messageListener
+    port.addMessageListener(messageListener)
+    const disconnectListener = () => this.handleDisconnect(active, port)
+    active.disconnectListener = disconnectListener
+    port.addDisconnectListener(disconnectListener)
+  }
+
+  private detach(active: ActiveStream, port: ChatStreamPort) {
+    if (active.messageListener) {
+      port.removeMessageListener(active.messageListener)
+      active.messageListener = undefined
+    }
+    if (active.disconnectListener) {
+      port.removeDisconnectListener(active.disconnectListener)
+      active.disconnectListener = undefined
+    }
+  }
+
+  private finish(active: ActiveStream, disconnect = true) {
+    if (!this.isCurrent(active)) return
+    active.settled = true
+    this.detach(active, active.port)
+    if (disconnect) active.port.disconnect()
+    this.active = null
+    this.callbacks.onActivityChange?.({ loading: false, streaming: false })
+  }
+
+  private isCurrent(active: ActiveStream) {
+    return this.active === active && !active.settled
+  }
+}

--- a/src/features/chat/hooks/use-chat-stream.ts
+++ b/src/features/chat/hooks/use-chat-stream.ts
@@ -1,11 +1,11 @@
-import {
-  makeStreamReducerState,
-  reduceStreamEvent,
-  type StreamReducerState
-} from "@ollama-client/runtime-core/chat-stream-reducer"
 import { useRef } from "react"
 import { useTranslation } from "react-i18next"
-import type { DurableTurnStart } from "@/application/turns/turn-contract"
+import {
+  type ChatStreamPort,
+  ChatStreamSession,
+  type ChatStreamSessionCallbacks,
+  type ChatStreamStartOptions
+} from "@/application/turns/chat-stream-session"
 import { useToast } from "@/hooks/use-toast"
 import { browser } from "@/lib/browser-api"
 import { ERROR_MESSAGES, MESSAGE_KEYS } from "@/lib/constants"
@@ -17,25 +17,9 @@ import { buildErrorReportUrl } from "@/lib/error-report"
 import { logger } from "@/lib/logger"
 import { providerErrorUserMessage } from "@/lib/providers/provider-errors"
 import { getProviderDisplayName } from "@/lib/providers/registry"
-import {
-  CHAT_STREAM_EVENT_TYPES,
-  parseChatStreamServerEvent,
-  STREAM_PROTOCOL_VERSION
-} from "@/protocol/streams"
 import type { ChatMessage } from "@/types"
 
-interface StreamOptions {
-  model: string
-  providerId?: string
-  messages: ChatMessage[]
-  sessionId?: string
-  generatedMessage?: ChatMessage
-  /** See {@link ChatWithModelMessage} `clientContextPrepared`. */
-  clientContextPrepared?: boolean
-  durableTurn?: DurableTurnStart & { assistantMessageId: number }
-}
-
-export type ChatStreamClaim = symbol
+export type { ChatStreamClaim } from "@/application/turns/chat-stream-session"
 
 export interface UseChatStreamProps {
   setMessages: (messages: ChatMessage[]) => void | Promise<void>
@@ -45,6 +29,28 @@ export interface UseChatStreamProps {
   onSuccessfulResponse?: (message: ChatMessage) => void | Promise<void>
 }
 
+const createPort = (): ChatStreamPort => {
+  const port = browser.runtime.connect({
+    name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
+  })
+  return {
+    postMessage: (message) => port.postMessage(message),
+    disconnect: () => port.disconnect(),
+    addMessageListener: (listener) => port.onMessage.addListener(listener),
+    removeMessageListener: (listener) =>
+      port.onMessage.removeListener(listener),
+    addDisconnectListener: (listener) =>
+      port.onDisconnect.addListener(listener),
+    removeDisconnectListener: (listener) =>
+      port.onDisconnect.removeListener(listener)
+  }
+}
+
+const createRequestId = () =>
+  globalThis.crypto?.randomUUID?.() ||
+  `chat-stream-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+/** React effects adapter for the framework-independent ChatStreamSession. */
 export const useChatStream = ({
   setMessages,
   setIsLoading,
@@ -52,296 +58,120 @@ export const useChatStream = ({
   onToken,
   onSuccessfulResponse
 }: UseChatStreamProps) => {
-  const DEBUG_THINKING_STREAM = false
   const { t } = useTranslation()
   const { toast } = useToast()
-  const portRef = useRef<browser.Runtime.Port | null>(null)
-  const streamClaimRef = useRef<ChatStreamClaim | null>(null)
-  const currentMessagesRef = useRef<ChatMessage[]>([])
-  const currentRequestIdRef = useRef<string | null>(null)
-  // The request id of a turn the user explicitly stopped. Lets the disconnect
-  // handler tell a user-initiated stop (finalize cleanly) from an unexpected
-  // worker/port death (finalize as interrupted, offer retry).
-  const manualStopRequestIdRef = useRef<string | null>(null)
-  // Finalizes the active turn's assistant message as a clean `done:true` and
-  // persists it (via the render → persistence bridge). Set by the active
-  // stream; invoked by `stopStream`, because calling `port.disconnect()`
-  // ourselves does NOT fire our own `onDisconnect`, so the disconnect fallback
-  // never runs on a manual stop and the row would otherwise stay `done=0`.
-  const finalizeCleanRef = useRef<(() => void) | null>(null)
+  const sessionRef = useRef<ChatStreamSession | null>(null)
 
-  const claimStream = (): ChatStreamClaim | null => {
-    if (portRef.current || streamClaimRef.current) return null
-    const claim = Symbol("chat-stream-claim")
-    streamClaimRef.current = claim
-    return claim
-  }
-
-  const releaseStreamClaim = (claim: ChatStreamClaim) => {
-    if (streamClaimRef.current === claim) streamClaimRef.current = null
-  }
-
-  const startStream = (
-    {
-      model,
-      providerId,
-      messages,
-      sessionId,
-      generatedMessage,
-      clientContextPrepared,
-      durableTurn
-    }: StreamOptions,
-    claim?: ChatStreamClaim
-  ): boolean => {
-    if (portRef.current) {
-      logger.warn(
-        "Ignored stream start while another request is active",
-        "useChatStream",
-        { requestId: currentRequestIdRef.current }
-      )
-      if (claim) releaseStreamClaim(claim)
-      return false
-    }
-    const streamClaim = claim ?? claimStream()
-    if (!streamClaim || streamClaimRef.current !== streamClaim) {
-      logger.warn("Ignored stream start without ownership", "useChatStream")
-      return false
-    }
-    streamClaimRef.current = null
-    // Create port synchronously BEFORE any async operations
-    let port = browser.runtime.connect({
-      name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
+  if (!sessionRef.current) {
+    sessionRef.current = new ChatStreamSession({
+      connectPort: createPort,
+      schedule: (callback, delayMs) => window.setTimeout(callback, delayMs),
+      createRequestId,
+      getLastDisconnectError: () => browser.runtime.lastError?.message
     })
-    portRef.current = port
-    const requestId =
-      durableTurn?.submission.id ||
-      globalThis.crypto?.randomUUID?.() ||
-      `chat-stream-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    currentRequestIdRef.current = requestId
+  }
+  const session = sessionRef.current
 
-    setIsLoading(true)
-    setIsStreaming(false)
+  const renderAssistant = (
+    assistant: ChatMessage,
+    options: ChatStreamStartOptions
+  ) => setMessages([...options.messages, assistant])
 
-    const assistantMessage: ChatMessage = generatedMessage || {
-      role: "assistant",
-      content: "",
-      model
-    }
-
-    // Initialize with user + assistant shell. `messages` is the stable base
-    // (everything before the assistant turn); every render replaces only the
-    // trailing assistant message with the reducer's latest.
-    currentMessagesRef.current = [...messages, assistantMessage]
-    setMessages(currentMessagesRef.current)
-
-    // All per-turn accumulation lives in the reducer state; the hook keeps
-    // only the port-lifecycle flags. `state.lastSeq` resets to -1 on reconnect
-    // because a restarted worker restarts its sequence counter at 0.
-    let state: StreamReducerState<ChatMessage> =
-      makeStreamReducerState(assistantMessage)
-    let streamSettled = false
-    let resumeAttempts = 0
-
-    const renderAssistant = (assistant: ChatMessage) => {
-      const updated = [...messages, assistant]
-      currentMessagesRef.current = updated
-      return setMessages(updated)
-    }
-
-    // Persist a clean completion for the current partial answer. Used by a
-    // user stop, where no terminal stream event arrives to flip `done`.
-    finalizeCleanRef.current = () => {
-      if (streamSettled || state.assistant.done) return
-      state = { ...state, assistant: { ...state.assistant, done: true } }
-      renderAssistant(state.assistant)
-    }
-
-    const requestPayload = {
-      model,
-      providerId,
-      messages,
-      sessionId,
-      requestId,
-      clientContextPrepared
-    }
-    const requestMessage = durableTurn
-      ? {
-          version: STREAM_PROTOCOL_VERSION,
-          type: MESSAGE_KEYS.PROVIDER.START_TURN,
-          payload: {
-            start: {
-              submission: durableTurn.submission,
-              userMessageId: durableTurn.userMessageId
-            },
-            assistantMessageId: durableTurn.assistantMessageId
-          }
-        }
-      : {
-          version: STREAM_PROTOCOL_VERSION,
-          type: MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL,
-          payload: requestPayload
-        }
-
-    const cleanupPort = () => {
-      streamSettled = true
-      finalizeCleanRef.current = null
-      port.onMessage.removeListener(listener)
-      port.onDisconnect.removeListener(handleDisconnect)
-      port.disconnect()
-      if (portRef.current === port) {
-        portRef.current = null
-        currentRequestIdRef.current = null
+  const callbacks: ChatStreamSessionCallbacks = {
+    onAssistant: renderAssistant,
+    onActivityChange: ({ loading, streaming }) => {
+      setIsLoading(loading)
+      setIsStreaming(streaming)
+    },
+    onToken,
+    onWarning: (warning) => {
+      if (!warning.titleKey) return
+      toast({
+        variant: warning.variant,
+        title: t(warning.titleKey),
+        description: warning.descriptionKey
+          ? t(warning.descriptionKey, warning.descriptionValues)
+          : undefined
+      })
+    },
+    onInvalidEvent: (issueCount) => {
+      logger.warn("Dropped invalid chat stream event", "StreamProtocol", {
+        issues: issueCount
+      })
+    },
+    onStartRejected: (requestId) => {
+      if (requestId) {
+        logger.warn(
+          "Ignored stream start while another request is active",
+          "useChatStream",
+          { requestId }
+        )
+      } else {
+        logger.warn("Ignored stream start without ownership", "useChatStream")
       }
-    }
-
-    const listener = (rawMsg: unknown) => {
-      if (streamSettled) return
-      const parsed = parseChatStreamServerEvent(rawMsg)
-      if (!parsed.success) {
-        logger.warn("Dropped invalid chat stream event", "StreamProtocol", {
-          issues: parsed.error.issues.length
-        })
-        return
-      }
-      const msg = parsed.data
-      if (msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_WARNING) {
-        const warning = msg.payload
-        if (warning?.titleKey) {
-          toast({
-            variant: warning.variant,
-            title: t(warning.titleKey),
-            description: warning.descriptionKey
-              ? t(warning.descriptionKey, warning.descriptionValues)
-              : undefined
-          })
-        }
-        return
-      }
-      if (msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_PROGRESS) return
-      if (msg.type === CHAT_STREAM_EVENT_TYPES.SNAPSHOT) {
-        if (!msg.sequenceReset && msg.seq < state.lastSeq) return
-        if (msg.assistant) {
-          state = {
-            ...makeStreamReducerState(msg.assistant),
-            ...(msg.thinkingState ? { thinkingState: msg.thinkingState } : {}),
-            lastSeq: msg.seq,
-            started: Boolean(msg.assistant.content || msg.assistant.thinking)
-          }
-          renderAssistant(msg.assistant)
-        } else {
-          state = { ...state, lastSeq: msg.seq }
-        }
-        if (
-          msg.assistant?.done ||
-          msg.status === "completed" ||
-          msg.status === "failed" ||
-          msg.status === "cancelled"
-        ) {
-          setIsLoading(false)
-          setIsStreaming(false)
-          cleanupPort()
-        }
-        return
-      }
-      if (
-        msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT ||
-        msg.type === CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR ||
-        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_CHUNK ||
-        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_DONE ||
-        msg.type === MESSAGE_KEYS.BROWSER.SELECTION_ACTION_ERROR
-      ) {
-        return
-      }
-
-      // Fold the chunk into turn state purely; the hook only performs effects.
-      const result = reduceStreamEvent(state, msg)
-      state = result.state
-      if (result.dropped) return
-
-      if (DEBUG_THINKING_STREAM && msg.type === CHAT_STREAM_EVENT_TYPES.CHUNK) {
-        logger.debug("Stream msg", "useChatStream", {
-          type: msg.type,
-          hasDelta: typeof msg.delta === "string" && msg.delta.length > 0,
-          hasThinkingDelta:
-            typeof msg.thinkingDelta === "string" &&
-            msg.thinkingDelta.length > 0,
-          done: msg.done,
-          aborted: msg.aborted,
-          error: msg.error
-        })
-      }
-
-      if (result.justStarted) setIsStreaming(true)
-      if (onToken) {
-        for (const token of result.tokens) onToken(token)
-      }
-
-      if (result.terminal) {
-        setIsLoading(false)
-        setIsStreaming(false)
-
-        if (result.terminal.type === "error") {
-          const { error, partial } = result.terminal
-          const isProviderError = error.kind === "provider"
-          // An explicit providerId from the background is authoritative for any
-          // kind — a disabled provider is `kind: "validation"` but still names
-          // the provider, and recovery actions need that id. Only the fallback
-          // to the request's providerId stays provider-kind-gated, so a generic
-          // background 500 is not mislabelled as a provider failure.
-          const errorProviderId =
-            error.providerId || (isProviderError ? providerId : undefined)
-          const providerName =
-            error.providerName ||
-            (errorProviderId
-              ? getProviderDisplayName(errorProviderId)
-              : undefined)
-          const errorModel = error.model || model
-          const localizedUserMessage = error.messageKey
-            ? t(error.messageKey)
-            : error.userMessage
-          const displayError = formatErrorForDisplay(
-            { ...error, userMessage: localizedUserMessage },
-            t("chat.errors.unknown_error_description")
-          )
-          const errMsg =
-            localizedUserMessage ??
-            ERROR_MESSAGES[error.status] ??
-            // Any provider error with a real HTTP status gets the clean
-            // per-status copy — raw response bodies never render in chat.
-            (isProviderError && error.status > 0
-              ? providerErrorUserMessage(error.status, {
-                  providerName,
-                  model: errorModel,
-                  baseUrl: error.baseUrl
-                })
-              : t("chat.errors.unknown_error", {
-                  message:
-                    getDisplayErrorMessage(error) || t("chat.errors.no_message")
-                }))
-          const issueUrl =
-            isProviderError && error.status >= 500
-              ? buildErrorReportUrl({
-                  status: error.status,
-                  kind: error.kind,
-                  message: errMsg,
-                  providerId: errorProviderId,
-                  providerName,
-                  model: errorModel,
-                  baseUrl: error.baseUrl,
-                  code: error.code,
-                  phase: error.phase,
-                  incidentId: error.incidentId,
-                  durationMs: error.durationMs,
-                  recoveryAction: error.recoveryAction
-                })
-              : undefined
-          const toastDescription =
-            error.kind === "provider" && providerName
-              ? `${displayError.message}${
-                  error.retryable ? " This may be temporary; try again." : ""
-                }`
-              : displayError.message
-          void renderAssistant({
+    },
+    onStopWithoutActiveStream: () => {
+      logger.warn("Stop requested but port not created yet", "useChatStream")
+    },
+    onStopError: (error) => {
+      logger.error("Failed to send stop message", "useChatStream", { error })
+    },
+    onDisconnectError: (error) => {
+      logger.debug("Port disconnected unexpectedly", "useChatStream", {
+        error
+      })
+    },
+    onTerminal: (terminal, options) => {
+      if (terminal.type === "error") {
+        const { error, partial } = terminal
+        const isProviderError = error.kind === "provider"
+        const errorProviderId =
+          error.providerId || (isProviderError ? options.providerId : undefined)
+        const providerName =
+          error.providerName ||
+          (errorProviderId
+            ? getProviderDisplayName(errorProviderId)
+            : undefined)
+        const errorModel = error.model || options.model
+        const localizedUserMessage = error.messageKey
+          ? t(error.messageKey)
+          : error.userMessage
+        const displayError = formatErrorForDisplay(
+          { ...error, userMessage: localizedUserMessage },
+          t("chat.errors.unknown_error_description")
+        )
+        const errMsg =
+          localizedUserMessage ??
+          ERROR_MESSAGES[error.status] ??
+          (isProviderError && error.status > 0
+            ? providerErrorUserMessage(error.status, {
+                providerName,
+                model: errorModel,
+                baseUrl: error.baseUrl
+              })
+            : t("chat.errors.unknown_error", {
+                message:
+                  getDisplayErrorMessage(error) || t("chat.errors.no_message")
+              }))
+        const issueUrl =
+          isProviderError && error.status >= 500
+            ? buildErrorReportUrl({
+                status: error.status,
+                kind: error.kind,
+                message: errMsg,
+                providerId: errorProviderId,
+                providerName,
+                model: errorModel,
+                baseUrl: error.baseUrl,
+                code: error.code,
+                phase: error.phase,
+                incidentId: error.incidentId,
+                durationMs: error.durationMs,
+                recoveryAction: error.recoveryAction
+              })
+            : undefined
+        void renderAssistant(
+          {
             ...partial,
             content: errMsg,
             done: true,
@@ -361,182 +191,67 @@ export const useChatStream = ({
               durationMs: error.durationMs,
               recoveryAction: error.recoveryAction
             }
-          })
-          toast({
-            variant: "destructive",
-            title: displayError.kind
-              ? error.kind === "provider" && providerName
-                ? `${providerName} error`
-                : displayError.title
-              : t("chat.errors.response_failed_title"),
-            description: toastDescription,
-            ...(issueUrl && {
-              action: {
-                label: "Open new issue",
-                onClick: () => {
-                  void browser.tabs.create({ url: issueUrl })
-                }
+          },
+          options
+        )
+        toast({
+          variant: "destructive",
+          title: displayError.kind
+            ? isProviderError && providerName
+              ? `${providerName} error`
+              : displayError.title
+            : t("chat.errors.response_failed_title"),
+          description:
+            isProviderError && providerName
+              ? `${displayError.message}${
+                  error.retryable ? " This may be temporary; try again." : ""
+                }`
+              : displayError.message,
+          ...(issueUrl && {
+            action: {
+              label: "Open new issue",
+              onClick: () => {
+                void browser.tabs.create({ url: issueUrl })
               }
-            })
+            }
           })
-        } else {
-          // A finished turn with nothing to show gets its copy here, where i18n
-          // lives; the reducer only reports why it was empty.
-          const emptyReason = result.terminal.emptyReason
-          const message = emptyReason
-            ? {
-                ...result.terminal.message,
-                content:
-                  emptyReason === "thinking-only"
-                    ? t("chat.errors.thinking_only_response")
-                    : t("chat.errors.empty_response")
-              }
-            : result.terminal.message
-          Promise.resolve(renderAssistant(message))
-            .then(async () => {
-              await onSuccessfulResponse?.(message)
-            })
-            .catch((error) => {
-              logger.debug(
-                "Successful response persistence finalization failed",
-                "useChatStream",
-                { error }
-              )
-            })
-        }
-
-        cleanupPort()
-        return
-      }
-
-      if (result.changed) renderAssistant(state.assistant)
-    }
-
-    const handleDisconnect = () => {
-      if (browser.runtime.lastError) {
-        logger.debug("Port disconnected unexpectedly", "useChatStream", {
-          error: browser.runtime.lastError.message
         })
-      }
-      const awaitingConfirmation =
-        state.assistant.metrics?.toolRuns?.some(
-          (run) => run.status === "awaiting-confirmation"
-        ) ?? false
-
-      // Reconnect with the same request id after an MV3 worker restart.
-      // Background restores its force-flushed SQLite checkpoint and
-      // re-registers the exact pending tool call.
-      if (
-        !streamSettled &&
-        !state.assistant.done &&
-        (durableTurn !== undefined || awaitingConfirmation) &&
-        currentRequestIdRef.current === requestId &&
-        resumeAttempts < 3
-      ) {
-        resumeAttempts += 1
-        window.setTimeout(() => {
-          if (
-            streamSettled ||
-            state.assistant.done ||
-            currentRequestIdRef.current !== requestId
-          ) {
-            return
-          }
-          // Legacy tool-loop reconnects restart their sequence at 0. Durable
-          // turns request a snapshot and keep their last accepted sequence.
-          if (!durableTurn) state = { ...state, lastSeq: -1 }
-          port = browser.runtime.connect({
-            name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
-          })
-          portRef.current = port
-          port.onMessage.addListener(listener)
-          port.onDisconnect.addListener(handleDisconnect)
-          port.postMessage(
-            durableTurn
-              ? {
-                  version: STREAM_PROTOCOL_VERSION,
-                  type: MESSAGE_KEYS.PROVIDER.RECONNECT_STREAM,
-                  payload: {
-                    requestId,
-                    afterSeq: state.lastSeq
-                  }
-                }
-              : requestMessage
-          )
-        }, 250)
         return
       }
 
-      if (!streamSettled && !state.assistant.done) {
-        setIsLoading(false)
-        setIsStreaming(false)
-        // A user-initiated stop finalizes cleanly. An unexpected disconnect
-        // (worker death) truncated a live answer: flag it interrupted so the
-        // startup sweep's `done=0` scan isn't the only recovery path — the
-        // partial persists with the interrupted note + retry immediately.
-        const userStopped = manualStopRequestIdRef.current === requestId
-        const finalized: ChatMessage = {
-          ...state.assistant,
-          done: true,
-          ...(userStopped
-            ? {}
-            : { metrics: { ...state.assistant.metrics, interrupted: true } })
-        }
-        state = { ...state, assistant: finalized }
-        renderAssistant(finalized)
-        if (portRef.current === port) {
-          portRef.current = null
-          currentRequestIdRef.current = null
-        }
-      }
-    }
-
-    port.onMessage.addListener(listener)
-    port.onDisconnect.addListener(handleDisconnect)
-    port.postMessage(requestMessage)
-    return true
-  }
-
-  const stopStream = () => {
-    // Handle case where port hasn't been created yet
-    if (!portRef.current) {
-      logger.warn("Stop requested but port not created yet", "useChatStream")
-      setIsLoading(false)
-      setIsStreaming(false)
-      return
-    }
-
-    try {
-      const requestId = currentRequestIdRef.current
-      // Record the stop so a racing disconnect finalizes cleanly rather than
-      // flagging this turn as interrupted.
-      manualStopRequestIdRef.current = requestId
-      // Persist the partial answer as a clean completion now. `disconnect()`
-      // below won't fire our own `onDisconnect`, so this is the only place the
-      // stopped turn gets its `done:true` written — otherwise the recovery
-      // sweep would later mark this clean stop as interrupted.
-      finalizeCleanRef.current?.()
-      currentRequestIdRef.current = null
-      portRef.current.postMessage({
-        version: STREAM_PROTOCOL_VERSION,
-        type: MESSAGE_KEYS.PROVIDER.STOP_GENERATION,
-        payload: requestId ? { requestId } : undefined
-      })
-      portRef.current.disconnect()
-      portRef.current = null
-    } catch (error) {
-      logger.error("Failed to send stop message", "useChatStream", { error })
-    } finally {
-      // Always reset state, even if message fails
-      setIsLoading(false)
-      setIsStreaming(false)
+      const message = terminal.emptyReason
+        ? {
+            ...terminal.message,
+            content:
+              terminal.emptyReason === "thinking-only"
+                ? t("chat.errors.thinking_only_response")
+                : t("chat.errors.empty_response")
+          }
+        : terminal.message
+      Promise.resolve(renderAssistant(message, options))
+        .then(async () => {
+          await onSuccessfulResponse?.(message)
+        })
+        .catch((error) => {
+          logger.debug(
+            "Successful response persistence finalization failed",
+            "useChatStream",
+            { error }
+          )
+        })
     }
   }
+  session.updateCallbacks(callbacks)
 
   return {
-    startStream,
-    stopStream,
-    claimStream,
-    releaseStreamClaim
+    startStream: (
+      options: ChatStreamStartOptions,
+      claim?: import("@/application/turns/chat-stream-session").ChatStreamClaim
+    ) => session.start(options, claim),
+    stopStream: () => session.stop(),
+    claimStream: () => session.claimStream(),
+    releaseStreamClaim: (
+      claim: import("@/application/turns/chat-stream-session").ChatStreamClaim
+    ) => session.releaseStreamClaim(claim)
   }
 }


### PR DESCRIPTION
## What changed

- introduce a framework-independent `ChatStreamSession`
- enforce one active stream claim/request at a time
- move port ownership, protocol parsing, reducer transitions, reconnects, snapshots, and cancellation out of React
- keep `useChatStream` as the React/i18n/browser-effects adapter
- add direct session tests for single-flight admission, reduction, durable reconnects, stale-port isolation, and clean cancellation

## Why

The chat hook owned transport state, reducer state, reconnect policy, cancellation, and presentation effects in one closure. That made stream lifecycle behavior difficult to test independently and left single-flight enforcement coupled to React refs.

The new session provides one explicit owner for the streaming lifecycle while preserving the hook's existing observable behavior.

## Impact

Streaming behavior remains compatible for the UI. The lifecycle can now be exercised without React, and concurrent starts are rejected before a second port opens.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 345 files, 2,912 tests
- `pnpm build`
- pre-push i18n drift, package, bundle-size, and docs checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts chat streaming lifecycle management into a framework-independent session while retaining React, localization, and browser-facing effects in the hook.

- Adds `ChatStreamSession` for stream admission, transport ownership, protocol reduction, reconnects, snapshots, and cancellation.
- Refactors `useChatStream` into an adapter around the session.
- Adds direct lifecycle tests and updates the documented architecture boundary.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/application/turns/chat-stream-session.ts | Introduces the framework-independent owner for single-flight admission, stream transport, reduction, reconnect, snapshot, and cancellation behavior. |
| src/features/chat/hooks/use-chat-stream.ts | Reduces the hook to a React, localization, logging, and browser-effects adapter around `ChatStreamSession`. |
| src/application/turns/__tests__/chat-stream-session.test.ts | Covers stream admission, reduction, durable reconnection, stale-port isolation, and clean cancellation directly at the session boundary. |
| AGENTS.md | Updates hotspot guidance to document the newly established stream-session boundary. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as React chat UI
  participant Hook as useChatStream
  participant Session as ChatStreamSession
  participant BG as Background stream port
  UI->>Hook: startStream(options, claim)
  Hook->>Session: start(options, claim)
  Session->>BG: open port and post start request
  BG-->>Session: validated stream events or snapshot
  Session->>Session: reduce event and update lifecycle
  Session-->>Hook: assistant, activity, token, or terminal callback
  Hook-->>UI: update React state and presentation effects
  UI->>Hook: stopStream()
  Hook->>Session: stop()
  Session->>BG: STOP_GENERATION
  Session-->>Hook: finalized activity state
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: record stream session boundary"](https://github.com/shishir435/ollama-client/commit/a4e844a30be8c6f486731944d208770ea44acbd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52705121)</sub>

**Context used:**

- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)

<!-- /greptile_comment -->