### PR TITLE
refactor(chat): centralize turn submission

### DIFF
--- a/src/application/turns/__tests__/prepare-turn-submission.test.ts
+++ b/src/application/turns/__tests__/prepare-turn-submission.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import type { ChatMessage } from "@/types"
+import { prepareTurnSubmission } from "../prepare-turn-submission"
+
+const policy = {
+  id: "turn-1",
+  sessionId: "session-1",
+  model: "llama3",
+  selectedModel: "llama3",
+  selectedModelRef: { providerId: "ollama", modelId: "llama3" },
+  memoryEnabled: true,
+  maxTabContextChars: 4_000,
+  maxRagContextChars: 8_000,
+  createdAt: 123
+}
+
+describe("prepareTurnSubmission", () => {
+  it("builds a new turn with captured tab and file context", () => {
+    const priorMessages: ChatMessage[] = [
+      { id: 1, role: "user", content: "earlier" },
+      { id: 2, role: "assistant", content: "answer", done: true }
+    ]
+    const userMessage: ChatMessage = {
+      role: "user",
+      content: "summarize",
+      images: [
+        {
+          imageId: "image-1",
+          fileName: "chart.png",
+          mimeType: "image/png",
+          size: 1,
+          base64: "AA=="
+        }
+      ]
+    }
+
+    const result = prepareTurnSubmission({
+      ...policy,
+      mode: "new",
+      userMessage,
+      userMessageId: 3,
+      priorMessages,
+      rawInput: "summarize",
+      files: [
+        {
+          text: "file body",
+          metadata: { fileName: "notes.txt", fileId: "file-1" }
+        }
+      ],
+      hasTabContext: true,
+      contextText: "page body",
+      tabDocuments: [{ id: "tab-1", title: "Page", content: "page body" }],
+      groundedOnlyMode: true
+    })
+
+    expect(result).toEqual({
+      submission: {
+        id: "turn-1",
+        sessionId: "session-1",
+        mode: "new",
+        model: "llama3",
+        providerId: "ollama",
+        request: {
+          version: 1,
+          context: {
+            rawInput: "summarize",
+            files: [
+              {
+                text: "file body",
+                metadata: { fileName: "notes.txt", fileId: "file-1" }
+              }
+            ],
+            messages: priorMessages,
+            hasTabContext: true,
+            contextText: "page body",
+            tabDocuments: [
+              { id: "tab-1", title: "Page", content: "page body" }
+            ],
+            groundedOnlyMode: true,
+            memoryEnabled: true,
+            maxTabContextChars: 4_000,
+            maxRagContextChars: 8_000,
+            selectedModel: "llama3",
+            selectedModelRef: {
+              providerId: "ollama",
+              modelId: "llama3"
+            }
+          },
+          userMessage
+        },
+        createdAt: 123
+      },
+      userMessageId: 3
+    })
+  })
+
+  it.each([
+    "regenerate",
+    "fork"
+  ] as const)("builds a %s turn from the last persisted user", (mode) => {
+    const contextMessages: ChatMessage[] = [
+      { id: 1, role: "user", content: "first" },
+      { id: 2, role: "assistant", content: "first answer", done: true },
+      { id: 3, role: "user", content: "again" }
+    ]
+
+    const result = prepareTurnSubmission({
+      ...policy,
+      mode,
+      contextMessages
+    })
+
+    expect(result).toMatchObject({
+      submission: {
+        mode,
+        providerId: "ollama",
+        request: {
+          context: {
+            rawInput: "again",
+            messages: contextMessages.slice(0, 2),
+            hasTabContext: false,
+            contextText: "",
+            tabDocuments: [],
+            groundedOnlyMode: false
+          },
+          userMessage: contextMessages[2]
+        }
+      },
+      userMessageId: 3
+    })
+  })
+
+  it("does not build a replay turn without a persisted user message", () => {
+    expect(
+      prepareTurnSubmission({
+        ...policy,
+        mode: "regenerate",
+        contextMessages: [
+          { id: 1, role: "user", content: "persisted earlier" },
+          { id: 2, role: "assistant", content: "answer" },
+          { role: "user", content: "not persisted" }
+        ]
+      })
+    ).toBeUndefined()
+  })
+})

