### PR TITLE
perf(tabs): bound page-extraction lifecycle

### DIFF
--- a/src/background/__tests__/tab-lifecycle.test.ts
+++ b/src/background/__tests__/tab-lifecycle.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { listeners, mockBrowser } = vi.hoisted(() => {
+  const listeners: Array<(tabId: number) => void> = []
+  return {
+    listeners,
+    mockBrowser: {
+      tabs: {
+        onRemoved: {
+          addListener: (fn: (tabId: number) => void) => {
+            listeners.push(fn)
+          }
+        }
+      }
+    } as { tabs?: { onRemoved: { addListener: (fn: unknown) => void } } }
+  }
+})
+
+vi.mock("@/lib/browser-api", () => ({ browser: mockBrowser }))
+vi.mock("@/lib/tools/internal/tab-utils", () => ({
+  clearTabContentCache: vi.fn()
+}))
+
+import { clearTabContentCache } from "@/lib/tools/internal/tab-utils"
+import { registerTabLifecycle } from "../tab-lifecycle"
+
+describe("registerTabLifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listeners.length = 0
+  })
+
+  it("evicts a closed tab's cached page content", () => {
+    registerTabLifecycle()
+
+    expect(listeners).toHaveLength(1)
+    listeners[0](42)
+
+    expect(clearTabContentCache).toHaveBeenCalledWith(42)
+  })
+
+  it("does nothing on a runtime without tabs.onRemoved", () => {
+    const original = mockBrowser.tabs
+    mockBrowser.tabs = undefined
+
+    expect(() => registerTabLifecycle()).not.toThrow()
+    expect(listeners).toHaveLength(0)
+
+    mockBrowser.tabs = original
+  })
+})

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,7 @@ import { registerMessageRouter } from "@/background/message-router"
 import { startPersistenceTopology } from "@/background/persistence-readiness"
 import { registerPortRouter } from "@/background/port-router"
 import { initializeBackgroundStartup } from "@/background/startup"
+import { registerTabLifecycle } from "@/background/tab-lifecycle"
 
 /**
  * The persistence topology starts first and hands its readiness to startup,
@@ -17,6 +18,7 @@ const persistenceReady = startPersistenceTopology()
 initializeBackgroundStartup(persistenceReady)
 registerPortRouter()
 registerMessageRouter()
+registerTabLifecycle()
 
 /**
  * Dev-only section 9.4 spike host (offscreen OPFS owner). The flag is false

--- a/src/background/tab-lifecycle.ts
+++ b/src/background/tab-lifecycle.ts
@@ -1,0 +1,16 @@
+import { browser } from "@/lib/browser-api"
+import { clearTabContentCache } from "@/lib/tools/internal/tab-utils"
+
+/**
+ * Release a closed tab's cached page content.
+ *
+ * The cache holds whole extracted documents keyed by tab id. On Firefox MV2 the
+ * background page never unloads, so without this the entries of every tab the
+ * user ever opened survive for the whole browser session.
+ */
+export const registerTabLifecycle = (): void => {
+  if (typeof browser.tabs?.onRemoved?.addListener !== "function") return
+  browser.tabs.onRemoved.addListener((tabId: number) => {
+    clearTabContentCache(tabId)
+  })
+}

--- a/src/features/tabs/hooks/__tests__/use-tab-contents-auto-refresh.test.ts
+++ b/src/features/tabs/hooks/__tests__/use-tab-contents-auto-refresh.test.ts
@@ -189,4 +189,55 @@ describe("useTabContents auto refresh", () => {
 
     unmount()
   })
+
+  /**
+   * The transcript fetch has no timeout, so an extraction can stay pending
+   * indefinitely. A sweep-wide in-flight flag turned that into a permanent
+   * stall for every selected tab; the guard has to be per tab.
+   *
+   * The hang has to begin inside a sweep to matter: an extraction already
+   * running when the sweep starts is skipped by the per-tab guard, so the
+   * sweep would settle normally.
+   */
+  it("keeps refreshing other tabs when a sweep extraction never settles", async () => {
+    const stuckTabId = freshTabId()
+    const healthyTabId = freshTabId()
+    useSelectedTabsStore.setState({
+      selectedTabIds: [String(stuckTabId), String(healthyTabId)],
+      errors: {}
+    })
+
+    let stuckCalls = 0
+    sendMessage.mockImplementation((tabId: number) => {
+      if (tabId !== stuckTabId) {
+        return Promise.resolve({ html: "<p>ok</p>", title: "OK" })
+      }
+      stuckCalls += 1
+      // The mount read completes; the first sweep read never does.
+      if (stuckCalls === 1) {
+        return Promise.resolve({ html: "<p>s</p>", title: "S" })
+      }
+      return new Promise(() => {})
+    })
+
+    const { unmount } = renderHook(() => useTabContents())
+    await flush()
+
+    const healthyCalls = () =>
+      sendMessage.mock.calls.filter(([tabId]) => tabId === healthyTabId).length
+
+    // First sweep: the stuck tab starts an extraction that never settles.
+    await tick()
+    const afterFirstSweep = healthyCalls()
+    expect(stuckCalls).toBeGreaterThan(1)
+
+    // Later sweeps must still reach the healthy tab. A sweep-wide flag would
+    // have been left set by the first sweep and skipped everything from here.
+    await tick()
+    expect(healthyCalls()).toBeGreaterThan(afterFirstSweep)
+
+    await tick()
+    expect(healthyCalls()).toBeGreaterThan(afterFirstSweep + 1)
+    unmount()
+  })
 })

