### PR TITLE
refactor(model): split embedding settings

### DIFF
--- a/src/features/model/components/embedding-config/embedding-storage-settings.tsx
+++ b/src/features/model/components/embedding-config/embedding-storage-settings.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from "react-i18next"
+
+import { TwoColumnGrid } from "@/components/layout"
+import { ConfirmActionDialog } from "@/components/settings"
+import { useEmbeddingStorageMaintenance } from "@/features/model/hooks/use-embedding-storage-maintenance"
+import type { EmbeddingConfig } from "@/lib/constants"
+
+import { EmbeddingIndexControls } from "../embedding-index-controls"
+import { DatabaseManagementCard } from "./database-management-card"
+import { EmbeddingLimitsConfig } from "./embedding-limits-config"
+import { StorageStatsCard } from "./storage-stats-card"
+
+export interface EmbeddingStorageSettingsProps {
+  config: EmbeddingConfig
+  updateConfig: (updates: Partial<EmbeddingConfig>) => void
+  isRebuilding: boolean
+  onStoreChanged: () => Promise<void> | void
+}
+
+/** Vector statistics, limits, index controls, and destructive maintenance UI. */
+export const EmbeddingStorageSettings = ({
+  config,
+  updateConfig,
+  isRebuilding,
+  onStoreChanged
+}: EmbeddingStorageSettingsProps) => {
+  const { t } = useTranslation()
+  const maintenance = useEmbeddingStorageMaintenance({ onStoreChanged })
+
+  const confirmConfig = (() => {
+    switch (maintenance.confirmAction) {
+      case "removeDuplicates":
+        return {
+          title: t(
+            "model.embedding_config.database_management.remove_duplicates_confirm"
+          ),
+          confirmLabel: t("model.embedding_config.remove_duplicates_button")
+        }
+      case "clearChat":
+        return {
+          title: t(
+            "model.embedding_config.database_management.clear_chat_confirm"
+          ),
+          confirmLabel: t("model.embedding_config.clear_chat_button")
+        }
+      case "clearAll":
+        return {
+          title: t(
+            "model.embedding_config.database_management.clear_all_confirm"
+          ),
+          confirmLabel: t("model.embedding_config.clear_all_button")
+        }
+      default:
+        return null
+    }
+  })()
+
+  return (
+    <>
+      {maintenance.storageStats && (
+        <StorageStatsCard
+          storageStats={maintenance.storageStats}
+          cacheStats={maintenance.cacheStats}
+        />
+      )}
+      <TwoColumnGrid>
+        <DatabaseManagementCard
+          onRemoveDuplicates={() => maintenance.openConfirm("removeDuplicates")}
+          onClearChat={() => maintenance.openConfirm("clearChat")}
+          onClearAll={() => maintenance.openConfirm("clearAll")}
+          isCleaning={maintenance.isCleaning || isRebuilding}
+          hasVectors={!!maintenance.storageStats?.totalVectors}
+          hasChatVectors={!!maintenance.storageStats?.byType?.chat}
+        />
+        <EmbeddingLimitsConfig config={config} updateConfig={updateConfig} />
+      </TwoColumnGrid>
+      <EmbeddingIndexControls />
+      <ConfirmActionDialog
+        open={maintenance.confirmOpen}
+        onOpenChange={(open) => {
+          if (!open) maintenance.closeConfirm()
+        }}
+        title={confirmConfig?.title || ""}
+        confirmLabel={confirmConfig?.confirmLabel || t("common.save")}
+        onConfirm={async () => {
+          const action = maintenance.confirmAction
+          if (!action) return
+          maintenance.closeConfirm()
+          await maintenance.runMaintenance(action)
+        }}
+      />
+    </>
+  )
+}

--- a/src/features/model/components/embedding-settings.tsx
+++ b/src/features/model/components/embedding-settings.tsx
@@ -1,368 +1,54 @@
 import { AlertTriangle, RefreshCw } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
-import { SectionStack, TwoColumnGrid } from "@/components/layout"
-import { ConfirmActionDialog, StatusAlert } from "@/components/settings"
-import { FeedbackSettings } from "@/features/knowledge/components/feedback-settings"
-import { useEmbeddingDimensionStats } from "@/features/model/hooks/use-embedding-dimension-stats"
-import { useEmbeddingModelCheck } from "@/features/model/hooks/use-embedding-model-check"
-import { useEmbeddingRebuild } from "@/features/model/hooks/use-embedding-rebuild"
-import { useProviderModels } from "@/features/model/hooks/use-provider-models"
-import { useConfirmAction } from "@/hooks/use-confirm-action"
-import { useSetting } from "@/hooks/use-setting"
-import { useToast } from "@/hooks/use-toast"
-import {
-  DEFAULT_EMBEDDING_CONFIG,
-  DEFAULT_PROVIDER_ID,
-  type EmbeddingConfig
-} from "@/lib/constants"
-import { getCacheStats } from "@/lib/embeddings/embedding-client"
-import {
-  isLikelyEmbeddingModelName,
-  recommendedEmbeddingBaseSet
-} from "@/lib/embeddings/model-name-filter"
-import {
-  clearAllVectors,
-  getStorageStats,
-  removeDuplicateVectors
-} from "@/lib/embeddings/vector-store"
-import { logger } from "@/lib/logger"
-import { SETTINGS } from "@/lib/storage/settings"
 