--- a/src/application/turns/prepare-turn-submission.ts
+++ b/src/application/turns/prepare-turn-submission.ts
@@ -1,0 +1,128 @@
+import type { TurnMode } from "@ollama-client/contracts/turns"
+import type { DurableContextOptions } from "@/application/context/context-contract"
+import type { DurableTurnStart } from "@/application/turns/turn-contract"
+import type { ChatMessage, SelectedModelRef } from "@/types"
+
+interface TurnSubmissionPolicy {
+  id: string
+  sessionId: string
+  model: string
+  selectedModel: string
+  selectedModelRef: SelectedModelRef | null
+  customModel?: string
+  memoryEnabled: boolean
+  maxTabContextChars: number
+  maxRagContextChars: number
+  createdAt: number
+}
+
+export interface PrepareNewTurnSubmissionInput extends TurnSubmissionPolicy {
+  mode: "new"
+  userMessage: ChatMessage
+  userMessageId: number
+  priorMessages: ChatMessage[]
+  rawInput: string
+  files?: DurableContextOptions["files"]
+  hasTabContext: boolean
+  contextText: string
+  tabDocuments: DurableContextOptions["tabDocuments"]
+  groundedOnlyMode: boolean
+}
+
+export interface PrepareReplayTurnSubmissionInput extends TurnSubmissionPolicy {
+  mode: Exclude<TurnMode, "new">
+  contextMessages: ChatMessage[]
+}
+
+export type PrepareTurnSubmissionInput =
+  | PrepareNewTurnSubmissionInput
+  | PrepareReplayTurnSubmissionInput
+
+const replaySource = (
+  messages: ChatMessage[]
+):
+  | { userMessage: ChatMessage & { id: number }; priorMessages: ChatMessage[] }
+  | undefined => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message.role !== "user") continue
+    if (typeof message.id !== "number") return undefined
+    return {
+      userMessage: message as ChatMessage & { id: number },
+      priorMessages: messages.slice(0, index)
+    }
+  }
+  return undefined
+}
+
+export function prepareTurnSubmission(
+  input: PrepareNewTurnSubmissionInput
+): DurableTurnStart
+export function prepareTurnSubmission(
+  input: PrepareReplayTurnSubmissionInput
+): DurableTurnStart | undefined
+export function prepareTurnSubmission(
+  input: PrepareTurnSubmissionInput
+): DurableTurnStart | undefined {
+  const source =
+    input.mode === "new"
+      ? {
+          userMessage: input.userMessage,
+          userMessageId: input.userMessageId,
+          context: {
+            rawInput: input.rawInput,
+            files: input.files,
+            messages: input.priorMessages,
+            hasTabContext: input.hasTabContext,
+            contextText: input.contextText,
+            tabDocuments: input.tabDocuments,
+            groundedOnlyMode: input.groundedOnlyMode
+          }
+        }
+      : (() => {
+          const replay = replaySource(input.contextMessages)
+          if (!replay) return undefined
+          return {
+            userMessage: replay.userMessage,
+            userMessageId: replay.userMessage.id,
+            context: {
+              rawInput: replay.userMessage.content,
+              files: undefined,
+              messages: replay.priorMessages,
+              hasTabContext: false,
+              contextText: "",
+              tabDocuments: [],
+              groundedOnlyMode: false
+            }
+          }
+        })()
+
+  if (!source) return undefined
+
+  const context: DurableContextOptions = {
+    ...source.context,
+    memoryEnabled: input.memoryEnabled,
+    maxTabContextChars: input.maxTabContextChars,
+    maxRagContextChars: input.maxRagContextChars,
+    selectedModel: input.selectedModel,
+    selectedModelRef: input.selectedModelRef,
+    customModel: input.customModel
+  }
+
+  return {
+    submission: {
+      id: input.id,
+      sessionId: input.sessionId,
+      mode: input.mode,
+      model: input.model,
+      providerId: input.selectedModelRef?.providerId,
+      request: {
+        version: 1,
+        context,
+        userMessage: source.userMessage
+      },
+      createdAt: input.createdAt
+    },
+    userMessageId: source.userMessageId
+  }
+}

