### PR TITLE
fix(storage): persist vector cleanup intent

### DIFF
--- a/src/background/__tests__/startup-database-order.test.ts
+++ b/src/background/__tests__/startup-database-order.test.ts
@@ -80,6 +80,9 @@ vi.mock("@/lib/migration/embedding-dimension-migration", () => ({
   runEmbeddingDimensionMigration: (signal?: AbortSignal) =>
     tasks["embedding-migration"].run(signal)
 }))
+vi.mock("@/lib/embeddings/vector-cleanup-receipts", () => ({
+  sweepVectorCleanupReceipts: vi.fn().mockResolvedValue(0)
+}))
 vi.mock("@/lib/repositories/tool-loop-runs", () => ({
   pruneStaleToolLoopRuns: (_olderThan: unknown, signal?: AbortSignal) =>
     tasks["prune-tool-loops"].run(signal)

--- a/src/background/startup.ts
+++ b/src/background/startup.ts
@@ -14,6 +14,7 @@ import {
   STORAGE_KEYS
 } from "@/lib/constants"
 import { recordDiagnosticEvent } from "@/lib/diagnostics/diagnostic-recorder"
+import { sweepVectorCleanupReceipts } from "@/lib/embeddings/vector-cleanup-receipts"
 import { IngestionService } from "@/lib/ingestion/ingestion-service"
 import { logger } from "@/lib/logger"
 import { runEmbeddingDimensionMigration } from "@/lib/migration/embedding-dimension-migration"
@@ -254,6 +255,11 @@ const SCHEMA_STARTUP_TASKS: StartupTask[] = [
  * should not hold up an ingestion job the user is waiting on.
  */
 const WORKFLOW_STARTUP_TASKS: StartupTask[] = [
+  {
+    id: "vector-cleanup-receipts",
+    name: "pending vector cleanup receipts",
+    run: (signal) => sweepVectorCleanupReceipts(signal)
+  },
   {
     id: "tool-loop-prune",
     name: "stale tool-loop checkpoints",

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -7,6 +7,9 @@ vi.mock("@/lib/repositories/chat-history")
 vi.mock("@/lib/embeddings/vector-store", () => ({
   deleteVectors: vi.fn().mockResolvedValue(0)
 }))
+vi.mock("@/lib/embeddings/vector-cleanup-receipts", () => ({
+  sweepVectorCleanupReceipts: vi.fn().mockResolvedValue(0)
+}))
 vi.mock("@/lib/logger", () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() }
 }))

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -7,6 +7,7 @@ import {
   traversePathFromLeafWithFetcher
 } from "@/features/sessions/lib/message-tree"
 import { CHAT_PAGINATION_LIMIT } from "@/lib/constants"
+import { sweepVectorCleanupReceipts } from "@/lib/embeddings/vector-cleanup-receipts"
 import { deleteVectors } from "@/lib/embeddings/vector-store"
 import { imageToStoredFile } from "@/lib/image-utils"
 import { logger } from "@/lib/logger"
@@ -346,15 +347,11 @@ export const createChatSessionMessageActions = (
     } = deleted
     const toDeleteIds = new Set(idsToDelete)
 
-    for (const id of idsToDelete) {
-      deleteVectors({ messageId: id }).catch((error) => {
-        logger.error(
-          "Failed to delete message embeddings",
-          "chatSessionStore",
-          { error, messageId: id }
-        )
+    sweepVectorCleanupReceipts().catch((error) => {
+      logger.error("Failed to sweep message embeddings", "chatSessionStore", {
+        error
       })
-    }
+    })
 
     set((state) => ({
       sessions: state.sessions.map((s) =>

--- a/src/lib/embeddings/__tests__/vector-cleanup-receipts.test.ts
+++ b/src/lib/embeddings/__tests__/vector-cleanup-receipts.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  run: vi.fn(),
+  deleteVectors: vi.fn()
+}))
+
+vi.mock("@/lib/sqlite/db", () => ({ query: mocks.query, run: mocks.run }))
+vi.mock("../vector-store", () => ({ deleteVectors: mocks.deleteVectors }))
+
+import { sweepVectorCleanupReceipts } from "../vector-cleanup-receipts"
+
+describe("vector cleanup receipts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.run.mockResolvedValue(undefined)
+    mocks.deleteVectors.mockResolvedValue(0)
+  })
+
+  it("acknowledges each receipt only after its idempotent vector delete", async () => {
+    mocks.query.mockResolvedValue([
+      { messageId: 11, createdAt: 1 },
+      { messageId: 12, createdAt: 1 }
+    ])
+
+    await expect(sweepVectorCleanupReceipts()).resolves.toBe(2)
+
+    expect(mocks.deleteVectors.mock.calls).toEqual([
+      [{ messageId: 11 }],
+      [{ messageId: 12 }]
+    ])
+    expect(mocks.run.mock.calls).toEqual([
+      ["DELETE FROM vector_cleanup_receipts WHERE messageId = ?", [11]],
+      ["DELETE FROM vector_cleanup_receipts WHERE messageId = ?", [12]]
+    ])
+    expect(mocks.deleteVectors.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.run.mock.invocationCallOrder[0]
+    )
+  })
+
+  it("leaves the receipt pending when Dexie cleanup fails", async () => {
+    mocks.query.mockResolvedValue([{ messageId: 11, createdAt: 1 }])
+    mocks.deleteVectors.mockRejectedValue(new Error("Dexie unavailable"))
+
+    await expect(sweepVectorCleanupReceipts()).rejects.toThrow(
+      "Dexie unavailable"
+    )
+    expect(mocks.run).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/embeddings/vector-cleanup-receipts.ts
+++ b/src/lib/embeddings/vector-cleanup-receipts.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+import { logger } from "@/lib/logger"
+import { query, run } from "@/lib/sqlite/db"
+import { deleteVectors } from "./vector-store"
+
+const VectorCleanupReceiptSchema = z.object({
+  messageId: z.number().int().positive(),
+  createdAt: z.number().int().nonnegative()
+})
+
+const readPendingReceipts = async (): Promise<number[]> => {
+  const rows = await query(
+    `SELECT messageId, createdAt FROM vector_cleanup_receipts
+     ORDER BY createdAt, messageId`
+  )
+  return rows.flatMap((row) => {
+    const parsed = VectorCleanupReceiptSchema.safeParse(row)
+    if (parsed.success) return [parsed.data.messageId]
+    logger.warn("Refused an unreadable vector cleanup receipt", "Embeddings")
+    return []
+  })
+}
+
+/**
+ * Converge derived Dexie vectors with committed SQLite message deletions.
+ * Both deletion and acknowledgement are idempotent, so a worker may restart
+ * between them without losing cleanup intent or harming live messages.
+ */
+export const sweepVectorCleanupReceipts = async (
+  signal?: AbortSignal
+): Promise<number> => {
+  const messageIds = await readPendingReceipts()
+  let completed = 0
+  for (const messageId of messageIds) {
+    signal?.throwIfAborted()
+    await deleteVectors({ messageId })
+    signal?.throwIfAborted()
+    await run("DELETE FROM vector_cleanup_receipts WHERE messageId = ?", [
+      messageId
+    ])
+    completed += 1
+  }
+  return completed
+}

--- a/src/lib/persistence/__tests__/durable-tables.test.ts
+++ b/src/lib/persistence/__tests__/durable-tables.test.ts
@@ -101,6 +101,7 @@ describe("table count verification", () => {
         turn_runs: 0,
         ingestion_runs: 0,
         model_pull_runs: 0,
+        vector_cleanup_receipts: 0,
         chunk_feedback: 0
       })
     ).toEqual([])

--- a/src/lib/persistence/__tests__/migration-verification.test.ts
+++ b/src/lib/persistence/__tests__/migration-verification.test.ts
@@ -83,6 +83,7 @@ const importedTables = {
   turn_runs: 0,
   ingestion_runs: 0,
   model_pull_runs: 0,
+  vector_cleanup_receipts: 0,
   chunk_feedback: 0
 }
 

--- a/src/lib/persistence/durable-tables.ts
+++ b/src/lib/persistence/durable-tables.ts
@@ -13,6 +13,7 @@ export const DURABLE_TABLES = [
   "turn_runs",
   "ingestion_runs",
   "model_pull_runs",
+  "vector_cleanup_receipts",
   "chunk_feedback"
 ] as const
 

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -642,6 +642,9 @@ describe("messages", () => {
     expect(mockedRun.mock.calls).toEqual([
       ["BEGIN IMMEDIATE"],
       ["UPDATE sessions SET currentLeafId = ? WHERE id = ?", [9, "s1"]],
+      [expect.stringContaining("INSERT OR IGNORE"), [10, expect.any(Number)]],
+      [expect.stringContaining("INSERT OR IGNORE"), [11, expect.any(Number)]],
+      [expect.stringContaining("INSERT OR IGNORE"), [12, expect.any(Number)]],
       ["DELETE FROM files WHERE messageId IN (?, ?, ?)", [10, 11, 12]],
       ["DELETE FROM messages WHERE id IN (?, ?, ?)", [10, 11, 12]],
       ["COMMIT"]
@@ -663,6 +666,8 @@ describe("messages", () => {
     })
     expect(mockedRun.mock.calls).toEqual([
       ["BEGIN IMMEDIATE"],
+      [expect.stringContaining("INSERT OR IGNORE"), [10, expect.any(Number)]],
+      [expect.stringContaining("INSERT OR IGNORE"), [11, expect.any(Number)]],
       ["DELETE FROM files WHERE messageId IN (?, ?)", [10, 11]],
       ["DELETE FROM messages WHERE id IN (?, ?)", [10, 11]],
       ["COMMIT"]

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -759,6 +759,14 @@ export const deleteMessageSubtree = async (
       )
     }
     const batches = idBatches(messageIds)
+    const createdAt = Date.now()
+    for (const id of messageIds) {
+      await transaction.run(
+        `INSERT OR IGNORE INTO vector_cleanup_receipts (messageId, createdAt)
+         VALUES (?, ?)`,
+        [id, createdAt]
+      )
+    }
     for (const batch of batches) {
       await transaction.run(
         `DELETE FROM files WHERE messageId IN (${placeholders(batch.length)})`,

--- a/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
+++ b/src/lib/sqlite/migrations/__tests__/migration-runner.test.ts
@@ -68,6 +68,12 @@ vi.mock("../add-model-pull-runs-table", () => ({
   ensureModelPullRunsTable: (db: unknown) => ensureModelPullRunsTable(db)
 }))
 
+const ensureVectorCleanupReceiptsTable = vi.fn()
+vi.mock("../add-vector-cleanup-receipts-table", () => ({
+  ensureVectorCleanupReceiptsTable: (db: unknown) =>
+    ensureVectorCleanupReceiptsTable(db)
+}))
+
 import {
   getSchemaVersion,
   LATEST_SCHEMA_VERSION,
@@ -102,7 +108,8 @@ const makeDb = (
       "prompt_templates",
       "turn_runs",
       "ingestion_runs",
-      "model_pull_runs"
+      "model_pull_runs",
+      "vector_cleanup_receipts"
     ]
   )
   return {
@@ -249,7 +256,7 @@ describe("migration-runner", () => {
 
     const repaired = repairSchemaDrift(db as never)
 
-    expect(repaired).toBe(8)
+    expect(repaired).toBe(9)
     expect(ensureMessagesReplayArtifactColumn).toHaveBeenCalledWith(db)
     expect(ensureMessagesErrorColumn).toHaveBeenCalledWith(db)
     expect(ensureSessionsTagsColumn).toHaveBeenCalledWith(db)
@@ -258,6 +265,7 @@ describe("migration-runner", () => {
     expect(ensureTurnRunsTable).toHaveBeenCalledWith(db)
     expect(ensureIngestionRunsTable).toHaveBeenCalledWith(db)
     expect(ensureModelPullRunsTable).toHaveBeenCalledWith(db)
+    expect(ensureVectorCleanupReceiptsTable).toHaveBeenCalledWith(db)
     expect(ensureMessagesThinkingColumn).not.toHaveBeenCalled()
     expect(getSchemaVersion(db as never)).toBe(LATEST_SCHEMA_VERSION)
   })
@@ -276,5 +284,6 @@ describe("migration-runner", () => {
     expect(ensurePromptTemplatesTable).not.toHaveBeenCalled()
     expect(ensureIngestionRunsTable).not.toHaveBeenCalled()
     expect(ensureModelPullRunsTable).not.toHaveBeenCalled()
+    expect(ensureVectorCleanupReceiptsTable).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/sqlite/migrations/add-vector-cleanup-receipts-table.ts
+++ b/src/lib/sqlite/migrations/add-vector-cleanup-receipts-table.ts
@@ -1,0 +1,16 @@
+import type { MigrationDatabase } from "./database"
+
+export const ensureVectorCleanupReceiptsTable = (
+  db: MigrationDatabase
+): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS vector_cleanup_receipts (
+      messageId INTEGER PRIMARY KEY,
+      createdAt INTEGER NOT NULL
+    )
+  `)
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_vector_cleanup_receipts_createdAt
+    ON vector_cleanup_receipts(createdAt)
+  `)
+}

--- a/src/lib/sqlite/migrations/migration-runner.ts
+++ b/src/lib/sqlite/migrations/migration-runner.ts
@@ -11,6 +11,7 @@ import { ensureSessionsTagsColumn } from "./add-session-tags-column"
 import { ensureMessagesThinkingColumn } from "./add-thinking-column"
 import { ensureToolLoopRunsTable } from "./add-tool-loop-runs-table"
 import { ensureTurnRunsTable } from "./add-turn-runs-table"
+import { ensureVectorCleanupReceiptsTable } from "./add-vector-cleanup-receipts-table"
 import { compactTerminalTurnRequests } from "./compact-terminal-turn-requests"
 import type { MigrationDatabase } from "./database"
 import { renameBuildingContextStatus } from "./rename-building-context-status"
@@ -108,6 +109,11 @@ export const MIGRATIONS: Migration[] = [
     version: 14,
     name: "compact-terminal-turn-requests",
     up: compactTerminalTurnRequests
+  },
+  {
+    version: 15,
+    name: "add-vector-cleanup-receipts-table",
+    up: ensureVectorCleanupReceiptsTable
   }
 ]
 
@@ -158,6 +164,7 @@ const hasTable = (
     | "turn_runs"
     | "ingestion_runs"
     | "model_pull_runs"
+    | "vector_cleanup_receipts"
 ) => {
   const stmt = db.prepare(
     "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
@@ -227,6 +234,10 @@ export const repairSchemaDrift = (db: MigrationDatabase): number => {
     {
       missing: !hasTable(db, "model_pull_runs"),
       apply: () => ensureModelPullRunsTable(db)
+    },
+    {
+      missing: !hasTable(db, "vector_cleanup_receipts"),
+      apply: () => ensureVectorCleanupReceiptsTable(db)
     }
   ]
 

--- a/src/lib/sqlite/schema.ts
+++ b/src/lib/sqlite/schema.ts
@@ -88,6 +88,16 @@ CREATE INDEX IF NOT EXISTS idx_files_sessionId ON files(sessionId);
 CREATE INDEX IF NOT EXISTS idx_files_messageId ON files(messageId);
 CREATE INDEX IF NOT EXISTS idx_tool_loop_runs_sessionId ON tool_loop_runs(sessionId);
 
+-- Cross-store handoff for derived chat vectors. A row is committed with the
+-- SQLite message deletion and acknowledged only after idempotent Dexie cleanup.
+CREATE TABLE IF NOT EXISTS vector_cleanup_receipts (
+  messageId INTEGER PRIMARY KEY,
+  createdAt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_vector_cleanup_receipts_createdAt
+ON vector_cleanup_receipts(createdAt);
+
 -- Durable owner for every submitted turn. Unlike tool_loop_runs, these rows
 -- begin before context building and remain as lifecycle receipts.
 CREATE TABLE IF NOT EXISTS turn_runs (


### PR DESCRIPTION
## What changed

- add a forward-only SQLite migration for durable vector-cleanup receipts
- commit one cleanup receipt per deleted message inside the subtree-deletion transaction
- add an idempotent Dexie sweep that acknowledges receipts only after vector deletion succeeds
- run the sweep immediately after deletion and again during background startup recovery

## Why

SQLite message deletion and Dexie vector deletion cannot share a transaction. The previous best-effort cleanup could be lost if the MV3 worker stopped after SQLite committed but before Dexie finished.

## Impact

Message deletion remains immediate. Orphaned derived vectors now converge after failures or worker restarts without merging SQLite and Dexie ownership.

## Migration

Schema version 15 adds `vector_cleanup_receipts`; fresh databases include the same table in the baseline schema.

## Validation

- TypeScript typecheck
- Biome check on changed files
- 94 focused migration, durable-table, repository, store, cleanup-sweep, and persistence smoke tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces durable SQLite receipts so message-vector cleanup can recover after MV3 worker interruption.

- Adds the receipt table to the baseline schema, forward migration, drift repair, and durable-table verification.
- Records cleanup intent atomically with message-subtree deletion.
- Sweeps receipts after deletion and during background startup, acknowledging each only after Dexie cleanup succeeds.
- Updates focused repository, migration, persistence, startup, store, and sweep tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/persistence/__tests__/migration-verification.test.ts | Updates the successful-import fixture with the new durable table, resolving the previously reported stale-fixture failure. |
| src/lib/persistence/durable-tables.ts | Registers cleanup receipts for migration and import preservation checks. |
| src/lib/repositories/sqlite-chat-history.ts | Persists one cleanup receipt per deleted message within the existing subtree-deletion transaction. |
| src/lib/embeddings/vector-cleanup-receipts.ts | Implements ordered, idempotent vector cleanup and receipt acknowledgement. |
| src/background/startup.ts | Adds receipt recovery to persistence-ready workflow startup. |
| src/lib/sqlite/migrations/migration-runner.ts | Adds schema version 15 and drift repair for the cleanup-receipt table. |
| src/lib/sqlite/schema.ts | Includes cleanup receipts and their created-time index in fresh databases. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Session Store
  participant SQL as SQLite
  participant Sweep as Receipt Sweeper
  participant Dexie as Vector Store
  UI->>SQL: Delete message subtree
  SQL->>SQL: Insert cleanup receipts
  SQL->>SQL: Delete files and messages
  SQL-->>UI: Commit deleted IDs
  UI->>Sweep: Run immediate sweep
  Sweep->>SQL: Read pending receipts
  loop Each receipt
    Sweep->>Dexie: Delete vectors by messageId
    Dexie-->>Sweep: Cleanup succeeds
    Sweep->>SQL: Delete acknowledged receipt
  end
  Note over Sweep,SQL: Startup recovery repeats the idempotent sweep
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(storage): update cleanup fixtures"](https://github.com/shishir435/ollama-client/commit/238896c45b884389ba8c27e5bb5a48c6f1e1f8db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52722747)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)
- Knowledge Base — [Local RAG: File Upload, Chunking, Embedding, and Retrieval](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/knowledge-rag.md)
- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)
- Knowledge Base — [Sessions, Memory, and Prompt Templates](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/sessions-memory.md)
</details>

<!-- /greptile_comment -->