-import { DatabaseManagementCard } from "./embedding-config/database-management-card"
+import { SectionStack } from "@/components/layout"
+import { StatusAlert } from "@/components/settings"
+import { FeedbackSettings } from "@/features/knowledge/components/feedback-settings"
+import { useEmbeddingRebuildWorkflow } from "@/features/model/hooks/use-embedding-rebuild-workflow"
+import { useEmbeddingSettingsState } from "@/features/model/hooks/use-embedding-settings-state"
+
 import { EmbeddingGenerationConfig } from "./embedding-config/embedding-generation-config"
 import { EmbeddingHealthAlert } from "./embedding-config/embedding-health-alert"
-import { EmbeddingLimitsConfig } from "./embedding-config/embedding-limits-config"
 import { EmbeddingModelSelector } from "./embedding-config/embedding-model-selector"
 import { EmbeddingRebuildDialogs } from "./embedding-config/embedding-rebuild-dialogs"
+import { EmbeddingStorageSettings } from "./embedding-config/embedding-storage-settings"
 import { EmbeddingTestGeneration } from "./embedding-config/embedding-test-generation"
 import { EmbeddingTestSearch } from "./embedding-config/embedding-test-search"
-import { StorageStatsCard } from "./embedding-config/storage-stats-card"
-import { EmbeddingIndexControls } from "./embedding-index-controls"
 
