### PR TITLE
perf(embeddings): fix content-hash collisions, memoize config reads

### DIFF
--- a/src/features/model/components/__tests__/loaded-models-info.test.tsx
+++ b/src/features/model/components/__tests__/loaded-models-info.test.tsx
@@ -122,4 +122,47 @@ describe("LoadedModelsInfo concurrent fetches", () => {
       expect(screen.queryByText("gone-model")).not.toBeInTheDocument()
     })
   })
+
+  /**
+   * The invalidated request is still the newest one in flight, so it has to
+   * clear the progress flags it set. Nothing newer exists to do it for them.
+   */
+  it("clears the loading state when an unload invalidates the in-flight fetch", async () => {
+    const inFlight = deferred<{ models: ReturnType<typeof model>[] }>()
+
+    mockedCall.mockReturnValueOnce({
+      models: [model("gone-model")]
+    } as never)
+
+    const { container } = render(<LoadedModelsInfo />)
+    expandPanel()
+    await waitFor(() => {
+      expect(screen.getByText("gone-model")).toBeInTheDocument()
+    })
+
+    mockedCall.mockReturnValueOnce(inFlight.promise as never)
+    document.dispatchEvent(new Event("visibilitychange"))
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll(".animate-spin").length
+      ).toBeGreaterThan(0)
+    })
+
+    mockedCall.mockResolvedValueOnce({ unloaded: true } as never)
+    fireEvent.click(
+      screen.getByLabelText("settings.loaded_models.unload_tooltip")
+    )
+    await waitFor(() => {
+      expect(mockedCall).toHaveBeenCalledWith(
+        RpcMethod.ModelsUnload,
+        expect.objectContaining({ model: "gone-model" })
+      )
+    })
+
+    inFlight.resolve({ models: [model("gone-model")] })
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".animate-spin")).toHaveLength(0)
+    })
+  })
 })

