### PR TITLE
refactor(background): name retained handlers

### DIFF
--- a/src/background/__tests__/message-router.test.ts
+++ b/src/background/__tests__/message-router.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Runtime } from "webextension-polyfill"
-import { handleLoadSelectionOverlay } from "@/background/message-router"
+import { handleLoadSelectionOverlay } from "@/background/handlers/handle-selection-messages"
 import { browser } from "@/lib/browser-api"
 import {
   CONTENT_MESSAGE_PROTOCOL_VERSION,

--- a/src/background/handlers/__tests__/retained-message-handlers.test.ts
+++ b/src/background/handlers/__tests__/retained-message-handlers.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Runtime } from "webextension-polyfill"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import type { ChromeMessage, SendResponseFunction } from "@/types"
+
+const handlers = vi.hoisted(() => ({
+  getModels: vi.fn(),
+  openTabs: vi.fn(() => true as const),
+  keepAlive: vi.fn(() => undefined),
+  notify: vi.fn(() => true as const),
+  selection: vi.fn(() => true as const),
+  overlay: vi.fn(() => true as const),
+  confirmation: vi.fn(() => undefined)
+}))
+
+vi.mock("@/background/handlers/handle-get-models", () => ({
+  handleGetModels: handlers.getModels
+}))
+vi.mock("@/background/handlers/handle-browser-messages", () => ({
+  handleOpenTabs: handlers.openTabs
+}))
+vi.mock("@/background/handlers/handle-app-messages", () => ({
+  handleKeepToolLoopAlive: handlers.keepAlive,
+  handleJobCompleteNotification: handlers.notify
+}))
+vi.mock("@/background/handlers/handle-selection-messages", () => ({
+  handleSelectionMessage: handlers.selection,
+  handleLoadSelectionOverlay: handlers.overlay
+}))
+vi.mock("@/background/handlers/handle-tool-confirmation", () => ({
+  handleToolConfirmation: handlers.confirmation
+}))
+
+import { dispatchRetainedMessage } from "../retained-message-handlers"
+
+describe("dispatchRetainedMessage", () => {
+  const sender = { tab: { id: 7 } } as Runtime.MessageSender
+  const response = vi.fn<SendResponseFunction>()
+
+  beforeEach(() => vi.clearAllMocks())
+
+  const dispatch = (type: string, payload?: unknown) =>
+    dispatchRetainedMessage(
+      { type, payload } as ChromeMessage,
+      sender,
+      response
+    )
+
+  it("dispatches every retained message to its named handler", () => {
+    expect(dispatch(MESSAGE_KEYS.PROVIDER.GET_MODELS)).toBe(true)
+    expect(handlers.getModels).toHaveBeenCalledWith(response)
+
+    expect(dispatch(MESSAGE_KEYS.BROWSER.OPEN_TAB)).toBe(true)
+    expect(handlers.openTabs).toHaveBeenCalledWith(response)
+
+    expect(dispatch(MESSAGE_KEYS.APP.KEEP_TOOL_LOOP_ALIVE)).toBeUndefined()
+    expect(handlers.keepAlive).toHaveBeenCalledWith(response)
+
+    const notification = { title: "Done", message: "Finished" }
+    expect(dispatch(MESSAGE_KEYS.APP.NOTIFY_JOB_COMPLETE, notification)).toBe(
+      true
+    )
+    expect(handlers.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: notification }),
+      response
+    )
+
+    expect(dispatch(MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT, "text")).toBe(
+      true
+    )
+    expect(handlers.selection).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: "text" }),
+      sender.tab,
+      response
+    )
+
+    const overlay = { requestId: "request-1" }
+    expect(dispatch(MESSAGE_KEYS.BROWSER.LOAD_SELECTION_OVERLAY, overlay)).toBe(
+      true
+    )
+    expect(handlers.overlay).toHaveBeenCalledWith(overlay, sender, response)
+
+    expect(
+      dispatch(MESSAGE_KEYS.PROVIDER.CONFIRM_TOOL, { callId: "1" })
+    ).toBeUndefined()
+    expect(handlers.confirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { callId: "1" } }),
+      response
+    )
+  })
+
+  it("leaves unknown and inherited object keys unhandled", () => {
+    expect(dispatch("unknown-message")).toBeUndefined()
+    expect(dispatch("toString")).toBeUndefined()
+    expect(dispatch("__proto__")).toBeUndefined()
+  })
+})

