### PR TITLE
refactor(providers): add explicit draft boundary

### DIFF
--- a/packages/contracts/src/__tests__/provider-rpc.test.ts
+++ b/packages/contracts/src/__tests__/provider-rpc.test.ts
@@ -14,7 +14,7 @@ describe("provider RPC contracts", () => {
         type: "openai",
         enabled: true,
         baseUrl: "https://example.test/v1",
-        apiKey: "secret",
+        apiKey: { state: "replaced", value: "secret" },
         name: "Example",
         customModels: ["model-a"],
         serviceProfile: "openrouter",

--- a/packages/contracts/src/provider-rpc.ts
+++ b/packages/contracts/src/provider-rpc.ts
@@ -44,6 +44,31 @@ export const PublicProviderConfigSchema = ProviderConfigInputSchema.omit({
 /** @see PublicProviderConfigSchema */
 export type PublicProviderConfig = z.infer<typeof PublicProviderConfigSchema>
 
+const ProviderApiKeyDraftSchema = z.discriminatedUnion("state", [
+  z.object({ state: z.literal("unchanged") }).strict(),
+  z
+    .object({
+      state: z.literal("replaced"),
+      value: z.string().max(32_768)
+    })
+    .strict(),
+  z.object({ state: z.literal("cleared") }).strict()
+])
+
+/**
+ * Editable provider shape used by extension pages. Credentials are represented
+ * as an explicit mutation intent; a public config is never widened into the
+ * secret-bearing stored shape.
+ */
+export const ProviderDraftInputSchema = ProviderConfigInputSchema.omit({
+  apiKey: true
+})
+  .extend({ apiKey: ProviderApiKeyDraftSchema })
+  .strict()
+
+/** @see ProviderDraftInputSchema */
+export type ProviderDraftInput = z.infer<typeof ProviderDraftInputSchema>
+
 const ProviderModelSchema = z
   .object({
     name: z.string().min(1),
@@ -151,7 +176,7 @@ export const ProvidersUpsertRequestSchema = z.discriminatedUnion("target", [
   z
     .object({
       target: z.literal("existing"),
-      config: ProviderConfigInputSchema
+      config: ProviderDraftInputSchema
     })
     .strict(),
   z
@@ -200,7 +225,7 @@ export const ProviderTestConnectionRequestSchema = z.discriminatedUnion(
     z
       .object({
         target: z.literal("draft"),
-        config: ProviderConfigInputSchema
+        config: ProviderDraftInputSchema
       })
       .strict()
   ]

--- a/src/features/model/components/__tests__/provider-settings.test.tsx
+++ b/src/features/model/components/__tests__/provider-settings.test.tsx
@@ -48,7 +48,7 @@ const remoteProvider = {
   type: ProviderType.OPENAI,
   enabled: true,
   baseUrl: "https://api.example.com/v1",
-  apiKey: "secret",
+  apiKey: { state: "replaced", value: "secret" },
   customModels: ["remote-model"]
 }
 

--- a/src/features/model/components/provider-connection-fields.tsx
+++ b/src/features/model/components/provider-connection-fields.tsx
@@ -3,17 +3,21 @@ import { useTranslation } from "react-i18next"
 import { SettingsActionRow, SettingsFormField } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  type ProviderDraft,
+  type ProviderDraftUpdate,
+  providerDraftApiKeyValue
+} from "@/features/model/types/provider-draft"
 import { DEFAULT_PROVIDERS } from "@/lib/providers/manager"
-import type { ProviderConfig } from "@/lib/providers/types"
 
 interface ProviderConnectionFieldsProps {
-  activeConfig: ProviderConfig
+  activeConfig: ProviderDraft
   cspCompatibilityHint: string | null
   isLocalProvider: boolean
   isRemoteEndpoint: boolean
   hasUnsavedChanges: boolean
-  onSave: (config: ProviderConfig) => void
-  updateConfig: (updates: Partial<ProviderConfig>) => void
+  onSave: (config: ProviderDraft) => void
+  updateConfig: (updates: ProviderDraftUpdate) => void
 }
 
 export const ProviderConnectionFields = ({
@@ -75,7 +79,7 @@ export const ProviderConnectionFields = ({
           label={t("settings.providers.api_key")}>
           <Input
             type="password"
-            value={activeConfig.apiKey || ""}
+            value={providerDraftApiKeyValue(activeConfig)}
             onChange={(e) => updateConfig({ apiKey: e.target.value })}
             placeholder="sk-..."
           />

--- a/src/features/model/components/provider-custom-models.tsx
+++ b/src/features/model/components/provider-custom-models.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from "react-i18next"
 
 import { SettingsFormField } from "@/components/settings"
 import { ModelIdListEditor } from "@/features/model/components/model-id-list-editor"
-import type { ProviderConfig } from "@/lib/providers/types"
+import type { ProviderDraft } from "@/features/model/types/provider-draft"
 
 interface ProviderCustomModelsProps {
-  activeConfig: ProviderConfig
+  activeConfig: ProviderDraft
   onChange: (customModels: string[]) => void | Promise<void>
 }
 

--- a/src/features/model/components/provider-grid.tsx
+++ b/src/features/model/components/provider-grid.tsx
@@ -38,7 +38,7 @@ const getStatusDotClass = (
   "bg-status-warning"
 
 export interface ProviderGridProps {
-  providers: ProviderConfig[]
+  providers: Array<Omit<ProviderConfig, "apiKey">>
   selectedId: string
   providerHealth: ProviderHealthMap
   manualTestStatus: { success: boolean; message: string } | null

--- a/src/features/model/hooks/__tests__/use-provider-settings-state.test.ts
+++ b/src/features/model/hooks/__tests__/use-provider-settings-state.test.ts
@@ -30,7 +30,8 @@ const ollama = {
   type: ProviderType.OLLAMA,
   enabled: true,
   baseUrl: "http://localhost:11434",
-  hasApiKey: false
+  hasApiKey: false,
+  apiKey: { state: "unchanged" as const }
 }
 
 const custom = {
@@ -39,7 +40,8 @@ const custom = {
   type: ProviderType.OPENAI,
   enabled: true,
   baseUrl: "https://example.test/v1",
-  hasApiKey: false
+  hasApiKey: false,
+  apiKey: { state: "unchanged" as const }
 }
 
 const getMutationTarget = (request: unknown) =>
@@ -340,6 +342,48 @@ describe("useProviderSettingsState", () => {
       "trustedrouter/cheap"
     ])
     expect(result.current.hasUnsavedChanges).toBe(false)
+  })
+
+  it("sends explicit replace and clear intents for API-key edits", async () => {
+    vi.mocked(extensionRpcClient.call).mockImplementation(
+      async (method, request) => {
+        if (method === RpcMethod.ProvidersList) {
+          return { providers: [custom] } as never
+        }
+        if (method === RpcMethod.ProvidersUpsert) {
+          const config = request as { config: { apiKey: { state: string } } }
+          return {
+            provider: {
+              ...custom,
+              hasApiKey: config.config.apiKey.state !== "cleared"
+            }
+          } as never
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }
+    )
+
+    const { result } = renderHook(() => useProviderSettingsState())
+    await waitFor(() => expect(result.current.providers).toHaveLength(1))
+    await act(async () => result.current.setSelectedId(custom.id))
+
+    act(() => result.current.updateConfig({ apiKey: "replacement" }))
+    const replacementDraft = result.current.activeConfig
+    if (!replacementDraft) throw new Error("Expected an active provider")
+    await act(async () => result.current.handleSave(replacementDraft))
+    act(() => result.current.updateConfig({ apiKey: "" }))
+    const clearedDraft = result.current.activeConfig
+    if (!clearedDraft) throw new Error("Expected an active provider")
+    await act(async () => result.current.handleSave(clearedDraft))
+
+    const configs = vi
+      .mocked(extensionRpcClient.call)
+      .mock.calls.filter(([method]) => method === RpcMethod.ProvidersUpsert)
+      .map(([, request]) => (request as { config: { apiKey: unknown } }).config)
+    expect(configs.map(({ apiKey }) => apiKey)).toEqual([
+      { state: "replaced", value: "replacement" },
+      { state: "cleared" }
+    ])
   })
 
   it("flushes pending edits before enabling another provider", async () => {

--- a/src/features/model/hooks/use-provider-health.ts
+++ b/src/features/model/hooks/use-provider-health.ts
@@ -40,7 +40,7 @@ const HEALTH_CHECK_INTERVAL_MS = 60_000
  * signal for "the set of providers changed".
  */
 const healthSignature = (
-  providers: ProviderConfig[],
+  providers: Array<Omit<ProviderConfig, "apiKey">>,
   savedRevision: number
 ): string =>
   [
@@ -63,7 +63,7 @@ const healthSignature = (
  * a settings tab left open in a window nobody is looking at costs nothing.
  */
 export const useProviderHealth = (
-  providers: ProviderConfig[],
+  providers: Array<Omit<ProviderConfig, "apiKey">>,
   savedRevision = 0
 ): ProviderHealthMap => {
   const [health, setHealth] = useState<ProviderHealthMap>({})

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -1,4 +1,4 @@
-import type { PublicProviderConfig } from "@ollama-client/contracts/provider-rpc"
+import type { ProviderDraftInput } from "@ollama-client/contracts/provider-rpc"
 import { RpcMethod } from "@ollama-client/contracts/rpc"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -14,12 +14,16 @@ import {
 import {
   type CustomProviderWire,
   isCustomProviderId,
-  type ProviderConfig,
   ProviderId,
-  ProviderServiceProfile,
-  ProviderType
+  type ProviderServiceProfile
 } from "@/lib/providers/types"
 import { extensionRpcClient } from "@/protocol/extension-client"
+import {
+  type ProviderDraft,
+  type ProviderDraftUpdate,
+  providerDraftFromPublic,
+  providerDraftHasUsableApiKey
+} from "../types/provider-draft"
 import { useProviderHealth } from "./use-provider-health"
 
 const LOCAL_PROVIDER_IDS = [
@@ -27,47 +31,6 @@ const LOCAL_PROVIDER_IDS = [
   ProviderId.LM_STUDIO,
   ProviderId.LLAMA_CPP
 ]
-
-type ProviderSettingsConfig = ProviderConfig & {
-  hasApiKey?: boolean
-}
-
-const toSettingsConfig = (
-  provider: PublicProviderConfig
-): ProviderSettingsConfig => ({
-  id: provider.id,
-  type:
-    provider.type === "ollama"
-      ? ProviderType.OLLAMA
-      : provider.type === "openai"
-        ? ProviderType.OPENAI
-        : provider.type === "anthropic"
-          ? ProviderType.ANTHROPIC
-          : ProviderType.CUSTOM,
-  enabled: provider.enabled,
-  name: provider.name,
-  hasApiKey: provider.hasApiKey,
-  ...(provider.baseUrl !== undefined ? { baseUrl: provider.baseUrl } : {}),
-  ...(provider.modelId !== undefined ? { modelId: provider.modelId } : {}),
-  ...(provider.customModels !== undefined
-    ? { customModels: provider.customModels }
-    : {}),
-  ...(provider.serviceProfile !== undefined
-    ? {
-        serviceProfile:
-          provider.serviceProfile === "openai"
-            ? ProviderServiceProfile.OPENAI
-            : provider.serviceProfile === "anthropic"
-              ? ProviderServiceProfile.ANTHROPIC
-              : provider.serviceProfile === "openrouter"
-                ? ProviderServiceProfile.OPENROUTER
-                : ProviderServiceProfile.GENERIC
-      }
-    : {}),
-  ...(provider.compatibility !== undefined
-    ? { compatibility: provider.compatibility }
-    : {})
-})
 
 const isLocalhostEndpoint = (baseUrl?: string) => {
   const url = baseUrl?.trim()
@@ -101,7 +64,7 @@ const getCspCompatibilityHint = (baseUrl?: string) => {
 
 export const useProviderSettingsState = () => {
   const { t } = useTranslation()
-  const [providers, setProviders] = useState<ProviderSettingsConfig[]>([])
+  const [providers, setProviders] = useState<ProviderDraft[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedId, setSelectedIdState] = useState<string>(DEFAULT_PROVIDER_ID)
   const [testingConnection, setTestingConnection] = useState(false)
@@ -110,9 +73,6 @@ export const useProviderSettingsState = () => {
     message: string
   } | null>(null)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
-  const [apiKeyEditedProviderIds, setApiKeyEditedProviderIds] = useState<
-    Set<string>
-  >(new Set())
   // Incremented synchronously for every local edit. An RPC response may update
   // local state only when the provider still has the revision it started with.
   const configRevisions = useRef(new Map<string, number>())
@@ -134,7 +94,7 @@ export const useProviderSettingsState = () => {
         RpcMethod.ProvidersList,
         {}
       )
-      setProviders(data.map(toSettingsConfig))
+      setProviders(data.map(providerDraftFromPublic))
     } catch (error) {
       logger.error("Failed to load providers", "ProviderSettings", { error })
     } finally {
@@ -165,20 +125,26 @@ export const useProviderSettingsState = () => {
   const isRemoteEndpoint =
     Boolean(activeConfig?.baseUrl?.trim()) &&
     !isLocalhostEndpoint(activeConfig?.baseUrl)
-  const apiKeyWasEdited = activeConfig
-    ? apiKeyEditedProviderIds.has(String(activeConfig.id))
-    : false
-
   const configForRpc = useCallback(
-    (config: ProviderSettingsConfig): ProviderConfig => {
-      const { hasApiKey: _hasApiKey, ...withoutPublicMarker } = config
-      if (apiKeyEditedProviderIds.has(String(config.id))) {
-        return withoutPublicMarker
-      }
-      const { apiKey: _apiKey, ...publicConfig } = withoutPublicMarker
-      return publicConfig as ProviderConfig
-    },
-    [apiKeyEditedProviderIds]
+    (config: ProviderDraft): ProviderDraftInput => ({
+      id: String(config.id),
+      type: config.type,
+      enabled: config.enabled,
+      name: config.name,
+      apiKey: config.apiKey,
+      ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl } : {}),
+      ...(config.modelId !== undefined ? { modelId: config.modelId } : {}),
+      ...(config.customModels !== undefined
+        ? { customModels: config.customModels }
+        : {}),
+      ...(config.serviceProfile !== undefined
+        ? { serviceProfile: config.serviceProfile }
+        : {}),
+      ...(config.compatibility !== undefined
+        ? { compatibility: config.compatibility }
+        : {})
+    }),
+    []
   )
 
   const handleTestConnection = async () => {
@@ -200,8 +166,7 @@ export const useProviderSettingsState = () => {
       providerProfileRequiresApiKey(
         resolveProviderServiceProfile(activeConfig)
       ) &&
-      !activeConfig.apiKey?.trim() &&
-      (!activeConfig.hasApiKey || apiKeyWasEdited)
+      !providerDraftHasUsableApiKey(activeConfig)
     ) {
       const message = t("settings.providers.test_connection.api_key_required", {
         name: activeConfig.name
@@ -321,7 +286,7 @@ export const useProviderSettingsState = () => {
 
   const persistConfig = useCallback(
     async (
-      config: ProviderSettingsConfig,
+      config: ProviderDraft,
       showSuccessToast = true,
       showErrorToast = true
     ): Promise<boolean> => {
@@ -347,14 +312,11 @@ export const useProviderSettingsState = () => {
         }
         setProviders((prev) =>
           prev.map((provider) =>
-            provider.id === config.id ? toSettingsConfig(saved) : provider
+            provider.id === config.id
+              ? providerDraftFromPublic(saved)
+              : provider
           )
         )
-        setApiKeyEditedProviderIds((previous) => {
-          const next = new Set(previous)
-          next.delete(providerId)
-          return next
-        })
         setHasUnsavedChanges(false)
         // The stored endpoint may now be somewhere else, so the health entry
         // describing the previous one is out of date as of this line.
@@ -402,7 +364,7 @@ export const useProviderSettingsState = () => {
     [activeConfig, hasUnsavedChanges, persistConfig, selectedId]
   )
 
-  const handleSave = async (config: ProviderConfig) => {
+  const handleSave = async (config: ProviderDraft) => {
     await persistConfig(config, true)
   }
 
@@ -431,7 +393,7 @@ export const useProviderSettingsState = () => {
       // that may have started before another pending save completed.
       setProviders((current) => [
         ...current.filter((provider) => provider.id !== config.id),
-        toSettingsConfig(config)
+        providerDraftFromPublic(config)
       ])
       setSelectedIdState(String(config.id))
       markSaved()
@@ -493,19 +455,25 @@ export const useProviderSettingsState = () => {
     }
   }
 
-  const updateConfig = (updates: Partial<ProviderConfig>) => {
+  const updateConfig = (updates: ProviderDraftUpdate) => {
     if (!activeConfig) return
     const providerId = String(activeConfig.id)
     configRevisions.current.set(
       providerId,
       (configRevisions.current.get(providerId) ?? 0) + 1
     )
-    if (Object.hasOwn(updates, "apiKey")) {
-      setApiKeyEditedProviderIds((previous) =>
-        new Set(previous).add(String(activeConfig.id))
-      )
+    const { apiKey, ...configUpdates } = updates
+    const updated: ProviderDraft = {
+      ...activeConfig,
+      ...configUpdates,
+      ...(Object.hasOwn(updates, "apiKey")
+        ? {
+            apiKey: apiKey
+              ? { state: "replaced", value: apiKey }
+              : { state: "cleared" }
+          }
+        : {})
     }
-    const updated = { ...activeConfig, ...updates }
     setProviders((prev) =>
       prev.map((p) => (p.id === activeConfig.id ? updated : p))
     )
@@ -553,7 +521,7 @@ export const useProviderSettingsState = () => {
       setProviders((prev) =>
         prev.map((provider) =>
           String(provider.id) === providerId
-            ? toSettingsConfig(saved)
+            ? providerDraftFromPublic(saved)
             : provider
         )
       )

--- a/src/features/model/types/provider-draft.ts
+++ b/src/features/model/types/provider-draft.ts
@@ -1,0 +1,78 @@
+import type { PublicProviderConfig } from "@ollama-client/contracts/provider-rpc"
+import {
+  type OpenAICompatibilityOptions,
+  ProviderServiceProfile,
+  ProviderType
+} from "@/lib/providers/types"
+
+export type ProviderApiKeyDraft =
+  | { state: "unchanged" }
+  | { state: "replaced"; value: string }
+  | { state: "cleared" }
+
+/** Credential-safe editable provider state owned by the settings UI. */
+export interface ProviderDraft {
+  id: string
+  type: ProviderType
+  enabled: boolean
+  baseUrl?: string
+  modelId?: string
+  name: string
+  customModels?: string[]
+  serviceProfile?: ProviderServiceProfile
+  compatibility?: OpenAICompatibilityOptions
+  hasApiKey: boolean
+  apiKey: ProviderApiKeyDraft
+}
+
+export type ProviderDraftUpdate = Partial<Omit<ProviderDraft, "apiKey">> & {
+  apiKey?: string
+}
+
+export const providerDraftFromPublic = (
+  provider: PublicProviderConfig
+): ProviderDraft => ({
+  id: provider.id,
+  type:
+    provider.type === "ollama"
+      ? ProviderType.OLLAMA
+      : provider.type === "openai"
+        ? ProviderType.OPENAI
+        : provider.type === "anthropic"
+          ? ProviderType.ANTHROPIC
+          : ProviderType.CUSTOM,
+  enabled: provider.enabled,
+  name: provider.name,
+  hasApiKey: provider.hasApiKey,
+  apiKey: { state: "unchanged" },
+  ...(provider.baseUrl !== undefined ? { baseUrl: provider.baseUrl } : {}),
+  ...(provider.modelId !== undefined ? { modelId: provider.modelId } : {}),
+  ...(provider.customModels !== undefined
+    ? { customModels: provider.customModels }
+    : {}),
+  ...(provider.serviceProfile !== undefined
+    ? {
+        serviceProfile:
+          provider.serviceProfile === "openai"
+            ? ProviderServiceProfile.OPENAI
+            : provider.serviceProfile === "anthropic"
+              ? ProviderServiceProfile.ANTHROPIC
+              : provider.serviceProfile === "openrouter"
+                ? ProviderServiceProfile.OPENROUTER
+                : ProviderServiceProfile.GENERIC
+      }
+    : {}),
+  ...(provider.compatibility !== undefined
+    ? { compatibility: provider.compatibility }
+    : {})
+})
+
+export const providerDraftApiKeyValue = (draft: ProviderDraft): string =>
+  draft.apiKey.state === "replaced" ? draft.apiKey.value : ""
+
+export const providerDraftHasUsableApiKey = (draft: ProviderDraft): boolean => {
+  if (draft.apiKey.state === "replaced")
+    return Boolean(draft.apiKey.value.trim())
+  if (draft.apiKey.state === "cleared") return false
+  return draft.hasApiKey
+}

--- a/src/lib/providers/__tests__/provider-rpc-service.test.ts
+++ b/src/lib/providers/__tests__/provider-rpc-service.test.ts
@@ -50,7 +50,10 @@ vi.mock("../factory", () => ({
   }
 }))
 
-import { ProvidersListResultSchema } from "@ollama-client/contracts/provider-rpc"
+import {
+  type ProviderDraftInput,
+  ProvidersListResultSchema
+} from "@ollama-client/contracts/provider-rpc"
 import { createAppError } from "@/lib/error-utils"
 import {
   clearModelCatalogSupport,
@@ -80,6 +83,14 @@ const configs: ProviderConfig[] = [
     name: "Remote"
   }
 ]
+
+const draft = (
+  config: ProviderConfig,
+  apiKey: ProviderDraftInput["apiKey"] = { state: "unchanged" }
+): ProviderDraftInput => {
+  const { apiKey: _storedSecret, ...publicConfig } = config
+  return { ...publicConfig, apiKey }
+}
 
 const model = (name: string) => ({
   name,
@@ -172,7 +183,7 @@ describe("ProviderRpcService", () => {
   it("tests an unsaved draft without returning its credential", async () => {
     const result = await ProviderRpcService.testConnection({
       target: "draft",
-      config: configs[0]
+      config: draft(configs[0])
     })
 
     expect(mocks.getProviderWithConfig).toHaveBeenCalledWith(configs[0])
@@ -204,7 +215,10 @@ describe("ProviderRpcService", () => {
     })
 
     await expect(
-      ProviderRpcService.testConnection({ target: "draft", config: configs[0] })
+      ProviderRpcService.testConnection({
+        target: "draft",
+        config: draft(configs[0])
+      })
     ).resolves.toMatchObject({
       providerId: "ollama",
       reachable: true,
@@ -241,7 +255,10 @@ describe("ProviderRpcService", () => {
     })
 
     await expect(
-      ProviderRpcService.testConnection({ target: "draft", config: configs[0] })
+      ProviderRpcService.testConnection({
+        target: "draft",
+        config: draft(configs[0])
+      })
     ).rejects.toMatchObject({
       status: 502,
       code: "OLC-PROVIDER-UNREACHABLE",
@@ -278,7 +295,7 @@ describe("ProviderRpcService", () => {
 
       const pending = ProviderRpcService.testConnection({
         target: "draft",
-        config: configs[0]
+        config: draft(configs[0])
       })
       const rejects = expect(pending).rejects.toMatchObject({
         status: 504,
@@ -305,7 +322,10 @@ describe("ProviderRpcService", () => {
     // A mistyped base URL 404s on the catalog exactly like a chat-only gateway
     // does; only the chat endpoint tells them apart.
     await expect(
-      ProviderRpcService.testConnection({ target: "draft", config: configs[0] })
+      ProviderRpcService.testConnection({
+        target: "draft",
+        config: draft(configs[0])
+      })
     ).rejects.toMatchObject({
       status: 404,
       userMessage: expect.stringContaining("Check the base URL")
@@ -380,7 +400,7 @@ describe("ProviderRpcService", () => {
 
     const result = await ProviderRpcService.testConnection({
       target: "draft",
-      config: configs[0]
+      config: draft(configs[0])
     })
 
     // Pressing Test is a deliberate re-check: a server that gained the endpoint
@@ -419,18 +439,20 @@ describe("ProviderRpcService", () => {
     })
 
     await expect(
-      ProviderRpcService.testConnection({ target: "draft", config: configs[0] })
+      ProviderRpcService.testConnection({
+        target: "draft",
+        config: draft(configs[0])
+      })
     ).rejects.toMatchObject({ status: 401 })
   })
 
   it("keeps a stored credential background-only when testing an edited draft", async () => {
     await ProviderRpcService.testConnection({
       target: "draft",
-      config: {
-        ...configs[0],
-        apiKey: undefined,
-        baseUrl: "https://edited.example.test/v1"
-      }
+      config: draft(
+        { ...configs[0], baseUrl: "https://edited.example.test/v1" },
+        { state: "unchanged" }
+      )
     })
 
     expect(mocks.getProviderWithConfig).toHaveBeenCalledWith(
@@ -444,7 +466,7 @@ describe("ProviderRpcService", () => {
   it("does not restore a stored credential after the user explicitly clears it", async () => {
     await ProviderRpcService.testConnection({
       target: "draft",
-      config: { ...configs[0], apiKey: "" }
+      config: draft(configs[0], { state: "cleared" })
     })
 
     expect(mocks.getProviderWithConfig).toHaveBeenCalledWith(
@@ -552,6 +574,27 @@ describe("ProviderRpcService", () => {
       ProviderRpcService.remove({ providerId: "custom:openai:new" })
     ).resolves.toEqual({ removedProviderId: "custom:openai:new" })
     expect(mocks.removeCustomProvider).toHaveBeenCalledWith("custom:openai:new")
+  })
+
+  it("applies explicit credential intent when updating a provider", async () => {
+    await ProviderRpcService.upsert({
+      target: "existing",
+      config: draft(configs[0])
+    })
+    await ProviderRpcService.upsert({
+      target: "existing",
+      config: draft(configs[0], { state: "replaced", value: "new-key" })
+    })
+    await ProviderRpcService.upsert({
+      target: "existing",
+      config: draft(configs[0], { state: "cleared" })
+    })
+
+    expect(mocks.updateProviderConfig.mock.calls).toEqual([
+      ["ollama", expect.objectContaining({ apiKey: "private-key" })],
+      ["ollama", expect.objectContaining({ apiKey: "new-key" })],
+      ["ollama", expect.objectContaining({ apiKey: "" })]
+    ])
   })
 
   it("toggles enabled with a partial update so stored credentials survive", async () => {

--- a/src/lib/providers/provider-rpc-service.ts
+++ b/src/lib/providers/provider-rpc-service.ts
@@ -1,5 +1,6 @@
 import {
   MODEL_DISCOVERY_FAILURE,
+  type ProviderDraftInput,
   type ProvidersIconsResult,
   type ProvidersListModelsRequest,
   type ProvidersListModelsResult,
@@ -40,7 +41,72 @@ import {
   isFaviconLookupEnabled,
   resolveProviderFavicon
 } from "./provider-favicon"
-import type { LLMProvider, ProviderConfig } from "./types"
+import {
+  type LLMProvider,
+  type ProviderConfig,
+  ProviderServiceProfile,
+  ProviderType
+} from "./types"
+
+const providerTypeFromDraft = (
+  type: ProviderDraftInput["type"]
+): ProviderType => {
+  switch (type) {
+    case "ollama":
+      return ProviderType.OLLAMA
+    case "openai":
+      return ProviderType.OPENAI
+    case "anthropic":
+      return ProviderType.ANTHROPIC
+    case "custom":
+      return ProviderType.CUSTOM
+  }
+}
+
+const serviceProfileFromDraft = (
+  profile: ProviderDraftInput["serviceProfile"]
+): ProviderServiceProfile | undefined => {
+  switch (profile) {
+    case "generic":
+      return ProviderServiceProfile.GENERIC
+    case "openai":
+      return ProviderServiceProfile.OPENAI
+    case "anthropic":
+      return ProviderServiceProfile.ANTHROPIC
+    case "openrouter":
+      return ProviderServiceProfile.OPENROUTER
+    case undefined:
+      return undefined
+  }
+}
+
+const providerConfigFromDraft = (
+  draft: ProviderDraftInput,
+  stored?: ProviderConfig
+): ProviderConfig => ({
+  id: draft.id,
+  type: providerTypeFromDraft(draft.type),
+  enabled: draft.enabled,
+  name: draft.name,
+  ...(draft.baseUrl !== undefined ? { baseUrl: draft.baseUrl } : {}),
+  ...(draft.modelId !== undefined ? { modelId: draft.modelId } : {}),
+  ...(draft.customModels !== undefined
+    ? { customModels: draft.customModels }
+    : {}),
+  ...(serviceProfileFromDraft(draft.serviceProfile) !== undefined
+    ? { serviceProfile: serviceProfileFromDraft(draft.serviceProfile) }
+    : {}),
+  ...(draft.compatibility !== undefined
+    ? { compatibility: draft.compatibility }
+    : {}),
+  ...(draft.apiKey.state === "replaced"
+    ? { apiKey: draft.apiKey.value }
+    : draft.apiKey.state === "cleared"
+      ? { apiKey: "" }
+      : stored?.apiKey !== undefined
+        ? { apiKey: stored.apiKey }
+        : {})
+})
 
 const toPublicConfig = (config: ProviderConfig): PublicProviderConfig => {
   return {
@@ -327,17 +393,11 @@ export const ProviderRpcService = {
     const resolved =
       request.target === "draft"
         ? await (async () => {
-            const draft = request.config as ProviderConfig
             const stored =
-              draft.apiKey === undefined
-                ? await ProviderManager.getProviderConfig(String(draft.id))
+              request.config.apiKey.state === "unchanged"
+                ? await ProviderManager.getProviderConfig(request.config.id)
                 : undefined
-            const config = {
-              ...draft,
-              ...(draft.apiKey === undefined && stored?.apiKey
-                ? { apiKey: stored.apiKey }
-                : {})
-            }
+            const config = providerConfigFromDraft(request.config, stored)
             return {
               config,
               provider: await ProviderFactory.getProviderWithConfig(config)
@@ -422,7 +482,7 @@ export const ProviderRpcService = {
     }
     await ProviderManager.updateProviderConfig(
       id,
-      request.config as ProviderConfig
+      providerConfigFromDraft(request.config, existing)
     )
     const saved = await ProviderManager.getProviderConfig(id)
     if (!saved) {

--- a/src/lib/providers/service-profile.ts
+++ b/src/lib/providers/service-profile.ts
@@ -26,7 +26,7 @@ const STREAM_USAGE_PROVIDER_IDS = new Set<string>([
 ])
 
 export const resolveProviderServiceProfile = (
-  config: ProviderConfig
+  config: Pick<ProviderConfig, "baseUrl" | "serviceProfile" | "type">
 ): ProviderServiceProfile => {
   if (config.serviceProfile) return config.serviceProfile
 


### PR DESCRIPTION
## What changed

- introduce an explicit credential-safe `ProviderDraft` UI shape
- model API-key intent as `unchanged`, `replaced`, or `cleared`
- validate that intent at the provider RPC boundary
- remove widening casts from public provider config to stored secret-bearing config

## Why

The settings UI only receives public provider data, but previously treated it as stored `ProviderConfig`. Missing optional API-key fields implicitly controlled whether a secret survived, which made contract evolution and autosave behavior unsafe.

## Impact

Provider settings behavior stays the same for users, while credential replacement and clearing become explicit and testable.

## Validation

- TypeScript typecheck
- Biome check on changed files
- 63 focused provider contract, RPC, hook, health, and component tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces an explicit credential-safe provider draft boundary and carries API-key mutation intent through provider settings RPCs.
- Adds `unchanged`, `replaced`, and `cleared` credential states to provider contracts.
- Converts public provider configurations into UI-owned drafts without exposing stored secrets.
- Resolves credential intent in the background before connection tests and persistence.
- Narrows provider UI and health interfaces to secret-free configuration shapes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed credential-draft flow.

Explicit credential intents are validated at the RPC boundary and resolve consistently through provider persistence, connection tests, and secret-free UI responses.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/contracts/src/provider-rpc.ts | Adds a strict provider-draft schema and applies it to existing-provider upserts and draft connection tests. |
| src/features/model/types/provider-draft.ts | Defines the credential-safe UI draft shape and conversion and credential-state helpers. |
| src/features/model/hooks/use-provider-settings-state.ts | Replaces implicit API-key edit tracking with explicit draft intents while preserving stale-response and autosave handling. |
| src/lib/providers/provider-rpc-service.ts | Resolves draft credential intent against stored configuration before testing or persisting providers. |
| src/features/model/components/provider-connection-fields.tsx | Adapts the API-key field to display and update the explicit provider draft. |
| src/lib/providers/service-profile.ts | Narrows service-profile resolution to the configuration fields it actually consumes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Provider settings UI
  participant RPC as Provider RPC boundary
  participant Service as ProviderRpcService
  participant Store as ProviderManager / secret store

  Store-->>UI: PublicProviderConfig(hasApiKey only)
  UI->>UI: Create ProviderDraft(apiKey: unchanged)
  UI->>RPC: Upsert or test with explicit key intent
  RPC->>Service: Validated ProviderDraftInput
  Service->>Store: Resolve stored key when unchanged
  Service->>Service: Replace or clear when explicitly requested
  Service->>Store: Persist sanitized provider configuration
  Store-->>UI: PublicProviderConfig without secret
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(providers): add explicit draft ..."](https://github.com/shishir435/ollama-client/commit/3f8466f63531cb380288959ba2e0e3a67c6cd97c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52722619)</sub>

**Context used:**

- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)
- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)

<!-- /greptile_comment -->