### PR TITLE
Refactor provider and context orchestration

### DIFF
--- a/src/application/context/__tests__/context-assembly.test.ts
+++ b/src/application/context/__tests__/context-assembly.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest"
+import { ACTIVITY_LABELS } from "@/application/context/activity-labels"
+import { ContextAssembly } from "../context-assembly"
+import { createContextPlan } from "../context-plan"
+
+const plan = (maxRagContextChars = 100) =>
+  createContextPlan({
+    rawInput: "Question",
+    maxRagContextChars,
+    groundedOnlyMode: false
+  })
+
+describe("ContextAssembly", () => {
+  it("shares one budget across stored context sources", () => {
+    const assembly = new ContextAssembly(plan(10), false)
+    assembly.appendStoredContext(
+      "123456",
+      [{ id: "f", title: "File", content: "123456", score: 0.9 }],
+      "query",
+      () => "file"
+    )
+    assembly.appendStoredContext(
+      "abcdef",
+      [{ id: "m", title: "Memory", content: "abcdef", score: 0.8 }],
+      "query",
+      () => "memory"
+    )
+
+    const result = assembly.finish()
+    expect(result.promptContextStats.ragContextLength).toBeGreaterThanOrEqual(
+      10
+    )
+    expect(assembly.remainingRagBudget).toBe(0)
+    expect(result.promptContextStats.usedContextChunks).toEqual([
+      expect.objectContaining({ id: "f", source: "file" }),
+      expect.objectContaining({ id: "m", source: "memory" })
+    ])
+  })
+
+  it("publishes immutable activity snapshots", () => {
+    const onActivity = vi.fn()
+    const assembly = new ContextAssembly(plan(), false, onActivity)
+    const event = assembly.startActivity(
+      "files",
+      "searching_files",
+      ACTIVITY_LABELS.searchingFiles
+    )
+    assembly.finishActivity(event, { resultCount: 2 })
+
+    expect(onActivity).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([expect.objectContaining({ status: "running" })])
+    )
+    expect(onActivity).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([
+        expect.objectContaining({ status: "done", resultCount: 2 })
+      ])
+    )
+  })
+
+  it("adds the tab fallback and emits grounded stats", () => {
+    const groundedPlan = createContextPlan({
+      rawInput: "Question",
+      maxRagContextChars: 100,
+      groundedOnlyMode: true
+    })
+    const assembly = new ContextAssembly(groundedPlan, true)
+    assembly.appendTabFallback("Page text", 100)
+
+    const result = assembly.finish()
+    expect(result.contentWithRAG).toContain("Page text")
+    expect(result.promptContextStats.insufficientContext).toBe(false)
+  })
+})