--- a/src/features/model/components/__tests__/loaded-models-info.test.tsx
+++ b/src/features/model/components/__tests__/loaded-models-info.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/protocol/extension-client", () => ({
+  extensionRpcClient: { call: vi.fn() }
+}))
+
+vi.mock("@/features/model/hooks/use-provider-models", () => ({
+  useProviderModels: () => ({
+    selectedProviderCapabilities: { modelUnload: true },
+    selectedProviderId: "ollama"
+  })
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+import { RpcMethod } from "@ollama-client/contracts/rpc"
+import { extensionRpcClient } from "@/protocol/extension-client"
+
+import { LoadedModelsInfo } from "../loaded-models-info"
+
+const mockedCall = vi.mocked(extensionRpcClient.call)
+
+const model = (name: string) => ({
+  name,
+  family: "llama",
+  sizeBytes: 1000,
+  parameterSize: "8B",
+  quantizationLevel: "Q4"
+})
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Model rows live inside the collapsible, which starts closed. */
+const expandPanel = () => {
+  fireEvent.click(screen.getByText("settings.loaded_models.title"))
+}
+
+beforeEach(() => {
+  mockedCall.mockReset()
+})
+
+describe("LoadedModelsInfo concurrent fetches", () => {
+  /**
+   * A visibility change, an interval tick and a manual refresh each issue their
+   * own request. If a slow earlier one is allowed to write state it overwrites
+   * the newer list.
+   */
+  it("ignores a stale response that settles after a newer one", async () => {
+    const first = deferred<{ models: ReturnType<typeof model>[] }>()
+    const second = deferred<{ models: ReturnType<typeof model>[] }>()
+
+    mockedCall
+      .mockReturnValueOnce(first.promise as never)
+      .mockReturnValueOnce(second.promise as never)
+
+    render(<LoadedModelsInfo />)
+    expandPanel()
+
+    // Second request starts and settles first.
+    document.dispatchEvent(new Event("visibilitychange"))
+    await waitFor(() => {
+      expect(mockedCall).toHaveBeenCalledTimes(2)
+    })
+
+    second.resolve({ models: [model("current-model")] })
+    await waitFor(() => {
+      expect(screen.getByText("current-model")).toBeInTheDocument()
+    })
+
+    // The earlier request now settles with an older list.
+    first.resolve({ models: [model("stale-model")] })
+    await waitFor(() => {
+      expect(screen.queryByText("stale-model")).not.toBeInTheDocument()
+    })
+    expect(screen.getByText("current-model")).toBeInTheDocument()
+  })
+
+  it("does not reintroduce a model that was just unloaded", async () => {
+    const inFlight = deferred<{ models: ReturnType<typeof model>[] }>()
+
+    mockedCall.mockReturnValueOnce({
+      models: [model("gone-model")]
+    } as never)
+
+    render(<LoadedModelsInfo />)
+    expandPanel()
+    await waitFor(() => {
+      expect(screen.getByText("gone-model")).toBeInTheDocument()
+    })
+
+    // A refresh is in flight when the unload completes.
+    mockedCall.mockReturnValueOnce(inFlight.promise as never)
+    document.dispatchEvent(new Event("visibilitychange"))
+    await waitFor(() => {
+      expect(mockedCall).toHaveBeenCalledTimes(2)
+    })
+
+    mockedCall.mockResolvedValueOnce({ unloaded: true } as never)
+    fireEvent.click(
+      screen.getByLabelText("settings.loaded_models.unload_tooltip")
+    )
+
+    await waitFor(() => {
+      expect(mockedCall).toHaveBeenCalledWith(
+        RpcMethod.ModelsUnload,
+        expect.objectContaining({ model: "gone-model" })
+      )
+    })
+
+    inFlight.resolve({ models: [model("gone-model")] })
+
+    await waitFor(() => {
+      expect(screen.queryByText("gone-model")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/model/components/loaded-models-info.tsx
+++ b/src/features/model/components/loaded-models-info.tsx
@@ -1,6 +1,6 @@
 import { RpcMethod } from "@ollama-client/contracts/rpc"
 import { Brain, ChevronDown, Loader2, RefreshCw, Trash } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { TooltipActionButton } from "@/components/actions"
 import { Badge } from "@/components/ui/badge"
@@ -34,9 +34,18 @@ export const LoadedModelsInfo = () => {
   const [unloading, setUnloading] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  /**
+   * Interval tick, visibility change and manual refresh each issue their own
+   * request, so two can be in flight at once and settle out of order. Only the
+   * newest is allowed to write state — otherwise a slow earlier response
+   * overwrites the current list, which shows up as a model reappearing right
+   * after the user unloaded it.
+   */
+  const latestFetchRef = useRef(0)
 
   const fetchModels = useCallback(
     async (isRefresh = false) => {
+      const fetchId = ++latestFetchRef.current
       if (isRefresh) {
         setRefreshing(true)
       } else {
@@ -48,15 +57,19 @@ export const LoadedModelsInfo = () => {
           RpcMethod.ModelsListLoaded,
           selectedProviderId ? { providerId: selectedProviderId } : {}
         )
+        if (fetchId !== latestFetchRef.current) return
         setModels(models)
       } catch (error) {
         logger.error("Failed to fetch loaded models", "LoadedModelsInfo", {
           error
         })
+        if (fetchId !== latestFetchRef.current) return
         setModels([])
       } finally {
-        setLoading(false)
-        setRefreshing(false)
+        if (fetchId === latestFetchRef.current) {
+          setLoading(false)
+          setRefreshing(false)
+        }
       }
     },
     [selectedProviderId]
@@ -73,6 +86,9 @@ export const LoadedModelsInfo = () => {
         }
       )
       if (unloaded) {
+        // Invalidate any fetch started before the unload; it would still list
+        // the model we just removed.
+        latestFetchRef.current += 1
         setModels((prev) => prev.filter((m) => m.name !== modelName))
       } else {
         logger.error("Unload did not take effect", "LoadedModelsInfo", {

--- a/src/features/model/components/loaded-models-info.tsx
+++ b/src/features/model/components/loaded-models-info.tsx
@@ -15,6 +15,8 @@ import { cn } from "@/lib/class-names"
 import { logger } from "@/lib/logger"
 import { extensionRpcClient } from "@/protocol/extension-client"
 
+const LOADED_MODELS_POLL_INTERVAL_MS = 10_000
+
 const formatBytes = (bytes: number): string => {
   if (bytes === 0) return "0 B"
   const k = 1024
@@ -90,9 +92,25 @@ export const LoadedModelsInfo = () => {
 
   useEffect(() => {
     if (!selectedProviderCapabilities?.modelUnload) return
-    fetchModels()
-    const interval = setInterval(() => fetchModels(), 10000)
-    return () => clearInterval(interval)
+
+    // Skipped while hidden: this is a background options tab most of the time,
+    // and each tick wakes the worker to ask the provider what is loaded.
+    const poll = () => {
+      if (typeof document !== "undefined" && document.hidden) return
+      fetchModels()
+    }
+
+    poll()
+    const interval = setInterval(poll, LOADED_MODELS_POLL_INTERVAL_MS)
+    const onVisibilityChange = () => {
+      if (!document.hidden) poll()
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
   }, [fetchModels, selectedProviderCapabilities?.modelUnload])
 
   if (!selectedProviderCapabilities?.modelUnload) {

--- a/src/features/model/components/loaded-models-info.tsx
+++ b/src/features/model/components/loaded-models-info.tsx
@@ -37,11 +37,21 @@ export const LoadedModelsInfo = () => {
   /**
    * Interval tick, visibility change and manual refresh each issue their own
    * request, so two can be in flight at once and settle out of order. Only the
-   * newest is allowed to write state — otherwise a slow earlier response
-   * overwrites the current list, which shows up as a model reappearing right
-   * after the user unloaded it.
+   * newest may write the list.
    */
   const latestFetchRef = useRef(0)
+  /**
+   * Results from requests started before this point describe the pre-unload
+   * server state, so they must not be written even when they are the newest
+   * request in flight.
+   *
+   * Deliberately a second counter. Folding this into `latestFetchRef` made an
+   * unload strand the spinner: the in-flight request was no longer "newest", so
+   * it skipped its own cleanup, and nothing newer existed to take it over.
+   * Whether a result is usable and whether a request owns the progress flags
+   * are different questions.
+   */
+  const staleBeforeRef = useRef(0)
 
   const fetchModels = useCallback(
     async (isRefresh = false) => {
@@ -52,20 +62,24 @@ export const LoadedModelsInfo = () => {
         setLoading(true)
       }
 
+      const isUsable = () =>
+        fetchId === latestFetchRef.current && fetchId >= staleBeforeRef.current
+
       try {
         const { models } = await extensionRpcClient.call(
           RpcMethod.ModelsListLoaded,
           selectedProviderId ? { providerId: selectedProviderId } : {}
         )
-        if (fetchId !== latestFetchRef.current) return
-        setModels(models)
+        if (isUsable()) setModels(models)
       } catch (error) {
         logger.error("Failed to fetch loaded models", "LoadedModelsInfo", {
           error
         })
-        if (fetchId !== latestFetchRef.current) return
-        setModels([])
+        if (isUsable()) setModels([])
       } finally {
+        // Cleared by whichever request is newest, regardless of whether its
+        // result was usable — an older request bowing out must never leave the
+        // panel showing progress that nothing will finish.
         if (fetchId === latestFetchRef.current) {
           setLoading(false)
           setRefreshing(false)
@@ -86,9 +100,10 @@ export const LoadedModelsInfo = () => {
         }
       )
       if (unloaded) {
-        // Invalidate any fetch started before the unload; it would still list
-        // the model we just removed.
-        latestFetchRef.current += 1
+        // Every request already in flight predates the unload, so its result
+        // would reintroduce the model. Marking them stale does not disturb
+        // their ownership of the progress flags.
+        staleBeforeRef.current = latestFetchRef.current + 1
         setModels((prev) => prev.filter((m) => m.name !== modelName))
       } else {
         logger.error("Unload did not take effect", "LoadedModelsInfo", {

--- a/src/features/model/hooks/__tests__/use-embedding-model-check.test.ts
+++ b/src/features/model/hooks/__tests__/use-embedding-model-check.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/protocol/extension-client", () => ({
+  extensionRpcClient: {
+    call: vi.fn()
+  }
+}))
+
+import { extensionRpcClient } from "@/protocol/extension-client"
+
+import { useEmbeddingModelCheck } from "../use-embedding-model-check"
+
+const mockedCall = vi.mocked(extensionRpcClient.call)
+
+const POLL_INTERVAL_MS = 5_000
+
+const renderCheck = () =>
+  renderHook(() =>
+    useEmbeddingModelCheck({
+      selectedModel: "all-minilm:latest",
+      setSelectedModel: vi.fn(),
+      applyModelChange: vi.fn(),
+      embeddingModels: [],
+      resolveProviderForModel: () => "ollama"
+    })
+  )
+
+const setHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden
+  })
+}
+
+beforeEach(() => {
+  mockedCall.mockReset()
+  setHidden(false)
+})
+
+describe("useEmbeddingModelCheck polling", () => {
+  it("stops polling once the model is present", async () => {
+    vi.useFakeTimers()
+    mockedCall.mockResolvedValue({ exists: true } as never)
+
+    renderCheck()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockedCall).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 4)
+
+    // The model is installed; nothing is left to watch for, so the worker is
+    // not woken again.
+    expect(mockedCall).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
+  it("keeps polling while the model is missing", async () => {
+    vi.useFakeTimers()
+    mockedCall.mockResolvedValue({ exists: false } as never)
+
+    renderCheck()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2)
+
+    expect(mockedCall.mock.calls.length).toBeGreaterThan(1)
+    vi.useRealTimers()
+  })
+
+  it("skips ticks while the document is hidden", async () => {
+    vi.useFakeTimers()
+    mockedCall.mockResolvedValue({ exists: false } as never)
+    setHidden(true)
+
+    renderCheck()
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3)
+
+    expect(mockedCall).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it("checks once when the document becomes visible again", async () => {
+    mockedCall.mockResolvedValue({ exists: false } as never)
+    setHidden(true)
+
+    renderCheck()
+    expect(mockedCall).not.toHaveBeenCalled()
+
+    setHidden(false)
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    await waitFor(() => {
+      expect(mockedCall).toHaveBeenCalled()
+    })
+  })
+
+  it("stops polling after unmount", async () => {
+    vi.useFakeTimers()
+    mockedCall.mockResolvedValue({ exists: false } as never)
+
+    const { unmount } = renderCheck()
+    await vi.advanceTimersByTimeAsync(0)
+    const callsAtUnmount = mockedCall.mock.calls.length
+    unmount()
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3)
+
+    expect(mockedCall.mock.calls.length).toBe(callsAtUnmount)
+    vi.useRealTimers()
+  })
+})

--- a/src/features/model/hooks/use-embedding-model-check.ts
+++ b/src/features/model/hooks/use-embedding-model-check.ts
@@ -13,6 +13,12 @@ import { logger } from "@/lib/logger"
 import { extensionRpcClient } from "@/protocol/extension-client"
 import type { ProviderModel } from "@/types"
 
+/**
+ * Only the "model is missing" state needs re-checking on a timer — the user is
+ * expected to be pulling it right now. Once the model is present nothing polls,
+ * because every tick wakes the MV3 service worker and issues a provider
+ * request; a settings tab left open used to do that forever.
+ */
 const POLL_INTERVAL_MS = 5_000
 
 export interface UseEmbeddingModelCheckOptions {
@@ -69,7 +75,7 @@ export const useEmbeddingModelCheck = ({
       lastCheckedModelRef.current = selectedModel
     }
 
-    const checkModel = async () => {
+    const checkModel = async (): Promise<boolean> => {
       try {
         const currentModel = selectedModel || DEFAULT_EMBEDDING_MODEL
         const looksLikeEmbedding = isLikelyEmbeddingModelName(currentModel)
@@ -93,10 +99,10 @@ export const useEmbeddingModelCheck = ({
         const exists = looksLikeEmbedding && response.exists
 
         setModelExists(exists)
-        if (exists) return
+        if (exists) return true
 
         // Auto-switch only once per selectedModel cycle.
-        if (autoSwitchedRef.current) return
+        if (autoSwitchedRef.current) return false
 
         const providerModels = embeddingModels.filter(
           (m) => m.providerId === DEFAULT_PROVIDER_ID
@@ -117,6 +123,7 @@ export const useEmbeddingModelCheck = ({
           autoSwitchedRef.current = true
           applyModelChange(nextModel, resolveProviderForModel(nextModel))
         }
+        return false
       } catch (error) {
         logger.error(
           "Error checking embedding model",
@@ -124,12 +131,49 @@ export const useEmbeddingModelCheck = ({
           { error }
         )
         setModelExists(false)
+        return false
       }
     }
 
-    checkModel()
-    const interval = setInterval(checkModel, POLL_INTERVAL_MS)
-    return () => clearInterval(interval)
+    let cancelled = false
+    let running = false
+    let interval: ReturnType<typeof setInterval> | null = null
+
+    const stopPolling = () => {
+      if (!interval) return
+      clearInterval(interval)
+      interval = null
+    }
+
+    // A visibility change and an interval tick can land together; without the
+    // in-flight guard the same RPC runs twice, concurrently.
+    const runCheck = async () => {
+      if (cancelled || running) return
+      if (typeof document !== "undefined" && document.hidden) return
+      running = true
+      try {
+        const exists = await checkModel()
+        // Nothing left to watch for once the model is present. A later change
+        // to `selectedModel` re-runs this effect and re-arms the timer.
+        if (exists) stopPolling()
+      } finally {
+        running = false
+      }
+    }
+
+    runCheck()
+    interval = setInterval(runCheck, POLL_INTERVAL_MS)
+
+    const onVisibilityChange = () => {
+      if (!document.hidden) runCheck()
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
+    return () => {
+      cancelled = true
+      stopPolling()
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
   }, [
     applyModelChange,
     embeddingModels,

--- a/src/lib/embeddings/__tests__/config.test.ts
+++ b/src/lib/embeddings/__tests__/config.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { STORAGE_KEYS } from "@/lib/constants"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
-import { getEmbeddingConfig } from "../config"
+import { getEmbeddingConfig, resetEmbeddingConfigCache } from "../config"
+
+/**
+ * The memo is process-wide, so every case starts from a clean one. Without
+ * this the second case silently reads the first's value and passes only
+ * because their expectations happen to agree.
+ */
+beforeEach(() => {
+  resetEmbeddingConfigCache()
+})
 
 describe("getEmbeddingConfig", () => {
   it("normalizes legacy backend values", async () => {
@@ -25,5 +35,97 @@ describe("getEmbeddingConfig", () => {
     const config = await getEmbeddingConfig()
 
     expect(config.rerankerBackend).toBe("cosine")
+  })
+})
+
+describe("getEmbeddingConfig caching", () => {
+  it("reads storage once for repeated calls", async () => {
+    vi.mocked(getPlasmoStoredValue).mockClear()
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue({
+      chunkSize: 400
+    } as unknown)
+
+    const first = await getEmbeddingConfig()
+    const second = await getEmbeddingConfig()
+
+    expect(first.chunkSize).toBe(400)
+    expect(second.chunkSize).toBe(400)
+    expect(vi.mocked(getPlasmoStoredValue)).toHaveBeenCalledTimes(1)
+  })
+
+  it("collapses concurrent callers onto one read", async () => {
+    vi.mocked(getPlasmoStoredValue).mockClear()
+    vi.mocked(getPlasmoStoredValue).mockResolvedValue({
+      chunkSize: 400
+    } as unknown)
+
+    await Promise.all([
+      getEmbeddingConfig(),
+      getEmbeddingConfig(),
+      getEmbeddingConfig()
+    ])
+
+    expect(vi.mocked(getPlasmoStoredValue)).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The watcher registers once per module instance, and the global test setup
+   * clears mock call history between cases — so the registration call is only
+   * observable from a freshly imported module.
+   */
+  const loadFreshConfigModule = async () => {
+    vi.resetModules()
+    const mod = await import("../config")
+    vi.mocked(getPlasmoStoredValue).mockResolvedValueOnce({
+      chunkSize: 400
+    } as unknown)
+    const first = await mod.getEmbeddingConfig()
+    const listener = vi
+      .mocked(globalThis.chrome.storage.onChanged.addListener)
+      .mock.calls.at(-1)?.[0] as
+      | ((changes: Record<string, unknown>) => void)
+      | undefined
+    return { mod, first, listener }
+  }
+
+  it("re-reads after the stored config changes", async () => {
+    const { mod, first, listener } = await loadFreshConfigModule()
+    expect(first.chunkSize).toBe(400)
+    expect(listener).toBeTypeOf("function")
+
+    listener?.({ [STORAGE_KEYS.EMBEDDINGS.CONFIG]: { newValue: {} } })
+
+    vi.mocked(getPlasmoStoredValue).mockResolvedValueOnce({
+      chunkSize: 900
+    } as unknown)
+    const after = await mod.getEmbeddingConfig()
+
+    expect(after.chunkSize).toBe(900)
+  })
+
+  it("keeps the memo when an unrelated key changes", async () => {
+    const { mod, listener } = await loadFreshConfigModule()
+
+    listener?.({ "some-other-key": { newValue: 1 } })
+
+    vi.mocked(getPlasmoStoredValue).mockClear()
+    const after = await mod.getEmbeddingConfig()
+
+    expect(after.chunkSize).toBe(400)
+    expect(vi.mocked(getPlasmoStoredValue)).not.toHaveBeenCalled()
+  })
+
+  it("does not memoize a failed read", async () => {
+    vi.mocked(getPlasmoStoredValue).mockRejectedValueOnce(
+      new Error("storage unavailable")
+    )
+    await expect(getEmbeddingConfig()).rejects.toThrow("storage unavailable")
+
+    vi.mocked(getPlasmoStoredValue).mockResolvedValueOnce({
+      chunkSize: 400
+    } as unknown)
+    const recovered = await getEmbeddingConfig()
+
+    expect(recovered.chunkSize).toBe(400)
   })
 })

--- a/src/lib/embeddings/__tests__/embedding-client.test.ts
+++ b/src/lib/embeddings/__tests__/embedding-client.test.ts
@@ -251,5 +251,37 @@ describe("Embedding Client", () => {
       await generateEmbedding(longText)
       expect(mockEmbed).toHaveBeenCalledTimes(1)
     })
+
+    /**
+     * The previous sampled hash bounded its loop by the sample count rather
+     * than the text length, so it only ever read positions inside the first
+     * 1000 characters. Two long chunks sharing an opening collided and the
+     * second silently received the first's vector.
+     */
+    it("distinguishes long texts that differ only after the first 1000 chars", async () => {
+      const shared = "a".repeat(1000)
+      mockEmbed.mockReset()
+      mockEmbed.mockResolvedValueOnce([0.1, 0.2, 0.3])
+      mockEmbed.mockResolvedValueOnce([0.9, 0.8, 0.7])
+
+      const first = await generateEmbedding(`${shared}${"b".repeat(1000)}`)
+      const second = await generateEmbedding(`${shared}${"c".repeat(1000)}`)
+
+      expect(mockEmbed).toHaveBeenCalledTimes(2)
+      expect(getCacheSize()).toBe(2)
+      expect(first).toMatchObject({ embedding: [0.1, 0.2, 0.3] })
+      expect(second).toMatchObject({ embedding: [0.9, 0.8, 0.7] })
+    })
+
+    it("distinguishes texts differing only in trailing length", async () => {
+      mockEmbed.mockReset()
+      mockEmbed.mockResolvedValue([0.1, 0.2, 0.3])
+
+      await generateEmbedding("a".repeat(1500))
+      await generateEmbedding("a".repeat(1501))
+
+      expect(mockEmbed).toHaveBeenCalledTimes(2)
+      expect(getCacheSize()).toBe(2)
+    })
   })
 })

--- a/src/lib/embeddings/config.ts
+++ b/src/lib/embeddings/config.ts
@@ -1,10 +1,77 @@
+import { browser } from "@/lib/browser-api"
 import type { EmbeddingConfig } from "@/lib/constants"
+import { STORAGE_KEYS } from "@/lib/constants"
 import { readSetting } from "@/lib/storage/setting-access"
 import { SETTINGS } from "@/lib/storage/settings"
 
 /**
- * Gets embedding configuration
+ * Embedding config is read from paths that run once per chunk and once per
+ * vector operation — ingestion, retrieval, index add, index search — and every
+ * read is a live `chrome.storage` round trip, because Plasmo does not cache.
+ * Ingesting a file therefore spent thousands of IPC hops re-reading settings
+ * that did not change for the duration of the job.
+ *
+ * The memo is invalidated from `storage.onChanged` rather than expiring on a
+ * timer: a stale retrieval config silently changes what RAG returns, so
+ * bounded staleness is not good enough. A context without the storage API
+ * keeps reading every time, which is the behaviour this replaces.
+ *
+ * Registration is attempted once, lazily, so importing this module in a
+ * context with no extension APIs stays inert.
+ */
+let cachedConfig: Promise<EmbeddingConfig> | null = null
+let watcherRegistered = false
+let watcherActive = false
+
+const registerConfigWatcher = (): void => {
+  if (watcherRegistered) return
+  watcherRegistered = true
+  try {
+    const onChanged = browser.storage?.onChanged
+    if (!onChanged?.addListener) return
+    onChanged.addListener((changes) => {
+      // Matched on key alone rather than area: the storage wrapper routes by
+      // registry scope, and a key that moves between areas must still
+      // invalidate.
+      if (STORAGE_KEYS.EMBEDDINGS.CONFIG in changes) cachedConfig = null
+    })
+    watcherActive = true
+  } catch {
+    // No storage API here. Leave the memo disabled rather than risk serving a
+    // config that can never be invalidated.
+  }
+}
+
+/**
+ * Gets embedding configuration.
+ *
+ * Memoized until the stored value changes. Callers on hot loops should still
+ * resolve it once per operation and pass the snapshot down rather than calling
+ * this per item — the memo removes the IPC, not the await.
  */
 export const getEmbeddingConfig = async (): Promise<EmbeddingConfig> => {
-  return readSetting(SETTINGS.EMBEDDING_CONFIG)
+  registerConfigWatcher()
+  if (!watcherActive) return readSetting(SETTINGS.EMBEDDING_CONFIG)
+
+  if (!cachedConfig) {
+    cachedConfig = readSetting(SETTINGS.EMBEDDING_CONFIG).catch(
+      (error: unknown) => {
+        // A rejected read must not be memoized, or one transient failure
+        // pins the error for the life of the context.
+        cachedConfig = null
+        throw error
+      }
+    )
+  }
+  return cachedConfig
+}
+
+/**
+ * Drops the memo.
+ *
+ * For tests, and for a caller that has just written the config and needs its
+ * own next read to reflect that without waiting for the change event.
+ */
+export const resetEmbeddingConfigCache = (): void => {
+  cachedConfig = null
 }

--- a/src/lib/embeddings/embedding-client.ts
+++ b/src/lib/embeddings/embedding-client.ts
@@ -1,3 +1,4 @@
+import type { EmbeddingConfig } from "@/lib/constants"
 import { getErrorMessage } from "@/lib/error-utils"
 import { readSetting } from "@/lib/storage/setting-access"
 import { SETTINGS } from "@/lib/storage/settings"
@@ -34,29 +35,25 @@ const CACHE_MAX_SIZE = 100
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
 /**
- * Simple hash function for content caching
- * Optimized for performance
+ * Content hash for the embedding cache.
+ *
+ * Covers the whole input. The previous sampled variant bounded its loop by the
+ * sample count rather than the text length, so for anything over 1000
+ * characters it read only positions inside the first 1000 — a 100 KB chunk was
+ * identified by ten characters ending at index 900. Two chunks sharing an
+ * opening then collided and the cache returned the wrong vector, with no error
+ * path and no way to notice beyond degraded retrieval. A full pass over a
+ * ~500-token chunk is negligible next to the embedding request it guards.
+ *
+ * The length is mixed in so inputs that differ only by a suffix the character
+ * loop happens to cancel out cannot collide on the digest alone.
  */
 const hashContent = (text: string): string => {
-  // Use a faster hash for short strings, more robust for long strings
-  if (text.length < 100) {
-    // Simple hash for short strings
-    let hash = 0
-    for (let i = 0; i < text.length; i++) {
-      hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0
-    }
-    return hash.toString()
-  }
-
-  // For longer strings, use a more efficient approach
-  // Take samples instead of processing entire string
-  const sampleSize = Math.min(1000, text.length)
-  const step = Math.floor(text.length / sampleSize)
   let hash = 0
-  for (let i = 0; i < sampleSize; i += step) {
+  for (let i = 0; i < text.length; i++) {
     hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0
   }
-  return hash.toString()
+  return `${hash.toString(36)}:${text.length.toString(36)}`
 }
 
 /**
@@ -71,8 +68,14 @@ const cleanExpiredCache = (): void => {
   }
 }
 
-const getCacheModelKey = async (modelName?: string): Promise<string> => {
-  const config = await getEmbeddingConfig()
+/**
+ * Takes the already-resolved config rather than reading it again: this runs
+ * once per chunk, and the caller has just resolved the same value.
+ */
+const getCacheModelKey = async (
+  config: EmbeddingConfig,
+  modelName?: string
+): Promise<string> => {
   const providerId = config.sharedEmbeddingProviderId || "default"
 
   if (modelName) {
@@ -86,16 +89,20 @@ const getCacheModelKey = async (modelName?: string): Promise<string> => {
 /**
  * Generates embeddings for text using the browser-safe embedding strategy chain.
  * Optimized with caching and batch processing support.
+ *
+ * `config` lets a batch caller resolve the snapshot once and reuse it for every
+ * item instead of re-resolving per chunk.
  */
 export const generateEmbedding = async (
   text: string,
-  modelName?: string
+  modelName?: string,
+  config?: EmbeddingConfig
 ): Promise<EmbeddingResult | EmbeddingError> => {
-  const config = await getEmbeddingConfig()
-  const modelKey = await getCacheModelKey(modelName)
+  const resolvedConfig = config ?? (await getEmbeddingConfig())
+  const modelKey = await getCacheModelKey(resolvedConfig, modelName)
 
   // Check cache if enabled
-  if (config.enableCaching) {
+  if (resolvedConfig.enableCaching) {
     const contentHash = `${hashContent(text)}:${modelKey}`
     const cached = embeddingCache.get(contentHash)
     if (cached) {
@@ -121,7 +128,7 @@ export const generateEmbedding = async (
     const embedding = resolved.embedding
 
     // Cache if enabled
-    if (config.enableCaching) {
+    if (resolvedConfig.enableCaching) {
       const contentHash = `${hashContent(text)}:${modelKey}`
       const now = Date.now()
 
@@ -186,7 +193,7 @@ export const generateEmbeddingsBatch = async (
   for (let i = 0; i < texts.length; i += batchSize) {
     const batch = texts.slice(i, i + batchSize)
     const batchResults = await Promise.all(
-      batch.map((text) => generateEmbedding(text, modelName))
+      batch.map((text) => generateEmbedding(text, modelName, config))
     )
     results.push(...batchResults)
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -98,6 +98,29 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+/**
+ * Drop module-level caches that outlive a test.
+ *
+ * The embedding config is memoized until `storage.onChanged` fires. Tests
+ * reconfigure it by swapping the `getPlasmoStoredValue` mock, which bypasses
+ * storage and so emits no event — the memo would then serve the previous
+ * test's value. Production has the event; only the test double does not.
+ *
+ * Guarded because a handful of suites replace this module with `vi.mock`;
+ * reading a name their factory does not define throws rather than yielding
+ * undefined. Those suites stub the config outright and need no reset.
+ */
+beforeEach(async () => {
+  try {
+    const embeddingConfig = (await import("@/lib/embeddings/config")) as {
+      resetEmbeddingConfigCache?: () => void
+    }
+    embeddingConfig.resetEmbeddingConfigCache?.()
+  } catch {
+    // Module is mocked without the reset export.
+  }
+})
+
 /** Reset per-test IndexedDB state supplied by fake-indexeddb. */
 beforeEach(() => {
   // fake-indexeddb is already set up globally


### PR DESCRIPTION
Three fixes on the embedding path.

- Embedding cache hash only covered the first 1000 chars of long text, so chunks sharing an opening returned each other's vectors. Silent wrong-retrieval, no error path.
- Embedding config was an uncached `chrome.storage` read on every chunk and every vector add/search. Now memoized until `storage.onChanged` fires — invalidated by event, not a TTL, since a stale retrieval config changes RAG results.
- Embedding-model check polled every 5s forever; now stops once the model exists and pauses while hidden. Same for the loaded-models poll, plus a sequence guard so overlapping requests can't settle out of order.

The memo needed a global test reset: suites reconfigure the config by swapping the storage mock, which bypasses the change event that production relies on.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects embedding cache keys, memoizes embedding configuration with storage-change invalidation, and reduces unnecessary model polling.
- Hashes complete embedding input content and includes input length in cache keys.
- Memoizes embedding configuration reads and resets the memo after relevant storage changes.
- Pauses model polling while hidden and stops embedding-model polling once the model exists.
- Uses request sequencing and unload-specific invalidation to prevent stale loaded-model responses while preserving loading-state cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the request sequence guard prevents older loaded-model responses from overwriting newer state, and the separate stale boundary lets an unload invalidate results without preventing the responsible request from clearing progress.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/model/components/loaded-models-info.tsx | Separates response usability from progress ownership, preventing out-of-order writes and fully resolving both previously reported concurrency issues. |
| src/features/model/components/__tests__/loaded-models-info.test.tsx | Exercises stale-response suppression, unload invalidation, and loading-state cleanup under overlapping requests. |
| src/features/model/hooks/use-embedding-model-check.ts | Adds visibility-aware single-flight polling that stops after the selected embedding model is found. |
| src/lib/embeddings/config.ts | Memoizes embedding configuration reads with relevant storage-change invalidation and failed-read recovery. |
| src/lib/embeddings/embedding-client.ts | Replaces sampled cache hashing with full-content hashing and reuses one resolved configuration across batch items. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Loaded-model fetch starts] --> B[Assign increasing fetch ID]
  B --> C{Unload completes?}
  C -- No --> D{Still newest?}
  C -- Yes --> E[Advance stale-before boundary]
  E --> F[Remove unloaded model locally]
  F --> D
  D -- Yes and usable --> G[Apply fetched model list]
  D -- No or invalidated --> H[Discard response]
  G --> I{Request still newest?}
  H --> I
  I -- Yes --> J[Clear loading and refreshing]
  I -- No --> K[Newest request owns cleanup]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(model): clear loading state when an ..."](https://github.com/shishir435/ollama-client/commit/5391412711c9142c4145d0207531b95b34394ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53605990)</sub>

**Context used:**

- Knowledge Base — [Local RAG: File Upload, Chunking, Embedding, and Retrieval](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/knowledge-rag.md)
- Knowledge Base — [Provider Abstraction Layer](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/providers.md)

<!-- /greptile_comment -->