--- a/src/background/handlers/handle-app-messages.ts
+++ b/src/background/handlers/handle-app-messages.ts
@@ -1,0 +1,56 @@
+import { notifyJobComplete } from "@/background/lib/notify"
+import { safeSendResponse } from "@/background/lib/utils"
+import type { ChromeMessage, SendResponseFunction } from "@/types"
+
+export const handleKeepToolLoopAlive = (
+  sendResponse: SendResponseFunction
+): undefined => {
+  // A visible approval prompt sends this periodically. Runtime messages reset
+  // Chromium's MV3 idle timer; SQLite recovery remains the restart fallback.
+  safeSendResponse(sendResponse, { success: true })
+}
+
+export const handleJobCompleteNotification = (
+  message: ChromeMessage,
+  sendResponse: SendResponseFunction
+): true => {
+  const payload = message.payload as
+    | { id?: string; title?: unknown; message?: unknown }
+    | undefined
+  if (
+    !payload ||
+    typeof payload.title !== "string" ||
+    typeof payload.message !== "string"
+  ) {
+    safeSendResponse(sendResponse, {
+      success: false,
+      error: { status: 400, message: "Invalid message payload" }
+    })
+    return true
+  }
+
+  notifyJobComplete({
+    id: typeof payload.id === "string" ? payload.id : undefined,
+    title: payload.title,
+    message: payload.message
+  })
+    .then((result) => {
+      safeSendResponse(sendResponse, {
+        success: result.sent,
+        data: result,
+        error: result.sent
+          ? undefined
+          : { status: 0, message: result.reason || "Notification skipped" }
+      })
+    })
+    .catch((error) => {
+      safeSendResponse(sendResponse, {
+        success: false,
+        error: {
+          status: 0,
+          message: error instanceof Error ? error.message : String(error)
+        }
+      })
+    })
+  return true
+}

--- a/src/background/handlers/handle-browser-messages.ts
+++ b/src/background/handlers/handle-browser-messages.ts
@@ -1,0 +1,27 @@
+import { safeSendResponse } from "@/background/lib/utils"
+import { browser } from "@/lib/browser-api"
+import { logger } from "@/lib/logger"
+import type { SendResponseFunction } from "@/types"
+
+export const handleOpenTabs = (sendResponse: SendResponseFunction): true => {
+  browser.tabs
+    .query({})
+    .then((tabs) => {
+      logger.info("Queried browser tabs", "BackgroundSW", {
+        tabCount: tabs.length
+      })
+      safeSendResponse(sendResponse, { success: true, tabs })
+    })
+    .catch((error: unknown) => {
+      logger.error("Failed to query browser tabs", "BackgroundSW", { error })
+      safeSendResponse(sendResponse, {
+        success: false,
+        error: {
+          status: 0,
+          message:
+            error instanceof Error ? error.message : "Failed to query tabs"
+        }
+      })
+    })
+  return true
+}