--- a/src/application/context/build-context.ts
+++ b/src/application/context/build-context.ts
@@ -2,9 +2,7 @@ import type { ContextFileInput } from "@ollama-client/contracts/context"
 import type { TurnToast } from "@ollama-client/contracts/turns"
 import {
   ACTIVITY_LABELS,
-  ACTIVITY_TEXTS,
-  type ActivityLabel,
-  CONTEXT_CHUNK_LABELS
+  ACTIVITY_TEXTS
 } from "@/application/context/activity-labels"
 import {
   reformulateQuestion,
@@ -34,8 +32,9 @@ import type {
   RagSources,
   UsedContextChunk
 } from "@/types"
+import { ContextAssembly, type PromptContextStats } from "./context-assembly"
 import type { DurableContextOptions } from "./context-contract"
-import { createContextPlan, remainingRagBudget } from "./context-plan"
+import { createContextPlan } from "./context-plan"
 
 /**
  * The minimal file shape context building needs: the scope id and the raw text
@@ -44,19 +43,8 @@ import { createContextPlan, remainingRagBudget } from "./context-plan"
  * context building runs in the background.
  */
 export type { ContextFileInput } from "@ollama-client/contracts/context"
+export type { PromptContextStats } from "./context-assembly"
 export type { RagSource, RagSources, UsedContextChunk }
-
-export interface PromptContextStats {
-  promptInputLength: number
-  promptAugmentedLength: number
-  tabContextLength: number
-  ragContextLength: number
-  tabContextTruncated: boolean
-  groundedOnlyMode: boolean
-  insufficientContext: boolean
-  usedContextChunks: UsedContextChunk[]
-  activityEvents: ActivityEvent[]
-}
 
 export interface BuildRagContextOptions extends DurableContextOptions {
   /**
@@ -88,41 +76,6 @@ export interface BuildRagContextResult {
   pageContextAdded: boolean
 }
 
-const clampContext = (value: string, maxChars: number) => {
-  if (value.length <= maxChars) return { text: value, truncated: false }
-  return {
-    text: `${value.slice(0, maxChars)}\n\n[Context truncated due to length]`,
-    truncated: true
-  }
-}
-
-const mergeRagSources = (
-  current: RagSources | null,
-  sources: RagSource[],
-  query: string
-): RagSources => ({
-  sources: [...(current?.sources || []), ...sources],
-  query
-})
-
-const addUsedContextChunks = (
-  usedContextChunks: UsedContextChunk[],
-  sources: RagSource[],
-  sourceFor: (source: RagSource) => UsedContextChunk["source"]
-) => {
-  sources.forEach((source) => {
-    usedContextChunks.push({
-      id: source.id,
-      title: source.title,
-      excerpt: source.content.slice(0, 220),
-      score: source.score,
-      sectionPath: source.source || source.type,
-      source: sourceFor(source),
-      chunkIndex: source.chunkIndex
-    })
-  })
-}
-
 const resolveFileRagScope = async (
   files: ContextFileInput[] | undefined,
   activeKnowledgeSet: KnowledgeSetRecord | undefined
@@ -143,31 +96,6 @@ const resolveFileRagScope = async (
   const setFileIds = await getKnowledgeSetFileIds(activeKnowledgeSet.id)
   return setFileIds.length > 0 ? setFileIds : undefined
 }
-
-const buildTabFallbackContext = (contextText: string, maxChars: number) => {
-  const clampedFallback = clampContext(contextText, maxChars)
-  const chunk: UsedContextChunk = {
-    id: "tab-fallback",
-    title: CONTEXT_CHUNK_LABELS.selectedTabContext.text,
-    titleKey: CONTEXT_CHUNK_LABELS.selectedTabContext.key,
-    excerpt: clampedFallback.text.slice(0, 220),
-    score: 0.5,
-    sectionPath: "fallback-full-context",
-    source: "tab"
-  }
-
-  return { clampedFallback, chunk }
-}
-
-const buildFileFullTextFallback = (files: ContextFileInput[]) =>
-  files
-    .map(
-      (file) =>
-        `[File: ${file.metadata.fileName}]\n${file.text.slice(0, 10000)}${
-          file.text.length > 10000 ? "\n... (truncated)" : ""
-        }`
-    )
-    .join("\n\n---\n\n")
 
 const REFORMULATION_TIMEOUT_MS = 8000
 const PREVIEW_LIMIT = 180
@@ -231,64 +159,14 @@ export const buildRagContext = async (
     groundedOnlyMode,
     retrievalToolsActive
   })
-  const userContent = plan.userContent
-  let contentWithRAG = userContent
-  let tabContextLength = 0
-  let ragContextLength = 0
-  let tabContextTruncated = false
-
-  // Stored file context and conversation-memory context share ONE budget: the
-  // configured RAG cap is the ceiling for their combined length, not a per-step
-  // limit. Otherwise a turn with both could inject nearly twice the budget and
-  // crowd out recent messages / the answer. `<= 0` means unlimited.
-  const getRemainingRagBudget = () => remainingRagBudget(plan, ragContextLength)
-  const usedContextChunks: UsedContextChunk[] = []
-  const activityEvents: ActivityEvent[] = []
-  let ragSources: RagSources | null = null
-  let pageContextAdded = false
-
-  const upsertActivityEvent = (event: ActivityEvent) => {
-    const index = activityEvents.findIndex((item) => item.id === event.id)
-    if (index >= 0) activityEvents[index] = event
-    else activityEvents.push(event)
-    onActivityEvent?.([...activityEvents])
-  }
-
-  const startActivityEvent = (
-    id: string,
-    kind: ActivityEvent["kind"],
-    label: ActivityLabel,
-    inputPreview?: string
-  ): ActivityEvent => {
-    const event: ActivityEvent = {
-      id,
-      kind,
-      label: label.text,
-      labelKey: label.key,
-      status: "running",
-      startedAt: Date.now(),
-      inputPreview
-    }
-    upsertActivityEvent(event)
-    return event
-  }
-
-  const finishActivityEvent = (
-    event: ActivityEvent,
-    updates: Partial<ActivityEvent> = {}
-  ) => {
-    upsertActivityEvent({
-      ...event,
-      ...updates,
-      status: updates.status ?? "done",
-      finishedAt: Date.now()
-    })
-  }
+  const assembly = new ContextAssembly(
+    plan,
+    groundedOnlyMode,
+    onActivityEvent,
+    DEFAULT_RAG_PROMPT
+  )
 
   const useRag = await readSetting(SETTINGS.USE_RAG)
-
-  let ragInstruction = DEFAULT_RAG_PROMPT
-  let ragInstructionAdded = false
 
   const invokeModelOnce = async (prompt: string): Promise<string> => {
     try {
@@ -326,15 +204,6 @@ export const buildRagContext = async (
     }
   }
 
-  const appendRagContext = (current: string, context: string) => {
-    const block =
-      !ragInstructionAdded && ragInstruction
-        ? `${ragInstruction}\n\n${context}`
-        : context
-    ragInstructionAdded = true
-    return current ? `${current}\n\n---\n\n${block}` : block
-  }
-
   let queryForRag = plan.initialRetrievalQuery
 
   if (useRag) {
@@ -360,7 +229,7 @@ export const buildRagContext = async (
       } else {
         const activeKnowledgeSet = await getActiveKnowledgeSet()
         if (activeKnowledgeSet?.ragPrompt?.trim()) {
-          ragInstruction = activeKnowledgeSet.ragPrompt.trim()
+          assembly.setRagInstruction(activeKnowledgeSet.ragPrompt.trim())
         }
 
         const retrievalOverrides = activeKnowledgeSet?.retrieval
@@ -369,7 +238,7 @@ export const buildRagContext = async (
           activeKnowledgeSet?.questionPrompt?.trim() &&
           recentHistory.length >= 2
         ) {
-          const rewriteEvent = startActivityEvent(
+          const rewriteEvent = assembly.startActivity(
             "query-rewrite",
             "query_rewrite",
             ACTIVITY_LABELS.rewritingQuery,
@@ -381,7 +250,7 @@ export const buildRagContext = async (
             invokeModelOnce,
             activeKnowledgeSet.questionPrompt
           )
-          finishActivityEvent(rewriteEvent, {
+          assembly.finishActivity(rewriteEvent, {
             outputPreview: preview(reformulated || rawInput || "summary")
           })
           if (reformulated) {
@@ -394,7 +263,7 @@ export const buildRagContext = async (
 
         // Page-only context (ephemeral, not persisted).
         if (hasTabContext) {
-          const pageEvent = startActivityEvent(
+          const pageEvent = assembly.startActivity(
             "page-context",
             "reading_page",
             ACTIVITY_LABELS.readingPageContext,
@@ -415,26 +284,14 @@ export const buildRagContext = async (
           )
 
           if (pageContext.documents.length > 0) {
-            const clamped = clampContext(
+            assembly.appendPageContext(
               pageContext.formattedContext,
+              pageContext.sources,
+              rawInput || "summary",
               maxTabContextChars
             )
-            contentWithRAG = appendRagContext(contentWithRAG, clamped.text)
-            tabContextLength += clamped.text.length
-            tabContextTruncated = tabContextTruncated || clamped.truncated
-            ragSources = mergeRagSources(
-              ragSources,
-              pageContext.sources,
-              rawInput || "summary"
-            )
-            addUsedContextChunks(
-              usedContextChunks,
-              pageContext.sources,
-              () => "tab"
-            )
-            pageContextAdded = true
           }
-          finishActivityEvent(pageEvent, {
+          assembly.finishActivity(pageEvent, {
             resultCount: pageContext.documents.length,
             sourceTitles: pageContext.sources
               .slice(0, 3)
@@ -456,7 +313,7 @@ export const buildRagContext = async (
           const fileIds = await resolveFileRagScope(files, activeKnowledgeSet)
 
           if (fileIds && fileIds.length > 0) {
-            const searchEvent = startActivityEvent(
+            const searchEvent = assembly.startActivity(
               "file-search",
               "searching_files",
               ACTIVITY_LABELS.searchingFiles,
@@ -484,24 +341,14 @@ export const buildRagContext = async (
               logger.info("RAG found relevant chunks", "useChat", {
                 chunkCount: context.documents.length
               })
-              const clamped = clampContext(
+              assembly.appendStoredContext(
                 context.formattedContext,
-                getRemainingRagBudget()
-              )
-              ragSources = mergeRagSources(
-                ragSources,
                 context.sources,
-                queryForRag
-              )
-              addUsedContextChunks(
-                usedContextChunks,
-                context.sources,
+                queryForRag,
                 (source) => source.source
               )
-              contentWithRAG = appendRagContext(contentWithRAG, clamped.text)
-              ragContextLength += clamped.text.length
             }
-            finishActivityEvent(searchEvent, {
+            assembly.finishActivity(searchEvent, {
               resultCount: context.documents.length,
               sourceTitles: context.sources
                 .slice(0, 3)
@@ -525,7 +372,7 @@ export const buildRagContext = async (
           // path that answers "based on our past conversation …": it runs
           // whenever memory is enabled, with or without selected files.
           if (memoryEnabled) {
-            const memoryEvent = startActivityEvent(
+            const memoryEvent = assembly.startActivity(
               "memory-recall",
               "searching_memory",
               ACTIVITY_LABELS.searchingMemory,
@@ -537,17 +384,18 @@ export const buildRagContext = async (
             })
             // Memory shares the RAG budget with file context above; only append
             // what fits in the remainder so the two together stay within cap.
-            const memoryBudget = getRemainingRagBudget()
+            const memoryBudget = assembly.remainingRagBudget
             if (memoryResults.length > 0 && memoryBudget > 0) {
               const { formattedContext, sources } =
                 formatEnhancedResults(memoryResults)
-              const clamped = clampContext(formattedContext, memoryBudget)
-              contentWithRAG = appendRagContext(contentWithRAG, clamped.text)
-              ragContextLength += clamped.text.length
-              ragSources = mergeRagSources(ragSources, sources, queryForRag)
-              addUsedContextChunks(usedContextChunks, sources, () => "memory")
+              assembly.appendStoredContext(
+                formattedContext,
+                sources,
+                queryForRag,
+                () => "memory"
+              )
             }
-            finishActivityEvent(memoryEvent, {
+            assembly.finishActivity(memoryEvent, {
               resultCount: memoryResults.length,
               sourceTitles: memoryResults.slice(0, 3).map((result) =>
                 result.isMemory
@@ -576,16 +424,7 @@ export const buildRagContext = async (
       }
     } catch (e) {
       logger.error("RAG error", "useChat", { error: e })
-      upsertActivityEvent({
-        id: "rag-error",
-        kind: "searching_memory",
-        label: ACTIVITY_LABELS.searchingContext.text,
-        labelKey: ACTIVITY_LABELS.searchingContext.key,
-        status: "error",
-        startedAt: Date.now(),
-        finishedAt: Date.now(),
-        error: e instanceof Error ? e.message : "Context search failed"
-      })
+      assembly.recordError(e)
       toast?.({
         variant: "destructive",
         titleKey: "chat.errors.context_retrieval_warning_title",
@@ -595,48 +434,12 @@ export const buildRagContext = async (
   }
 
   // Tab fallback: full extracted page text when RAG didn't add page context.
-  if (!pageContextAdded && hasTabContext) {
-    const { clampedFallback, chunk } = buildTabFallbackContext(
-      options.contextText,
-      maxTabContextChars
-    )
-    contentWithRAG = contentWithRAG
-      ? `${contentWithRAG}\n\n---\n\n${clampedFallback.text}`
-      : clampedFallback.text
-    tabContextLength += clampedFallback.text.length
-    tabContextTruncated = tabContextTruncated || clampedFallback.truncated
-    usedContextChunks.push(chunk)
+  if (hasTabContext) {
+    assembly.appendTabFallback(options.contextText, maxTabContextChars)
   }
 
   // File full-text fallback: only when specific files attached and RAG added nothing.
-  if (contentWithRAG === userContent && files && files.length > 0) {
-    const fullTextContext = buildFileFullTextFallback(files)
-    contentWithRAG = `${contentWithRAG}\n\n---\n\n${fullTextContext}`
-  }
+  assembly.appendFileFallback(files)
 
-  const insufficientContext = groundedOnlyMode && tabContextLength === 0
-  if (groundedOnlyMode && !insufficientContext) {
-    const strictGroundingInstruction =
-      'You must answer only from the supplied selected-page context. If context is insufficient, respond with: "Insufficient page context."'
-    contentWithRAG = `${strictGroundingInstruction}\n\n${contentWithRAG}`
-  }
-
-  const promptContextStats: PromptContextStats = {
-    promptInputLength: userContent.length,
-    promptAugmentedLength: contentWithRAG.length,
-    tabContextLength,
-    ragContextLength,
-    tabContextTruncated,
-    groundedOnlyMode,
-    insufficientContext,
-    usedContextChunks,
-    activityEvents
-  }
-
-  return {
-    contentWithRAG,
-    ragSources,
-    promptContextStats,
-    pageContextAdded
-  }
+  return assembly.finish()
 }

--- a/src/application/context/context-assembly.ts
+++ b/src/application/context/context-assembly.ts
@@ -1,0 +1,252 @@
+import type { ContextFileInput } from "@ollama-client/contracts/context"
+import {
+  ACTIVITY_LABELS,
+  type ActivityLabel,
+  CONTEXT_CHUNK_LABELS
+} from "@/application/context/activity-labels"
+import type {
+  ActivityEvent,
+  RagSource,
+  RagSources,
+  UsedContextChunk
+} from "@/types"
+import type { ContextPlan } from "./context-plan"
+import { remainingRagBudget } from "./context-plan"
+
+export interface PromptContextStats {
+  promptInputLength: number
+  promptAugmentedLength: number
+  tabContextLength: number
+  ragContextLength: number
+  tabContextTruncated: boolean
+  groundedOnlyMode: boolean
+  insufficientContext: boolean
+  usedContextChunks: UsedContextChunk[]
+  activityEvents: ActivityEvent[]
+}
+
+export interface ContextAssemblyResult {
+  contentWithRAG: string
+  ragSources: RagSources | null
+  promptContextStats: PromptContextStats
+  pageContextAdded: boolean
+}
+
+const clampContext = (value: string, maxChars: number) => {
+  if (value.length <= maxChars) return { text: value, truncated: false }
+  return {
+    text: `${value.slice(0, maxChars)}\n\n[Context truncated due to length]`,
+    truncated: true
+  }
+}
+
+const buildFileFullTextFallback = (files: ContextFileInput[]) =>
+  files
+    .map(
+      (file) =>
+        `[File: ${file.metadata.fileName}]\n${file.text.slice(0, 10000)}${
+          file.text.length > 10000 ? "\n... (truncated)" : ""
+        }`
+    )
+    .join("\n\n---\n\n")
+
+/**
+ * Owns deterministic prompt assembly and telemetry for one context build.
+ * Environment-facing retrieval stays in the orchestrator; this object is the
+ * single mutation boundary for budgets, source receipts, and activity events.
+ */
+export class ContextAssembly {
+  private contentWithRAG: string
+  private tabContextLength = 0
+  private ragContextLength = 0
+  private tabContextTruncated = false
+  private readonly usedContextChunks: UsedContextChunk[] = []
+  private readonly activityEvents: ActivityEvent[] = []
+  private ragSources: RagSources | null = null
+  private pageContextAdded = false
+  private ragInstructionAdded = false
+
+  constructor(
+    private readonly plan: ContextPlan,
+    private readonly groundedOnlyMode: boolean,
+    private readonly onActivityEvent?: (events: ActivityEvent[]) => void,
+    private ragInstruction = ""
+  ) {
+    this.contentWithRAG = plan.userContent
+  }
+
+  get remainingRagBudget(): number {
+    return remainingRagBudget(this.plan, this.ragContextLength)
+  }
+
+  setRagInstruction(instruction: string): void {
+    this.ragInstruction = instruction
+  }
+
+  startActivity(
+    id: string,
+    kind: ActivityEvent["kind"],
+    label: ActivityLabel,
+    inputPreview?: string
+  ): ActivityEvent {
+    const event: ActivityEvent = {
+      id,
+      kind,
+      label: label.text,
+      labelKey: label.key,
+      status: "running",
+      startedAt: Date.now(),
+      inputPreview
+    }
+    this.upsertActivity(event)
+    return event
+  }
+
+  finishActivity(
+    event: ActivityEvent,
+    updates: Partial<ActivityEvent> = {}
+  ): void {
+    this.upsertActivity({
+      ...event,
+      ...updates,
+      status: updates.status ?? "done",
+      finishedAt: Date.now()
+    })
+  }
+
+  recordError(error: unknown): void {
+    const now = Date.now()
+    this.upsertActivity({
+      id: "rag-error",
+      kind: "searching_memory",
+      label: ACTIVITY_LABELS.searchingContext.text,
+      labelKey: ACTIVITY_LABELS.searchingContext.key,
+      status: "error",
+      startedAt: now,
+      finishedAt: now,
+      error: error instanceof Error ? error.message : "Context search failed"
+    })
+  }
+
+  appendPageContext(
+    formattedContext: string,
+    sources: RagSource[],
+    query: string,
+    maxChars: number
+  ): void {
+    const clamped = clampContext(formattedContext, maxChars)
+    this.appendRagContext(clamped.text)
+    this.tabContextLength += clamped.text.length
+    this.tabContextTruncated ||= clamped.truncated
+    this.mergeSources(sources, query)
+    this.addUsedChunks(sources, () => "tab")
+    this.pageContextAdded = true
+  }
+
+  appendStoredContext(
+    formattedContext: string,
+    sources: RagSource[],
+    query: string,
+    sourceFor: (source: RagSource) => UsedContextChunk["source"]
+  ): void {
+    const clamped = clampContext(formattedContext, this.remainingRagBudget)
+    this.appendRagContext(clamped.text)
+    this.ragContextLength += clamped.text.length
+    this.mergeSources(sources, query)
+    this.addUsedChunks(sources, sourceFor)
+  }
+
+  appendTabFallback(contextText: string, maxChars: number): void {
+    if (this.pageContextAdded) return
+    const clamped = clampContext(contextText, maxChars)
+    this.appendPlainContext(clamped.text)
+    this.tabContextLength += clamped.text.length
+    this.tabContextTruncated ||= clamped.truncated
+    this.usedContextChunks.push({
+      id: "tab-fallback",
+      title: CONTEXT_CHUNK_LABELS.selectedTabContext.text,
+      titleKey: CONTEXT_CHUNK_LABELS.selectedTabContext.key,
+      excerpt: clamped.text.slice(0, 220),
+      score: 0.5,
+      sectionPath: "fallback-full-context",
+      source: "tab"
+    })
+  }
+
+  appendFileFallback(files: ContextFileInput[] | undefined): void {
+    if (this.contentWithRAG !== this.plan.userContent || !files?.length) return
+    this.contentWithRAG = `${this.contentWithRAG}\n\n---\n\n${buildFileFullTextFallback(files)}`
+  }
+
+  finish(): ContextAssemblyResult {
+    const insufficientContext =
+      this.groundedOnlyMode && this.tabContextLength === 0
+    if (this.groundedOnlyMode && !insufficientContext) {
+      const instruction = `You must answer only from the supplied selected-page context. If context is insufficient, respond with: "Insufficient page context."`
+      this.contentWithRAG = `${instruction}\n\n${this.contentWithRAG}`
+    }
+
+    return {
+      contentWithRAG: this.contentWithRAG,
+      ragSources: this.ragSources,
+      promptContextStats: {
+        promptInputLength: this.plan.userContent.length,
+        promptAugmentedLength: this.contentWithRAG.length,
+        tabContextLength: this.tabContextLength,
+        ragContextLength: this.ragContextLength,
+        tabContextTruncated: this.tabContextTruncated,
+        groundedOnlyMode: this.groundedOnlyMode,
+        insufficientContext,
+        usedContextChunks: this.usedContextChunks,
+        activityEvents: this.activityEvents
+      },
+      pageContextAdded: this.pageContextAdded
+    }
+  }
+
+  private appendRagContext(context: string): void {
+    const block =
+      !this.ragInstructionAdded && this.ragInstruction
+        ? `${this.ragInstruction}\n\n${context}`
+        : context
+    this.ragInstructionAdded = true
+    this.appendPlainContext(block)
+  }
+
+  private appendPlainContext(context: string): void {
+    this.contentWithRAG = this.contentWithRAG
+      ? `${this.contentWithRAG}\n\n---\n\n${context}`
+      : context
+  }
+
+  private mergeSources(sources: RagSource[], query: string): void {
+    this.ragSources = {
+      sources: [...(this.ragSources?.sources || []), ...sources],
+      query
+    }
+  }
+
+  private addUsedChunks(
+    sources: RagSource[],
+    sourceFor: (source: RagSource) => UsedContextChunk["source"]
+  ): void {
+    for (const source of sources) {
+      this.usedContextChunks.push({
+        id: source.id,
+        title: source.title,
+        excerpt: source.content.slice(0, 220),
+        score: source.score,
+        sectionPath: source.source || source.type,
+        source: sourceFor(source),
+        chunkIndex: source.chunkIndex
+      })
+    }
+  }
+
+  private upsertActivity(event: ActivityEvent): void {
+    const index = this.activityEvents.findIndex((item) => item.id === event.id)
+    if (index >= 0) this.activityEvents[index] = event
+    else this.activityEvents.push(event)
+    this.onActivityEvent?.([...this.activityEvents])
+  }
+}

--- a/src/features/model/hooks/__tests__/provider-settings-view.test.ts
+++ b/src/features/model/hooks/__tests__/provider-settings-view.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { ProviderId, ProviderType } from "@/lib/providers/types"
+import { deriveProviderSettingsView } from "../provider-settings-view"
+
+const provider = {
+  id: ProviderId.OLLAMA,
+  name: "Ollama",
+  type: ProviderType.OLLAMA,
+  enabled: true,
+  baseUrl: "http://localhost:11434",
+  hasApiKey: false,
+  apiKey: { state: "unchanged" as const }
+}
+
+const derive = (
+  overrides: Partial<Parameters<typeof deriveProviderSettingsView>[0]> = {}
+) =>
+  deriveProviderSettingsView({
+    providers: [provider],
+    selectedId: ProviderId.OLLAMA,
+    connectionStatus: null,
+    providerHealth: {},
+    defaultUrl: "default",
+    ...overrides
+  })
+
+describe("deriveProviderSettingsView", () => {
+  it("prioritizes inactive and manual-model statuses", () => {
+    expect(
+      derive({ providers: [{ ...provider, enabled: false }] }).headerStatus
+        .label
+    ).toBe("inactive")
+    expect(
+      derive({
+        providerHealth: {
+          [ProviderId.OLLAMA]: {
+            success: true,
+            modelListSupported: false
+          }
+        }
+      }).headerStatus.label
+    ).toBe("manual_models")
+  })
+
+  it("lets an explicit connection result override background health", () => {
+    expect(
+      derive({
+        connectionStatus: { success: false, message: "failed" },
+        providerHealth: { [ProviderId.OLLAMA]: { success: true } }
+      }).headerStatus.label
+    ).toBe("connection_failed")
+  })
+
+  it("derives endpoint flags while suppressing hints for invalid URLs", () => {
+    const result = derive({
+      providers: [{ ...provider, baseUrl: "not a url" }]
+    })
+    expect(result.cspCompatibilityHint).toBeNull()
+    expect(result.isRemoteEndpoint).toBe(true)
+  })
+})

--- a/src/features/model/hooks/provider-settings-commands.ts
+++ b/src/features/model/hooks/provider-settings-commands.ts
@@ -1,0 +1,106 @@
+import type { ProviderDraftInput } from "@ollama-client/contracts/provider-rpc"
+import { RpcMethod } from "@ollama-client/contracts/rpc"
+import {
+  providerProfileRequiresApiKey,
+  resolveProviderServiceProfile
+} from "@/lib/providers/service-profile"
+import type {
+  CustomProviderWire,
+  ProviderServiceProfile
+} from "@/lib/providers/types"
+import { extensionRpcClient } from "@/protocol/extension-client"
+import {
+  type ProviderDraft,
+  providerDraftFromPublic,
+  providerDraftHasUsableApiKey
+} from "../types/provider-draft"
+
+export interface AddProviderInput {
+  name: string
+  baseUrl: string
+  wire: CustomProviderWire
+  apiKey?: string
+  customModels?: string[]
+  serviceProfile?: ProviderServiceProfile
+}
+
+export const providerDraftToInput = (
+  config: ProviderDraft
+): ProviderDraftInput => ({
+  id: String(config.id),
+  type: config.type,
+  enabled: config.enabled,
+  name: config.name,
+  apiKey: config.apiKey,
+  ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl } : {}),
+  ...(config.modelId !== undefined ? { modelId: config.modelId } : {}),
+  ...(config.customModels !== undefined
+    ? { customModels: config.customModels }
+    : {}),
+  ...(config.serviceProfile !== undefined
+    ? { serviceProfile: config.serviceProfile }
+    : {}),
+  ...(config.compatibility !== undefined
+    ? { compatibility: config.compatibility }
+    : {})
+})
+
+export const loadProviderDrafts = async (): Promise<ProviderDraft[]> => {
+  const { providers } = await extensionRpcClient.call(
+    RpcMethod.ProvidersList,
+    {}
+  )
+  return providers.map(providerDraftFromPublic)
+}
+
+export const saveProviderDraft = async (
+  config: ProviderDraft
+): Promise<ProviderDraft> => {
+  const { provider } = await extensionRpcClient.call(
+    RpcMethod.ProvidersUpsert,
+    { target: "existing", config: providerDraftToInput(config) }
+  )
+  return providerDraftFromPublic(provider)
+}
+
+export const addProviderDraft = async (
+  input: AddProviderInput
+): Promise<ProviderDraft> => {
+  const { provider } = await extensionRpcClient.call(
+    RpcMethod.ProvidersUpsert,
+    { target: "new", provider: input }
+  )
+  return providerDraftFromPublic(provider)
+}
+
+export const removeProviderDraft = async (
+  providerId: string
+): Promise<void> => {
+  await extensionRpcClient.call(RpcMethod.ProvidersRemove, { providerId })
+}
+
+export const updateProviderEnabled = async (
+  providerId: string,
+  enabled: boolean
+): Promise<ProviderDraft> => {
+  const { provider } = await extensionRpcClient.call(
+    RpcMethod.ProvidersSetEnabled,
+    { providerId, enabled }
+  )
+  return providerDraftFromPublic(provider)
+}
+
+export const testProviderConnection = async (config: ProviderDraft) => {
+  if (
+    providerProfileRequiresApiKey(resolveProviderServiceProfile(config)) &&
+    !providerDraftHasUsableApiKey(config)
+  ) {
+    return { kind: "api-key-required" } as const
+  }
+
+  const result = await extensionRpcClient.call(
+    RpcMethod.ProvidersTestConnection,
+    { target: "draft", config: providerDraftToInput(config) }
+  )
+  return { kind: "completed", result } as const
+}

