### PR TITLE
fix(chat): reject stale stream port events

### DIFF
--- a/src/application/turns/__tests__/chat-stream-session.test.ts
+++ b/src/application/turns/__tests__/chat-stream-session.test.ts
@@ -143,6 +143,7 @@ describe("ChatStreamSession", () => {
     }
     session.start({ ...startOptions, durableTurn })
     const firstPort = ports[0]
+    const queuedFirstPortListener = [...firstPort.messageListeners][0]
     firstPort.emit({ seq: 3, delta: "partial" })
     firstPort.drop()
 
@@ -154,13 +155,96 @@ describe("ChatStreamSession", () => {
     })
     expect(firstPort.messageListeners.size).toBe(0)
 
-    firstPort.emit({ seq: 4, delta: " stale" })
+    // A browser event can already be queued when the disconnect callback
+    // detaches its listener. Source-port identity, not listener removal alone,
+    // keeps that old event out of the reconnected stream.
+    queuedFirstPortListener({ seq: 4, delta: " stale" })
     ports[1].emit({ seq: 4, delta: " resumed", done: true })
     expect(callbacks.onTerminal).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.objectContaining({ content: "partial resumed" })
       }),
       expect.anything()
+    )
+  })
+
+  it("cancels while a reconnect is scheduled without reopening a port", () => {
+    const scheduled: Array<() => void> = []
+    const session = new ChatStreamSession(
+      {
+        connectPort: () => {
+          const port = new FakePort()
+          ports.push(port)
+          return port
+        },
+        schedule: (callback) => scheduled.push(callback),
+        createRequestId: () => "request-1"
+      },
+      callbacks
+    )
+    const durableTurn = {
+      submission: {
+        id: "turn-cancel-reconnect",
+        sessionId: "session-1",
+        mode: "new" as const,
+        model: "llama3",
+        request: {
+          version: 1 as const,
+          context: {
+            rawInput: "Hello",
+            messages: [],
+            hasTabContext: false,
+            contextText: "",
+            tabDocuments: [],
+            memoryEnabled: false,
+            maxTabContextChars: 1000,
+            maxRagContextChars: 1000,
+            groundedOnlyMode: false,
+            selectedModel: "llama3",
+            selectedModelRef: null
+          },
+          userMessage: { role: "user" as const, content: "Hello" }
+        },
+        createdAt: 1
+      },
+      userMessageId: 1,
+      assistantMessageId: 2
+    }
+
+    session.start({ ...startOptions, durableTurn })
+    ports[0].emit({ delta: "partial" })
+    ports[0].drop()
+    expect(scheduled).toHaveLength(1)
+
+    expect(session.stop()).toBe(true)
+    scheduled[0]()
+
+    expect(ports).toHaveLength(1)
+    expect(rendered.at(-1)).toMatchObject({
+      content: "partial",
+      done: true
+    })
+    expect(rendered.at(-1)?.metrics?.interrupted).toBeUndefined()
+  })
+
+  it("admits a replacement only after the previous stream settles", () => {
+    const session = createSession()
+    expect(session.start(startOptions)).toBe(true)
+    const firstPort = ports[0]
+    const queuedFirstPortListener = [...firstPort.messageListeners][0]
+
+    firstPort.emit({ delta: "first", done: true })
+    expect(session.start({ ...startOptions, model: "replacement" })).toBe(true)
+    expect(ports).toHaveLength(2)
+
+    queuedFirstPortListener({ delta: " stale", done: true })
+    ports[1].emit({ delta: "second", done: true })
+
+    expect(callbacks.onTerminal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "second" })
+      }),
+      expect.objectContaining({ model: "replacement" })
     )
   })
 

--- a/src/application/turns/chat-stream-session.ts
+++ b/src/application/turns/chat-stream-session.ts
@@ -223,8 +223,12 @@ export class ChatStreamSession {
     }
   }
 
-  private readonly handleMessage = (active: ActiveStream, raw: unknown) => {
-    if (!this.isCurrent(active)) return
+  private readonly handleMessage = (
+    active: ActiveStream,
+    sourcePort: ChatStreamPort,
+    raw: unknown
+  ) => {
+    if (!this.isCurrent(active) || active.port !== sourcePort) return
     const parsed = parseChatStreamServerEvent(raw)
     if (!parsed.success) {
       this.callbacks.onInvalidEvent?.(parsed.error.issues.length)
@@ -346,7 +350,7 @@ export class ChatStreamSession {
 
   private attach(active: ActiveStream, port: ChatStreamPort) {
     const messageListener = (message: unknown) =>
-      this.handleMessage(active, message)
+      this.handleMessage(active, port, message)
     active.messageListener = messageListener
     port.addMessageListener(messageListener)
     const disconnectListener = () => this.handleDisconnect(active, port)


### PR DESCRIPTION
## What changed

- reject chat stream events unless they originate from the currently attached port
- exercise a queued event from a replaced reconnect port
- verify stopping during a scheduled reconnect does not reopen a port
- verify a replacement stream starts only after the previous stream settles

## Why

Follow-up to #274. Listener removal prevents future delivery, but an event callback already queued by the browser can still execute after a reconnect. The session previously checked logical stream identity without checking the source port, allowing that queued event to enter the reconnected stream.

## Impact

Reconnects cannot accept late chunks from the port they replaced. Cancellation also remains authoritative while a reconnect timer is pending, and single-flight admission is explicitly covered across successive streams.

No React hook or UI behavior was refactored.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 345 files, 2,914 tests
- pre-push i18n, package, bundle-size, and docs checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents queued events from a replaced chat-stream port from entering the currently active stream.
- Passes the listener’s source port into message handling and rejects events whose source is no longer active.
- Adds coverage for stale queued events, cancellation during scheduled reconnect, and replacement-stream admission after settlement.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed port-identity guard matching the existing attachment and reconnect lifecycle.

Each production connection receives a distinct port adapter, the active port is assigned before its listener is attached, and existing current-stream and settlement guards preserve valid reconnect, cancellation, and replacement behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/application/turns/chat-stream-session.ts | Adds a source-port identity check that rejects callbacks queued by a replaced port while preserving valid events from the currently attached port. |
| src/application/turns/__tests__/chat-stream-session.test.ts | Expands lifecycle coverage for stale queued callbacks, cancellation during pending reconnect, and single-flight replacement streams. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Old as Replaced port
  participant Session as ChatStreamSession
  participant New as Current port
  Old-->>Session: disconnect
  Session->>Session: detach old listeners
  Session->>New: reconnect and attach
  Old-->>Session: previously queued event
  Session->>Session: "reject because sourcePort != active.port"
  New-->>Session: current stream event
  Session->>Session: parse and reduce event
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): reject stale stream port even..."](https://github.com/shishir435/ollama-client/commit/0dd07012b023dcfda57e7c693a3b6e46f208785c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52710994)</sub>

**Context used:**

- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)

<!-- /greptile_comment -->