--- a/src/background/handlers/handle-selection-messages.ts
+++ b/src/background/handlers/handle-selection-messages.ts
@@ -1,0 +1,184 @@
+import type { Runtime } from "webextension-polyfill"
+import { postSelectionToSidePanels } from "@/background/lib/selection-bridge"
+import { safeSendResponse } from "@/background/lib/utils"
+import { browser, isChromiumBased } from "@/lib/browser-api"
+import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
+import { getErrorMessage } from "@/lib/error-utils"
+import { logger } from "@/lib/logger"
+import { setPlasmoStoredValue } from "@/lib/plasmo-global-storage"
+import {
+  isSelectionOverlayLoadRequest,
+  SELECTION_OVERLAY_REQUEST_ID_GLOBAL,
+  type SelectionOverlayLoadResult
+} from "@/protocol/content-messages"
+import type {
+  ChromeMessage,
+  ChromeSidePanel,
+  SendResponseFunction
+} from "@/types"
+
+const SELECTION_OVERLAY_FILE = "content-scripts/selection-overlay.js"
+
+const setSelectionOverlayRequestId = (key: string, requestId: string) => {
+  Reflect.set(globalThis, key, requestId)
+}
+
+export const handleLoadSelectionOverlay = (
+  payload: unknown,
+  sender: Runtime.MessageSender,
+  sendResponse: SendResponseFunction
+): true => {
+  if (!isSelectionOverlayLoadRequest(payload)) {
+    safeSendResponse(sendResponse, {
+      success: false,
+      error: {
+        status: 400,
+        message: "Invalid selection overlay request"
+      }
+    })
+    return true
+  }
+
+  const tabId = sender.tab?.id
+  if (typeof tabId !== "number") {
+    safeSendResponse(sendResponse, {
+      success: false,
+      error: {
+        status: 400,
+        message: "Selection overlay requires a source tab"
+      }
+    })
+    return true
+  }
+
+  const frameId = sender.frameId
+  const target = {
+    tabId,
+    ...(typeof frameId === "number" ? { frameIds: [frameId] } : {})
+  }
+  browser.scripting
+    .executeScript({
+      target,
+      func: setSelectionOverlayRequestId,
+      args: [SELECTION_OVERLAY_REQUEST_ID_GLOBAL, payload.requestId]
+    })
+    .then(() =>
+      browser.scripting.executeScript({
+        target,
+        files: [SELECTION_OVERLAY_FILE]
+      })
+    )
+    .then(() => {
+      const senderWithDocument = sender as Runtime.MessageSender & {
+        documentId?: string
+      }
+      const result: SelectionOverlayLoadResult = {
+        requestId: payload.requestId,
+        tabId,
+        frameId: sender.frameId ?? 0,
+        ...(senderWithDocument.documentId
+          ? { documentId: senderWithDocument.documentId }
+          : {})
+      }
+      safeSendResponse(sendResponse, { success: true, data: result })
+    })
+    .catch((error: unknown) => {
+      logger.debug("Could not inject selection overlay", "SelectionOverlay", {
+        error
+      })
+      safeSendResponse(sendResponse, {
+        success: false,
+        error: {
+          status: 0,
+          message: error instanceof Error ? error.message : String(error)
+        }
+      })
+    })
+
+  return true
+}
+
+const openSidePanelForSelection = (tab?: {
+  windowId?: number
+  id?: number
+}) => {
+  if (!isChromiumBased() || !("sidePanel" in browser)) return
+
+  const sidePanel = (browser as unknown as { sidePanel: ChromeSidePanel })
+    .sidePanel
+  const windowId = tab?.windowId
+  const tabId = tab?.id
+  if (!windowId || !sidePanel.open) return
+
+  sidePanel.open({ windowId, tabId }).catch((err: unknown) => {
+    logger.error("Failed to open sidepanel", "BackgroundSW", {
+      error: err instanceof Error ? err.message : String(err)
+    })
+  })
+}
+
+export const handleSelectionMessage = (
+  message: ChromeMessage,
+  tab: { windowId?: number; id?: number } | undefined,
+  sendResponse: SendResponseFunction
+): true => {
+  if (message.fromBackground) {
+    safeSendResponse(sendResponse, { success: true })
+    return true
+  }
+
+  const selectionText =
+    typeof message.payload === "string" ? message.payload.trim() : ""
+
+  if (!selectionText) {
+    safeSendResponse(sendResponse, {
+      success: false,
+      error: {
+        status: 400,
+        message: "Selection text is required"
+      }
+    })
+    return true
+  }
+
+  const pendingSelectionWrite = setPlasmoStoredValue(
+    STORAGE_KEYS.BROWSER.PENDING_SELECTION_TEXT,
+    selectionText
+  )
+
+  openSidePanelForSelection(tab)
+
+  pendingSelectionWrite
+    .then(() => {
+      safeSendResponse(sendResponse, { success: true })
+      postSelectionToSidePanels(selectionText)
+
+      setTimeout(() => {
+        postSelectionToSidePanels(selectionText)
+        browser.runtime
+          .sendMessage({
+            type: MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT,
+            payload: selectionText,
+            fromBackground: true
+          })
+          .catch((err) => {
+            logger.debug(
+              "Could not forward selection to chat (sidepanel might be closed)",
+              "BackgroundSW",
+              { error: err }
+            )
+          })
+      }, 500)
+    })
+    .catch((error) => {
+      safeSendResponse(sendResponse, {
+        success: false,
+        error: {
+          status: 0,
+          message: getErrorMessage(error)
+        }
+      })
+    })
+
+  return true
+}