--- a/src/features/tabs/hooks/__tests__/use-tab-contents-auto-refresh.test.ts
+++ b/src/features/tabs/hooks/__tests__/use-tab-contents-auto-refresh.test.ts
@@ -1,0 +1,192 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/features/tabs/hooks/use-open-tab", () => ({
+  useOpenTabs: vi.fn(() => ({ tabs: [], refreshTabs: vi.fn() }))
+}))
+
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: vi.fn(() => [true, vi.fn(), { isLoading: false }])
+}))
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: {
+    tabs: { sendMessage: vi.fn() },
+    scripting: { executeScript: vi.fn() }
+  }
+}))
+
+import { useSelectedTabsStore } from "@/features/tabs/stores/selected-tabs-store"
+import { browser } from "@/lib/browser-api"
+import { TAB_CONTENT_REFRESH_INTERVAL_MS } from "@/lib/constants"
+import { useTabContents } from "../use-tab-contents"
+
+const sendMessage = vi.mocked(browser.tabs.sendMessage)
+
+let hidden = false
+
+/** Fake timers are on throughout, so settle work by draining them, not waitFor. */
+const flush = async (ms = 0) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+    await Promise.resolve()
+  })
+}
+
+const tick = () => flush(TAB_CONTENT_REFRESH_INTERVAL_MS)
+
+/** Distinct ids per test: the fetching store is module-level and persists. */
+let nextTabId = 1000
+const freshTabId = () => {
+  nextTabId += 1
+  return nextTabId
+}
+
+const selectTab = (tabId: number) => {
+  useSelectedTabsStore.setState({ selectedTabIds: [String(tabId)], errors: {} })
+}
+
+describe("useTabContents auto refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hidden = false
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden
+    })
+    useSelectedTabsStore.setState({ selectedTabIds: [], errors: {} })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    useSelectedTabsStore.setState({ selectedTabIds: [], errors: {} })
+  })
+
+  it("runs one refresh timer no matter how many consumers mount", async () => {
+    const tabId = freshTabId()
+    selectTab(tabId)
+    sendMessage.mockResolvedValue({ html: "<p>a</p>", title: "A" })
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval")
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+
+    const first = renderHook(() => useTabContents())
+    const second = renderHook(() => useTabContents())
+    const third = renderHook(() => useTabContents())
+    await flush()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(
+      setIntervalSpy.mock.calls.filter(
+        (call) => call[1] === TAB_CONTENT_REFRESH_INTERVAL_MS
+      )
+    ).toHaveLength(1)
+
+    await tick()
+
+    // Three mounted consumers used to mean three concurrent extractions.
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+
+    first.unmount()
+    second.unmount()
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+
+    third.unmount()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+  })
+
+  it("does not start a second extraction for a tab already being read", async () => {
+    const tabId = freshTabId()
+    selectTab(tabId)
+    let release: ((value: unknown) => void) | undefined
+    sendMessage.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve
+      })
+    )
+
+    const { result, unmount } = renderHook(() => useTabContents())
+    await flush()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // The manual path forces, which used to mean "ignore the in-flight fetch".
+    await act(async () => {
+      void result.current.refreshSelectedTabContents()
+    })
+    await flush()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    await tick()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      release?.({ html: "<p>a</p>", title: "A" })
+    })
+    await flush()
+    unmount()
+  })
+
+  it("pauses while the document is hidden and re-checks when it returns", async () => {
+    const tabId = freshTabId()
+    selectTab(tabId)
+    sendMessage.mockResolvedValue({ html: "<p>a</p>", title: "A" })
+
+    const { unmount } = renderHook(() => useTabContents())
+    await flush()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    hidden = true
+    await tick()
+    await tick()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    hidden = false
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    await flush()
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+
+    unmount()
+  })
+
+  it("keeps the cached entry when the content hash is unchanged", async () => {
+    const tabId = freshTabId()
+    selectTab(tabId)
+    const extractionDebug = {
+      url: "https://example.com",
+      title: "A",
+      scraper: "basic",
+      hasTranscript: false,
+      transcriptLength: 0,
+      contentLength: 3,
+      contentHash: "hash-1"
+    }
+    sendMessage.mockResolvedValue({
+      html: "<p>a</p>",
+      title: "A",
+      extractionDebug
+    })
+
+    const { result, unmount } = renderHook(() => useTabContents())
+    await flush()
+    const cached = result.current.tabContents[tabId]
+    expect(cached).toBeDefined()
+
+    await tick()
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+    expect(result.current.tabContents[tabId]).toBe(cached)
+    expect(result.current.updatedIds[tabId]).toBeFalsy()
+
+    sendMessage.mockResolvedValue({
+      html: "<p>b</p>",
+      title: "A",
+      extractionDebug: { ...extractionDebug, contentHash: "hash-2" }
+    })
+    await tick()
+    expect(result.current.tabContents[tabId]?.html).toBe("<p>b</p>")
+    expect(result.current.updatedIds[tabId]).toBe(true)
+
+    unmount()
+  })
+})