--- a/src/features/chat/hooks/use-chat-response.ts
+++ b/src/features/chat/hooks/use-chat-response.ts
@@ -4,6 +4,7 @@ import type {
   PromptContextStats,
   RagSources
 } from "@/application/context/build-context"
+import { prepareTurnSubmission } from "@/application/turns/prepare-turn-submission"
 import type { DurableTurnStart } from "@/application/turns/turn-contract"
 import type { useChatConfig } from "@/features/chat/hooks/use-chat-config"
 import type { ChatStreamClaim } from "@/features/chat/hooks/use-chat-stream"
@@ -65,7 +66,7 @@ export const useChatResponse = ({
     options?: {
       contextPrepared?: boolean
       durableTurn?: DurableTurnStart
-      mode?: TurnMode
+      mode?: Exclude<TurnMode, "new">
       streamClaim?: ChatStreamClaim
     }
   ): Promise<boolean> => {
@@ -110,48 +111,23 @@ export const useChatResponse = ({
 
       let durableTurn = options?.durableTurn
       if (!durableTurn && contextMessages) {
-        let userMessageIndex = -1
-        for (let index = contextMessages.length - 1; index >= 0; index -= 1) {
-          if (contextMessages[index].role === "user") {
-            userMessageIndex = index
-            break
-          }
-        }
-        const userMessage = contextMessages[userMessageIndex]
-        if (userMessage && typeof userMessage.id === "number") {
-          const turnId =
-            globalThis.crypto?.randomUUID?.() ??
-            `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`
-          durableTurn = {
-            submission: {
-              id: turnId,
-              sessionId,
-              mode: options?.mode ?? "regenerate",
-              model: modelForRequest,
-              providerId: config.selectedModelRef?.providerId,
-              request: {
-                version: 1,
-                context: {
-                  rawInput: userMessage.content,
-                  messages: contextMessages.slice(0, userMessageIndex),
-                  hasTabContext: false,
-                  contextText: "",
-                  tabDocuments: [],
-                  memoryEnabled: config.memoryEnabled,
-                  maxTabContextChars: config.maxTabContextChars,
-                  maxRagContextChars: config.maxRagContextChars,
-                  groundedOnlyMode: false,
-                  selectedModel: config.selectedModel,
-                  selectedModelRef: config.selectedModelRef,
-                  customModel
-                },
-                userMessage
-              },
-              createdAt: Date.now()
-            },
-            userMessageId: userMessage.id
-          }
-        }
+        const turnId =
+          globalThis.crypto?.randomUUID?.() ??
+          `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`
+        durableTurn = prepareTurnSubmission({
+          id: turnId,
+          sessionId,
+          mode: options?.mode ?? "regenerate",
+          model: modelForRequest,
+          selectedModel: config.selectedModel,
+          selectedModelRef: config.selectedModelRef,
+          customModel,
+          memoryEnabled: config.memoryEnabled,
+          maxTabContextChars: config.maxTabContextChars,
+          maxRagContextChars: config.maxRagContextChars,
+          createdAt: Date.now(),
+          contextMessages
+        })
       }
 
       const started = startStream(

--- a/src/features/chat/hooks/use-chat-turn-controller.ts
+++ b/src/features/chat/hooks/use-chat-turn-controller.ts
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ACTIVITY_LABELS } from "@/application/context/activity-labels"
+import { prepareTurnSubmission } from "@/application/turns/prepare-turn-submission"
 import type { DurableTurnStart } from "@/application/turns/turn-contract"
 import {
   buildUserMessage,
@@ -41,7 +42,7 @@ interface UseChatTurnControllerOptions {
     options?: {
       contextPrepared?: boolean
       durableTurn?: DurableTurnStart
-      mode?: import("@ollama-client/contracts/turns").TurnMode
+      mode?: Exclude<import("@ollama-client/contracts/turns").TurnMode, "new">
       streamClaim?: ChatStreamClaim
     }
   ) => Promise<boolean>
@@ -196,7 +197,21 @@ export const useChatTurnController = ({
     const turnId =
       globalThis.crypto?.randomUUID?.() ??
       `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    const contextRequest = {
+    const durableTurn = prepareTurnSubmission({
+      id: turnId,
+      sessionId,
+      mode: "new",
+      model: resolvedModel,
+      selectedModel: config.selectedModel,
+      selectedModelRef: config.selectedModelRef,
+      customModel,
+      memoryEnabled: config.memoryEnabled,
+      maxTabContextChars: config.maxTabContextChars,
+      maxRagContextChars: config.maxRagContextChars,
+      createdAt: Date.now(),
+      userMessage,
+      userMessageId,
+      priorMessages: messages,
       rawInput: userContent,
       files: files?.map((file) => ({
         text: file.text,
@@ -205,31 +220,11 @@ export const useChatTurnController = ({
           fileId: file.metadata.fileId
         }
       })),
-      messages,
       hasTabContext,
       contextText: contextText || "",
       tabDocuments,
-      memoryEnabled: config.memoryEnabled,
-      maxTabContextChars: config.maxTabContextChars,
-      maxRagContextChars: config.maxRagContextChars,
-      groundedOnlyMode: config.groundedOnlyMode,
-      selectedModel: config.selectedModel,
-      selectedModelRef: config.selectedModelRef,
-      customModel
-    }
-
-    const durableTurn: DurableTurnStart = {
-      submission: {
-        id: turnId,
-        sessionId,
-        mode: "new",
-        model: resolvedModel,
-        providerId: config.selectedModelRef?.providerId,
-        request: { version: 1, context: contextRequest, userMessage },
-        createdAt: Date.now()
-      },
-      userMessageId
-    }
+      groundedOnlyMode: config.groundedOnlyMode
+    })
 
     try {
       const submitted = await generateResponse(


### PR DESCRIPTION
## Summary
- extract deterministic turn-submission preparation into the application layer
- share new, regenerate, and fork request assembly across chat hooks
- preserve persisted-user replay behavior and add focused contract coverage

## Verification
- pnpm lint:check
- pnpm typecheck
- pnpm test:run: 348 files, 2932 tests passed
- architecture boundary tests passed

## Coordination
- does not touch provider or web-search response decoding files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes deterministic durable-turn submission assembly in the application layer while preserving the existing new, regenerate, and fork behavior.
- Adds a shared `prepareTurnSubmission` helper for new and replayed turns.
- Updates both chat hooks to use the shared request assembly.
- Adds focused contract tests for new, regenerate, fork, and non-persisted replay cases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the centralized submission preparation preserving the existing reachable chat flows.

The new helper retains the prior request fields, replay-message selection, turn modes, and fallback behavior, and no blocking or independently actionable issue remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/application/turns/prepare-turn-submission.ts | Introduces deterministic request assembly that preserves the former new-turn and replay field mappings and persisted-user guard. |
| src/features/chat/hooks/use-chat-response.ts | Replaces inline regenerate/fork submission assembly with the shared helper while retaining the legacy fallback when no durable replay can be built. |
| src/features/chat/hooks/use-chat-turn-controller.ts | Delegates new-turn request construction to the application helper without changing captured context or submission behavior. |
| src/application/turns/__tests__/prepare-turn-submission.test.ts | Covers the shared helper’s new, regenerate, fork, and missing-persisted-user contracts. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Chat UI
  participant Prep as prepareTurnSubmission
  participant Response as useChatResponse
  participant Stream as Chat Stream
  UI->>Prep: New turn inputs
  Prep-->>UI: DurableTurnStart (mode: new)
  UI->>Response: generateResponse(durableTurn)
  Response->>Stream: START_TURN
  UI->>Response: Regenerate or fork context
  Response->>Prep: Replay inputs
  alt Persisted user message found
    Prep-->>Response: DurableTurnStart
    Response->>Stream: START_TURN
  else No persisted user message
    Prep-->>Response: undefined
    Response->>Stream: Legacy CHAT_WITH_MODEL
  end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23283%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=283&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(chat): centralize turn submissi..."](https://github.com/shishir435/ollama-client/commit/0108c328b8aaf15a856579f1e4c365966c61612e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53051875)</sub>

**Context used:**

- Knowledge Base — [Chat Flow: Send, Stream, Cancel, Edit, and Fork](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/chat-flow.md)

<!-- /greptile_comment -->