--- a/src/background/handlers/handle-tool-confirmation.ts
+++ b/src/background/handlers/handle-tool-confirmation.ts
@@ -1,0 +1,27 @@
+import { resolveToolConfirmation } from "@/background/lib/tool-confirmation-registry"
+import { safeSendResponse } from "@/background/lib/utils"
+import type { ChromeMessage, SendResponseFunction } from "@/types"
+
+export const handleToolConfirmation = (
+  message: ChromeMessage,
+  sendResponse: SendResponseFunction
+): undefined => {
+  const payload = message.payload as
+    | { callId?: unknown; approved?: unknown; scope?: unknown }
+    | undefined
+  const valid = typeof payload?.callId === "string"
+  if (valid) {
+    const scope =
+      payload?.scope === "session" || payload?.scope === "always"
+        ? payload.scope
+        : undefined
+    resolveToolConfirmation(
+      payload.callId as string,
+      payload?.approved === true,
+      scope
+    )
+  }
+  // Respond synchronously — returning true without ever calling sendResponse
+  // makes the sender's promise reject when the message port closes.
+  safeSendResponse(sendResponse, { success: valid })
+}

--- a/src/background/handlers/retained-message-handlers.ts
+++ b/src/background/handlers/retained-message-handlers.ts
@@ -1,0 +1,64 @@
+import type { Runtime } from "webextension-polyfill"
+import {
+  handleJobCompleteNotification,
+  handleKeepToolLoopAlive
+} from "@/background/handlers/handle-app-messages"
+import { handleOpenTabs } from "@/background/handlers/handle-browser-messages"
+import { handleGetModels } from "@/background/handlers/handle-get-models"
+import {
+  handleLoadSelectionOverlay,
+  handleSelectionMessage
+} from "@/background/handlers/handle-selection-messages"
+import { handleToolConfirmation } from "@/background/handlers/handle-tool-confirmation"
+import { MESSAGE_KEYS } from "@/lib/constants"
+import type { ChromeMessage, SendResponseFunction } from "@/types"
+
+type RetainedMessageHandler = (
+  message: ChromeMessage,
+  sender: Runtime.MessageSender,
+  sendResponse: SendResponseFunction
+) => true | undefined
+
+const retainedMessageHandlers = new Map<string, RetainedMessageHandler>([
+  [
+    MESSAGE_KEYS.PROVIDER.GET_MODELS,
+    (_message, _sender, response) => {
+      handleGetModels(response)
+      return true
+    }
+  ],
+  [
+    MESSAGE_KEYS.BROWSER.OPEN_TAB,
+    (_message, _sender, response) => handleOpenTabs(response)
+  ],
+  [
+    MESSAGE_KEYS.APP.KEEP_TOOL_LOOP_ALIVE,
+    (_message, _sender, response) => handleKeepToolLoopAlive(response)
+  ],
+  [
+    MESSAGE_KEYS.APP.NOTIFY_JOB_COMPLETE,
+    (message, _sender, response) =>
+      handleJobCompleteNotification(message, response)
+  ],
+  [
+    MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT,
+    (message, sender, response) =>
+      handleSelectionMessage(message, sender.tab, response)
+  ],
+  [
+    MESSAGE_KEYS.BROWSER.LOAD_SELECTION_OVERLAY,
+    (message, sender, response) =>
+      handleLoadSelectionOverlay(message.payload, sender, response)
+  ],
+  [
+    MESSAGE_KEYS.PROVIDER.CONFIRM_TOOL,
+    (message, _sender, response) => handleToolConfirmation(message, response)
+  ]
+])
+
+export const dispatchRetainedMessage = (
+  message: ChromeMessage,
+  sender: Runtime.MessageSender,
+  sendResponse: SendResponseFunction
+): true | undefined =>
+  retainedMessageHandlers.get(message.type)?.(message, sender, sendResponse)

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -4,114 +4,19 @@ import {
 } from "@ollama-client/contracts/rpc"
 import { classifyRuntimeSender } from "@ollama-client/runtime-core/runtime-sender"
 import type { Runtime } from "webextension-polyfill"