-/**
- * Orchestrator for the Embeddings settings screen.
- *
- * Owns the high-level wiring between storage-backed state
- * (`selectedModel`, `config`) and the three extracted hooks:
- *
- *   - `useEmbeddingDimensionStats` — refreshable vector-store stats.
- *   - `useEmbeddingRebuild`        — the wipe + re-embed flow.
- *   - `useEmbeddingModelCheck`     — periodic background check + auto-switch.
- *
- * Renders four presentational sub-components plus four siblings
- * (`EmbeddingTestGeneration`, `EmbeddingTestSearch`, `EmbeddingGenerationConfig`,
- * `FeedbackSettings`, `DataMigrationSettings`).
- */
+/** Composition root for the embeddings settings screen. */
 export const EmbeddingSettings = () => {
   const { t } = useTranslation()
-  const { toast } = useToast()
-
-  const [selectedModel, setSelectedModel] = useSetting(
-    SETTINGS.EMBEDDING_SELECTED_MODEL
-  )
-  const [config, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
-  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
-
-  const { models } = useProviderModels()
-
-  // Keep `selectedModel` and `config.sharedEmbeddingModel` in sync if
-  // the latter is the more-authoritative value (e.g. just set via the
-  // model picker).
-  useEffect(() => {
-    if (
-      config?.sharedEmbeddingModel &&
-      config.sharedEmbeddingModel !== selectedModel
-    ) {
-      setSelectedModel(config.sharedEmbeddingModel)
-    }
-  }, [config?.sharedEmbeddingModel, selectedModel, setSelectedModel])
-
-  const embeddingModels = useMemo(
-    () => models.filter((model) => isLikelyEmbeddingModelName(model.name)),
-    [models]
-  )
-  const hasAdvancedModels = useMemo(
-    () =>
-      embeddingModels.some(
-        (model) =>
-          !recommendedEmbeddingBaseSet.has(
-            model.name.toLowerCase().split(":")[0]
-          )
-      ),
-    [embeddingModels]
-  )
-
-  const updateConfig = useCallback(
-    (updates: Partial<EmbeddingConfig>) => {
-      setConfig((prev) => ({
-        ...DEFAULT_EMBEDDING_CONFIG,
-        ...prev,
-        ...updates
-      }))
-    },
-    [setConfig]
-  )
-
-  const resolveProviderForModel = useCallback(
-    (modelName: string) => {
-      const match = models.find((model) => model.name === modelName)
-      return match?.providerId || DEFAULT_PROVIDER_ID
-    },
-    [models]
-  )
-
-  const applyModelChange = useCallback(
-    (model: string, providerId: string) => {
-      setSelectedModel(model)
-      updateConfig({
-        sharedEmbeddingModel: model,
-        sharedEmbeddingProviderId: providerId
-      })
-    },
-    [setSelectedModel, updateConfig]
-  )
-
-  const { stats: dimensionStats, refresh: refreshDimensionStats } =
-    useEmbeddingDimensionStats()
-
-  const {
-    isRebuilding,
-    progress: rebuildProgress,
-    error: rebuildError,
-    complete: rebuildComplete,
-    rebuild
-  } = useEmbeddingRebuild({
-    memoryEnabled,
-    onStoreChanged: refreshDimensionStats
+  const settings = useEmbeddingSettingsState()
+  const rebuild = useEmbeddingRebuildWorkflow({
+    memoryEnabled: settings.memoryEnabled,
+    applyModelChange: settings.applyModelChange
   })
-
-  const modelExists = useEmbeddingModelCheck({
-    selectedModel,
-    setSelectedModel,
-    applyModelChange,
-    embeddingModels,
-    resolveProviderForModel
-  })
-
-  // Vector-store stats + maintenance, relocated here from the Context tab so
-  // every embedding/vector-DB control lives on one screen. Dimension stats
-  // come from `useEmbeddingDimensionStats`; storage/cache totals are loaded
-  // locally and refreshed after any destructive action.
-  const [storageStats, setStorageStats] = useState<{
-    totalVectors: number
-    totalSizeMB: number
-    byType: Record<string, number>
-  } | null>(null)
-  const [cacheStats, setCacheStats] = useState<{
-    size: number
-    maxSize: number
-  } | null>(null)
-  const [isCleaning, setIsCleaning] = useState(false)
-  const [confirmAction, setConfirmAction] = useState<
-    "removeDuplicates" | "clearChat" | "clearAll" | null
-  >(null)
-  const confirmDialog = useConfirmAction()
-  const isLoadingStatsRef = useRef(false)
-
-  const loadStorageStats = useCallback(async () => {
-    if (isLoadingStatsRef.current) return
-    isLoadingStatsRef.current = true
-    try {
-      const [statsResult] = await Promise.allSettled([getStorageStats()])
-      if (statsResult.status === "fulfilled") setStorageStats(statsResult.value)
-      setCacheStats(getCacheStats())
-    } catch (error) {
-      logger.error("Failed to load storage stats", "EmbeddingSettings", {
-        error
-      })
-    } finally {
-      isLoadingStatsRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
-    loadStorageStats()
-    const interval = setInterval(() => {
-      if (document.visibilityState === "visible") loadStorageStats()
-    }, 10000)
-    return () => clearInterval(interval)
-  }, [loadStorageStats])
-
-  const refreshAfterMaintenance = useCallback(async () => {
-    await Promise.all([loadStorageStats(), refreshDimensionStats()])
-  }, [loadStorageStats, refreshDimensionStats])
-
-  const handleRemoveDuplicates = useCallback(async () => {
-    setIsCleaning(true)
-    try {
-      const { deleted, kept } = await removeDuplicateVectors()
-      toast({
-        title: t(
-          "model.embedding_config.database_management.remove_duplicates_success",
-          { deleted, kept }
-        )
-      })
-      await refreshAfterMaintenance()
-    } catch (error) {
-      logger.error("Failed to remove duplicates", "EmbeddingSettings", {
-        error
-      })
-      toast({
-        title: t(
-          "model.embedding_config.database_management.remove_duplicates_error"
-        ),
-        variant: "destructive"
-      })
-    } finally {
-      setIsCleaning(false)
-    }
-  }, [refreshAfterMaintenance, t, toast])
-
-  const handleClearChatVectors = useCallback(async () => {
-    setIsCleaning(true)
-    try {
-      const deleted = await clearAllVectors("chat")
-      toast({
-        title: t(
-          "model.embedding_config.database_management.clear_chat_success",
-          { count: deleted }
-        )
-      })
-      await refreshAfterMaintenance()
-    } catch (error) {
-      logger.error("Failed to clear chat vectors", "EmbeddingSettings", {
-        error
-      })
-      toast({
-        title: t("model.embedding_config.database_management.clear_chat_error"),
-        variant: "destructive"
-      })
-    } finally {
-      setIsCleaning(false)
-    }
-  }, [refreshAfterMaintenance, t, toast])
-
-  const handleClearAllVectors = useCallback(async () => {
-    setIsCleaning(true)
-    try {
-      await clearAllVectors()
-      toast({
-        title: t("model.embedding_config.database_management.clear_all_success")
-      })
-      await refreshAfterMaintenance()
-    } catch (error) {
-      logger.error("Failed to clear all vectors", "EmbeddingSettings", {
-        error
-      })
-      toast({
-        title: t("model.embedding_config.database_management.clear_all_error"),
-        variant: "destructive"
-      })
-    } finally {
-      setIsCleaning(false)
-    }
-  }, [refreshAfterMaintenance, t, toast])
-
-  const openConfirm = useCallback(
-    (action: "removeDuplicates" | "clearChat" | "clearAll") => {
-      setConfirmAction(action)
-      confirmDialog.openDialog()
-    },
-    [confirmDialog]
-  )
-
-  const closeConfirm = useCallback(() => {
-    confirmDialog.closeDialog()
-    setConfirmAction(null)
-  }, [confirmDialog])
-
-  const confirmConfig = (() => {
-    switch (confirmAction) {
-      case "removeDuplicates":
-        return {
-          title: t(
-            "model.embedding_config.database_management.remove_duplicates_confirm"
-          ),
-          confirmLabel: t("model.embedding_config.remove_duplicates_button"),
-          onConfirm: handleRemoveDuplicates
-        }
-      case "clearChat":
-        return {
-          title: t(
-            "model.embedding_config.database_management.clear_chat_confirm"
-          ),
-          confirmLabel: t("model.embedding_config.clear_chat_button"),
-          onConfirm: handleClearChatVectors
-        }
-      case "clearAll":
-        return {
-          title: t(
-            "model.embedding_config.database_management.clear_all_confirm"
-          ),
-          confirmLabel: t("model.embedding_config.clear_all_button"),
-          onConfirm: handleClearAllVectors
-        }
-      default:
-        return null
-    }
-  })()
-
-  // Dialog open-state lives here so it can drive the dialog component.
-  const [confirmRebuildOpen, setConfirmRebuildOpen] = useState(false)
-  const [modelChangeOpen, setModelChangeOpen] = useState(false)
-  const [pendingModel, setPendingModel] = useState<{
-    model: string
-    providerId: string
-  } | null>(null)
-
-  const handleModelSelected = useCallback(
-    (model: string, providerId: string) => {
-      setPendingModel({ model, providerId })
-      setModelChangeOpen(true)
-    },
-    []
-  )
-
-  const handleSwitchOnly = useCallback(() => {
-    if (!pendingModel) return
-    applyModelChange(pendingModel.model, pendingModel.providerId)
-    setPendingModel(null)
-    setModelChangeOpen(false)
-  }, [applyModelChange, pendingModel])
-
-  const handleSwitchAndRebuild = useCallback(async () => {
-    if (!pendingModel) return
-    applyModelChange(pendingModel.model, pendingModel.providerId)
-    setPendingModel(null)
-    setModelChangeOpen(false)
-    await rebuild()
-  }, [applyModelChange, pendingModel, rebuild])
 
   const handleToggleShowAdvanced = useCallback(
     (checked: boolean) =>
-      updateConfig({ showAdvancedEmbeddingModels: checked }),
-    [updateConfig]
+      settings.updateConfig({ showAdvancedEmbeddingModels: checked }),
+    [settings.updateConfig]
   )
 
   return (
     <SectionStack>
       <EmbeddingHealthAlert
-        stats={dimensionStats}
-        memoryEnabled={memoryEnabled}
-        isRebuilding={isRebuilding}
-        rebuildProgress={rebuildProgress}
-        onRebuildRequest={() => setConfirmRebuildOpen(true)}
+        stats={rebuild.dimensionStats}
+        memoryEnabled={settings.memoryEnabled}
+        isRebuilding={rebuild.isRebuilding}
+        rebuildProgress={rebuild.progress}
+        onRebuildRequest={() => rebuild.setConfirmRebuildOpen(true)}
       />
-      {rebuildError && (
+      {rebuild.error && (
         <StatusAlert
           variant="destructive"
           icon={AlertTriangle}
           title={t("settings.context.embedding_health.error")}
-          description={rebuildError}
+          description={rebuild.error}
         />
       )}
-      {rebuildComplete && (
+      {rebuild.complete && (
         <StatusAlert
           variant="success"
           icon={RefreshCw}
@@ -370,62 +56,37 @@ export const EmbeddingSettings = () => {
         />
       )}
       <EmbeddingModelSelector
-        selectedModel={selectedModel}
-        config={config || DEFAULT_EMBEDDING_CONFIG}
-        embeddingModels={embeddingModels}
-        hasAdvancedModels={hasAdvancedModels}
-        isRebuilding={isRebuilding}
-        rebuildProgress={rebuildProgress}
-        resolveProviderForModel={resolveProviderForModel}
-        onModelSelected={handleModelSelected}
+        selectedModel={settings.selectedModel}
+        config={settings.config}
+        embeddingModels={settings.embeddingModels}
+        hasAdvancedModels={settings.hasAdvancedModels}
+        isRebuilding={rebuild.isRebuilding}
+        rebuildProgress={rebuild.progress}
+        resolveProviderForModel={settings.resolveProviderForModel}
+        onModelSelected={rebuild.requestModelChange}
         onToggleShowAdvanced={handleToggleShowAdvanced}
       />
-      <EmbeddingTestGeneration modelExists={modelExists} />
-      <EmbeddingTestSearch modelExists={modelExists} />
+      <EmbeddingTestGeneration modelExists={settings.modelExists} />
+      <EmbeddingTestSearch modelExists={settings.modelExists} />
       <EmbeddingGenerationConfig
-        config={config || DEFAULT_EMBEDDING_CONFIG}
-        updateConfig={updateConfig}
+        config={settings.config}
+        updateConfig={settings.updateConfig}
       />
-      {storageStats && (
-        <StorageStatsCard storageStats={storageStats} cacheStats={cacheStats} />
-      )}
-      <TwoColumnGrid>
-        <DatabaseManagementCard
-          onRemoveDuplicates={() => openConfirm("removeDuplicates")}
-          onClearChat={() => openConfirm("clearChat")}
-          onClearAll={() => openConfirm("clearAll")}
-          isCleaning={isCleaning || isRebuilding}
-          hasVectors={!!storageStats?.totalVectors}
-          hasChatVectors={!!storageStats?.byType?.chat}
-        />
-        <EmbeddingLimitsConfig
-          config={config || DEFAULT_EMBEDDING_CONFIG}
-          updateConfig={updateConfig}
-        />
-      </TwoColumnGrid>
-      <EmbeddingIndexControls />
+      <EmbeddingStorageSettings
+        config={settings.config}
+        updateConfig={settings.updateConfig}
+        isRebuilding={rebuild.isRebuilding}
+        onStoreChanged={rebuild.refreshDimensionStats}
+      />
       <FeedbackSettings />
-      <ConfirmActionDialog
-        open={confirmDialog.open}
-        onOpenChange={(next) => {
-          if (!next) closeConfirm()
-        }}
-        title={confirmConfig?.title || ""}
-        confirmLabel={confirmConfig?.confirmLabel || t("common.save")}
-        onConfirm={async () => {
-          if (!confirmConfig) return
-          closeConfirm()
-          await confirmConfig.onConfirm()
-        }}
-      />
       <EmbeddingRebuildDialogs
-        confirmRebuildOpen={confirmRebuildOpen}
-        onConfirmRebuildOpenChange={setConfirmRebuildOpen}
-        onConfirmRebuild={rebuild}
-        modelChangeOpen={modelChangeOpen}
-        onModelChangeOpenChange={setModelChangeOpen}
-        onSwitchOnly={handleSwitchOnly}
-        onSwitchAndRebuild={handleSwitchAndRebuild}
+        confirmRebuildOpen={rebuild.confirmRebuildOpen}
+        onConfirmRebuildOpenChange={rebuild.setConfirmRebuildOpen}
+        onConfirmRebuild={rebuild.rebuild}
+        modelChangeOpen={rebuild.modelChangeOpen}
+        onModelChangeOpenChange={rebuild.setModelChangeOpen}
+        onSwitchOnly={rebuild.switchModel}
+        onSwitchAndRebuild={rebuild.switchModelAndRebuild}
       />
     </SectionStack>
   )

--- a/src/features/model/hooks/__tests__/use-embedding-rebuild-workflow.test.ts
+++ b/src/features/model/hooks/__tests__/use-embedding-rebuild-workflow.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useEmbeddingRebuildWorkflow } from "../use-embedding-rebuild-workflow"
+
+const mocks = vi.hoisted(() => ({
+  rebuild: vi.fn(async () => undefined),
+  refresh: vi.fn(async () => undefined)
+}))
+
+vi.mock("../use-embedding-dimension-stats", () => ({
+  useEmbeddingDimensionStats: () => ({
+    stats: { totalVectors: 2, mixedDimensions: false },
+    refresh: mocks.refresh
+  })
+}))
+vi.mock("../use-embedding-rebuild", () => ({
+  useEmbeddingRebuild: () => ({
+    isRebuilding: false,
+    progress: null,
+    error: null,
+    complete: false,
+    rebuild: mocks.rebuild,
+    resetComplete: vi.fn()
+  })
+}))
+
+describe("useEmbeddingRebuildWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("applies a pending model without rebuilding", () => {
+    const applyModelChange = vi.fn()
+    const { result } = renderHook(() =>
+      useEmbeddingRebuildWorkflow({ memoryEnabled: true, applyModelChange })
+    )
+
+    act(() => result.current.requestModelChange("embed-v2", "provider-2"))
+    expect(result.current.modelChangeOpen).toBe(true)
+
+    act(() => result.current.switchModel())
+
+    expect(applyModelChange).toHaveBeenCalledWith("embed-v2", "provider-2")
+    expect(mocks.rebuild).not.toHaveBeenCalled()
+    expect(result.current.modelChangeOpen).toBe(false)
+  })
+
+  it("applies a pending model before rebuilding", async () => {
+    const applyModelChange = vi.fn()
+    const { result } = renderHook(() =>
+      useEmbeddingRebuildWorkflow({ memoryEnabled: false, applyModelChange })
+    )
+
+    act(() => result.current.requestModelChange("embed-v3", "provider-3"))
+    await act(() => result.current.switchModelAndRebuild())
+
+    expect(applyModelChange).toHaveBeenCalledWith("embed-v3", "provider-3")
+    expect(applyModelChange.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.rebuild.mock.invocationCallOrder[0]
+    )
+    expect(result.current.modelChangeOpen).toBe(false)
+  })
+
+  it("drops a pending model when the dialog closes", () => {
+    const applyModelChange = vi.fn()
+    const { result } = renderHook(() =>
+      useEmbeddingRebuildWorkflow({ memoryEnabled: true, applyModelChange })
+    )
+
+    act(() => result.current.requestModelChange("embed-v4", "provider-4"))
+    act(() => result.current.setModelChangeOpen(false))
+    act(() => result.current.switchModel())
+
+    expect(result.current.modelChangeOpen).toBe(false)
+    expect(applyModelChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/model/hooks/__tests__/use-embedding-storage-maintenance.test.ts
+++ b/src/features/model/hooks/__tests__/use-embedding-storage-maintenance.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useEmbeddingStorageMaintenance } from "../use-embedding-storage-maintenance"
+
+const mocks = vi.hoisted(() => ({
+  toast: vi.fn(),
+  getCacheStats: vi.fn(() => ({ size: 3, maxSize: 100 })),
+  getStorageStats: vi.fn(async () => ({
+    totalVectors: 5,
+    totalSizeMB: 1.5,
+    byType: { chat: 4, file: 1 }
+  })),
+  removeDuplicateVectors: vi.fn(async () => ({ deleted: 2, kept: 3 })),
+  clearAllVectors: vi.fn(async () => 4)
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast })
+}))
+vi.mock("@/lib/embeddings/embedding-client", () => ({
+  getCacheStats: mocks.getCacheStats
+}))
+vi.mock("@/lib/embeddings/vector-store", () => ({
+  getStorageStats: mocks.getStorageStats,
+  removeDuplicateVectors: mocks.removeDuplicateVectors,
+  clearAllVectors: mocks.clearAllVectors
+}))
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+describe("useEmbeddingStorageMaintenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("loads storage and cache statistics", async () => {
+    const { result } = renderHook(() =>
+      useEmbeddingStorageMaintenance({ onStoreChanged: vi.fn() })
+    )
+
+    await waitFor(() => expect(result.current.storageStats).not.toBeNull())
+
+    expect(result.current.storageStats).toMatchObject({
+      totalVectors: 5,
+      byType: { chat: 4, file: 1 }
+    })
+    expect(result.current.cacheStats).toEqual({ size: 3, maxSize: 100 })
+  })
+
+  it("clears only chat vectors and refreshes dependent statistics", async () => {
+    const onStoreChanged = vi.fn(async () => undefined)
+    const { result } = renderHook(() =>
+      useEmbeddingStorageMaintenance({ onStoreChanged })
+    )
+    await waitFor(() => expect(result.current.storageStats).not.toBeNull())
+
+    await act(() => result.current.runMaintenance("clearChat"))
+
+    expect(mocks.clearAllVectors).toHaveBeenCalledWith("chat")
+    expect(onStoreChanged).toHaveBeenCalledOnce()
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: "model.embedding_config.database_management.clear_chat_success"
+    })
+  })
+
+  it("reports maintenance failures without refreshing", async () => {
+    mocks.removeDuplicateVectors.mockRejectedValueOnce(new Error("broken"))
+    const onStoreChanged = vi.fn()
+    const { result } = renderHook(() =>
+      useEmbeddingStorageMaintenance({ onStoreChanged })
+    )
+    await waitFor(() => expect(result.current.storageStats).not.toBeNull())
+
+    await act(() => result.current.runMaintenance("removeDuplicates"))
+
+    expect(onStoreChanged).not.toHaveBeenCalled()
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title:
+        "model.embedding_config.database_management.remove_duplicates_error",
+      variant: "destructive"
+    })
+  })
+})

--- a/src/features/model/hooks/use-embedding-rebuild-workflow.ts
+++ b/src/features/model/hooks/use-embedding-rebuild-workflow.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from "react"
+
+import { useEmbeddingDimensionStats } from "./use-embedding-dimension-stats"
+import { useEmbeddingRebuild } from "./use-embedding-rebuild"
+
+export interface PendingEmbeddingModel {
+  model: string
+  providerId: string
+}
+
+export interface UseEmbeddingRebuildWorkflowOptions {
+  memoryEnabled: boolean
+  applyModelChange: (model: string, providerId: string) => void
+}
+
+/** Owns rebuild status and the two confirmation flows on the embeddings page. */
+export const useEmbeddingRebuildWorkflow = ({
+  memoryEnabled,
+  applyModelChange
+}: UseEmbeddingRebuildWorkflowOptions) => {
+  const { stats, refresh } = useEmbeddingDimensionStats()
+  const rebuildState = useEmbeddingRebuild({
+    memoryEnabled,
+    onStoreChanged: refresh
+  })
+  const [confirmRebuildOpen, setConfirmRebuildOpen] = useState(false)
+  const [pendingModel, setPendingModel] =
+    useState<PendingEmbeddingModel | null>(null)
+
+  const requestModelChange = useCallback(
+    (model: string, providerId: string) => {
+      setPendingModel({ model, providerId })
+    },
+    []
+  )
+
+  const closeModelChange = useCallback(() => setPendingModel(null), [])
+
+  const switchModel = useCallback(() => {
+    if (!pendingModel) return
+    applyModelChange(pendingModel.model, pendingModel.providerId)
+    setPendingModel(null)
+  }, [applyModelChange, pendingModel])
+
+  const switchModelAndRebuild = useCallback(async () => {
+    if (!pendingModel) return
+    applyModelChange(pendingModel.model, pendingModel.providerId)
+    setPendingModel(null)
+    await rebuildState.rebuild()
+  }, [applyModelChange, pendingModel, rebuildState.rebuild])
+
+  return {
+    ...rebuildState,
+    dimensionStats: stats,
+    refreshDimensionStats: refresh,
+    confirmRebuildOpen,
+    setConfirmRebuildOpen,
+    modelChangeOpen: pendingModel !== null,
+    setModelChangeOpen: (open: boolean) => {
+      if (!open) closeModelChange()
+    },
+    requestModelChange,
+    switchModel,
+    switchModelAndRebuild
+  }
+}

--- a/src/features/model/hooks/use-embedding-settings-state.ts
+++ b/src/features/model/hooks/use-embedding-settings-state.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo } from "react"
+
+import { useSetting } from "@/hooks/use-setting"
+import {
+  DEFAULT_EMBEDDING_CONFIG,
+  DEFAULT_PROVIDER_ID,
+  type EmbeddingConfig
+} from "@/lib/constants"
+import {
+  isLikelyEmbeddingModelName,
+  recommendedEmbeddingBaseSet
+} from "@/lib/embeddings/model-name-filter"
+import { SETTINGS } from "@/lib/storage/settings"
+
+import { useEmbeddingModelCheck } from "./use-embedding-model-check"
+import { useProviderModels } from "./use-provider-models"
+
+/**
+ * Storage-backed model and configuration state for the embeddings screen.
+ * Keeps provider discovery and the selected-model compatibility setting out of
+ * the settings-page composition component.
+ */
+export const useEmbeddingSettingsState = () => {
+  const [selectedModel, setSelectedModel] = useSetting(
+    SETTINGS.EMBEDDING_SELECTED_MODEL
+  )
+  const [storedConfig, setConfig] = useSetting(SETTINGS.EMBEDDING_CONFIG)
+  const [memoryEnabled] = useSetting(SETTINGS.MEMORY_ENABLED)
+  const { models } = useProviderModels()
+  const config = storedConfig || DEFAULT_EMBEDDING_CONFIG
+
+  useEffect(() => {
+    if (
+      storedConfig?.sharedEmbeddingModel &&
+      storedConfig.sharedEmbeddingModel !== selectedModel
+    ) {
+      setSelectedModel(storedConfig.sharedEmbeddingModel)
+    }
+  }, [selectedModel, setSelectedModel, storedConfig?.sharedEmbeddingModel])
+
+  const embeddingModels = useMemo(
+    () => models.filter((model) => isLikelyEmbeddingModelName(model.name)),
+    [models]
+  )
+  const hasAdvancedModels = useMemo(
+    () =>
+      embeddingModels.some(
+        (model) =>
+          !recommendedEmbeddingBaseSet.has(
+            model.name.toLowerCase().split(":")[0]
+          )
+      ),
+    [embeddingModels]
+  )
+
+  const updateConfig = useCallback(
+    (updates: Partial<EmbeddingConfig>) => {
+      setConfig((previous) => ({
+        ...DEFAULT_EMBEDDING_CONFIG,
+        ...previous,
+        ...updates
+      }))
+    },
+    [setConfig]
+  )
+
+  const resolveProviderForModel = useCallback(
+    (modelName: string) =>
+      models.find((model) => model.name === modelName)?.providerId ||
+      DEFAULT_PROVIDER_ID,
+    [models]
+  )
+
+  const applyModelChange = useCallback(
+    (model: string, providerId: string) => {
+      setSelectedModel(model)
+      updateConfig({
+        sharedEmbeddingModel: model,
+        sharedEmbeddingProviderId: providerId
+      })
+    },
+    [setSelectedModel, updateConfig]
+  )
+
+  const modelExists = useEmbeddingModelCheck({
+    selectedModel,
+    setSelectedModel,
+    applyModelChange,
+    embeddingModels,
+    resolveProviderForModel
+  })
+
+  return {
+    selectedModel,
+    config,
+    memoryEnabled,
+    embeddingModels,
+    hasAdvancedModels,
+    modelExists,
+    updateConfig,
+    resolveProviderForModel,
+    applyModelChange
+  }
+}

