### PR TITLE
perf: throttle streaming markdown parses and narrow session load

### DIFF
--- a/src/components/__tests__/markdown-renderer.test.tsx
+++ b/src/components/__tests__/markdown-renderer.test.tsx
@@ -446,4 +446,28 @@ describe("MarkdownRenderer", () => {
       }
     })
   })
+
+  describe("streamed content", () => {
+    it("settles on the final content instead of an intermediate parse", () => {
+      vi.useFakeTimers()
+      try {
+        const { container, rerender } = render(
+          <MarkdownRenderer content={"Streaming"} />
+        )
+
+        rerender(<MarkdownRenderer content={"Streaming ans"} />)
+        rerender(<MarkdownRenderer content={"Streaming answ"} />)
+        rerender(<MarkdownRenderer content={"Streaming **answer**."} />)
+        act(() => {
+          vi.advanceTimersByTime(500)
+        })
+
+        const surface = container.querySelector(".markdown-container")
+        expect(surface).toHaveTextContent("Streaming answer.")
+        expect(surface?.querySelector("strong")).toHaveTextContent("answer")
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
 })

--- a/src/features/sessions/lib/message-tree.ts
+++ b/src/features/sessions/lib/message-tree.ts
@@ -12,8 +12,23 @@ import type { ChatMessage, FileAttachment, ImageAttachment } from "@/types"
  * without touching the database.
  */
 
+/**
+ * The columns tree traversal actually reads. Every helper below is generic
+ * over this so the active path can be resolved from a narrow projection —
+ * `getMessageTreeBySession` — without loading message bodies for rows that
+ * pagination is about to discard.
+ */
+export interface MessageTreeNode {
+  id?: number | string
+  parentId?: number | string
+  timestamp?: number
+}
+
 /** Stable ordering for sibling lists. */
-export const compareMessages = (a: ChatMessage, b: ChatMessage): number => {
+export const compareMessages = (
+  a: MessageTreeNode,
+  b: MessageTreeNode
+): number => {
   const tsA = a.timestamp ?? 0
   const tsB = b.timestamp ?? 0
   if (tsA !== tsB) return tsA - tsB
@@ -25,10 +40,10 @@ export const compareMessages = (a: ChatMessage, b: ChatMessage): number => {
  * messages. Root-level messages live under the key `"root"`. Sibling
  * lists are sorted by `compareMessages`.
  */
-export const buildSiblingsMap = (
-  messages: ChatMessage[]
-): Map<number | string, ChatMessage[]> => {
-  const map = new Map<number | string, ChatMessage[]>()
+export const buildSiblingsMap = <T extends MessageTreeNode>(
+  messages: T[]
+): Map<number | string, T[]> => {
+  const map = new Map<number | string, T[]>()
   for (const msg of messages) {
     const key = msg.parentId ?? "root"
     const list = map.get(key) || []
@@ -40,16 +55,16 @@ export const buildSiblingsMap = (
 }
 
 /** Build an id -> message lookup for messages that have an id. */
-const buildMessageMap = (messages: ChatMessage[]) =>
+const buildMessageMap = <T extends MessageTreeNode>(messages: T[]) =>
   new Map(
     messages
       .filter((m) => m.id !== undefined)
       .map((m) => [String(m.id), m] as const)
   )
 
-export interface PathResult {
+export interface PathResult<T extends MessageTreeNode = ChatMessage> {
   /** Active path from earliest ancestor we visited to the leaf. */
-  path: ChatMessage[]
+  path: T[]
   /** True if the traversal stopped before hitting a root message. */
   hasMore: boolean
 }
@@ -60,13 +75,13 @@ export interface PathResult {
  * root-to-leaf order plus a `hasMore` flag if there are earlier
  * messages we did not include.
  */
-export const traversePathFromLeaf = (
-  messages: ChatMessage[],
+export const traversePathFromLeaf = <T extends MessageTreeNode>(
+  messages: T[],
   leafId: number | string,
   limit: number
-): PathResult => {
+): PathResult<T> => {
   const msgMap = buildMessageMap(messages)
-  const path: ChatMessage[] = []
+  const path: T[] = []
   let currentId: number | string | undefined = leafId
   let iterations = 0
 
@@ -111,7 +126,7 @@ export const traversePathFromLeafWithFetcher = async (
  * cascading delete to find every descendant id below a target message.
  */
 export const collectDescendantIds = (
-  messages: ChatMessage[],
+  messages: MessageTreeNode[],
   rootId: number
 ): Set<number> => {
   const childrenMap = new Map<number, number[]>()
@@ -145,7 +160,7 @@ export const collectDescendantIds = (
  */
 export const enrichPathWithSiblingsAndAttachments = (
   path: ChatMessage[],
-  siblingsMap: Map<number | string, ChatMessage[]>,
+  siblingsMap: Map<number | string, MessageTreeNode[]>,
   filesByMessageId: Map<number, FileAttachment[]>
 ): ChatMessage[] =>
   path.map((msg) => {
@@ -188,11 +203,11 @@ export const splitStoredFiles = (
  * Find the latest leaf descending from `nodeId`, picking the
  * timestamp-latest child at each step.
  */
-export const findLatestLeafDescendant = (
-  messages: ChatMessage[],
+export const findLatestLeafDescendant = <T extends MessageTreeNode>(
+  messages: T[],
   nodeId: number | string
 ): number | string => {
-  const childrenByParent = new Map<string, ChatMessage[]>()
+  const childrenByParent = new Map<string, T[]>()
   for (const msg of messages) {
     if (msg.id === undefined || msg.parentId === undefined) continue
     const key = String(msg.parentId)

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -105,6 +105,76 @@ describe("loadSessionMessages", () => {
     expect(loaded[49].content).toBe("message 120")
   })
 
+  /**
+   * The projection decoder drops rows it cannot read, and anything that
+   * removed messages without repairing `sessions.currentLeafId` leaves the same
+   * disagreement. Walking from an id the tree does not contain returns an empty
+   * path, which renders as an empty conversation while the rows are intact.
+   */
+  it("loads from the newest node when the stored leaf is missing from the tree", async () => {
+    const messages = chain(5)
+    setupLoadSessionMessagesMocks(messages, {
+      id: SESSION_ID,
+      title: "T",
+      // Never present in the tree — e.g. its row failed to decode.
+      currentLeafId: 9999
+    })
+    chatSessionStore.setState({
+      sessions: [
+        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
+
+    const state = chatSessionStore.getState()
+    const loaded = state.sessions[0].messages ?? []
+    expect(loaded.map((m) => m.id)).toEqual([1, 2, 3, 4, 5])
+    expect(state.sessions[0].currentLeafId).toBe(5)
+    expect(state.hasMoreMessages).toBe(false)
+  })
+
+  it("still loads the branch when an ancestor is missing from the tree", async () => {
+    const messages = chain(5)
+    mockRepo.getSession.mockResolvedValue({
+      id: SESSION_ID,
+      title: "T",
+      currentLeafId: 5
+    } as never)
+    // Row 3 failed to decode and was dropped, detaching 4 and 5 from the root.
+    mockRepo.getMessageTreeBySession.mockResolvedValue(
+      messages
+        .filter((m) => m.id !== 3)
+        .map((m) => ({
+          id: m.id,
+          parentId: m.parentId,
+          timestamp: m.timestamp
+        })) as never
+    )
+    mockRepo.getMessagesByIds.mockImplementation(async (ids: any) =>
+      messages.filter((m) =>
+        ids.some((id: unknown) => String(id) === String(m.id))
+      )
+    )
+    mockRepo.getFilesByMessageIds.mockResolvedValue([] as never)
+    chatSessionStore.setState({
+      sessions: [
+        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
+
+    const state = chatSessionStore.getState()
+    const loaded = state.sessions[0].messages ?? []
+    // Truncated at the gap rather than empty, and pagination stays open so the
+    // full-row load-more path can walk past it.
+    expect(loaded.map((m) => m.id)).toEqual([4, 5])
+    expect(state.hasMoreMessages).toBe(true)
+  })
+
   it("keeps sibling ids for forked branches off the narrow tree", async () => {
     const messages = [
       {

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -24,12 +24,21 @@ const SESSION_ID = "session-abc"
 
 /** Minimal helpers to avoid repeating loadSessionMessages dependencies */
 function setupLoadSessionMessagesMocks(
-  messages: unknown[] = [],
+  messages: any[] = [],
   session: unknown = { id: SESSION_ID, title: "Test", currentLeafId: undefined }
 ) {
   mockRepo.getSession.mockResolvedValue(session as any)
-  mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue(
-    messages as any
+  mockRepo.getMessageTreeBySession.mockResolvedValue(
+    messages.map((m) => ({
+      id: m.id,
+      parentId: m.parentId,
+      timestamp: m.timestamp
+    })) as any
+  )
+  mockRepo.getMessagesByIds.mockImplementation(async (ids: any) =>
+    messages.filter((m) =>
+      ids.some((id: unknown) => String(id) === String(m.id))
+    )
   )
   mockRepo.getFilesByMessageIds.mockResolvedValue([])
 }
@@ -48,6 +57,117 @@ function resetStore() {
 beforeEach(() => {
   resetStore()
   vi.clearAllMocks()
+})
+
+describe("loadSessionMessages", () => {
+  const chain = (length: number) =>
+    Array.from({ length }, (_unused, index) => ({
+      id: index + 1,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `message ${index + 1}`,
+      sessionId: SESSION_ID,
+      parentId: index === 0 ? undefined : index,
+      timestamp: index + 1
+    }))
+
+  it("reads the tree narrowly and full rows only for the paginated path", async () => {
+    const messages = chain(120)
+    setupLoadSessionMessagesMocks(messages, {
+      id: SESSION_ID,
+      title: "T",
+      currentLeafId: 120
+    })
+    chatSessionStore.setState({
+      sessions: [
+        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
+
+    expect(mockRepo.getMessageTreeBySession).toHaveBeenCalledWith(SESSION_ID)
+    expect(
+      mockRepo.getMessagesBySessionOrderedByTimestamp
+    ).not.toHaveBeenCalled()
+
+    const pathIds = mockRepo.getMessagesByIds.mock.calls[0][0]
+    expect(pathIds).toHaveLength(50)
+    expect(pathIds[0]).toBe(71)
+    expect(pathIds[49]).toBe(120)
+    expect(mockRepo.getFilesByMessageIds).toHaveBeenCalledWith(pathIds)
+
+    const state = chatSessionStore.getState()
+    expect(state.hasMoreMessages).toBe(true)
+    const loaded = state.sessions[0].messages ?? []
+    expect(loaded).toHaveLength(50)
+    expect(loaded[0].content).toBe("message 71")
+    expect(loaded[49].content).toBe("message 120")
+  })
+
+  it("keeps sibling ids for forked branches off the narrow tree", async () => {
+    const messages = [
+      {
+        id: 1,
+        role: "user" as const,
+        content: "root",
+        sessionId: SESSION_ID,
+        timestamp: 1
+      },
+      {
+        id: 2,
+        role: "assistant" as const,
+        content: "branch a",
+        sessionId: SESSION_ID,
+        parentId: 1,
+        timestamp: 2
+      },
+      {
+        id: 3,
+        role: "assistant" as const,
+        content: "branch b",
+        sessionId: SESSION_ID,
+        parentId: 1,
+        timestamp: 3
+      }
+    ]
+    setupLoadSessionMessagesMocks(messages, {
+      id: SESSION_ID,
+      title: "T",
+      currentLeafId: 3
+    })
+    chatSessionStore.setState({
+      sessions: [
+        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
+
+    const state = chatSessionStore.getState()
+    expect(state.hasMoreMessages).toBe(false)
+    expect(state.sessions[0].currentLeafId).toBe(3)
+    const loaded = state.sessions[0].messages ?? []
+    expect(loaded.map((m) => m.id)).toEqual([1, 3])
+    expect(loaded[1].siblingIds).toEqual([2, 3])
+    expect(loaded[0].siblingIds).toBeUndefined()
+  })
+
+  it("falls back to the newest tree node when the session has no leaf", async () => {
+    const messages = chain(3)
+    setupLoadSessionMessagesMocks(messages)
+    chatSessionStore.setState({
+      sessions: [
+        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+      ],
+      currentSessionId: SESSION_ID
+    })
+
+    await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
+
+    expect(chatSessionStore.getState().sessions[0].currentLeafId).toBe(3)
+  })
 })
 
 describe("loadMoreMessages", () => {
@@ -679,40 +799,37 @@ describe("navigateToNode", () => {
     })
   })
 
-  it("calls repo.getMessagesBySessionOrderedByTimestamp when exact=false", async () => {
-    mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue([
+  it("resolves the leaf from the narrow message tree when exact=false", async () => {
+    setupLoadSessionMessagesMocks([
+      { id: 30, role: "user", content: "msg", timestamp: 1 },
       {
-        id: 30,
-        role: "user",
-        content: "msg",
-        sessionId: SESSION_ID,
-        parentId: undefined
+        id: 31,
+        role: "assistant",
+        content: "reply",
+        parentId: 30,
+        timestamp: 2
       }
-    ] as any)
+    ])
 
     await chatSessionStore.getState().navigateToNode(SESSION_ID, 30, false)
 
+    expect(mockRepo.getMessageTreeBySession).toHaveBeenCalledWith(SESSION_ID)
     expect(
       mockRepo.getMessagesBySessionOrderedByTimestamp
-    ).toHaveBeenCalledWith(SESSION_ID)
+    ).not.toHaveBeenCalled()
+    expect(mockRepo.updateSession).toHaveBeenCalledWith(SESSION_ID, {
+      currentLeafId: 31
+    })
   })
 
   it("default (no exact arg) behaves like exact=false and fetches messages", async () => {
-    mockRepo.getMessagesBySessionOrderedByTimestamp.mockResolvedValue([
-      {
-        id: 30,
-        role: "user",
-        content: "msg",
-        sessionId: SESSION_ID,
-        parentId: undefined
-      }
-    ] as any)
+    setupLoadSessionMessagesMocks([
+      { id: 30, role: "user", content: "msg", timestamp: 1 }
+    ])
 
     await chatSessionStore.getState().navigateToNode(SESSION_ID, 30)
 
-    expect(
-      mockRepo.getMessagesBySessionOrderedByTimestamp
-    ).toHaveBeenCalledWith(SESSION_ID)
+    expect(mockRepo.getMessageTreeBySession).toHaveBeenCalledWith(SESSION_ID)
   })
 })
 

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -135,44 +135,57 @@ describe("loadSessionMessages", () => {
     expect(state.hasMoreMessages).toBe(false)
   })
 
-  it("still loads the branch when an ancestor is missing from the tree", async () => {
+  /**
+   * The store's `currentLeafId` becomes the next message's `parentId` and is
+   * persisted, so publishing a leaf guessed from an incomplete tree would
+   * durably re-parent whatever the user sends next.
+   */
+  it("leaves the session untouched when the tree fails to decode", async () => {
     const messages = chain(5)
-    mockRepo.getSession.mockResolvedValue({
+    setupLoadSessionMessagesMocks(messages, {
       id: SESSION_ID,
       title: "T",
       currentLeafId: 5
-    } as never)
-    // Row 3 failed to decode and was dropped, detaching 4 and 5 from the root.
-    mockRepo.getMessageTreeBySession.mockResolvedValue(
-      messages
-        .filter((m) => m.id !== 3)
-        .map((m) => ({
-          id: m.id,
-          parentId: m.parentId,
-          timestamp: m.timestamp
-        })) as never
-    )
-    mockRepo.getMessagesByIds.mockImplementation(async (ids: any) =>
-      messages.filter((m) =>
-        ids.some((id: unknown) => String(id) === String(m.id))
-      )
-    )
-    mockRepo.getFilesByMessageIds.mockResolvedValue([] as never)
+    })
     chatSessionStore.setState({
       sessions: [
-        { id: SESSION_ID, title: "T", createdAt: 1, updatedAt: 1, messages: [] }
+        {
+          id: SESSION_ID,
+          title: "T",
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 5, role: "user", content: "existing" } as never],
+          currentLeafId: 5
+        }
       ],
       currentSessionId: SESSION_ID
     })
+    mockRepo.getMessageTreeBySession.mockRejectedValueOnce(
+      new Error(
+        "Message tree for a session did not decode: 1 of 5 rows unreadable"
+      )
+    )
 
     await chatSessionStore.getState().loadSessionMessages(SESSION_ID)
 
-    const state = chatSessionStore.getState()
-    const loaded = state.sessions[0].messages ?? []
-    // Truncated at the gap rather than empty, and pagination stays open so the
-    // full-row load-more path can walk past it.
-    expect(loaded.map((m) => m.id)).toEqual([4, 5])
-    expect(state.hasMoreMessages).toBe(true)
+    const session = chatSessionStore.getState().sessions[0]
+    // Crucially the leaf is not replaced by a guess, so the next send still
+    // parents to the real branch.
+    expect(session.currentLeafId).toBe(5)
+    expect(session.messages).toHaveLength(1)
+    expect(mockRepo.getMessagesByIds).not.toHaveBeenCalled()
+  })
+
+  it("does not persist a branch move when navigateToNode cannot read the tree", async () => {
+    mockRepo.getMessageTreeBySession.mockRejectedValueOnce(
+      new Error(
+        "Message tree for a session did not decode: 1 of 5 rows unreadable"
+      )
+    )
+
+    await chatSessionStore.getState().navigateToNode(SESSION_ID, 3)
+
+    expect(mockRepo.updateSession).not.toHaveBeenCalled()
   })
 
   it("keeps sibling ids for forked branches off the narrow tree", async () => {

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -43,7 +43,26 @@ export const createChatSessionMessageActions = (
     if (isStaleLoad()) return
     if (!session) return
 
-    const treeNodes = await repo.getMessageTreeBySession(sessionId)
+    /**
+     * A tree that did not fully decode is not published at all.
+     *
+     * Leaving the session's existing state alone keeps the store's
+     * `currentLeafId` as it was, which matters more than the render: `addMessage`
+     * takes that value as the new message's `parentId` and persists it, so a
+     * leaf guessed from an incomplete tree would durably re-parent the next
+     * thing the user sends.
+     */
+    let treeNodes: repo.MessageTreeRow[]
+    try {
+      treeNodes = await repo.getMessageTreeBySession(sessionId)
+    } catch (error) {
+      logger.error(
+        "Failed to read the message tree; leaving the session unchanged",
+        "chatSessionStore",
+        { error, sessionId }
+      )
+      return
+    }
     if (isStaleLoad()) return
 
     if (treeNodes.length === 0) {
@@ -66,17 +85,17 @@ export const createChatSessionMessageActions = (
      * The walk starts from a node the tree actually contains.
      *
      * `traversePathFromLeaf` stops the moment an id is missing, so a leaf that
-     * is not in the tree produces an empty path — which renders as an empty
-     * conversation, with a load-more affordance, while every row is still
-     * sitting in SQLite. That is reachable whenever the stored pointer and the
-     * tree disagree: a row dropped by the projection decoder, or a stale
-     * `currentLeafId` left by anything that removed messages without repairing
-     * it.
+     * is not in the tree produces an empty path — an empty conversation, with a
+     * load-more affordance, while every row is still sitting in SQLite.
      *
-     * The fallback is the newest node, which is what a session with no stored
-     * leaf already uses. Not written back — a read must not repair durable
-     * state, or a transient decode failure would permanently move the user's
-     * branch.
+     * Reaching here means the tree decoded completely, so this is a stale
+     * pointer rather than missing data: something removed messages without
+     * repairing `sessions.currentLeafId`. The newest node is then a real leaf,
+     * which is what a session with no stored leaf already falls back to, and is
+     * safe to hand `addMessage` as the next parent. The decode-failure case
+     * cannot arrive here at all — it returned above rather than guess.
+     *
+     * Still not written back: a read does not repair durable state.
      */
     const leafId = treeNodes.some(
       (node) => String(node.id) === String(storedLeafId)
@@ -366,8 +385,20 @@ export const createChatSessionMessageActions = (
   ) => {
     let leafId = nodeId
     if (!exact) {
-      const treeNodes = await repo.getMessageTreeBySession(sessionId)
-      leafId = findLatestLeafDescendant(treeNodes, nodeId)
+      // This branch resolves a leaf and then *persists* it, so an incomplete
+      // tree would durably move the user's conversation to whatever descendant
+      // survived. Abort the navigation instead.
+      try {
+        const treeNodes = await repo.getMessageTreeBySession(sessionId)
+        leafId = findLatestLeafDescendant(treeNodes, nodeId)
+      } catch (error) {
+        logger.error(
+          "Failed to read the message tree; leaving the branch unchanged",
+          "chatSessionStore",
+          { error, sessionId }
+        )
+        return
+      }
     }
 
     await repo.updateSession(sessionId, { currentLeafId: leafId })

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -58,8 +58,38 @@ export const createChatSessionMessageActions = (
       return
     }
 
-    const leafId = session.currentLeafId ?? treeNodes[treeNodes.length - 1].id
-    if (leafId === undefined) return
+    const storedLeafId =
+      session.currentLeafId ?? treeNodes[treeNodes.length - 1].id
+    if (storedLeafId === undefined) return
+
+    /**
+     * The walk starts from a node the tree actually contains.
+     *
+     * `traversePathFromLeaf` stops the moment an id is missing, so a leaf that
+     * is not in the tree produces an empty path — which renders as an empty
+     * conversation, with a load-more affordance, while every row is still
+     * sitting in SQLite. That is reachable whenever the stored pointer and the
+     * tree disagree: a row dropped by the projection decoder, or a stale
+     * `currentLeafId` left by anything that removed messages without repairing
+     * it.
+     *
+     * The fallback is the newest node, which is what a session with no stored
+     * leaf already uses. Not written back — a read must not repair durable
+     * state, or a transient decode failure would permanently move the user's
+     * branch.
+     */
+    const leafId = treeNodes.some(
+      (node) => String(node.id) === String(storedLeafId)
+    )
+      ? storedLeafId
+      : treeNodes[treeNodes.length - 1].id
+    if (leafId !== storedLeafId) {
+      logger.warn(
+        "Stored leaf is not in the message tree; falling back to the newest node",
+        "chatSessionStore",
+        { sessionId, treeSize: treeNodes.length }
+      )
+    }
 
     const siblingsMap = buildSiblingsMap(treeNodes)
     const { path: pathNodes, hasMore } = traversePathFromLeaf(

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -43,11 +43,10 @@ export const createChatSessionMessageActions = (
     if (isStaleLoad()) return
     if (!session) return
 
-    const allMessages =
-      await repo.getMessagesBySessionOrderedByTimestamp(sessionId)
+    const treeNodes = await repo.getMessageTreeBySession(sessionId)
     if (isStaleLoad()) return
 
-    if (allMessages.length === 0) {
+    if (treeNodes.length === 0) {
       set((state) => ({
         sessions: state.sessions.map((s) =>
           s.id === sessionId
@@ -59,23 +58,34 @@ export const createChatSessionMessageActions = (
       return
     }
 
-    const leafId =
-      session.currentLeafId ?? allMessages[allMessages.length - 1].id
+    const leafId = session.currentLeafId ?? treeNodes[treeNodes.length - 1].id
     if (leafId === undefined) return
 
-    const siblingsMap = buildSiblingsMap(allMessages)
-    const { path, hasMore } = traversePathFromLeaf(
-      allMessages,
+    const siblingsMap = buildSiblingsMap(treeNodes)
+    const { path: pathNodes, hasMore } = traversePathFromLeaf(
+      treeNodes,
       leafId,
       CHAT_PAGINATION_LIMIT
     )
 
-    const messageIds = path
+    const messageIds = pathNodes
       .map((m) => m.id)
       .filter((id): id is number => typeof id === "number")
-    const files =
-      messageIds.length > 0 ? await repo.getFilesByMessageIds(messageIds) : []
+
+    // Whole rows are read only for the <=CHAT_PAGINATION_LIMIT ids on the
+    // resolved path; the rest of the tree never leaves the worker.
+    const [pathMessages, files] = await Promise.all([
+      messageIds.length > 0 ? repo.getMessagesByIds(messageIds) : [],
+      messageIds.length > 0 ? repo.getFilesByMessageIds(messageIds) : []
+    ])
     if (isStaleLoad()) return
+
+    const messagesById = new Map(
+      pathMessages.map((message) => [String(message.id), message] as const)
+    )
+    const path = messageIds
+      .map((id) => messagesById.get(String(id)))
+      .filter((message) => message !== undefined)
     const filesByMessageId = groupFilesByMessageId(files)
 
     const messagesWithData = enrichPathWithSiblingsAndAttachments(
@@ -326,9 +336,8 @@ export const createChatSessionMessageActions = (
   ) => {
     let leafId = nodeId
     if (!exact) {
-      const allMessages =
-        await repo.getMessagesBySessionOrderedByTimestamp(sessionId)
-      leafId = findLatestLeafDescendant(allMessages, nodeId)
+      const treeNodes = await repo.getMessageTreeBySession(sessionId)
+      leafId = findLatestLeafDescendant(treeNodes, nodeId)
     }
 
     await repo.updateSession(sessionId, { currentLeafId: leafId })

--- a/src/hooks/__tests__/use-markdown-parser.test.ts
+++ b/src/hooks/__tests__/use-markdown-parser.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const parserBuilds = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock("markdown-it", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("markdown-it")>()
+  const Actual = actual.default as unknown as new (...args: any[]) => any
+  class Tracked extends Actual {
+    constructor(...args: any[]) {
+      super(...args)
+      parserBuilds.count += 1
+    }
+  }
+  return { ...actual, default: Tracked }
+})
+
+import { useMarkdownParser } from "../use-markdown-parser"
+
+/**
+ * Render the hook while recording every distinct html value it produced, so a
+ * test can count parses rather than only inspect the latest one.
+ */
+const renderParser = (initial: string) => {
+  const seen: string[] = []
+  const view = renderHook(
+    ({ markdown }) => {
+      const html = useMarkdownParser(markdown)
+      if (seen[seen.length - 1] !== html) seen.push(html)
+      return html
+    },
+    { initialProps: { markdown: initial } }
+  )
+  return { ...view, seen }
+}
+
+const stream = (length: number) => `token${"x".repeat(length)}`
+
+describe("useMarkdownParser", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("parses static content on the first render with no deferred work", () => {
+    const { result, seen } = renderParser("# Title")
+
+    expect(result.current).toContain("<h1>Title</h1>")
+    expect(seen).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("coalesces a burst of streamed updates into a single trailing parse", () => {
+    const { seen, rerender } = renderParser(stream(0))
+
+    for (let step = 1; step <= 20; step += 1) {
+      rerender({ markdown: stream(step) })
+      act(() => {
+        vi.advanceTimersByTime(5)
+      })
+    }
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toBe("<p>token</p>\n")
+  })
+
+  it("renders the final content exactly once after changes stop", () => {
+    const { result, seen, rerender } = renderParser(stream(0))
+
+    for (let step = 1; step <= 20; step += 1) {
+      rerender({ markdown: stream(step) })
+      act(() => {
+        vi.advanceTimersByTime(5)
+      })
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(seen).toHaveLength(2)
+    expect(seen[1]).toContain(stream(20))
+    expect(result.current).toContain(stream(20))
+    expect(vi.getTimerCount()).toBe(0)
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(seen).toHaveLength(2)
+  })
+
+  it("never leaves a settled message on an intermediate parse", () => {
+    const { result, rerender } = renderParser("partial answ")
+
+    rerender({ markdown: "partial answer" })
+    rerender({ markdown: "partial answer." })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current).toContain("partial answer.")
+    expect(result.current).not.toContain("partial answ<")
+  })
+
+  it("renders immediately when a change arrives after an idle gap", () => {
+    const { seen, rerender } = renderParser("first")
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    rerender({ markdown: "second" })
+
+    expect(seen).toHaveLength(2)
+    expect(seen[1]).toContain("second")
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("drops a pending trailing parse on unmount", () => {
+    const { rerender, unmount } = renderParser("a")
+
+    rerender({ markdown: "ab" })
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("configures one MarkdownIt instance for every renderer", () => {
+    renderParser("one")
+    renderParser("two")
+
+    expect(parserBuilds.count).toBe(1)
+  })
+})

--- a/src/hooks/use-markdown-parser.ts
+++ b/src/hooks/use-markdown-parser.ts
@@ -8,7 +8,7 @@ import markdownItMark from "markdown-it-mark"
 import sub from "markdown-it-sub"
 import sup from "markdown-it-sup"
 import taskLists from "markdown-it-task-lists"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 /**
  * highlight.js (core + ~20 languages) is heavy; keep it out of the eager
@@ -35,66 +35,108 @@ const ensureHljs = (): Promise<void> => {
 
 const CODE_FENCE = /(^|\n)\s*(```|~~~)/
 
-export const useMarkdownParser = (markdown: string) => {
-  const md = useMemo(() => {
-    const instance: MarkdownIt = new MarkdownIt({
-      html: true,
-      linkify: true,
-      typographer: true,
-      highlight(str: string, lang: string): string {
-        const safeLang: string = instance.utils.escapeHtml(lang || "")
-        const langAttrs: string = safeLang
-          ? ` data-code-language="${safeLang}"`
-          : ""
-        const hljs = hljsModule?.hljs
-        if (hljs && lang && hljs.getLanguage(lang)) {
-          try {
-            return `<pre class="hljs"${langAttrs}><code class="language-${safeLang}">${
-              hljs.highlight(str, {
-                language: lang,
-                ignoreIllegals: true
-              }).value
-            }</code></pre>`
-          } catch {}
-        }
-        return `<pre class="hljs"${langAttrs}><code>${instance.utils.escapeHtml(str)}</code></pre>`
+/**
+ * Shortest gap between two parses of the same message while its content is
+ * still growing. A parse plus sanitize is O(message length) and replaces the
+ * whole subtree, so one per token makes the last tokens the most expensive to
+ * show; batching to this interval keeps the text reading as continuous.
+ */
+const STREAM_RENDER_INTERVAL_MS = 120
+
+const createMarkdownParser = (): MarkdownIt => {
+  const instance: MarkdownIt = new MarkdownIt({
+    html: true,
+    linkify: true,
+    typographer: true,
+    highlight(str: string, lang: string): string {
+      const safeLang: string = instance.utils.escapeHtml(lang || "")
+      const langAttrs: string = safeLang
+        ? ` data-code-language="${safeLang}"`
+        : ""
+      const hljs = hljsModule?.hljs
+      if (hljs && lang && hljs.getLanguage(lang)) {
+        try {
+          return `<pre class="hljs"${langAttrs}><code class="language-${safeLang}">${
+            hljs.highlight(str, {
+              language: lang,
+              ignoreIllegals: true
+            }).value
+          }</code></pre>`
+        } catch {}
       }
-    })
-
-    instance
-      .use(taskLists, { enabled: true })
-      .use(footnote)
-      // markdown-it-container ships @types/markdown-it v13, whose MarkdownIt type
-      // is structurally incompatible with our v14; the plugin is valid at runtime,
-      // so cast to the v14 params-plugin shape.
-      .use(container as unknown as PluginWithParams, "info")
-      .use(container as unknown as PluginWithParams, "warning")
-      .use(emoji)
-      .use(markdownItMark)
-      .use(deflist)
-      .use(sub)
-      .use(sup)
-
-    return instance
-  }, [])
-
-  const [hljsReady, setHljsReady] = useState(() => hljsModule !== null)
-  const [html, setHtml] = useState(() => {
-    const rawHtml = md.render(markdown)
-    return DOMPurify.sanitize(rawHtml)
+      return `<pre class="hljs"${langAttrs}><code>${instance.utils.escapeHtml(str)}</code></pre>`
+    }
   })
 
-  // Re-render on content change and once highlight.js has loaded.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hljsReady is a deliberate re-render trigger (highlight after lazy load)
-  useEffect(() => {
-    const rafId = requestAnimationFrame(() => {
-      const rawHtml = md.render(markdown)
-      const safeHtml = DOMPurify.sanitize(rawHtml)
-      setHtml(safeHtml)
-    })
+  instance
+    .use(taskLists, { enabled: true })
+    .use(footnote)
+    // markdown-it-container ships @types/markdown-it v13, whose MarkdownIt type
+    // is structurally incompatible with our v14; the plugin is valid at runtime,
+    // so cast to the v14 params-plugin shape.
+    .use(container as unknown as PluginWithParams, "info")
+    .use(container as unknown as PluginWithParams, "warning")
+    .use(emoji)
+    .use(markdownItMark)
+    .use(deflist)
+    .use(sub)
+    .use(sup)
 
-    return () => cancelAnimationFrame(rafId)
-  }, [markdown, md, hljsReady])
+  return instance
+}
+
+/**
+ * One configured parser for the whole page.
+ *
+ * `MarkdownIt#render` carries nothing between calls — every rule works off the
+ * per-call token stream and a fresh `env`, so footnote numbering still restarts
+ * per message — while the nine plugin registrations and the rule-chain rebuild
+ * were being paid once per mounted message bubble.
+ *
+ * The `highlight` callback reads `hljsModule`, which is module state already,
+ * so sharing the instance does not change when highlighting turns on.
+ */
+const markdownParser = createMarkdownParser()
+
+const renderMarkdown = (markdown: string): string =>
+  DOMPurify.sanitize(markdownParser.render(markdown))
+
+export const useMarkdownParser = (markdown: string) => {
+  const [hljsReady, setHljsReady] = useState(() => hljsModule !== null)
+  const [html, setHtml] = useState(() => renderMarkdown(markdown))
+
+  /** The inputs the current `html` was produced from. */
+  const renderedRef = useRef({ markdown, hljsReady })
+  const lastRenderAtRef = useRef(Date.now())
+
+  /**
+   * Throttle rather than debounce: the first change after an idle gap renders
+   * immediately, and anything arriving inside the window is coalesced into one
+   * trailing render at the window's end. Because the trailing timer is
+   * re-anchored on the last render — never on the last change — a stream that
+   * stops mid-window still gets its final content rendered, exactly once.
+   */
+  useEffect(() => {
+    const rendered = renderedRef.current
+    if (rendered.markdown === markdown && rendered.hljsReady === hljsReady) {
+      return
+    }
+
+    const render = () => {
+      renderedRef.current = { markdown, hljsReady }
+      lastRenderAtRef.current = Date.now()
+      setHtml(renderMarkdown(markdown))
+    }
+
+    const elapsed = Date.now() - lastRenderAtRef.current
+    if (elapsed >= STREAM_RENDER_INTERVAL_MS) {
+      render()
+      return
+    }
+
+    const timer = setTimeout(render, STREAM_RENDER_INTERVAL_MS - elapsed)
+    return () => clearTimeout(timer)
+  }, [markdown, hljsReady])
 
   // Lazy-load highlight.js the first time the content has a code fence.
   useEffect(() => {

--- a/src/lib/repositories/__tests__/chat-history-facade.test.ts
+++ b/src/lib/repositories/__tests__/chat-history-facade.test.ts
@@ -14,6 +14,8 @@ vi.mock("../sqlite-chat-history", () => ({
   getAllMessages: vi.fn(),
   getMessagesPaginated: vi.fn(),
   getMessagesBySessionOrderedByTimestamp: vi.fn(),
+  getMessageTreeBySession: vi.fn(),
+  getMessagesByIds: vi.fn(),
   getMessagesBySession: vi.fn(),
   getMessagesBySessionAtTimestamp: vi.fn(),
   getMessagesByParents: vi.fn(),

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -470,32 +470,40 @@ describe("messages", () => {
     ])
   })
 
-  it("getMessageTreeBySession drops a row whose tree columns do not decode", async () => {
+  it("getMessageTreeBySession raises when a tree row does not decode", async () => {
     mockedQuery.mockResolvedValueOnce([
       { id: 1, parentId: null, timestamp: 10 },
-      // A half-applied migration or a foreign writer can leave this shape. It
-      // is the ancestry, so asserting over it detaches a subtree silently.
+      // A half-applied migration or a foreign writer can leave this shape.
+      // Returning the rest would be a wrong tree, not a smaller one.
       { id: null, parentId: 1, timestamp: 20 },
       { id: 3, parentId: 1, timestamp: 30 }
     ])
 
-    const nodes = await repo.getMessageTreeBySession("s1")
-
-    expect(nodes).toEqual([
-      { id: 1, parentId: undefined, timestamp: 10 },
-      { id: 3, parentId: 1, timestamp: 30 }
-    ])
+    await expect(repo.getMessageTreeBySession("s1")).rejects.toThrow(
+      /did not decode/
+    )
   })
 
-  it("getMessageTreeBySession rejects a non-numeric timestamp", async () => {
+  it("getMessageTreeBySession raises on a non-numeric timestamp", async () => {
     mockedQuery.mockResolvedValueOnce([
       { id: 1, parentId: null, timestamp: "10" },
       { id: 2, parentId: 1, timestamp: 20 }
     ])
 
-    const nodes = await repo.getMessageTreeBySession("s1")
+    await expect(repo.getMessageTreeBySession("s1")).rejects.toThrow(
+      /did not decode/
+    )
+  })
 
-    expect(nodes).toEqual([{ id: 2, parentId: 1, timestamp: 20 }])
+  it("getMessageTreeBySession reports the unreadable count without row content", async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { id: 1, parentId: null, timestamp: 10 },
+      { id: null, parentId: 1, timestamp: 20 }
+    ])
+
+    await expect(repo.getMessageTreeBySession("s1")).rejects.toThrow(
+      "Message tree for a session did not decode: 1 of 2 rows unreadable"
+    )
   })
 
   it("getMessagesByIds returns [] for empty ids without hitting the db", async () => {

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -453,6 +453,36 @@ describe("messages", () => {
     expect(params).toEqual([1, 2, 3])
   })
 
+  it("getMessageTreeBySession selects only the tree columns", async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { id: 1, parentId: null, timestamp: 10 },
+      { id: 2, parentId: 1, timestamp: 20 }
+    ])
+    const nodes = await repo.getMessageTreeBySession("s1")
+    const [sql, params] = mockedQuery.mock.calls[0]
+    expect(sql).toBe(
+      "SELECT id, parentId, timestamp FROM messages WHERE sessionId = ? ORDER BY timestamp ASC"
+    )
+    expect(params).toEqual(["s1"])
+    expect(nodes).toEqual([
+      { id: 1, parentId: undefined, timestamp: 10 },
+      { id: 2, parentId: 1, timestamp: 20 }
+    ])
+  })
+
+  it("getMessagesByIds returns [] for empty ids without hitting the db", async () => {
+    expect(await repo.getMessagesByIds([])).toEqual([])
+    expect(mockedQuery).not.toHaveBeenCalled()
+  })
+
+  it("getMessagesByIds builds an IN clause sized to the input", async () => {
+    mockedQuery.mockResolvedValueOnce([])
+    await repo.getMessagesByIds([3, "4"])
+    const [sql, params] = mockedQuery.mock.calls[0]
+    expect(sql).toBe("SELECT * FROM messages WHERE id IN (?, ?)")
+    expect(params).toEqual([3, 4])
+  })
+
   it("getRootMessagesForSession filters parentId IS NULL", async () => {
     mockedQuery.mockResolvedValueOnce([])
     await repo.getRootMessagesForSession("s1")

--- a/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
+++ b/src/lib/repositories/__tests__/sqlite-chat-history.test.ts
@@ -470,6 +470,34 @@ describe("messages", () => {
     ])
   })
 
+  it("getMessageTreeBySession drops a row whose tree columns do not decode", async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { id: 1, parentId: null, timestamp: 10 },
+      // A half-applied migration or a foreign writer can leave this shape. It
+      // is the ancestry, so asserting over it detaches a subtree silently.
+      { id: null, parentId: 1, timestamp: 20 },
+      { id: 3, parentId: 1, timestamp: 30 }
+    ])
+
+    const nodes = await repo.getMessageTreeBySession("s1")
+
+    expect(nodes).toEqual([
+      { id: 1, parentId: undefined, timestamp: 10 },
+      { id: 3, parentId: 1, timestamp: 30 }
+    ])
+  })
+
+  it("getMessageTreeBySession rejects a non-numeric timestamp", async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { id: 1, parentId: null, timestamp: "10" },
+      { id: 2, parentId: 1, timestamp: 20 }
+    ])
+
+    const nodes = await repo.getMessageTreeBySession("s1")
+
+    expect(nodes).toEqual([{ id: 2, parentId: 1, timestamp: 20 }])
+  })
+
   it("getMessagesByIds returns [] for empty ids without hitting the db", async () => {
     expect(await repo.getMessagesByIds([])).toEqual([])
     expect(mockedQuery).not.toHaveBeenCalled()

--- a/src/lib/repositories/chat-history.ts
+++ b/src/lib/repositories/chat-history.ts
@@ -1,5 +1,7 @@
 import * as sqliteRepo from "./sqlite-chat-history"
 
+export type { MessageTreeRow } from "./sqlite-chat-history"
+
 /**
  * SQLite-only chat-history facade.
  *
@@ -24,6 +26,8 @@ export const getAllMessages = sqliteRepo.getAllMessages
 export const getMessagesPaginated = sqliteRepo.getMessagesPaginated
 export const getMessagesBySessionOrderedByTimestamp =
   sqliteRepo.getMessagesBySessionOrderedByTimestamp
+export const getMessageTreeBySession = sqliteRepo.getMessageTreeBySession
+export const getMessagesByIds = sqliteRepo.getMessagesByIds
 export const getMessagesBySession = sqliteRepo.getMessagesBySession
 export const getMessagesBySessionAtTimestamp =
   sqliteRepo.getMessagesBySessionAtTimestamp

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -32,6 +32,13 @@ import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
 type StoredMessage = ChatMessage & { sessionId: string; id?: number }
 type StoredFile = FileAttachment & { sessionId: string; id?: number }
 
+/** Narrow message projection: the columns the message tree is built from. */
+export type MessageTreeRow = {
+  id: number
+  parentId?: number
+  timestamp: number
+}
+
 type RowValue = string | number | null | Uint8Array
 type Row = Record<string, RowValue>
 
@@ -422,6 +429,39 @@ export const getMessagesBySessionOrderedByTimestamp = async (
   const rows = await query(
     "SELECT * FROM messages WHERE sessionId = ? ORDER BY timestamp ASC",
     [sessionId]
+  )
+  return rows.map(messageFromRow)
+}
+
+/**
+ * The `id`/`parentId`/`timestamp` triple every message in a session
+ * contributes to the tree: enough to build the siblings map and walk the
+ * active path, and nothing else. Reading whole rows to do that shipped every
+ * message body, attachment blob and inlined image across the persistence
+ * worker's structured clone on each session switch, to keep fifty.
+ */
+export const getMessageTreeBySession = async (
+  sessionId: string
+): Promise<MessageTreeRow[]> => {
+  const rows = await query(
+    "SELECT id, parentId, timestamp FROM messages WHERE sessionId = ? ORDER BY timestamp ASC",
+    [sessionId]
+  )
+  return rows.map((row) => ({
+    id: row.id as number,
+    parentId: (row.parentId as number | null) ?? undefined,
+    timestamp: row.timestamp as number
+  }))
+}
+
+export const getMessagesByIds = async (
+  ids: Array<number | string>
+): Promise<StoredMessage[]> => {
+  if (ids.length === 0) return []
+  const numericIds = ids.map((id) => Number(id))
+  const rows = await query(
+    `SELECT * FROM messages WHERE id IN (${placeholders(numericIds.length)})`,
+    numericIds
   )
   return rows.map(messageFromRow)
 }

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -3,6 +3,7 @@ import {
   ChatMessageMetricsSchema
 } from "@ollama-client/contracts/chat"
 import { TURN_OWNED_ASSISTANT_STATUSES } from "@ollama-client/contracts/turns"
+import { z } from "zod"
 import { imageToStoredFile } from "@/lib/image-utils"
 import { PERSISTENCE_LIMITS } from "@/lib/persistence/protocol"
 import {
@@ -19,6 +20,7 @@ import {
   withTransaction
 } from "@/lib/sqlite/db"
 import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
+import { decodeRows } from "./row-decoder"
 
 /**
  * SQLite-backed implementation of the chat-history persistence surface.
@@ -32,12 +34,26 @@ import type { ChatMessage, ChatSession, FileAttachment, Role } from "@/types"
 type StoredMessage = ChatMessage & { sessionId: string; id?: number }
 type StoredFile = FileAttachment & { sessionId: string; id?: number }
 
-/** Narrow message projection: the columns the message tree is built from. */
-export type MessageTreeRow = {
-  id: number
-  parentId?: number
-  timestamp: number
-}
+/**
+ * Narrow message projection: the columns the message tree is built from.
+ *
+ * Decoded rather than asserted, unlike the whole-row mappers below. These three
+ * values *are* the ancestry — a null id or a timestamp that is not a number
+ * does not surface as a rendering glitch, it reorders siblings or detaches a
+ * subtree, and the visible branch silently ends early with nothing to point at.
+ * A per-field `as` on a bag of `SqlValue`s is unconditionally true and
+ * unconditionally unchecked, so the first thing to notice would be the user.
+ */
+const MessageTreeRowSchema = z.object({
+  id: z.number(),
+  parentId: z
+    .number()
+    .nullish()
+    .transform((value) => value ?? undefined),
+  timestamp: z.number()
+})
+
+export type MessageTreeRow = z.infer<typeof MessageTreeRowSchema>
 
 type RowValue = string | number | null | Uint8Array
 type Row = Record<string, RowValue>
@@ -447,11 +463,14 @@ export const getMessageTreeBySession = async (
     "SELECT id, parentId, timestamp FROM messages WHERE sessionId = ? ORDER BY timestamp ASC",
     [sessionId]
   )
-  return rows.map((row) => ({
-    id: row.id as number,
-    parentId: (row.parentId as number | null) ?? undefined,
-    timestamp: row.timestamp as number
-  }))
+  // Drop-and-log rather than raise: one unreadable row must not deny the user
+  // the rest of the conversation. Its descendants lose their ancestor and fall
+  // out of the walked path, which is a bounded, logged loss instead of a tree
+  // built on a NaN id.
+  return decodeRows(MessageTreeRowSchema, rows, {
+    table: "messages",
+    operation: "getMessageTreeBySession"
+  })
 }
 
 export const getMessagesByIds = async (

--- a/src/lib/repositories/sqlite-chat-history.ts
+++ b/src/lib/repositories/sqlite-chat-history.ts
@@ -463,14 +463,32 @@ export const getMessageTreeBySession = async (
     "SELECT id, parentId, timestamp FROM messages WHERE sessionId = ? ORDER BY timestamp ASC",
     [sessionId]
   )
-  // Drop-and-log rather than raise: one unreadable row must not deny the user
-  // the rest of the conversation. Its descendants lose their ancestor and fall
-  // out of the walked path, which is a bounded, logged loss instead of a tree
-  // built on a NaN id.
-  return decodeRows(MessageTreeRowSchema, rows, {
+  const decoded = decodeRows(MessageTreeRowSchema, rows, {
     table: "messages",
     operation: "getMessageTreeBySession"
   })
+
+  /**
+   * Raises rather than dropping, unlike the ingestion and model-pull
+   * repositories.
+   *
+   * Their rows are independent — one unreadable job denies recovery to itself
+   * and nothing else. These rows are a single interdependent structure, and a
+   * partial tree is not a smaller tree, it is a wrong one: the walk stops at
+   * the first missing id, so losing one node silently truncates or empties the
+   * branch beneath it, and the leaf the caller then settles on becomes the
+   * parent of the next message the user sends. Returning a subset asks every
+   * caller to detect an incompleteness the repository already knows about.
+   *
+   * `decodeRows` has logged each offending row's paths and codes by now, so
+   * this carries only the count.
+   */
+  if (decoded.length !== rows.length) {
+    throw new Error(
+      `Message tree for a session did not decode: ${rows.length - decoded.length} of ${rows.length} rows unreadable`
+    )
+  }
+  return decoded
 }
 
 export const getMessagesByIds = async (


### PR DESCRIPTION
- Every token re-parsed the whole message, re-sanitized it, replaced the subtree via `innerHTML` and rebuilt every code-block toolbar. Work is O(message length) and content grows monotonically, so the last tokens of a long answer cost the most. Now throttled to 120ms; the trailing timer is anchored on the last render, not the last change, so a stream that stops mid-window still renders its final content exactly once.
- `MarkdownIt` (nine plugins) was constructed per mounted renderer. Hoisted to module scope — `render` carries nothing between calls, so footnote numbering still restarts per message.
- Session load ran `SELECT * FROM messages WHERE sessionId = ?` with no LIMIT to build a sibling map, then kept 50. Now a narrow `id/parentId/timestamp` query for the tree plus an id-restricted full read for the path. `navigateToNode` had the same full read and is fixed too.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces streaming-render and session-loading work while completing the requested persistence-safety fixes.
- Throttles Markdown parsing while preserving a final trailing render and shares one configured parser.
- Loads narrow message-tree projections before fetching full rows only for the visible path.
- Validates every projected durable row and aborts session loading or navigation when any row is unreadable.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/repositories/sqlite-chat-history.ts | Adds validated narrow tree reads and rejects partial projections, resolving both prior persistence-decoding findings. |
| src/features/sessions/stores/chat-session-message-actions.ts | Uses narrow tree reads, fetches full rows only for the active path, and preserves branch state when projection decoding fails. |
| src/features/sessions/lib/message-tree.ts | Generalizes tree helpers to operate on narrow node projections without changing traversal semantics. |
| src/hooks/use-markdown-parser.ts | Shares the MarkdownIt configuration and throttles streaming parses while retaining sanitization and trailing updates. |
| src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts | Covers narrow reads, decode-failure preservation, branch navigation, pagination, and fallback behavior. |
| src/lib/repositories/__tests__/sqlite-chat-history.test.ts | Verifies projection SQL, strict decoding, safe aggregate errors, and id-restricted reads. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Session Store
  participant Repo as Chat History Repository
  participant DB as SQLite
  UI->>Repo: getMessageTreeBySession(sessionId)
  Repo->>DB: SELECT id, parentId, timestamp
  DB-->>Repo: narrow rows
  Repo->>Repo: Decode every tree row
  alt Any row is unreadable
    Repo-->>UI: Throw controlled decode error
    UI->>UI: Preserve existing branch state
  else Tree is valid
    Repo-->>UI: Decoded tree
    UI->>UI: Resolve paginated active path
    UI->>Repo: getMessagesByIds(pathIds)
    Repo->>DB: SELECT full rows WHERE id IN (...)
    DB-->>UI: Visible path rows
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(persistence): raise on an undecodabl..."](https://github.com/shishir435/ollama-client/commit/23a618dc84765e39e79e3b5cbd24ecb082db129d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53607958)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OPFS Single-Owner SQLite Persistence](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/persistence-sqlite.md)
- Knowledge Base — [Sessions, Memory, and Prompt Templates](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/sessions-memory.md)
- Knowledge Base — [Shared State Stores and Hooks](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/stores-state.md)
</details>

<!-- /greptile_comment -->