-import { handleGetModels } from "@/background/handlers/handle-get-models"
-import { notifyJobComplete } from "@/background/lib/notify"
-import { postSelectionToSidePanels } from "@/background/lib/selection-bridge"
-import { resolveToolConfirmation } from "@/background/lib/tool-confirmation-registry"
+import { dispatchRetainedMessage } from "@/background/handlers/retained-message-handlers"
 import { safeSendResponse } from "@/background/lib/utils"
 import {
   handleRpcCancellation,
   handleRpcRequest
 } from "@/background/rpc-server"
 import { isRuntimeMessageAllowed } from "@/background/runtime-sender-authorization"
-import { browser, isChromiumBased } from "@/lib/browser-api"
-import { MESSAGE_KEYS, STORAGE_KEYS } from "@/lib/constants"
-import { getErrorMessage } from "@/lib/error-utils"
+import { browser } from "@/lib/browser-api"
 import { logger } from "@/lib/logger"
-import { setPlasmoStoredValue } from "@/lib/plasmo-global-storage"
-import {
-  isSelectionOverlayLoadRequest,
-  SELECTION_OVERLAY_REQUEST_ID_GLOBAL,
-  type SelectionOverlayLoadResult
-} from "@/protocol/content-messages"
 import { getMessageType } from "@/protocol/message-type"
-import type {
-  ChromeMessage,
-  ChromeSidePanel,
-  SendResponseFunction
-} from "@/types"
+import type { ChromeMessage, SendResponseFunction } from "@/types"
 
 const extensionUrlPrefix = browser.runtime.getURL("")