--- a/src/features/model/hooks/provider-settings-view.ts
+++ b/src/features/model/hooks/provider-settings-view.ts
@@ -1,0 +1,111 @@
+import { isCustomProviderId, ProviderId } from "@/lib/providers/types"
+import type { ProviderDraft } from "../types/provider-draft"
+import type { ProviderConnectionStatus } from "./provider-draft-reducer"
+
+const LOCAL_PROVIDER_IDS = [
+  ProviderId.OLLAMA,
+  ProviderId.LM_STUDIO,
+  ProviderId.LLAMA_CPP
+]
+
+const isLocalhostEndpoint = (baseUrl?: string) => {
+  const url = baseUrl?.trim()
+  if (!url) return false
+  try {
+    return ["localhost", "127.0.0.1", "::1"].includes(new URL(url).hostname)
+  } catch {
+    return false
+  }
+}
+
+const getCspCompatibilityHint = (baseUrl?: string) => {
+  const trimmedUrl = baseUrl?.trim()
+  if (!trimmedUrl) return null
+  try {
+    const parsed = new URL(trimmedUrl)
+    if (["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)) {
+      return null
+    }
+    return 'If you are on an older extension build and see "Failed to fetch" with Content Security Policy errors, update/reload the extension to apply LAN endpoint support.'
+  } catch {
+    return null
+  }
+}
+
+interface ProviderHealthState {
+  success: boolean
+  modelListSupported?: boolean
+}
+
+type HeaderStatus = {
+  dot: string
+  label:
+    | "inactive"
+    | "manual_models"
+    | "connected"
+    | "connection_failed"
+    | "not_tested"
+}
+
+export const deriveProviderSettingsView = (input: {
+  providers: ProviderDraft[]
+  selectedId: string
+  connectionStatus: ProviderConnectionStatus | null
+  providerHealth: Record<string, ProviderHealthState | undefined>
+  defaultUrl: string
+}) => {
+  const activeConfig = input.providers.find(
+    (provider) => provider.id === input.selectedId
+  )
+  const health = activeConfig
+    ? input.providerHealth[String(activeConfig.id)]
+    : undefined
+
+  let headerStatus: HeaderStatus = {
+    dot: "bg-status-warning ring-status-warning/30",
+    label: "not_tested"
+  }
+  if (!activeConfig?.enabled) {
+    headerStatus = {
+      dot: "bg-muted-foreground/40 ring-muted-foreground/20",
+      label: "inactive"
+    }
+  } else if (
+    input.connectionStatus === null &&
+    health?.modelListSupported === false
+  ) {
+    headerStatus = {
+      dot: "bg-status-warning ring-status-warning/30",
+      label: "manual_models"
+    }
+  } else if (input.connectionStatus?.success ?? health?.success) {
+    headerStatus = {
+      dot: "bg-status-success ring-status-success/30",
+      label: "connected"
+    }
+  } else if (
+    input.connectionStatus?.success === false ||
+    health?.success === false
+  ) {
+    headerStatus = {
+      dot: "bg-status-danger ring-status-danger/30",
+      label: "connection_failed"
+    }
+  }
+
+  return {
+    activeConfig,
+    cspCompatibilityHint: getCspCompatibilityHint(activeConfig?.baseUrl),
+    displayUrl: activeConfig?.baseUrl || input.defaultUrl,
+    isCustomProvider: activeConfig
+      ? isCustomProviderId(String(activeConfig.id))
+      : false,
+    isLocalProvider: LOCAL_PROVIDER_IDS.includes(
+      activeConfig?.id as ProviderId
+    ),
+    isRemoteEndpoint:
+      Boolean(activeConfig?.baseUrl?.trim()) &&
+      !isLocalhostEndpoint(activeConfig?.baseUrl),
+    headerStatus
+  }
+}

--- a/src/features/model/hooks/use-provider-settings-state.ts
+++ b/src/features/model/hooks/use-provider-settings-state.ts
@@ -1,69 +1,31 @@
-import type { ProviderDraftInput } from "@ollama-client/contracts/provider-rpc"
-import { RpcMethod } from "@ollama-client/contracts/rpc"
 import { useCallback, useEffect, useReducer, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "@/hooks/use-toast"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { isAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
-import {
-  providerProfileRequiresApiKey,
-  resolveProviderServiceProfile
-} from "@/lib/providers/service-profile"
-import {
-  type CustomProviderWire,
-  isCustomProviderId,
-  ProviderId,
-  type ProviderServiceProfile
+import type {
+  CustomProviderWire,
+  ProviderServiceProfile
 } from "@/lib/providers/types"
-import { extensionRpcClient } from "@/protocol/extension-client"
-import {
-  type ProviderDraft,
-  type ProviderDraftUpdate,
-  providerDraftFromPublic,
-  providerDraftHasUsableApiKey
+import type {
+  ProviderDraft,
+  ProviderDraftUpdate
 } from "../types/provider-draft"
 import {
   initialProviderDraftState,
   providerDraftReducer
 } from "./provider-draft-reducer"
+import {
+  addProviderDraft,
+  loadProviderDrafts,
+  removeProviderDraft,
+  saveProviderDraft,
+  testProviderConnection,
+  updateProviderEnabled
+} from "./provider-settings-commands"
+import { deriveProviderSettingsView } from "./provider-settings-view"
 import { useProviderHealth } from "./use-provider-health"
-
-const LOCAL_PROVIDER_IDS = [
-  ProviderId.OLLAMA,
-  ProviderId.LM_STUDIO,
-  ProviderId.LLAMA_CPP
-]
-
-const isLocalhostEndpoint = (baseUrl?: string) => {
-  const url = baseUrl?.trim()
-  if (!url) return false
-
-  try {
-    const parsed = new URL(url)
-    return ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)
-  } catch {
-    return false
-  }
-}
-
-const getCspCompatibilityHint = (baseUrl?: string) => {
-  const trimmedUrl = baseUrl?.trim()
-  if (!trimmedUrl) return null
-
-  try {
-    const parsed = new URL(trimmedUrl)
-    const isLocalhost = ["localhost", "127.0.0.1", "::1"].includes(
-      parsed.hostname
-    )
-
-    if (isLocalhost) return null
-
-    return 'If you are on an older extension build and see "Failed to fetch" with Content Security Policy errors, update/reload the extension to apply LAN endpoint support.'
-  } catch {
-    return null
-  }
-}
 
 export const useProviderSettingsState = () => {
   const { t } = useTranslation()
@@ -93,11 +55,7 @@ export const useProviderSettingsState = () => {
   const loadProviders = useCallback(async () => {
     dispatch({ type: "load-started" })
     try {
-      const { providers: data } = await extensionRpcClient.call(
-        RpcMethod.ProvidersList,
-        {}
-      )
-      const drafts = data.map(providerDraftFromPublic)
+      const drafts = await loadProviderDrafts()
       for (const provider of drafts) {
         storedEnabled.current.set(String(provider.id), provider.enabled)
       }
@@ -116,40 +74,21 @@ export const useProviderSettingsState = () => {
     loadProviders()
   }, [loadProviders])
 
-  const activeConfig = providers.find((p) => p.id === selectedId)
-  const cspCompatibilityHint = getCspCompatibilityHint(activeConfig?.baseUrl)
-  const displayUrl =
-    activeConfig?.baseUrl || t("settings.providers.test_connection.default_url")
-  const isCustomProvider = activeConfig
-    ? isCustomProviderId(String(activeConfig.id))
-    : false
-  const isLocalProvider = LOCAL_PROVIDER_IDS.includes(
-    activeConfig?.id as ProviderId
-  )
-  const isRemoteEndpoint =
-    Boolean(activeConfig?.baseUrl?.trim()) &&
-    !isLocalhostEndpoint(activeConfig?.baseUrl)
-  const configForRpc = useCallback(
-    (config: ProviderDraft): ProviderDraftInput => ({
-      id: String(config.id),
-      type: config.type,
-      enabled: config.enabled,
-      name: config.name,
-      apiKey: config.apiKey,
-      ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl } : {}),
-      ...(config.modelId !== undefined ? { modelId: config.modelId } : {}),
-      ...(config.customModels !== undefined
-        ? { customModels: config.customModels }
-        : {}),
-      ...(config.serviceProfile !== undefined
-        ? { serviceProfile: config.serviceProfile }
-        : {}),
-      ...(config.compatibility !== undefined
-        ? { compatibility: config.compatibility }
-        : {})
-    }),
-    []
-  )
+  const {
+    activeConfig,
+    cspCompatibilityHint,
+    displayUrl,
+    isCustomProvider,
+    isLocalProvider,
+    isRemoteEndpoint,
+    headerStatus
+  } = deriveProviderSettingsView({
+    providers,
+    selectedId,
+    connectionStatus,
+    providerHealth,
+    defaultUrl: t("settings.providers.test_connection.default_url")
+  })
 
   const handleTestConnection = async () => {
     if (!activeConfig) return
@@ -163,36 +102,25 @@ export const useProviderSettingsState = () => {
 
     dispatch({ type: "connection-test-started" })
 
-    // Custom endpoints may be keyless local/LAN servers — never require a key
-    // for them; a real 401 from the test surfaces its own error.
-    if (
-      providerProfileRequiresApiKey(
-        resolveProviderServiceProfile(activeConfig)
-      ) &&
-      !providerDraftHasUsableApiKey(activeConfig)
-    ) {
-      const message = t("settings.providers.test_connection.api_key_required", {
-        name: activeConfig.name
-      })
-
-      dispatch({
-        type: "connection-status-set",
-        status: { success: false, message }
-      })
-      toast({
-        title: t("settings.providers.test_connection.api_key_required_title"),
-        description: message,
-        variant: "destructive"
-      })
-      dispatch({ type: "connection-test-finished" })
-      return
-    }
-
     try {
-      const result = await extensionRpcClient.call(
-        RpcMethod.ProvidersTestConnection,
-        { target: "draft", config: configForRpc(activeConfig) }
-      )
+      const command = await testProviderConnection(activeConfig)
+      if (command.kind === "api-key-required") {
+        const message = t(
+          "settings.providers.test_connection.api_key_required",
+          { name: activeConfig.name }
+        )
+        dispatch({
+          type: "connection-status-set",
+          status: { success: false, message }
+        })
+        toast({
+          title: t("settings.providers.test_connection.api_key_required_title"),
+          description: message,
+          variant: "destructive"
+        })
+        return
+      }
+      const { result } = command
       logger.debug("Provider connection RPC succeeded", "ProviderSettings", {
         count: result.modelCount
       })
@@ -308,13 +236,7 @@ export const useProviderSettingsState = () => {
       const providerId = String(config.id)
       const startedRevision = configRevisions.current.get(providerId) ?? 0
       try {
-        const { provider: saved } = await extensionRpcClient.call(
-          RpcMethod.ProvidersUpsert,
-          {
-            target: "existing",
-            config: configForRpc(config)
-          }
-        )
+        const savedDraft = await saveProviderDraft(config)
         if (
           (configRevisions.current.get(providerId) ?? 0) !== startedRevision
         ) {
@@ -325,7 +247,6 @@ export const useProviderSettingsState = () => {
           )
           return false
         }
-        const savedDraft = providerDraftFromPublic(saved)
         storedEnabled.current.set(providerId, savedDraft.enabled)
         dispatch({
           type: "provider-saved",
@@ -356,7 +277,7 @@ export const useProviderSettingsState = () => {
         return false
       }
     },
-    [configForRpc, t]
+    [t]
   )
 
   const setSelectedId = useCallback(
@@ -394,14 +315,10 @@ export const useProviderSettingsState = () => {
       return false
     }
     try {
-      const { provider: config } = await extensionRpcClient.call(
-        RpcMethod.ProvidersUpsert,
-        { target: "new", provider: input }
-      )
+      const addedDraft = await addProviderDraft(input)
       // The mutation response is authoritative. Merge it into the current
       // client state instead of replacing every provider with a list snapshot
       // that may have started before another pending save completed.
-      const addedDraft = providerDraftFromPublic(config)
       storedEnabled.current.set(String(addedDraft.id), addedDraft.enabled)
       dispatch({
         type: "provider-added",
@@ -410,7 +327,7 @@ export const useProviderSettingsState = () => {
       toast({
         title: t("settings.providers.add.added_title"),
         description: t("settings.providers.add.added_description", {
-          name: config.name
+          name: addedDraft.name
         })
       })
       return true
@@ -433,9 +350,7 @@ export const useProviderSettingsState = () => {
       (provider) => String(provider.id) === id
     )?.name
     try {
-      await extensionRpcClient.call(RpcMethod.ProvidersRemove, {
-        providerId: id
-      })
+      await removeProviderDraft(id)
       // The mutation result is authoritative. Do not follow it with a full
       // list refresh: an older snapshot could overwrite concurrent edits or
       // reintroduce the removed provider locally.
@@ -506,14 +421,7 @@ export const useProviderSettingsState = () => {
       .catch(() => undefined)
       .then(async () => {
         try {
-          const { provider: saved } = await extensionRpcClient.call(
-            RpcMethod.ProvidersSetEnabled,
-            {
-              providerId,
-              enabled
-            }
-          )
-          const savedDraft = providerDraftFromPublic(saved)
+          const savedDraft = await updateProviderEnabled(providerId, enabled)
           storedEnabled.current.set(providerId, savedDraft.enabled)
           if (
             (configRevisions.current.get(providerId) ?? 0) !== toggleRevision
@@ -578,60 +486,6 @@ export const useProviderSettingsState = () => {
 
     return () => clearTimeout(timeoutId)
   }, [activeConfig, hasUnsavedChanges, persistConfig])
-
-  const headerStatusConfigs = [
-    {
-      test: () => !activeConfig?.enabled,
-      dot: "bg-muted-foreground/40 ring-muted-foreground/20",
-      label: "inactive"
-    },
-    /*
-     * An endpoint with no catalog is never asked for one after the first
-     * answer, so the background check reaches nothing and cannot claim a live
-     * connection. Say what is actually true — this provider runs on the model
-     * IDs you declared — rather than showing a red dot at a working provider,
-     * or a green one for a round trip nobody made.
-     *
-     * Ahead of "connected" on purpose: the background check reports a model
-     * count for the ids the user declared, and that count is what "connected"
-     * reads. An explicit test did reach the endpoint, so it still wins — this
-     * rule stands down as soon as there is one.
-     */
-    {
-      test: () =>
-        Boolean(
-          activeConfig &&
-            connectionStatus === null &&
-            providerHealth[activeConfig.id]?.modelListSupported === false
-        ),
-      dot: "bg-status-warning ring-status-warning/30",
-      label: "manual_models"
-    },
-    {
-      test: () =>
-        Boolean(
-          activeConfig &&
-            (connectionStatus?.success ??
-              providerHealth[activeConfig.id]?.success)
-        ),
-      dot: "bg-status-success ring-status-success/30",
-      label: "connected"
-    },
-    {
-      test: () =>
-        Boolean(
-          activeConfig &&
-            (connectionStatus?.success === false ||
-              providerHealth[activeConfig.id]?.success === false)
-        ),
-      dot: "bg-status-danger ring-status-danger/30",
-      label: "connection_failed"
-    }
-  ] as const
-  const headerStatus = headerStatusConfigs.find((c) => c.test()) ?? {
-    dot: "bg-status-warning ring-status-warning/30",
-    label: "not_tested"
-  }
 
   return {
     providers,


### PR DESCRIPTION
## Summary
- extract typed provider settings RPC commands and pure view-state derivation
- isolate context prompt assembly, budgets, receipts, fallbacks, and activity events
- add focused seam tests and mark audit findings M5/M7 closed

## Verification
- pnpm typecheck
- pnpm lint:check
- pnpm test:run (355 files, 2970 tests)
- pre-push Chrome production package and bundle-size checks
- pre-push docs build and i18n drift check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates provider-settings RPC operations and derived view state from the React hook, and moves context prompt assembly, budgeting, source receipts, fallbacks, and activity events into a dedicated class.
- Adds focused tests for shared context budgets, activity snapshots, grounded fallback behavior, and provider status derivation.
- Keeps environment-facing context retrieval in the orchestrator while centralizing deterministic prompt assembly.
- Converts provider mutations and connection testing into typed command helpers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/application/context/context-assembly.ts | Centralizes prompt assembly, shared RAG budgeting, source receipts, fallbacks, grounded-mode instructions, and activity snapshots; the previously reported quote-style issue is fixed. |
| src/application/context/build-context.ts | Delegates deterministic assembly state to ContextAssembly while retaining retrieval and environment-facing orchestration. |
| src/features/model/hooks/provider-settings-commands.ts | Extracts typed provider RPC operations and API-key validation from the React hook. |
| src/features/model/hooks/provider-settings-view.ts | Extracts provider endpoint flags and header-status derivation into a pure helper. |
| src/features/model/hooks/use-provider-settings-state.ts | Replaces inline RPC and view derivation with the extracted command and view modules while preserving reducer orchestration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Provider settings hook] --> View[Pure view-state derivation]
  UI --> Commands[Typed provider commands]
  Commands --> RPC[Extension RPC client]
  Orchestrator[Context retrieval orchestrator] --> Assembly[ContextAssembly]
  Assembly --> Prompt[Prompt and context statistics]
  Assembly --> Activity[Activity snapshots]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: split settings and context sea..."](https://github.com/shishir435/ollama-client/commit/3944a43c3f0b2bea78752fc0c096e0e9f8cd947a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53088738)</sub>

<!-- /greptile_comment -->