--- a/src/features/model/hooks/use-embedding-storage-maintenance.ts
+++ b/src/features/model/hooks/use-embedding-storage-maintenance.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useConfirmAction } from "@/hooks/use-confirm-action"
+import { useToast } from "@/hooks/use-toast"
+import { getCacheStats } from "@/lib/embeddings/embedding-client"
+import {
+  clearAllVectors,
+  getStorageStats,
+  removeDuplicateVectors
+} from "@/lib/embeddings/vector-store"
+import { logger } from "@/lib/logger"
+
+export type EmbeddingMaintenanceAction =
+  | "removeDuplicates"
+  | "clearChat"
+  | "clearAll"
+
+export interface UseEmbeddingStorageMaintenanceOptions {
+  onStoreChanged: () => Promise<void> | void
+}
+
+/** Loads vector-store metrics and owns all destructive maintenance actions. */
+export const useEmbeddingStorageMaintenance = ({
+  onStoreChanged
+}: UseEmbeddingStorageMaintenanceOptions) => {
+  const { t } = useTranslation()
+  const { toast } = useToast()
+  const confirmDialog = useConfirmAction()
+  const [storageStats, setStorageStats] = useState<{
+    totalVectors: number
+    totalSizeMB: number
+    byType: Record<string, number>
+  } | null>(null)
+  const [cacheStats, setCacheStats] = useState<{
+    size: number
+    maxSize: number
+  } | null>(null)
+  const [isCleaning, setIsCleaning] = useState(false)
+  const [confirmAction, setConfirmAction] =
+    useState<EmbeddingMaintenanceAction | null>(null)
+  const isLoadingStatsRef = useRef(false)
+
+  const loadStats = useCallback(async () => {
+    if (isLoadingStatsRef.current) return
+    isLoadingStatsRef.current = true
+    try {
+      const result = await Promise.allSettled([getStorageStats()])
+      if (result[0].status === "fulfilled") {
+        setStorageStats(result[0].value)
+      }
+      setCacheStats(getCacheStats())
+    } catch (error) {
+      logger.error(
+        "Failed to load storage stats",
+        "useEmbeddingStorageMaintenance",
+        { error }
+      )
+    } finally {
+      isLoadingStatsRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    loadStats()
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") loadStats()
+    }, 10_000)
+    return () => clearInterval(interval)
+  }, [loadStats])
+
+  const refresh = useCallback(async () => {
+    await Promise.all([loadStats(), onStoreChanged()])
+  }, [loadStats, onStoreChanged])
+
+  const runMaintenance = useCallback(
+    async (action: EmbeddingMaintenanceAction) => {
+      setIsCleaning(true)
+      try {
+        if (action === "removeDuplicates") {
+          const { deleted, kept } = await removeDuplicateVectors()
+          toast({
+            title: t(
+              "model.embedding_config.database_management.remove_duplicates_success",
+              { deleted, kept }
+            )
+          })
+        } else if (action === "clearChat") {
+          const deleted = await clearAllVectors("chat")
+          toast({
+            title: t(
+              "model.embedding_config.database_management.clear_chat_success",
+              { count: deleted }
+            )
+          })
+        } else {
+          await clearAllVectors()
+          toast({
+            title: t(
+              "model.embedding_config.database_management.clear_all_success"
+            )
+          })
+        }
+        await refresh()
+      } catch (error) {
+        const messageKey =
+          action === "removeDuplicates"
+            ? "model.embedding_config.database_management.remove_duplicates_error"
+            : action === "clearChat"
+              ? "model.embedding_config.database_management.clear_chat_error"
+              : "model.embedding_config.database_management.clear_all_error"
+        logger.error(
+          `Failed to run embedding maintenance action: ${action}`,
+          "useEmbeddingStorageMaintenance",
+          { error }
+        )
+        toast({ title: t(messageKey), variant: "destructive" })
+      } finally {
+        setIsCleaning(false)
+      }
+    },
+    [refresh, t, toast]
+  )
+
+  const openConfirm = useCallback(
+    (action: EmbeddingMaintenanceAction) => {
+      setConfirmAction(action)
+      confirmDialog.openDialog()
+    },
+    [confirmDialog.openDialog]
+  )
+
+  const closeConfirm = useCallback(() => {
+    confirmDialog.closeDialog()
+    setConfirmAction(null)
+  }, [confirmDialog.closeDialog])
+
+  return {
+    storageStats,
+    cacheStats,
+    isCleaning,
+    confirmAction,
+    confirmOpen: confirmDialog.open,
+    loadStats,
+    openConfirm,
+    closeConfirm,
+    runMaintenance
+  }
+}