-const SELECTION_OVERLAY_FILE = "content-scripts/selection-overlay.js"
-
-const setSelectionOverlayRequestId = (key: string, requestId: string) => {
-  Reflect.set(globalThis, key, requestId)
-}
-
-export const handleLoadSelectionOverlay = (
-  payload: unknown,
-  sender: Runtime.MessageSender,
-  sendResponse: SendResponseFunction
-): true => {
-  if (!isSelectionOverlayLoadRequest(payload)) {
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: {
-        status: 400,
-        message: "Invalid selection overlay request"
-      }
-    })
-    return true
-  }
-
-  const tabId = sender.tab?.id
-  if (typeof tabId !== "number") {
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: {
-        status: 400,
-        message: "Selection overlay requires a source tab"
-      }
-    })
-    return true
-  }
-
-  const frameId = sender.frameId
-  const target = {
-    tabId,
-    ...(typeof frameId === "number" ? { frameIds: [frameId] } : {})
-  }
-  browser.scripting
-    .executeScript({
-      target,
-      func: setSelectionOverlayRequestId,
-      args: [SELECTION_OVERLAY_REQUEST_ID_GLOBAL, payload.requestId]
-    })
-    .then(() =>
-      browser.scripting.executeScript({
-        target,
-        files: [SELECTION_OVERLAY_FILE]
-      })
-    )
-    .then(() => {
-      const senderWithDocument = sender as Runtime.MessageSender & {
-        documentId?: string
-      }
-      const result: SelectionOverlayLoadResult = {
-        requestId: payload.requestId,
-        tabId,
-        frameId: sender.frameId ?? 0,
-        ...(senderWithDocument.documentId
-          ? { documentId: senderWithDocument.documentId }
-          : {})
-      }
-      safeSendResponse(sendResponse, { success: true, data: result })
-    })
-    .catch((error: unknown) => {
-      logger.debug("Could not inject selection overlay", "SelectionOverlay", {
-        error
-      })
-      safeSendResponse(sendResponse, {
-        success: false,
-        error: {
-          status: 0,
-          message: error instanceof Error ? error.message : String(error)
-        }
-      })
-    })
-
-  return true
-}
 
 const respondForbidden = (
   type: string,
@@ -131,144 +36,6 @@ const respondForbidden = (
     success: false,
     error: { status: 403, message: "Message not allowed from this context" }
   })
