### PR TITLE
fix: decode external response envelopes

### DIFF
--- a/src/lib/providers/__tests__/anthropic.test.ts
+++ b/src/lib/providers/__tests__/anthropic.test.ts
@@ -100,6 +100,41 @@ describe("AnthropicProvider", () => {
     expect(headers["anthropic-version"]).toBe("2023-06-01")
   })
 
+  it("rejects malformed model catalogs with a safe response error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 42 }] }), { status: 200 })
+    )
+
+    await expect(
+      new AnthropicProvider(config).getModels()
+    ).rejects.toMatchObject({
+      message: "Provider returned an invalid model catalog",
+      kind: "provider",
+      phase: "response",
+      userMessage: "Anthropic returned an invalid model list."
+    })
+  })
+
+  it("ignores malformed stream events without crashing the stream", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      streamResponse([
+        "data: null\n\n",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n'
+      ])
+    )
+    const chunks: ChatStreamMessage[] = []
+
+    await new AnthropicProvider(config).streamChat(
+      {
+        model: "claude-sonnet",
+        messages: [{ role: "user", content: "hi" }]
+      },
+      (chunk) => chunks.push(chunk)
+    )
+
+    expect(chunks).toContainEqual(expect.objectContaining({ delta: "ok" }))
+  })
+
   it("maps system, tools, and tool results to native content blocks", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/src/lib/providers/__tests__/contract.test.ts
+++ b/src/lib/providers/__tests__/contract.test.ts
@@ -61,6 +61,7 @@ describe("provider contracts", () => {
       )
       .mockResolvedValueOnce(
         streamResponse([
+          "null\n",
           `${JSON.stringify({ message: { content: "hel" }, done: false })}\n`,
           `${JSON.stringify({
             message: { content: "lo" },
@@ -114,6 +115,24 @@ describe("provider contracts", () => {
     await expect(provider.getModels()).rejects.toThrow("offline")
   })
 
+  it("Ollama rejects malformed model catalogs with a safe response error", async () => {
+    const provider = new OllamaProvider({
+      id: ProviderId.OLLAMA,
+      name: "Ollama",
+      type: ProviderType.OLLAMA,
+      enabled: true,
+      baseUrl: "http://ollama.test"
+    })
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ models: null }))
+
+    await expect(provider.getModels()).rejects.toMatchObject({
+      message: "Provider returned an invalid model catalog",
+      kind: "provider",
+      phase: "response",
+      userMessage: "Ollama returned an invalid model list."
+    })
+  })
+
   it("OpenAI-compatible providers parse model lists and SSE chunks", async () => {
     const providers = [
       new OpenAICompatibleProvider({
@@ -152,6 +171,7 @@ describe("provider contracts", () => {
         .mockResolvedValueOnce(jsonResponse({ data: [{ id: "chat-model" }] }))
         .mockResolvedValueOnce(
           streamResponse([
+            "data: null\n\n",
             `data: ${JSON.stringify({
               choices: [{ delta: { content: "ok" } }]
             })}\n\n`,

--- a/src/lib/providers/__tests__/lm-studio.test.ts
+++ b/src/lib/providers/__tests__/lm-studio.test.ts
@@ -161,6 +161,23 @@ describe("LMStudioProvider.getModels", () => {
       "http://localhost:1234/api/v0/models"
     )
   })
+
+  it("falls back when the LM Studio catalog envelope is malformed", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: 42 }] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: "fallback-7b" }] })
+      } as Response)
+
+    await expect(makeProvider().getModels()).resolves.toEqual([
+      expect.objectContaining({ name: "fallback-7b" })
+    ])
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe("LMStudioProvider.modelLifecycle", () => {

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import {
@@ -13,6 +14,7 @@ import {
   createProviderReplayArtifact,
   getProviderReplayBlocks
 } from "./provider-replay"
+import { decodeProviderJson } from "./response-decoding"
 import { resolveProviderServiceProfile } from "./service-profile"
 import type {
   ChatRequest,
@@ -136,32 +138,71 @@ const mapTool = (tool: ToolDefinition) => ({
   input_schema: tool.parameters
 })
 
-interface AnthropicStreamEvent {
-  type?: string
-  index?: number
-  content_block?: {
-    type?: string
-    id?: string
-    name?: string
-    text?: string
-    thinking?: string
-    signature?: string
-    data?: string
-    input?: Record<string, unknown>
-  }
-  delta?: {
-    type?: string
-    text?: string
-    thinking?: string
-    signature?: string
-    partial_json?: string
-  }
-  message?: {
-    usage?: { input_tokens?: number; output_tokens?: number }
-  }
-  usage?: { input_tokens?: number; output_tokens?: number }
-  error?: { message?: string; type?: string }
-}
+const OptionalString = z.string().optional().catch(undefined)
+const UsageSchema = z
+  .object({
+    input_tokens: z.number().optional().catch(undefined),
+    output_tokens: z.number().optional().catch(undefined)
+  })
+  .passthrough()
+
+const AnthropicStreamEventSchema = z
+  .object({
+    type: z.string().min(1),
+    index: z.number().int().nonnegative().optional().catch(undefined),
+    content_block: z
+      .object({
+        type: OptionalString,
+        id: OptionalString,
+        name: OptionalString,
+        text: OptionalString,
+        thinking: OptionalString,
+        signature: OptionalString,
+        data: OptionalString,
+        input: z.record(z.string(), z.unknown()).optional().catch(undefined)
+      })
+      .passthrough()
+      .optional()
+      .catch(undefined),
+    delta: z
+      .object({
+        type: OptionalString,
+        text: OptionalString,
+        thinking: OptionalString,
+        signature: OptionalString,
+        partial_json: OptionalString
+      })
+      .passthrough()
+      .optional()
+      .catch(undefined),
+    message: z
+      .object({ usage: UsageSchema.optional().catch(undefined) })
+      .passthrough()
+      .optional()
+      .catch(undefined),
+    usage: UsageSchema.optional().catch(undefined),
+    error: z
+      .object({ message: OptionalString, type: OptionalString })
+      .passthrough()
+      .optional()
+      .catch(undefined)
+  })
+  .passthrough()
+type AnthropicStreamEvent = z.infer<typeof AnthropicStreamEventSchema>
+
+const AnthropicModelCatalogSchema = z
+  .object({
+    data: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          display_name: OptionalString,
+          created_at: OptionalString
+        })
+        .passthrough()
+    )
+  })
+  .passthrough()
 
 export class AnthropicProvider implements LLMProvider {
   id: string
@@ -211,28 +252,32 @@ export class AnthropicProvider implements LLMProvider {
       await this.responseError(response)
     }
 
-    const payload = (await response.json()) as {
-      data?: Array<{ id?: string; display_name?: string; created_at?: string }>
-    }
-    return (payload.data ?? [])
-      .filter((model): model is typeof model & { id: string } =>
-        Boolean(model.id)
-      )
-      .map((model) => ({
-        name: model.id,
-        model: model.id,
-        modified_at: model.created_at || new Date().toISOString(),
-        size: 0,
-        digest: model.id,
-        details: {
-          parent_model: "",
-          format: "anthropic",
-          family: "anthropic",
-          families: ["anthropic"],
-          parameter_size: "",
-          quantization_level: ""
-        }
-      }))
+    const payload = await decodeProviderJson(
+      response,
+      AnthropicModelCatalogSchema,
+      {
+        providerId: this.id,
+        providerName: this.config.name,
+        baseUrl: this.baseUrl,
+        label: "model catalog",
+        userMessage: "Anthropic returned an invalid model list."
+      }
+    )
+    return payload.data.map((model) => ({
+      name: model.id,
+      model: model.id,
+      modified_at: model.created_at || new Date().toISOString(),
+      size: 0,
+      digest: model.id,
+      details: {
+        parent_model: "",
+        format: "anthropic",
+        family: "anthropic",
+        families: ["anthropic"],
+        parameter_size: "",
+        quantization_level: ""
+      }
+    }))
   }
 
   async streamChat(
@@ -429,7 +474,17 @@ export class AnthropicProvider implements LLMProvider {
       if (!trimmed.startsWith("data: ")) return
       let event: AnthropicStreamEvent
       try {
-        event = JSON.parse(trimmed.slice(6)) as AnthropicStreamEvent
+        const parsed = AnthropicStreamEventSchema.safeParse(
+          JSON.parse(trimmed.slice(6))
+        )
+        if (!parsed.success) {
+          logger.warn(
+            "Ignored invalid Anthropic SSE event",
+            "AnthropicProvider"
+          )
+          return
+        }
+        event = parsed.data
       } catch (error) {
         logger.warn(
           "Failed to parse Anthropic SSE event",

--- a/src/lib/providers/lm-studio.ts
+++ b/src/lib/providers/lm-studio.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { logger } from "@/lib/logger"
 import type { ProviderModel } from "@/types"
 import { resolveProviderBaseUrl } from "./base-url"
@@ -8,7 +9,26 @@ import {
   normalizeLmStudioLoadedModel
 } from "./model-lifecycle"
 import { OpenAICompatibleProvider } from "./openai-compatible"
+import { decodeProviderJson } from "./response-decoding"
 import { type EmbeddingSupport, type ProviderConfig, ProviderId } from "./types"
+
+const OptionalString = z.string().optional().catch(undefined)
+const LMStudioModelCatalogSchema = z
+  .object({
+    data: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          type: OptionalString,
+          arch: OptionalString,
+          quantization: OptionalString,
+          max_context_length: z.number().positive().optional().catch(undefined),
+          capabilities: z.array(z.string()).optional().catch(undefined)
+        })
+        .passthrough()
+    )
+  })
+  .passthrough()
 
 /**
  * Specialized provider for LM Studio specific metadata.
@@ -78,18 +98,17 @@ export class LMStudioProvider extends OpenAICompatibleProvider {
 
       if (!response.ok) return super.getModels(signal)
 
-      const json = await response.json()
-      const data = json.data as Array<{
-        id: string
-        object: string
-        type: string
-        publisher: string
-        arch: string
-        quantization?: string
-        max_context_length?: number
-        /** e.g. ["tool_use"]. Absent on older LM Studio builds. */
-        capabilities?: string[]
-      }>
+      const { data } = await decodeProviderJson(
+        response,
+        LMStudioModelCatalogSchema,
+        {
+          providerId: this.id,
+          providerName: this.config.name,
+          baseUrl: apiBase,
+          label: "LM Studio model catalog",
+          userMessage: "LM Studio returned an invalid model list."
+        }
+      )
 
       return data.map((m) => ({
         name: m.id,

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import {
@@ -21,6 +22,7 @@ import {
   lifecycleRequestFailed,
   normalizeOllamaLoadedModel
 } from "./model-lifecycle"
+import { decodeProviderJson } from "./response-decoding"
 import {
   type ChatRequest,
   type EmbeddingSupport,
@@ -36,6 +38,52 @@ import {
  * metadata at all cannot turn one list request into dozens.
  */
 const OLLAMA_DETAIL_BACKFILL_LIMIT = 12
+
+const OptionalString = z.string().optional().catch(undefined)
+const OllamaModelCatalogSchema = z
+  .object({
+    models: z.array(
+      z
+        .object({
+          name: z.string().min(1),
+          model: OptionalString,
+          modified_at: OptionalString,
+          size: z.number().nonnegative().optional().catch(undefined),
+          digest: OptionalString,
+          details: z
+            .object({
+              parent_model: OptionalString,
+              format: OptionalString,
+              family: OptionalString,
+              families: z.array(z.string()).optional().catch(undefined),
+              parameter_size: OptionalString,
+              quantization_level: OptionalString
+            })
+            .passthrough()
+            .optional()
+            .catch(undefined)
+        })
+        .passthrough()
+        .transform(
+          (model): ProviderModel => ({
+            ...model,
+            model: model.model ?? model.name,
+            modified_at: model.modified_at ?? "",
+            size: model.size ?? 0,
+            digest: model.digest ?? "",
+            details: {
+              parent_model: model.details?.parent_model ?? "",
+              format: model.details?.format ?? "",
+              family: model.details?.family ?? "",
+              families: model.details?.families ?? [],
+              parameter_size: model.details?.parameter_size ?? "",
+              quantization_level: model.details?.quantization_level ?? ""
+            }
+          })
+        )
+    )
+  })
+  .passthrough()
 
 /**
  * Remembers backfilled details so a repeated model list costs no extra requests.
@@ -162,8 +210,17 @@ export class OllamaProvider implements LLMProvider {
           }
         )
       }
-      const data = await response.json()
-      const models = (data.models as ProviderModel[]) || []
+      const { models } = await decodeProviderJson(
+        response,
+        OllamaModelCatalogSchema,
+        {
+          providerId: this.id,
+          providerName: this.config.name,
+          baseUrl,
+          label: "model catalog",
+          userMessage: "Ollama returned an invalid model list."
+        }
+      )
       return await this.backfillMissingDetails(models, signal)
     } catch (e) {
       if (!signal?.aborted) {
@@ -425,7 +482,12 @@ export class OllamaProvider implements LLMProvider {
         eval_duration?: number
       }
       try {
-        data = JSON.parse(line)
+        const parsed = JSON.parse(line)
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          logger.warn("Ignored invalid stream chunk", "OllamaProvider")
+          return
+        }
+        data = parsed
       } catch (error) {
         logger.warn("Failed to parse chunk", "OllamaProvider", { error })
         return

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -22,6 +22,7 @@ import {
   createProviderReplayArtifact,
   getProviderReplayBlocks
 } from "./provider-replay"
+import { decodeProviderJson } from "./response-decoding"
 import {
   getOpenAIServiceCompatibility,
   resolveProviderServiceProfile
@@ -260,18 +261,18 @@ export class OpenAICompatibleProvider implements LLMProvider {
       if (!response.ok) {
         await this.responseError(response, "Model list failed", baseUrl)
       }
-      const parsed = OpenAIModelCatalogSchema.safeParse(await response.json())
-      if (!parsed.success) {
-        throw createAppError("Provider returned an invalid model catalog", {
-          kind: "provider",
-          phase: "response",
+      const catalog = await decodeProviderJson(
+        response,
+        OpenAIModelCatalogSchema,
+        {
           providerId: this.id,
           providerName: this.config.name,
           baseUrl,
+          label: "model catalog",
           userMessage: "The provider returned an invalid model list."
-        })
-      }
-      return parsed.data.data.map((m) => ({
+        }
+      )
+      return catalog.data.map((m) => ({
         name: m.id,
         model: m.id,
         modified_at: new Date().toISOString(),
@@ -458,7 +459,15 @@ export class OpenAICompatibleProvider implements LLMProvider {
         usage?: { prompt_tokens?: number; completion_tokens?: number }
       }
       try {
-        data = JSON.parse(trimmed.slice(6))
+        const parsed = asRecord(JSON.parse(trimmed.slice(6)))
+        if (!parsed) {
+          logger.warn(
+            "Ignored invalid SSE data event",
+            "OpenAICompatibleProvider"
+          )
+          return null
+        }
+        data = parsed
       } catch (e) {
         logger.warn(
           "Failed to parse SSE data line",
@@ -550,7 +559,15 @@ export class OpenAICompatibleProvider implements LLMProvider {
       }
 
       if (Array.isArray(delta?.tool_calls)) {
-        toolCalls.add(delta.tool_calls as ToolCallFragment[])
+        const fragments = delta.tool_calls.filter(
+          (fragment): fragment is ToolCallFragment =>
+            Boolean(
+              asRecord(fragment) &&
+                Number.isInteger(asRecord(fragment)?.index) &&
+                Number(asRecord(fragment)?.index) >= 0
+            )
+        )
+        toolCalls.add(fragments)
       }
 
       // Most providers set finish_reason "tool_calls" before usage; some
@@ -606,10 +623,9 @@ export class OpenAICompatibleProvider implements LLMProvider {
       if (trimmed === "data: [DONE]") return "done"
       if (!trimmed.startsWith("data: ")) return null
       try {
-        const data = JSON.parse(trimmed.slice(6)) as {
-          choices?: Array<{ finish_reason?: unknown }>
-        }
-        const finishReason = data.choices?.[0]?.finish_reason
+        const data = asRecord(JSON.parse(trimmed.slice(6)))
+        const choices = Array.isArray(data?.choices) ? data.choices : []
+        const finishReason = asRecord(choices[0])?.finish_reason
         return typeof finishReason === "string" && finishReason.length > 0
           ? "finish-reason"
           : null

--- a/src/lib/providers/response-decoding.ts
+++ b/src/lib/providers/response-decoding.ts
@@ -1,0 +1,47 @@
+import type { z } from "zod"
+import { createAppError } from "@/lib/error-utils"
+
+interface ProviderResponseContext {
+  providerId: string
+  providerName?: string
+  baseUrl: string
+  label: string
+  userMessage: string
+}
+
+/** Decode an untrusted provider JSON response without exposing its contents. */
+export const decodeProviderJson = async <T>(
+  response: Response,
+  schema: z.ZodType<T>,
+  context: ProviderResponseContext
+): Promise<T> => {
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw createAppError(
+      `Provider returned invalid JSON for ${context.label}`,
+      {
+        kind: "provider",
+        phase: "response",
+        providerId: context.providerId,
+        providerName: context.providerName,
+        baseUrl: context.baseUrl,
+        userMessage: context.userMessage
+      }
+    )
+  }
+
+  const parsed = schema.safeParse(payload)
+  if (!parsed.success) {
+    throw createAppError(`Provider returned an invalid ${context.label}`, {
+      kind: "provider",
+      phase: "response",
+      providerId: context.providerId,
+      providerName: context.providerName,
+      baseUrl: context.baseUrl,
+      userMessage: context.userMessage
+    })
+  }
+  return parsed.data
+}

--- a/src/lib/tools/web-search/__tests__/backends.test.ts
+++ b/src/lib/tools/web-search/__tests__/backends.test.ts
@@ -268,4 +268,51 @@ describe("web search backends", () => {
       )
     ).rejects.toThrow("Brave search failed with HTTP 500")
   })
+
+  it.each([
+    [
+      "Brave",
+      braveBackend,
+      { provider: "brave" as const, enabled: true, apiKey: "key" }
+    ],
+    [
+      "Tavily",
+      tavilyBackend,
+      { provider: "tavily" as const, enabled: true, apiKey: "key" }
+    ],
+    [
+      "SearXNG",
+      searxngBackend,
+      {
+        provider: "searxng" as const,
+        enabled: true,
+        endpoint: "http://localhost:8080"
+      }
+    ]
+  ])("rejects malformed %s result envelopes", async (name, backend, config) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(null)))
+
+    await expect(backend.search({ query: "test" }, config)).rejects.toThrow(
+      `${name} search returned an invalid response`
+    )
+  })
+
+  it("reports invalid search JSON without exposing response text", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("<html>upstream failure</html>", {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+      )
+    )
+
+    await expect(
+      braveBackend.search(
+        { query: "test" },
+        { provider: "brave", enabled: true, apiKey: "key" }
+      )
+    ).rejects.toThrow("Brave search returned invalid JSON")
+  })
 })

--- a/src/lib/tools/web-search/__tests__/backends.test.ts
+++ b/src/lib/tools/web-search/__tests__/backends.test.ts
@@ -270,6 +270,20 @@ describe("web search backends", () => {
   })
 
   it.each([
+    {},
+    { web: null }
+  ])("treats a missing Brave web section as an empty search", async (payload) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(payload)))
+
+    await expect(
+      braveBackend.search(
+        { query: "no matches" },
+        { provider: "brave", enabled: true, apiKey: "key" }
+      )
+    ).resolves.toEqual([])
+  })
+
+  it.each([
     [
       "Brave",
       braveBackend,

--- a/src/lib/tools/web-search/backends/brave.ts
+++ b/src/lib/tools/web-search/backends/brave.ts
@@ -37,6 +37,8 @@ const BraveResponseSchema = z
         )
       })
       .passthrough()
+      .nullable()
+      .optional()
   })
   .passthrough()
 

--- a/src/lib/tools/web-search/backends/brave.ts
+++ b/src/lib/tools/web-search/backends/brave.ts
@@ -1,27 +1,44 @@
+import { z } from "zod"
 import { BRAVE_SEARCH_ENDPOINT } from "../config"
 import type { WebSearchBackend } from "../types"
 import {
   assertOkResponse,
   clampSearchCount,
+  decodeSearchJson,
   normalizeResult,
   requireApiKey
 } from "./shared"
 
-interface BraveWebResult {
-  title?: string
-  url?: string
-  description?: string
-  extra_snippets?: string[]
-  meta_url?: { hostname?: string }
-  profile?: { name?: string }
-  age?: string
-}
-
-interface BraveResponse {
-  web?: {
-    results?: BraveWebResult[]
-  }
-}
+const OptionalString = z.string().optional().catch(undefined)
+const BraveResponseSchema = z
+  .object({
+    web: z
+      .object({
+        results: z.array(
+          z
+            .object({
+              title: OptionalString,
+              url: OptionalString,
+              description: OptionalString,
+              extra_snippets: z.array(z.string()).optional().catch(undefined),
+              meta_url: z
+                .object({ hostname: OptionalString })
+                .passthrough()
+                .optional()
+                .catch(undefined),
+              profile: z
+                .object({ name: OptionalString })
+                .passthrough()
+                .optional()
+                .catch(undefined),
+              age: OptionalString
+            })
+            .passthrough()
+        )
+      })
+      .passthrough()
+  })
+  .passthrough()
 
 const safeSearchMap = {
   off: "off",
@@ -63,7 +80,7 @@ export const braveBackend: WebSearchBackend = {
       }
     })
     await assertOkResponse(response, "Brave")
-    const data = (await response.json()) as BraveResponse
+    const data = await decodeSearchJson(response, BraveResponseSchema, "Brave")
     return (data.web?.results ?? [])
       .slice(0, count)
       .map((item) =>

--- a/src/lib/tools/web-search/backends/searxng.ts
+++ b/src/lib/tools/web-search/backends/searxng.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import type {
   WebSearchBackend,
   WebSearchProviderConfig,
@@ -7,23 +8,28 @@ import {
   assertOkResponse,
   clampSearchCount,
   clampSearchPages,
+  decodeSearchJson,
   normalizeResult,
   requireEndpoint
 } from "./shared"
 
-interface SearxngResult {
-  title?: string
-  url?: string
-  content?: string
-  publishedDate?: string
-  engine?: string
-  score?: number
-  category?: string
-}
+const OptionalString = z.string().optional().catch(undefined)
+const SearxngResultSchema = z
+  .object({
+    title: OptionalString,
+    url: OptionalString,
+    content: OptionalString,
+    publishedDate: OptionalString,
+    engine: OptionalString,
+    score: z.number().optional().catch(undefined),
+    category: OptionalString
+  })
+  .passthrough()
+type SearxngResult = z.infer<typeof SearxngResultSchema>
 
-interface SearxngResponse {
-  results?: SearxngResult[]
-}
+const SearxngResponseSchema = z
+  .object({ results: z.array(SearxngResultSchema) })
+  .passthrough()
 
 const safeSearchMap = {
   off: "0",
@@ -86,8 +92,12 @@ export const searxngBackend: WebSearchBackend = {
           headers: { Accept: "application/json" }
         })
         await assertOkResponse(response, "SearXNG")
-        const data = (await response.json()) as SearxngResponse
-        return data.results ?? []
+        const data = await decodeSearchJson(
+          response,
+          SearxngResponseSchema,
+          "SearXNG"
+        )
+        return data.results
       })
     )
     const results: SearxngResult[] = pageResults.flat()

--- a/src/lib/tools/web-search/backends/shared.ts
+++ b/src/lib/tools/web-search/backends/shared.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod"
 import type {
   WebSearchConfigValidation,
   WebSearchProviderConfig,
@@ -104,4 +105,24 @@ export const assertOkResponse = async (
   if (response.ok) return
   const message = `${provider} search failed with HTTP ${response.status}`
   throw new Error(message)
+}
+
+/** Decode a search backend response at the network boundary. */
+export const decodeSearchJson = async <T>(
+  response: Response,
+  schema: z.ZodType<T>,
+  provider: string
+): Promise<T> => {
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new Error(`${provider} search returned invalid JSON`)
+  }
+
+  const parsed = schema.safeParse(payload)
+  if (!parsed.success) {
+    throw new Error(`${provider} search returned an invalid response`)
+  }
+  return parsed.data
 }

--- a/src/lib/tools/web-search/backends/tavily.ts
+++ b/src/lib/tools/web-search/backends/tavily.ts
@@ -1,29 +1,30 @@
+import { z } from "zod"
 import { TAVILY_SEARCH_ENDPOINT } from "../config"
 import type { WebSearchBackend } from "../types"
 import {
   assertOkResponse,
   clampSearchCount,
+  decodeSearchJson,
   normalizeResult,
   requireApiKey
 } from "./shared"
 
-interface TavilyResult {
-  title?: string
-  url?: string
-  content?: string
-  raw_content?: string | null
-  published_date?: string
-  score?: number
-}
-
-interface TavilyResponse {
-  query?: string
-  answer?: string
-  images?: unknown[]
-  results?: TavilyResult[]
-  response_time?: number
-  request_id?: string
-}
+const OptionalString = z.string().optional().catch(undefined)
+const TavilyResponseSchema = z
+  .object({
+    results: z.array(
+      z
+        .object({
+          title: OptionalString,
+          url: OptionalString,
+          content: OptionalString,
+          published_date: OptionalString,
+          score: z.number().optional().catch(undefined)
+        })
+        .passthrough()
+    )
+  })
+  .passthrough()
 
 export const tavilyBackend: WebSearchBackend = {
   id: "tavily",
@@ -51,7 +52,11 @@ export const tavilyBackend: WebSearchBackend = {
       })
     })
     await assertOkResponse(response, "Tavily")
-    const data = (await response.json()) as TavilyResponse
+    const data = await decodeSearchJson(
+      response,
+      TavilyResponseSchema,
+      "Tavily"
+    )
     return (data.results ?? [])
       .slice(0, count)
       .map((item) =>


### PR DESCRIPTION
## Summary

- decode provider model catalogs before trusting their shape
- validate Brave, Tavily, and SearXNG result envelopes while tolerating optional metadata drift
- ignore malformed provider stream events and return safe response errors without exposing payload contents
- preserve LM Studio catalog fallback behavior

## Verification

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 2,936 tests passed
- `pnpm build`
- pre-push package, bundle-budget, i18n, and docs checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds schema-based decoding for external provider responses and safely ignores malformed stream events.
- Validates model catalogs for Anthropic, Ollama, LM Studio, and OpenAI-compatible providers.
- Validates Brave, Tavily, and SearXNG response envelopes while preserving Brave’s missing or null `web` fallback.
- Adds sanitized decoding errors and malformed-stream coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/providers/response-decoding.ts | Introduces shared schema-based provider JSON decoding with content-free response errors. |
| src/lib/providers/anthropic.ts | Validates model catalogs and ignores malformed Anthropic stream events. |
| src/lib/providers/ollama.ts | Normalizes validated catalog entries and rejects non-object stream chunks. |
| src/lib/providers/openai-compatible.ts | Uses shared catalog decoding and guards malformed SSE and tool-call fragments. |
| src/lib/providers/lm-studio.ts | Validates the native catalog while retaining OpenAI-compatible fallback behavior. |
| src/lib/tools/web-search/backends/brave.ts | Validates Brave envelopes and now accepts the missing or null `web` cases identified previously. |
| src/lib/tools/web-search/backends/tavily.ts | Validates Tavily result envelopes before normalization. |
| src/lib/tools/web-search/backends/searxng.ts | Validates each SearXNG page response before flattening results. |
| src/lib/tools/web-search/backends/shared.ts | Adds shared search-response decoding with sanitized errors. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23282%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=282&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(search): accept empty Brave response..."](https://github.com/shishir435/ollama-client/commit/1f6a951f081c9902615d8b45d82090974de6ec1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53050469)</sub>

<!-- /greptile_comment -->