--- a/src/features/tabs/hooks/use-tab-contents.ts
+++ b/src/features/tabs/hooks/use-tab-contents.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect } from "react"
 import { create } from "zustand"
 import { useOpenTabs } from "@/features/tabs/hooks/use-open-tab"
-import { useSelectedTabs } from "@/features/tabs/stores/selected-tabs-store"
+import {
+  useSelectedTabs,
+  useSelectedTabsStore
+} from "@/features/tabs/stores/selected-tabs-store"
 import { useSetting } from "@/hooks/use-setting"
 import {
   blockedTabAccessMessage,
@@ -57,13 +60,12 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
     force = false
   ) => {
     const state = get()
-    // Deduplicate: if already fetched or in-flight across ANY hook instance, abort.
-    if (
-      !force &&
-      (state.fetchedIds.includes(tabId) || state.loadingIds[tabId])
-    ) {
-      return
-    }
+    // An in-flight extraction is not a cache, so `force` does not override it:
+    // it means "ignore the cached signature", never "scroll and re-read a page
+    // that is already being scrolled and read".
+    if (state.loadingIds[tabId]) return
+    // Deduplicate: if already fetched across ANY hook instance, abort.
+    if (!force && state.fetchedIds.includes(tabId)) return
 
     if (tabUrl && !isContentScriptReadableUrl(tabUrl)) {
       setErrors((prev) => ({
@@ -74,7 +76,9 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
     }
 
     set((s) => ({
-      fetchedIds: [...s.fetchedIds, tabId],
+      fetchedIds: s.fetchedIds.includes(tabId)
+        ? s.fetchedIds
+        : [...s.fetchedIds, tabId],
       loadingIds: { ...s.loadingIds, [tabId]: true }
     }))
 
@@ -85,9 +89,23 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
 
       const html = response?.html || ""
       const title = response?.title || fallbackTitle || "Untitled"
-      const prevHash = state.tabContents[tabId]?.extractionDebug?.contentHash
+      const previous = get().tabContents[tabId]
+      const prevHash = previous?.extractionDebug?.contentHash
       const nextHash = response?.extractionDebug?.contentHash
       const didChange = !!prevHash && !!nextHash && prevHash !== nextHash
+
+      // Same hash, same title: the page did not change, so keep the entry we
+      // already hold. Rewriting it would hand every consumer a new object and
+      // rebuild the whole tab context for content that is byte-identical.
+      if (
+        previous &&
+        prevHash &&
+        prevHash === nextHash &&
+        previous.title === title
+      ) {
+        set((s) => ({ loadingIds: { ...s.loadingIds, [tabId]: false } }))
+        return
+      }
 
       set((s) => ({
         tabContents: {
@@ -179,6 +197,87 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
   }
 }))
 
+/**
+ * Auto-refresh runs on ONE module-level timer, not one per mounted hook.
+ *
+ * `useTabContents` has several simultaneous consumers, and a timer in the hook
+ * body meant N of them scheduled N sweeps — each of which scrolls the host page
+ * and holds a document-wide MutationObserver. Subscribers are reference
+ * counted: the timer starts with the first and stops with the last.
+ */
+let autoRefreshSubscribers = 0
+let autoRefreshTimer: ReturnType<typeof setInterval> | null = null
+let autoRefreshInFlight = false
+
+/**
+ * Latest known title/url per tab. Every consumer reads the same `useOpenTabs`
+ * data, so the sweep can take it from here instead of from whichever hook
+ * instance happened to register the timer.
+ */
+let knownTabs: Record<number, { title?: string; url?: string }> = {}
+
+const runAutoRefreshSweep = () => {
+  // A sweep that overruns the interval must not stack another one on top.
+  if (autoRefreshInFlight) return
+  if (typeof document !== "undefined" && document.hidden) return
+
+  const { selectedTabIds, setErrors } = useSelectedTabsStore.getState()
+  if (selectedTabIds.length === 0) return
+
+  const { fetchTabContent } = useTabFetchingStore.getState()
+  autoRefreshInFlight = true
+  void Promise.all(
+    selectedTabIds.map((id) => {
+      const tabId = parseInt(id, 10)
+      const known = knownTabs[tabId]
+      return fetchTabContent(
+        tabId,
+        known?.title || "",
+        known?.url,
+        setErrors,
+        true
+      )
+    })
+  ).finally(() => {
+    autoRefreshInFlight = false
+  })
+}
+
+const handleAutoRefreshVisibility = () => {
+  if (!document.hidden) runAutoRefreshSweep()
+}
+
+const subscribeAutoRefresh = (): (() => void) => {
+  autoRefreshSubscribers += 1
+  if (autoRefreshSubscribers === 1) {
+    autoRefreshTimer = setInterval(
+      runAutoRefreshSweep,
+      TAB_CONTENT_REFRESH_INTERVAL_MS
+    )
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", handleAutoRefreshVisibility)
+    }
+  }
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    autoRefreshSubscribers = Math.max(0, autoRefreshSubscribers - 1)
+    if (autoRefreshSubscribers > 0) return
+    if (autoRefreshTimer) {
+      clearInterval(autoRefreshTimer)
+      autoRefreshTimer = null
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener(
+        "visibilitychange",
+        handleAutoRefreshVisibility
+      )
+    }
+  }
+}
+
 export const useTabContents = () => {
   const { selectedTabIds, errors, setErrors } = useSelectedTabs()
   const {
@@ -226,30 +325,23 @@ export const useTabContents = () => {
   const [autoRefreshTabContext] = useSetting(SETTINGS.AUTO_REFRESH_TAB_CONTEXT)
 
   useEffect(() => {
-    if (!autoRefreshTabContext || selectedTabIds.length === 0) return
-    const interval = setInterval(() => {
-      selectedTabIds
-        .map((id) => parseInt(id, 10))
-        .forEach((tabId) => {
-          fetchTabContent(
-            tabId,
-            getTabTitle(tabId),
-            getTabUrl(tabId),
-            setErrors,
-            true
-          )
-        })
-    }, TAB_CONTENT_REFRESH_INTERVAL_MS)
+    const next: Record<number, { title?: string; url?: string }> = {}
+    for (const tab of openTabs) {
+      if (tab.id === undefined) continue
+      next[tab.id] = { title: tab.title, url: tab.url }
+    }
+    knownTabs = next
+  }, [openTabs])
 
-    return () => clearInterval(interval)
-  }, [
-    autoRefreshTabContext,
-    selectedTabIds,
-    fetchTabContent,
-    getTabTitle,
-    getTabUrl,
-    setErrors
-  ])
+  /*
+   * Deliberately keyed on the setting alone. The sweep reads the current
+   * selection and the current tab titles from module state, so a selection
+   * change must not tear the shared timer down and restart its interval.
+   */
+  useEffect(() => {
+    if (!autoRefreshTabContext) return
+    return subscribeAutoRefresh()
+  }, [autoRefreshTabContext])
 
   const refreshSelectedTabContents = async () => {
     await Promise.all(

--- a/src/features/tabs/hooks/use-tab-contents.ts
+++ b/src/features/tabs/hooks/use-tab-contents.ts
@@ -207,7 +207,6 @@ const useTabFetchingStore = create<TabFetchingState>((set, get) => ({
  */
 let autoRefreshSubscribers = 0
 let autoRefreshTimer: ReturnType<typeof setInterval> | null = null
-let autoRefreshInFlight = false
 
 /**
  * Latest known title/url per tab. Every consumer reads the same `useOpenTabs`
@@ -216,31 +215,31 @@ let autoRefreshInFlight = false
  */
 let knownTabs: Record<number, { title?: string; url?: string }> = {}
 
+/**
+ * Overrun is guarded per tab, not per sweep.
+ *
+ * `fetchTabContent` already returns early while a tab has an extraction in
+ * flight, and `force` cannot bypass that — which is the whole of what stacking
+ * protection needs, since each tab's extraction is independent.
+ *
+ * A single global in-flight flag looked equivalent and was not: one tab whose
+ * extraction never settles (the transcript fetch has no timeout) would hold the
+ * flag forever, and every later sweep would skip *every* selected tab until the
+ * extension context reloaded. Scoped to the tab, a hung extraction blocks only
+ * the tab it belongs to.
+ */
 const runAutoRefreshSweep = () => {
-  // A sweep that overruns the interval must not stack another one on top.
-  if (autoRefreshInFlight) return
   if (typeof document !== "undefined" && document.hidden) return
 
   const { selectedTabIds, setErrors } = useSelectedTabsStore.getState()
   if (selectedTabIds.length === 0) return
 
   const { fetchTabContent } = useTabFetchingStore.getState()
-  autoRefreshInFlight = true
-  void Promise.all(
-    selectedTabIds.map((id) => {
-      const tabId = parseInt(id, 10)
-      const known = knownTabs[tabId]
-      return fetchTabContent(
-        tabId,
-        known?.title || "",
-        known?.url,
-        setErrors,
-        true
-      )
-    })
-  ).finally(() => {
-    autoRefreshInFlight = false
-  })
+  for (const id of selectedTabIds) {
+    const tabId = parseInt(id, 10)
+    const known = knownTabs[tabId]
+    void fetchTabContent(tabId, known?.title || "", known?.url, setErrors, true)
+  }
 }
 
 const handleAutoRefreshVisibility = () => {

--- a/src/lib/__tests__/content-extractor.test.ts
+++ b/src/lib/__tests__/content-extractor.test.ts
@@ -142,6 +142,56 @@ describe("Content Extractor", () => {
       expect(window.fetch).toBe(originalFetch)
       expect(XMLHttpRequest.prototype.open).toBe(originalOpen)
     })
+
+    it("installs the patch once for concurrent waiters", async () => {
+      const originalFetch = window.fetch
+      const originalOpen = XMLHttpRequest.prototype.open
+
+      const first = waitForNetworkIdle(1000, 5000)
+      const patchedFetch = window.fetch
+      const patchedOpen = XMLHttpRequest.prototype.open
+      expect(patchedFetch).not.toBe(originalFetch)
+
+      const second = waitForNetworkIdle(300, 5000)
+      // The second waiter must not adopt the first waiter's wrapper as its
+      // "original" — that is what left a permanent wrapper chain behind.
+      expect(window.fetch).toBe(patchedFetch)
+      expect(XMLHttpRequest.prototype.open).toBe(patchedOpen)
+
+      await vi.advanceTimersByTimeAsync(300)
+      await second
+
+      // Out-of-order settle: the earlier waiter still needs instrumentation.
+      expect(window.fetch).toBe(patchedFetch)
+
+      await vi.advanceTimersByTimeAsync(700)
+      await first
+
+      expect(window.fetch).toBe(originalFetch)
+      expect(XMLHttpRequest.prototype.open).toBe(originalOpen)
+    })
+
+    it("resets every waiter's idle timer from the single patch", async () => {
+      const settled: string[] = []
+      const first = waitForNetworkIdle(10_000, 200).then(() =>
+        settled.push("first")
+      )
+      const second = waitForNetworkIdle(10_000, 200).then(() =>
+        settled.push("second")
+      )
+
+      await vi.advanceTimersByTimeAsync(150)
+      new XMLHttpRequest().open("GET", "https://example.com/")
+
+      // One request, two waiters: both idle timers restart, so neither settles
+      // at the deadline it had before the request.
+      await vi.advanceTimersByTimeAsync(100)
+      expect(settled).toEqual([])
+
+      await vi.advanceTimersByTimeAsync(150)
+      await Promise.all([first, second])
+      expect(settled).toHaveLength(2)
+    })
   })
 
   describe("extractContentWithLoading", () => {

--- a/src/lib/content-extractor.ts
+++ b/src/lib/content-extractor.ts
@@ -134,6 +134,84 @@ export const detectPagePatterns = (): string[] => {
 }
 
 /**
+ * Network instrumentation, installed once for however many extractions are
+ * waiting on it.
+ *
+ * Each waiter used to patch `window.fetch` itself and save the value it found
+ * as "the original". Two concurrent extractions therefore made the second
+ * waiter adopt the first one's wrapper, and restoring out of order left a
+ * wrapper installed forever — a retained closure plus dead instrumentation on
+ * every later request in this content-script world. A refcount is what makes
+ * install/uninstall independent of settle order.
+ */
+type NetworkActivityListener = () => void
+
+const networkActivityListeners = new Set<NetworkActivityListener>()
+let originalFetch: typeof window.fetch | null = null
+let originalXhrOpen: typeof XMLHttpRequest.prototype.open | null = null
+let patchedFetch: typeof window.fetch | null = null
+let patchedXhrOpen: typeof XMLHttpRequest.prototype.open | null = null
+
+const notifyNetworkActivity = (): void => {
+  for (const listener of [...networkActivityListeners]) listener()
+}
+
+const installNetworkInstrumentation = (): void => {
+  if (patchedFetch) return
+
+  const capturedFetch = window.fetch
+  const capturedOpen = XMLHttpRequest.prototype.open
+  originalFetch = capturedFetch
+  originalXhrOpen = capturedOpen
+
+  patchedFetch = ((...args: Parameters<typeof window.fetch>) => {
+    notifyNetworkActivity()
+    return capturedFetch.apply(window, args)
+  }) as typeof window.fetch
+
+  patchedXhrOpen = function (
+    this: XMLHttpRequest,
+    ...args: Parameters<typeof XMLHttpRequest.prototype.open>
+  ) {
+    notifyNetworkActivity()
+    return capturedOpen.apply(this, args)
+  } as typeof XMLHttpRequest.prototype.open
+
+  window.fetch = patchedFetch
+  XMLHttpRequest.prototype.open = patchedXhrOpen
+}
+
+const uninstallNetworkInstrumentation = (): void => {
+  // Only restore what is still ours. If the page patched over us, putting the
+  // captured value back would silently uninstall the page's own wrapper.
+  if (originalFetch && window.fetch === patchedFetch) {
+    window.fetch = originalFetch
+  }
+  if (originalXhrOpen && XMLHttpRequest.prototype.open === patchedXhrOpen) {
+    XMLHttpRequest.prototype.open = originalXhrOpen
+  }
+  originalFetch = null
+  originalXhrOpen = null
+  patchedFetch = null
+  patchedXhrOpen = null
+}
+
+const addNetworkActivityListener = (
+  listener: NetworkActivityListener
+): (() => void) => {
+  networkActivityListeners.add(listener)
+  if (networkActivityListeners.size === 1) installNetworkInstrumentation()
+
+  let removed = false
+  return () => {
+    if (removed) return
+    removed = true
+    networkActivityListeners.delete(listener)
+    if (networkActivityListeners.size === 0) uninstallNetworkInstrumentation()
+  }
+}
+
+/**
  * Wait for network idle
  */
 export const waitForNetworkIdle = (
@@ -143,47 +221,31 @@ export const waitForNetworkIdle = (
   return new Promise((resolve) => {
     let idleTimer: ReturnType<typeof setTimeout> | null = null
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null
-    let startTime = Date.now()
+    let lastActivity = Date.now()
     let settled = false
-
-    const originalFetch = window.fetch
-    const originalOpen = XMLHttpRequest.prototype.open
+    let removeActivityListener: (() => void) | null = null
 
     const cleanupAndResolve = () => {
       if (settled) return
       settled = true
       if (idleTimer) clearTimeout(idleTimer)
       if (timeoutTimer) clearTimeout(timeoutTimer)
-      window.fetch = originalFetch
-      XMLHttpRequest.prototype.open = originalOpen
+      removeActivityListener?.()
       resolve()
     }
 
     const resetIdleTimer = () => {
+      if (settled) return
       if (idleTimer) clearTimeout(idleTimer)
-      startTime = Date.now()
+      lastActivity = Date.now()
       idleTimer = setTimeout(() => {
-        const idleDuration = Date.now() - startTime
-        if (idleDuration >= minIdleTime) {
+        if (Date.now() - lastActivity >= minIdleTime) {
           cleanupAndResolve()
         }
       }, minIdleTime)
     }
 
-    // Monitor fetch requests
-    window.fetch = (...args) => {
-      resetIdleTimer()
-      return originalFetch.apply(window, args)
-    }
-
-    // Monitor XMLHttpRequest
-    XMLHttpRequest.prototype.open = function (
-      this: XMLHttpRequest,
-      ...args: Parameters<typeof XMLHttpRequest.prototype.open>
-    ) {
-      resetIdleTimer()
-      return originalOpen.apply(this, args)
-    } as typeof XMLHttpRequest.prototype.open
+    removeActivityListener = addNetworkActivityListener(resetIdleTimer)
 
     // Start idle timer
     resetIdleTimer()

--- a/src/lib/tools/internal/__tests__/tab-utils.test.ts
+++ b/src/lib/tools/internal/__tests__/tab-utils.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: {
+    tabs: { sendMessage: vi.fn(), get: vi.fn() },
+    scripting: { executeScript: vi.fn() }
+  }
+}))
+
+import { browser } from "@/lib/browser-api"
+import { clearTabContentCache, readTabContent } from "../tab-utils"
+
+const sendMessage = vi.mocked(browser.tabs.sendMessage)
+const getTab = vi.mocked(browser.tabs.get)
+
+const pageFor = (tabId: number, html = `<p>${tabId}</p>`) => ({
+  html,
+  title: `Tab ${tabId}`
+})
+
+describe("tab content cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearTabContentCache()
+    getTab.mockImplementation(
+      async (tabId: number) =>
+        ({
+          url: `https://example.com/${tabId}`,
+          title: `Tab ${tabId}`
+        }) as any
+    )
+    sendMessage.mockImplementation(async (tabId: number) => pageFor(tabId))
+  })
+
+  it("serves a repeated read from the cache", async () => {
+    await readTabContent(1)
+    await readTabContent(1)
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it("drops a single tab's entry when that tab is evicted", async () => {
+    await readTabContent(1)
+    clearTabContentCache(1)
+    await readTabContent(1)
+
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("evicts the least recently used tab once the cap is reached", async () => {
+    for (let tabId = 1; tabId <= 16; tabId += 1) await readTabContent(tabId)
+    // Tab 1 is the oldest, so touching tab 2 makes tab 1 the eviction target.
+    await readTabContent(2)
+    sendMessage.mockClear()
+
+    await readTabContent(99)
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    await readTabContent(1)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+
+    await readTabContent(2)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns an oversized page without giving it a cache slot", async () => {
+    const huge = "x".repeat(1_000_001)
+    sendMessage.mockImplementation(async (tabId: number) =>
+      pageFor(tabId, huge)
+    )
+
+    const first = await readTabContent(7)
+    expect(first.html).toHaveLength(huge.length)
+
+    await readTabContent(7)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps other tabs cached while an oversized page passes through", async () => {
+    await readTabContent(3)
+    sendMessage.mockImplementation(async (tabId: number) =>
+      pageFor(tabId, "x".repeat(1_000_001))
+    )
+    await readTabContent(4)
+    sendMessage.mockImplementation(async (tabId: number) => pageFor(tabId))
+    sendMessage.mockClear()
+
+    await readTabContent(3)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/tools/internal/tab-utils.ts
+++ b/src/lib/tools/internal/tab-utils.ts
@@ -24,9 +24,52 @@ interface TabContentCacheEntry {
   response: PageContentResponse
   url?: string
   title?: string
+  bytes: number
 }
 
+/**
+ * Bounds on the page-content cache.
+ *
+ * Entries hold whole extracted pages, keyed by tab id, in a background context
+ * that on Firefox MV2 never unloads. `browser.tabs.onRemoved` releases a closed
+ * tab's entry, but a long session with many tabs still needs a ceiling, and one
+ * enormous page must not be allowed to occupy the whole budget by itself.
+ */
+const MAX_TAB_CONTENT_CACHE_ENTRIES = 16
+const MAX_CACHED_HTML_BYTES = 1_000_000
+const MAX_TAB_CONTENT_CACHE_BYTES = 4_000_000
+
+/** Insertion order is the LRU order: a hit re-inserts, eviction takes the head. */
 const tabContentCache = new Map<number, TabContentCacheEntry>()
+let tabContentCacheBytes = 0
+
+const entryBytes = (response: PageContentResponse): number =>
+  (response.html?.length ?? 0) + (response.title?.length ?? 0)
+
+const dropCacheEntry = (tabId: number): void => {
+  const existing = tabContentCache.get(tabId)
+  if (!existing) return
+  tabContentCacheBytes -= existing.bytes
+  tabContentCache.delete(tabId)
+}
+
+const evictUntilWithinBounds = (): void => {
+  for (const tabId of [...tabContentCache.keys()]) {
+    if (
+      tabContentCache.size <= MAX_TAB_CONTENT_CACHE_ENTRIES &&
+      tabContentCacheBytes <= MAX_TAB_CONTENT_CACHE_BYTES
+    ) {
+      return
+    }
+    dropCacheEntry(tabId)
+  }
+}
+
+/** Move an entry to the LRU tail so the next eviction takes a colder one. */
+const touchCacheEntry = (tabId: number, entry: TabContentCacheEntry): void => {
+  tabContentCache.delete(tabId)
+  tabContentCache.set(tabId, entry)
+}
 
 const requestPageContent = (tabId: number): Promise<PageContentResponse> =>
   browser.tabs.sendMessage(tabId, {
@@ -82,8 +125,12 @@ const cacheMatches = (
 }
 
 export const clearTabContentCache = (tabId?: number) => {
-  if (tabId === undefined) tabContentCache.clear()
-  else tabContentCache.delete(tabId)
+  if (tabId === undefined) {
+    tabContentCache.clear()
+    tabContentCacheBytes = 0
+    return
+  }
+  dropCacheEntry(tabId)
 }
 
 /**
@@ -99,22 +146,34 @@ export const readTabContent = async (
   const signature = await getCurrentTabSignature(tabId)
   const cached = tabContentCache.get(tabId)
   if (!force && cached && cacheMatches(cached, signature)) {
+    touchCacheEntry(tabId, cached)
     return cached.response
   }
 
   // A forced refetch must not leave a stale entry behind if the new read fails.
-  if (force) tabContentCache.delete(tabId)
+  if (force) dropCacheEntry(tabId)
 
   const cacheAndReturn = (response: PageContentResponse) => {
     // Don't cache disabled/excluded/parse-failure placeholders — they carry an
     // explanatory string in `html` with `success: false`, and caching them
     // would pin that non-content message for the tab's lifetime.
     if (response.success === false) return response
+    const bytes = entryBytes(response)
+    // An oversized page is still returned in full; it is only denied a cache
+    // slot, so it can't evict every other tab to hold one document.
+    if (bytes > MAX_CACHED_HTML_BYTES) {
+      dropCacheEntry(tabId)
+      return response
+    }
+    dropCacheEntry(tabId)
     tabContentCache.set(tabId, {
       response,
       url: signature.url,
-      title: response.title || signature.title
+      title: response.title || signature.title,
+      bytes
     })
+    tabContentCacheBytes += bytes
+    evictUntilWithinBounds()
     return response
   }
 

--- a/tools/check-bundle-size.ts
+++ b/tools/check-bundle-size.ts
@@ -186,7 +186,7 @@ const budgets: Budget[] = [
   {
     metric: "background",
     field: "gzipBytes",
-    max: isFirefox ? 210_000 : 193_000
+    max: isFirefox ? 210_000 : 194_000
   }
 ]
 


### PR DESCRIPTION
Auto-refresh created one 15s interval per mounted `useTabContents()` — four call sites, several mountable at once — and each tick passed `force: true`, which bypassed the de-dup guard. So N consumers meant N concurrent full page extractions per tab (scroll to 80%, 2s whole-document MutationObserver, full re-parse).

- One refcounted timer regardless of mount count; pauses while hidden; `force` no longer bypasses the in-flight guard; unchanged content hash skips the state rewrite.
- `waitForNetworkIdle` patched `window.fetch`/`XHR.open` per caller and saved whatever it found as 'the original', so concurrent extractions left a wrapper installed forever. Now refcounted, and uninstall only restores if the current value is still ours.
- `tabContentCache` had no eviction and `clearTabContentCache` had no callers. Wired to `tabs.onRemoved`, plus LRU with entry/byte caps.

Bundle budget raised to 194k: baseline was 78 bytes under the old cap.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds tab-content extraction and caching lifecycles while preserving independent refresh progress across selected tabs.
- Replaces per-consumer refresh intervals with one reference-counted, visibility-aware timer and per-tab extraction admission.
- Shares network-idle instrumentation safely across concurrent extraction waiters.
- Adds tab-close eviction and entry/byte limits to the extracted-content cache.
- Adjusts the Chromium background bundle budget for the resulting implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported cross-tab refresh stall is fixed by removing the sweep-wide pending lifecycle and retaining only per-tab extraction guards.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/features/tabs/hooks/use-tab-contents.ts | Introduces one visibility-aware shared refresh subscription and uses per-tab loading guards so a pending extraction no longer blocks healthy selected tabs. |
| src/lib/content-extractor.ts | Refcounts shared fetch/XHR instrumentation and conditionally restores wrappers after the final network-idle waiter settles. |
| src/lib/tools/internal/tab-utils.ts | Adds LRU entry and byte bounds while preserving signature-based cache validation and forced-read invalidation. |
| src/background/tab-lifecycle.ts | Registers guarded tab-removal cleanup for cached extracted content. |
| tools/check-bundle-size.ts | Raises the Chromium background gzip budget from 193 KB to 194 KB. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[Mounted useTabContents consumers] --> R[Reference-counted shared timer]
  V[Visibility change] --> R
  R --> S[Read current selected tab IDs]
  S --> A{Extraction already loading for tab?}
  A -- Yes --> K[Skip only that tab]
  A -- No --> E[Extract tab content]
  E --> H{Content hash and title unchanged?}
  H -- Yes --> P[Preserve cached state object]
  H -- No --> U[Update tab content state]
  T[Tab removed] --> X[Evict background cache entry]
  B[Cache entry or byte cap exceeded] --> L[Evict least-recently-used entries]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tabs): scope auto-refresh overrun gu..."](https://github.com/shishir435/ollama-client/commit/ee66f4504b71c10e65a5293202a60274ac601a23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53607944)</sub>

**Context used:**

- Knowledge Base — [Tool-Calling and Browser Context Access](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/tools-context.md)
- Knowledge Base — [Background Runtime](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-runtime.md)

<!-- /greptile_comment -->