-}
-
-const openSidePanelForSelection = (tab?: {
-  windowId?: number
-  id?: number
-}) => {
-  if (!isChromiumBased() || !("sidePanel" in browser)) return
-
-  const sidePanel = (browser as unknown as { sidePanel: ChromeSidePanel })
-    .sidePanel
-  const windowId = tab?.windowId
-  const tabId = tab?.id
-  if (!windowId || !sidePanel.open) return
-
-  sidePanel.open({ windowId, tabId }).catch((err: unknown) => {
-    logger.error("Failed to open sidepanel", "BackgroundSW", {
-      error: err instanceof Error ? err.message : String(err)
-    })
-  })
-}
-
-const handleSelectionMessage = (
-  message: ChromeMessage,
-  tab: { windowId?: number; id?: number } | undefined,
-  sendResponse: SendResponseFunction
-): true => {
-  if (message.fromBackground) {
-    safeSendResponse(sendResponse, { success: true })
-    return true
-  }
-
-  const selectionText =
-    typeof message.payload === "string" ? message.payload.trim() : ""
-
-  if (!selectionText) {
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: {
-        status: 400,
-        message: "Selection text is required"
-      }
-    })
-    return true
-  }
-
-  const pendingSelectionWrite = setPlasmoStoredValue(
-    STORAGE_KEYS.BROWSER.PENDING_SELECTION_TEXT,
-    selectionText
-  )
-
-  openSidePanelForSelection(tab)
-
-  pendingSelectionWrite
-    .then(() => {
-      safeSendResponse(sendResponse, { success: true })
-      postSelectionToSidePanels(selectionText)
-
-      setTimeout(() => {
-        postSelectionToSidePanels(selectionText)
-        browser.runtime
-          .sendMessage({
-            type: MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT,
-            payload: selectionText,
-            fromBackground: true
-          })
-          .catch((err) => {
-            logger.debug(
-              "Could not forward selection to chat (sidepanel might be closed)",
-              "BackgroundSW",
-              { error: err }
-            )
-          })
-      }, 500)
-    })
-    .catch((error) => {
-      safeSendResponse(sendResponse, {
-        success: false,
-        error: {
-          status: 0,
-          message: getErrorMessage(error)
-        }
-      })
-    })
-
-  return true
-}
-
-const handleKeepToolLoopAlive = (
-  sendResponse: SendResponseFunction
-): undefined => {
-  // A visible approval prompt sends this periodically. Runtime messages reset
-  // Chromium's MV3 idle timer; SQLite recovery remains the restart fallback.
-  safeSendResponse(sendResponse, { success: true })
-}
-
-const handleJobCompleteNotification = (
-  message: ChromeMessage,
-  sendResponse: SendResponseFunction
-): true => {
-  const payload = message.payload as
-    | { id?: string; title?: unknown; message?: unknown }
-    | undefined
-  if (
-    !payload ||
-    typeof payload.title !== "string" ||
-    typeof payload.message !== "string"
-  ) {
-    safeSendResponse(sendResponse, {
-      success: false,
-      error: { status: 400, message: "Invalid message payload" }
-    })
-    return true
-  }
-
-  notifyJobComplete({
-    id: typeof payload.id === "string" ? payload.id : undefined,
-    title: payload.title,
-    message: payload.message
-  })
-    .then((result) => {
-      safeSendResponse(sendResponse, {
-        success: result.sent,
-        data: result,
-        error: result.sent
-          ? undefined
-          : { status: 0, message: result.reason || "Notification skipped" }
-      })
-    })
-    .catch((error) => {
-      safeSendResponse(sendResponse, {
-        success: false,
-        error: {
-          status: 0,
-          message: error instanceof Error ? error.message : String(error)
-        }
-      })
-    })
-  return true
 }
 
 export const registerMessageRouter = () => {
@@ -298,106 +65,28 @@ export const registerMessageRouter = () => {
       return true
     }
 
-    switch (message.type) {
-      case RPC_CANCEL_MESSAGE_TYPE: {
-        handleRpcCancellation(
-          rawMessage,
-          sender,
-          browser.runtime.id,
-          extensionUrlPrefix,
-          sendResponse
-        )
-        return true
-      }
-
-      case RPC_REQUEST_MESSAGE_TYPE: {
-        handleRpcRequest(
-          rawMessage,
-          sender,
-          browser.runtime.id,
-          extensionUrlPrefix,
-          sendResponse
-        )
-        return true
-      }
-
-      /*
-       * The last provider-domain runtime message, kept because its only caller
-       * is the selection overlay's content script. The RPC envelope is
-       * deliberately extension-page-only (plan section 4.13: never trust a
-       * content script), so this narrow, allowlisted read stays a plain
-       * message rather than opening the protocol to page contexts.
-       */
-      case MESSAGE_KEYS.PROVIDER.GET_MODELS: {
-        handleGetModels(response)
-        return true
-      }
-
-      case MESSAGE_KEYS.BROWSER.OPEN_TAB: {
-        browser.tabs
-          .query({})
-          .then((tabs) => {
-            logger.info("Queried browser tabs", "BackgroundSW", {
-              tabCount: tabs.length
-            })
-            safeSendResponse(response, { success: true, tabs })
-          })
-          .catch((error: unknown) => {
-            logger.error("Failed to query browser tabs", "BackgroundSW", {
-              error
-            })
-            safeSendResponse(response, {
-              success: false,
-              error: {
-                status: 0,
-                message:
-                  error instanceof Error
-                    ? error.message
-                    : "Failed to query tabs"
-              }
-            })
-          })
-        return true
-      }
-
-      case MESSAGE_KEYS.APP.KEEP_TOOL_LOOP_ALIVE: {
-        return handleKeepToolLoopAlive(response)
-      }
-
-      case MESSAGE_KEYS.APP.NOTIFY_JOB_COMPLETE: {
-        return handleJobCompleteNotification(message, response)
-      }
-
-      case MESSAGE_KEYS.BROWSER.ADD_SELECTION_TO_CHAT: {
-        return handleSelectionMessage(message, sender.tab, response)
-      }
-
-      case MESSAGE_KEYS.BROWSER.LOAD_SELECTION_OVERLAY: {
-        return handleLoadSelectionOverlay(message.payload, sender, response)
-      }
-
-      case MESSAGE_KEYS.PROVIDER.CONFIRM_TOOL: {
-        const payload = message.payload as
-          | { callId?: unknown; approved?: unknown; scope?: unknown }
-          | undefined
-        const valid = typeof payload?.callId === "string"
-        if (valid) {
-          const scope =
-            payload?.scope === "session" || payload?.scope === "always"
-              ? payload.scope
-              : undefined
-          resolveToolConfirmation(
-            payload.callId as string,
-            payload?.approved === true,
-            scope
-          )
-        }
-        // Respond synchronously — returning true without ever calling
-        // sendResponse makes the sender's promise reject with "The message
-        // port closed before a response was received."
-        safeSendResponse(response, { success: valid })
-        return
-      }
+    if (message.type === RPC_CANCEL_MESSAGE_TYPE) {
+      handleRpcCancellation(
+        rawMessage,
+        sender,
+        browser.runtime.id,
+        extensionUrlPrefix,
+        sendResponse
+      )
+      return true
     }
+
+    if (message.type === RPC_REQUEST_MESSAGE_TYPE) {
+      handleRpcRequest(
+        rawMessage,
+        sender,
+        browser.runtime.id,
+        extensionUrlPrefix,
+        sendResponse
+      )
+      return true
+    }
+
+    return dispatchRetainedMessage(message, sender, response)
   }) as Runtime.OnMessageListener)
 }