### PR DESCRIPTION
## Summary

- reduce the embeddings settings page to a composition root
- isolate storage-backed model/config state, rebuild transitions, and vector-store maintenance
- group storage statistics, limits, index controls, and destructive actions under one focused component
- add regression coverage for rebuild/model switching and storage maintenance

## Verification

- `pnpm verify`
- `pnpm build`
- pre-push release checks (tests, package, bundle budgets, docs build)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR decomposes the embeddings settings page into focused hooks and a storage-settings component while preserving the existing composition and workflows.

- Extracts storage-backed embedding model and configuration state.
- Extracts model-switch and rebuild dialog transitions.
- Extracts vector-store statistics, maintenance actions, and confirmation handling.
- Adds regression tests for model switching, rebuild ordering, statistics loading, and destructive maintenance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The extracted hooks and component preserve the prior embedding settings, model-switch, rebuild, polling, and vector-maintenance behavior, and the new tests cover the principal workflow transitions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/model/components/embedding-settings.tsx | Reduced to a composition root that wires extracted state, rebuild, and storage-maintenance modules without an established behavioral regression. |
| src/features/model/components/embedding-config/embedding-storage-settings.tsx | Groups statistics, limits, index controls, destructive actions, and their confirmation dialog into one focused component. |
| src/features/model/hooks/use-embedding-settings-state.ts | Preserves the prior storage-backed configuration, model filtering, provider resolution, and model-check behavior. |
| src/features/model/hooks/use-embedding-rebuild-workflow.ts | Encapsulates rebuild state and model-change dialog transitions while retaining the previous apply-then-rebuild sequence. |
| src/features/model/hooks/use-embedding-storage-maintenance.ts | Encapsulates statistics polling and vector maintenance with single-flight statistics loading and post-action refreshes. |
| src/features/model/hooks/__tests__/use-embedding-rebuild-workflow.test.ts | Adds coverage for switch-only, switch-and-rebuild ordering, and cancellation of pending model changes. |
| src/features/model/hooks/__tests__/use-embedding-storage-maintenance.test.ts | Adds coverage for statistics loading, chat-only deletion, dependent refreshes, and maintenance failures. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Settings["EmbeddingSettings"] --> State["useEmbeddingSettingsState"]
  Settings --> Workflow["useEmbeddingRebuildWorkflow"]
  Settings --> StorageUI["EmbeddingStorageSettings"]
  Workflow --> Rebuild["useEmbeddingRebuild"]
  Workflow --> DimensionStats["useEmbeddingDimensionStats"]
  StorageUI --> Maintenance["useEmbeddingStorageMaintenance"]
  Maintenance --> VectorStore["Vector store maintenance"]
  Maintenance --> DimensionStats
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23287%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=287&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(model): split embedding setting..."](https://github.com/shishir435/ollama-client/commit/28d3705df0f75722db007f1db62c7ebb81d00b38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53064687)</sub>

<!-- /greptile_comment -->