### PR TITLE
refactor(context): extract plan and receipt helpers

### DIFF
--- a/packages/chat-runtime/src/__tests__/context-runtime.test.ts
+++ b/packages/chat-runtime/src/__tests__/context-runtime.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
-import { type ContextResultEvidence, ContextRuntime } from "../context-runtime"
+import {
+  type ContextResultEvidence,
+  ContextRuntime,
+  createContextReceipt
+} from "../context-runtime"
 
 interface TestResult extends ContextResultEvidence {
   content: string
@@ -45,6 +49,21 @@ const command = {
 }
 
 describe("ContextRuntime", () => {
+  it("projects receipt evidence without invoking an environment adapter", () => {
+    expect(
+      createContextReceipt(command, result.promptContextStats, 42)
+    ).toMatchObject({
+      turnId: "turn-1",
+      createdAt: 42,
+      query: "hello",
+      model: { id: "llama3", providerId: "ollama" },
+      sources: [
+        { id: "file-1", source: "file" },
+        { id: "external-1", source: "unknown" }
+      ]
+    })
+  })
+
   it("builds context and durable evidence as one operation", async () => {
     const builder = { build: vi.fn().mockResolvedValue(result) }
     const runtime = new ContextRuntime(builder, { now: () => 42 })

--- a/packages/chat-runtime/src/context-runtime.ts
+++ b/packages/chat-runtime/src/context-runtime.ts
@@ -54,6 +54,36 @@ const normalizeSource = (
     ? source
     : "unknown"
 
+/** Project a completed context build into bounded, durable turn evidence. */
+export const createContextReceipt = <TOptions extends { rawInput: string }>(
+  command: ContextBuildCommand<TOptions>,
+  stats: ContextPromptStats,
+  createdAt: number
+): ContextReceipt => ({
+  version: 1,
+  turnId: command.turnId,
+  mode: command.mode,
+  createdAt,
+  query: command.options.rawInput,
+  model: {
+    id: command.model,
+    ...(command.providerId ? { providerId: command.providerId } : {})
+  },
+  prompt: {
+    inputLength: stats.promptInputLength,
+    augmentedLength: stats.promptAugmentedLength,
+    tabContextLength: stats.tabContextLength,
+    ragContextLength: stats.ragContextLength,
+    tabContextTruncated: stats.tabContextTruncated,
+    groundedOnlyMode: stats.groundedOnlyMode,
+    insufficientContext: stats.insufficientContext
+  },
+  sources: stats.usedContextChunks.map((source) => ({
+    ...source,
+    source: normalizeSource(source.source)
+  }))
+})
+
 /**
  * Couples environment-owned context construction with its durable evidence.
  *
@@ -78,30 +108,7 @@ export class ContextRuntime<
 
     return {
       result,
-      receipt: {
-        version: 1,
-        turnId: command.turnId,
-        mode: command.mode,
-        createdAt: this.clock.now(),
-        query: command.options.rawInput,
-        model: {
-          id: command.model,
-          ...(command.providerId ? { providerId: command.providerId } : {})
-        },
-        prompt: {
-          inputLength: stats.promptInputLength,
-          augmentedLength: stats.promptAugmentedLength,
-          tabContextLength: stats.tabContextLength,
-          ragContextLength: stats.ragContextLength,
-          tabContextTruncated: stats.tabContextTruncated,
-          groundedOnlyMode: stats.groundedOnlyMode,
-          insufficientContext: stats.insufficientContext
-        },
-        sources: stats.usedContextChunks.map((source) => ({
-          ...source,
-          source: normalizeSource(source.source)
-        }))
-      }
+      receipt: createContextReceipt(command, stats, this.clock.now())
     }
   }
 }

--- a/src/application/context/__tests__/context-plan.test.ts
+++ b/src/application/context/__tests__/context-plan.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { createContextPlan, remainingRagBudget } from "../context-plan"
+
+describe("context plan", () => {
+  it("normalizes the fallback query and bounded RAG budget", () => {
+    const plan = createContextPlan({
+      rawInput: "",
+      maxRagContextChars: 500,
+      groundedOnlyMode: false,
+      retrievalToolsActive: false
+    })
+
+    expect(plan).toEqual({
+      userContent: "",
+      initialRetrievalQuery: "summary",
+      ragBudget: 500,
+      injectStoredContext: true
+    })
+    expect(remainingRagBudget(plan, 125)).toBe(375)
+    expect(remainingRagBudget(plan, 700)).toBe(0)
+  })
+
+  it("treats a non-positive cap as unlimited", () => {
+    const plan = createContextPlan({
+      rawInput: "question",
+      maxRagContextChars: 0,
+      groundedOnlyMode: false,
+      retrievalToolsActive: false
+    })
+
+    expect(plan.initialRetrievalQuery).toBe("question")
+    expect(plan.ragBudget).toBe(Number.POSITIVE_INFINITY)
+    expect(remainingRagBudget(plan, 10_000)).toBe(Number.POSITIVE_INFINITY)
+  })
+
+  it.each([
+    { groundedOnlyMode: true, retrievalToolsActive: false },
+    { groundedOnlyMode: false, retrievalToolsActive: true },
+    { groundedOnlyMode: true, retrievalToolsActive: true }
+  ])("does not pre-inject stored context for policy $groundedOnlyMode/$retrievalToolsActive", ({
+    groundedOnlyMode,
+    retrievalToolsActive
+  }) => {
+    const plan = createContextPlan({
+      rawInput: "question",
+      maxRagContextChars: 500,
+      groundedOnlyMode,
+      retrievalToolsActive
+    })
+
+    expect(plan.injectStoredContext).toBe(false)
+  })
+})

--- a/src/application/context/build-context.ts
+++ b/src/application/context/build-context.ts
@@ -35,6 +35,7 @@ import type {
   UsedContextChunk
 } from "@/types"
 import type { DurableContextOptions } from "./context-contract"
+import { createContextPlan, remainingRagBudget } from "./context-plan"
 
 /**
  * The minimal file shape context building needs: the scope id and the raw text
@@ -224,7 +225,13 @@ export const buildRagContext = async (
     toast
   } = options
 
-  const userContent = rawInput
+  const plan = createContextPlan({
+    rawInput,
+    maxRagContextChars,
+    groundedOnlyMode,
+    retrievalToolsActive
+  })
+  const userContent = plan.userContent
   let contentWithRAG = userContent
   let tabContextLength = 0
   let ragContextLength = 0
@@ -234,9 +241,7 @@ export const buildRagContext = async (
   // configured RAG cap is the ceiling for their combined length, not a per-step
   // limit. Otherwise a turn with both could inject nearly twice the budget and
   // crowd out recent messages / the answer. `<= 0` means unlimited.
-  const ragBudget =
-    maxRagContextChars > 0 ? maxRagContextChars : Number.POSITIVE_INFINITY
-  const remainingRagBudget = () => Math.max(0, ragBudget - ragContextLength)
+  const getRemainingRagBudget = () => remainingRagBudget(plan, ragContextLength)
   const usedContextChunks: UsedContextChunk[] = []
   const activityEvents: ActivityEvent[] = []
   let ragSources: RagSources | null = null
@@ -330,7 +335,7 @@ export const buildRagContext = async (
     return current ? `${current}\n\n---\n\n${block}` : block
   }
 
-  let queryForRag = rawInput || "summary"
+  let queryForRag = plan.initialRetrievalQuery
 
   if (useRag) {
     try {
@@ -447,7 +452,7 @@ export const buildRagContext = async (
         // Skip pre-injecting stored file/memory context when the model has its
         // own retrieval tools this turn — it pulls on demand instead, so the
         // prompt stays clean and the same store isn't retrieved twice.
-        if (!groundedOnlyMode && !retrievalToolsActive) {
+        if (plan.injectStoredContext) {
           const fileIds = await resolveFileRagScope(files, activeKnowledgeSet)
 
           if (fileIds && fileIds.length > 0) {
@@ -481,7 +486,7 @@ export const buildRagContext = async (
               })
               const clamped = clampContext(
                 context.formattedContext,
-                remainingRagBudget()
+                getRemainingRagBudget()
               )
               ragSources = mergeRagSources(
                 ragSources,
@@ -532,7 +537,7 @@ export const buildRagContext = async (
             })
             // Memory shares the RAG budget with file context above; only append
             // what fits in the remainder so the two together stay within cap.
-            const memoryBudget = remainingRagBudget()
+            const memoryBudget = getRemainingRagBudget()
             if (memoryResults.length > 0 && memoryBudget > 0) {
               const { formattedContext, sources } =
                 formatEnhancedResults(memoryResults)

--- a/src/application/context/context-plan.ts
+++ b/src/application/context/context-plan.ts
@@ -1,0 +1,38 @@
+/** Inputs that determine context policy before any environment work begins. */
+export interface ContextPlanInput {
+  rawInput: string
+  maxRagContextChars: number
+  groundedOnlyMode: boolean
+  retrievalToolsActive?: boolean
+}
+
+/**
+ * Deterministic context policy shared by the retrieval steps in a build.
+ *
+ * Keeping this separate from the orchestrator makes the prompt budget and the
+ * pre-injection decision explicit without moving provider, storage, or browser
+ * work out of the application layer.
+ */
+export interface ContextPlan {
+  userContent: string
+  initialRetrievalQuery: string
+  ragBudget: number
+  injectStoredContext: boolean
+}
+
+/** Build the immutable policy used throughout one context-construction run. */
+export const createContextPlan = (input: ContextPlanInput): ContextPlan => ({
+  userContent: input.rawInput,
+  initialRetrievalQuery: input.rawInput || "summary",
+  ragBudget:
+    input.maxRagContextChars > 0
+      ? input.maxRagContextChars
+      : Number.POSITIVE_INFINITY,
+  injectStoredContext: !input.groundedOnlyMode && !input.retrievalToolsActive
+})
+
+/** Return the unspent shared file-and-memory context budget. */
+export const remainingRagBudget = (
+  plan: ContextPlan,
+  consumed: number
+): number => Math.max(0, plan.ragBudget - consumed)


### PR DESCRIPTION
## Summary
- extract deterministic context planning and shared RAG budget helpers
- project durable context receipts through a pure runtime helper
- add characterization coverage for planning policy and receipt normalization

## Verification
- pnpm typecheck
- pnpm lint:check
- pnpm test:run (2,948 tests)
- production Chrome package build
- bundle budget check
- docs build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts deterministic context-planning and receipt-projection logic into pure helpers without changing the established context-building behavior.

- Adds `createContextPlan` and shared remaining-budget calculation.
- Updates context construction to consume the immutable plan.
- Adds a pure `createContextReceipt` projection used by `ContextRuntime`.
- Adds characterization tests for planning policy, budgeting, and receipt normalization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the extracted helpers preserve the prior context-planning and receipt-projection behavior.

The changed production paths remain semantically equivalent to their previous inline implementations, and no actionable runtime, persistence, build, or security failure was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-runtime/src/context-runtime.ts | Extracts the existing durable receipt projection into an environment-independent helper with equivalent normalization and timestamp behavior. |
| src/application/context/context-plan.ts | Introduces a pure plan containing the existing query fallback, shared RAG budget, and stored-context injection policy. |
| src/application/context/build-context.ts | Replaces inline planning expressions with the extracted plan while preserving reachable behavior and shared-budget accounting. |
| packages/chat-runtime/src/__tests__/context-runtime.test.ts | Adds direct characterization coverage for receipt projection and source normalization. |
| src/application/context/__tests__/context-plan.test.ts | Covers query fallback, bounded and unlimited budgets, and stored-context injection policy combinations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Context build command] --> B[createContextPlan]
  B --> C[Build tab, file, and memory context]
  C --> D[Context prompt stats]
  A --> E[createContextReceipt]
  D --> E
  E --> F[Durable context receipt]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23285%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=285&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(context): extract pure helpers"](https://github.com/shishir435/ollama-client/commit/f768e19d55c712e2695618693423c22c7b4ef1d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53059213)</sub>

<!-- /greptile_comment -->