### PR DESCRIPTION
## Summary
- extract retained runtime-message behavior into named app, browser, selection, and tool handlers
- keep sender authorization centralized before RPC or retained-message dispatch
- replace the large retained-message switch with an exact-key Map dispatcher
- preserve unknown-message fallthrough and synchronous response semantics

## Verification
- typecheck passed
- Biome check passed
- 349 test files, 2944 tests passed
- focused router, authorization, entrypoint, and dispatcher tests passed

## Coordination
- no context-builder files changed; context plan/receipt extraction can proceed independently

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts retained runtime-message behavior into named handlers and replaces the router’s large switch tail with an exact-key Map dispatcher while preserving centralized authorization and response semantics.
- Adds dedicated handlers for app, browser, selection, and tool-confirmation messages.
- Keeps RPC routing ahead of retained-message dispatch.
- Adds focused dispatcher coverage for every retained key and unknown-key fallthrough.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the refactor preserves authorization, dispatch reachability, handler arguments, and message-port response semantics.

The extracted implementations match the former switch branches, all retained keys are distinct, asynchronous handlers still return true, synchronous handlers retain undefined returns, and unknown messages continue to fall through.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/background/message-router.ts | Centralized authorization and RPC routing remain intact while retained-message cases are delegated to the new dispatcher. |
| src/background/handlers/retained-message-handlers.ts | Defines distinct exact-key mappings for all retained messages and preserves each branch’s true-or-undefined return contract. |
| src/background/handlers/handle-selection-messages.ts | Moves selection forwarding and overlay injection behavior without changing parameters, asynchronous responses, or error handling. |
| src/background/handlers/handle-app-messages.ts | Moves keepalive and job-notification handling while preserving validation and response timing. |
| src/background/handlers/handle-browser-messages.ts | Moves browser-tab querying unchanged, including asynchronous success and error responses. |
| src/background/handlers/handle-tool-confirmation.ts | Preserves synchronous confirmation responses and intentionally returns undefined. |
| src/background/handlers/__tests__/retained-message-handlers.test.ts | Covers routing, arguments, return semantics, and fallthrough for unknown and inherited object-key names. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  M[Runtime message] --> N[Normalize message type]
  N --> A{Sender authorized?}
  A -- No --> F[Send forbidden response]
  A -- Yes --> C{RPC cancellation?}
  C -- Yes --> RC[Handle RPC cancellation]
  C -- No --> R{RPC request?}
  R -- Yes --> RR[Handle RPC request]
  R -- No --> D[Look up retained handler in Map]
  D --> H{Exact key found?}
  H -- Yes --> RH[Invoke named handler]
  H -- No --> U[Return undefined for listener fallthrough]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23284%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=284&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(background): name retained hand..."](https://github.com/shishir435/ollama-client/commit/2ff68c9598cf73afcf2593013223ab50726120dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53059201)</sub>

**Context used:**

- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)

<!-- /greptile_comment -->