### PR TITLE
perf(embeddings): drop vectors from the keyword index

### DIFF
--- a/src/lib/embeddings/__tests__/keyword-index.test.ts
+++ b/src/lib/embeddings/__tests__/keyword-index.test.ts
@@ -418,4 +418,82 @@ describe("Keyword Index Manager", () => {
       expect(stats.documentCount).toBe(0)
     })
   })
+
+  describe("retention", () => {
+    const withVectors = (id: number, content: string): VectorDocument => ({
+      id,
+      content,
+      embedding: [0.1, 0.2, 0.3, 0.4],
+      normalizedEmbedding: [0.1, 0.2, 0.3, 0.4],
+      norm: 1,
+      metadata: {
+        source: "",
+        type: "chat",
+        timestamp: Date.now()
+      }
+    })
+
+    it("retains no embedding arrays", () => {
+      const document = withVectors(1, "retention check")
+      keywordIndexManager.addDocument(1, document.content, document)
+
+      const [result] = keywordIndexManager.search("retention")
+
+      expect(result).toBeDefined()
+      expect(result.document.content).toBe("retention check")
+      expect(result.document).not.toHaveProperty("embedding")
+      expect(result.document).not.toHaveProperty("normalizedEmbedding")
+      expect(result.document).not.toHaveProperty("norm")
+    })
+
+    it("captures the embedding dimension so filtering stays synchronous", () => {
+      const document = withVectors(2, "dimension check")
+      keywordIndexManager.addDocument(2, document.content, document)
+
+      const [result] = keywordIndexManager.search("dimension")
+
+      expect(result.document.embeddingDim).toBe(4)
+    })
+
+    it("prefers a recorded metadata dimension over the array length", () => {
+      const document = withVectors(3, "recorded dimension")
+      document.metadata.embeddingDim = 768
+      keywordIndexManager.addDocument(3, document.content, document)
+
+      const [result] = keywordIndexManager.search("recorded")
+
+      expect(result.document.embeddingDim).toBe(768)
+    })
+
+    it("estimates size without serializing the corpus", () => {
+      keywordIndexManager.addDocument(4, "a".repeat(1000), {
+        ...withVectors(4, "a".repeat(1000))
+      })
+      const grown = keywordIndexManager.getStats().memorySizeMB
+
+      keywordIndexManager.removeDocument(4)
+      const shrunk = keywordIndexManager.getStats().memorySizeMB
+
+      expect(grown).toBeGreaterThan(shrunk)
+      expect(shrunk).toBe(0)
+    })
+
+    it("keeps the size estimate correct when a document is replaced", () => {
+      keywordIndexManager.addDocument(5, "short", withVectors(5, "short"))
+      const afterShort = keywordIndexManager.getStats().memorySizeMB
+
+      keywordIndexManager.addDocument(
+        5,
+        "a".repeat(5000),
+        withVectors(5, "a".repeat(5000))
+      )
+      const afterLong = keywordIndexManager.getStats().memorySizeMB
+
+      keywordIndexManager.addDocument(5, "short", withVectors(5, "short"))
+      const backToShort = keywordIndexManager.getStats().memorySizeMB
+
+      expect(afterLong).toBeGreaterThan(afterShort)
+      expect(backToShort).toBeCloseTo(afterShort, 10)
+    })
+  })
 })

--- a/src/lib/embeddings/__tests__/search-hybrid.test.ts
+++ b/src/lib/embeddings/__tests__/search-hybrid.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { KeywordIndexDocument } from "@/lib/embeddings/keyword-index"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
+import type { VectorDocument } from "@/lib/embeddings/vector-store"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import { searchHybrid, vectorDb } from "../vector-store"
 
@@ -92,13 +94,31 @@ beforeEach(async () => {
   vi.mocked(getPlasmoStoredValue).mockResolvedValue({})
 })
 
+/**
+ * Mirrors the projection the real index retains: content + metadata + the
+ * dimension captured at add time, and deliberately no vectors. Keeping the
+ * fixture in this shape is what makes these mocks exercise the rehydration
+ * path instead of handing `searchHybrid` a row it no longer receives.
+ */
+const keywordDoc = (doc: VectorDocument): KeywordIndexDocument => ({
+  id: doc.id,
+  content: doc.content,
+  embeddingDim: doc.metadata.embeddingDim ?? doc.embedding.length,
+  metadata: doc.metadata
+})
+
 describe("searchHybrid — RRF fusion", () => {
   it("doc in both lists scores higher than doc in only one list", async () => {
     await vectorDb.vectors.bulkAdd([docA, docB] as any)
 
     // keyword: only docA (rank 0)
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 10, document: docA as any, terms: ["typescript"] }
+      {
+        id: 1,
+        score: 10,
+        document: keywordDoc(docA as never),
+        terms: ["typescript"]
+      }
     ])
 
     // semantic: docA rank 0 (similarity 1.0), docB rank 1 (similarity 0.0)
@@ -118,8 +138,18 @@ describe("searchHybrid — RRF fusion", () => {
 
     // keyword: docB rank 0, docC rank 1 — docA absent
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 2, score: 20, document: docB as any, terms: ["python"] },
-      { id: 3, score: 10, document: docC as any, terms: ["script"] }
+      {
+        id: 2,
+        score: 20,
+        document: keywordDoc(docB as never),
+        terms: ["python"]
+      },
+      {
+        id: 3,
+        score: 10,
+        document: keywordDoc(docC as never),
+        terms: ["script"]
+      }
     ])
 
     // semantic: query [1,0] → docA rank 0, docC rank 1, docB rank 2 (approx)
@@ -140,8 +170,18 @@ describe("searchHybrid — RRF fusion", () => {
     await vectorDb.vectors.bulkAdd([docA, docB, docC] as any)
 
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 100, document: docA as any, terms: ["typescript"] },
-      { id: 2, score: 50, document: docB as any, terms: ["python"] }
+      {
+        id: 1,
+        score: 100,
+        document: keywordDoc(docA as never),
+        terms: ["typescript"]
+      },
+      {
+        id: 2,
+        score: 50,
+        document: keywordDoc(docB as never),
+        terms: ["python"]
+      }
     ])
 
     const results = await searchHybrid("typescript", [1, 0], {
@@ -158,7 +198,12 @@ describe("searchHybrid — RRF fusion", () => {
     await vectorDb.vectors.bulkAdd([docA, docB] as any)
 
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 10, document: docA as any, terms: ["typescript"] }
+      {
+        id: 1,
+        score: 10,
+        document: keywordDoc(docA as never),
+        terms: ["typescript"]
+      }
     ])
 
     const results = await searchHybrid("typescript", [1, 0], {
@@ -172,9 +217,9 @@ describe("searchHybrid — RRF fusion", () => {
     await vectorDb.vectors.bulkAdd([docA, docB, docC] as any)
 
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 30, document: docA as any, terms: ["a"] },
-      { id: 2, score: 20, document: docB as any, terms: ["b"] },
-      { id: 3, score: 10, document: docC as any, terms: ["c"] }
+      { id: 1, score: 30, document: keywordDoc(docA as never), terms: ["a"] },
+      { id: 2, score: 20, document: keywordDoc(docB as never), terms: ["b"] },
+      { id: 3, score: 10, document: keywordDoc(docC as never), terms: ["c"] }
     ])
 
     const results = await searchHybrid("query", [1, 0], {
@@ -287,7 +332,7 @@ describe("searchHybrid — edge cases", () => {
       partitioned.map((document) => ({
         id: document.id,
         score: 10,
-        document: document as any,
+        document: keywordDoc(document as never),
         terms: ["typescript"]
       }))
     )
@@ -314,8 +359,18 @@ describe("searchHybrid — edge cases", () => {
     }
     await vectorDb.vectors.bulkAdd([docA, modern] as any)
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 10, document: docA as any, terms: ["typescript"] },
-      { id: 104, score: 20, document: modern as any, terms: ["typescript"] }
+      {
+        id: 1,
+        score: 10,
+        document: keywordDoc(docA as never),
+        terms: ["typescript"]
+      },
+      {
+        id: 104,
+        score: 20,
+        document: keywordDoc(modern as never),
+        terms: ["typescript"]
+      }
     ])
 
     const results = await searchHybrid("typescript", [1, 0])
@@ -345,7 +400,12 @@ describe("searchHybrid — edge cases", () => {
     await vectorDb.vectors.bulkAdd([lowSimDoc] as any)
 
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 5, score: 10, document: lowSimDoc as any, terms: ["content"] }
+      {
+        id: 5,
+        score: 10,
+        document: keywordDoc(lowSimDoc as never),
+        terms: ["content"]
+      }
     ])
 
     const results = await searchHybrid("content", [1, 0], {
@@ -371,8 +431,8 @@ describe("searchHybrid — edge cases", () => {
     await vectorDb.vectors.bulkAdd([docA, docB, docC] as any)
 
     vi.mocked(keywordIndexManager.search).mockReturnValue([
-      { id: 1, score: 30, document: docA as any, terms: ["a"] },
-      { id: 2, score: 10, document: docB as any, terms: ["b"] }
+      { id: 1, score: 30, document: keywordDoc(docA as never), terms: ["a"] },
+      { id: 2, score: 10, document: keywordDoc(docB as never), terms: ["b"] }
     ])
 
     const results = await searchHybrid("query", [1, 0], {
@@ -384,5 +444,99 @@ describe("searchHybrid — edge cases", () => {
         results[i].similarity
       )
     }
+  })
+})
+
+describe("searchHybrid — keyword candidate rehydration", () => {
+  /**
+   * The keyword index retains no vectors. If a keyword-only hit reached the
+   * caller straight from the index it would arrive without an embedding, and
+   * the reranker scores a document with no embedding as neutral rather than
+   * failing — so the regression would be silent.
+   */
+  it("returns keyword-only hits with their stored vectors", async () => {
+    const stored = {
+      id: 42,
+      content: "keyword only hit",
+      embedding: [0, 1],
+      normalizedEmbedding: [0, 1],
+      metadata: {
+        source: "s",
+        type: "file" as const,
+        timestamp: 1
+      }
+    }
+    await vectorDb.vectors.bulkAdd([stored] as never)
+
+    vi.mocked(keywordIndexManager.search).mockReturnValue([
+      {
+        id: 42,
+        score: 10,
+        document: keywordDoc(stored as never),
+        terms: ["keyword"]
+      }
+    ])
+
+    const results = await searchHybrid("keyword", [1, 0], {
+      minSimilarity: 0.99
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].document.id).toBe(42)
+    expect(results[0].document.embedding).toEqual([0, 1])
+    expect(results[0].document.normalizedEmbedding).toEqual([0, 1])
+  })
+
+  it("drops a keyword hit whose row was deleted after indexing", async () => {
+    const orphan = {
+      id: 99,
+      content: "orphaned entry",
+      embedding: [0, 1],
+      metadata: {
+        source: "s",
+        type: "file" as const,
+        timestamp: 1
+      }
+    }
+    // Deliberately not added to the store.
+    vi.mocked(keywordIndexManager.search).mockReturnValue([
+      {
+        id: 99,
+        score: 10,
+        document: keywordDoc(orphan as never),
+        terms: ["orphaned"]
+      }
+    ])
+
+    const results = await searchHybrid("orphaned", [1, 0], {
+      minSimilarity: 0.99
+    })
+
+    expect(results).toHaveLength(0)
+  })
+
+  it("reads candidates by id rather than scanning the table", async () => {
+    const rows = Array.from({ length: 40 }, (_, index) => ({
+      id: index + 1,
+      content: `row ${index + 1}`,
+      embedding: [0, 1],
+      metadata: { source: "s", type: "file" as const, timestamp: index }
+    }))
+    await vectorDb.vectors.bulkAdd(rows as never)
+
+    const bulkGet = vi.spyOn(vectorDb.vectors, "bulkGet")
+    vi.mocked(keywordIndexManager.search).mockReturnValue([
+      {
+        id: 3,
+        score: 10,
+        document: keywordDoc(rows[2] as never),
+        terms: ["row"]
+      }
+    ])
+
+    await searchHybrid("row", [1, 0], { minSimilarity: 0.99 })
+
+    expect(bulkGet).toHaveBeenCalledWith([3])
+    bulkGet.mockRestore()
   })
 })

--- a/src/lib/embeddings/__tests__/vector-store-advanced.test.ts
+++ b/src/lib/embeddings/__tests__/vector-store-advanced.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { KeywordIndexDocument } from "@/lib/embeddings/keyword-index"
 import { keywordIndexManager } from "@/lib/embeddings/keyword-index"
+import type { VectorDocument } from "@/lib/embeddings/vector-store"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
 import {
   searchHybrid,
@@ -42,6 +44,19 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
   getPlasmoStoredValue: vi.fn()
 }))
 
+/**
+ * Mirrors the projection the real index retains: content + metadata + the
+ * dimension captured at add time, and deliberately no vectors. Keeping the
+ * fixture in this shape is what makes these mocks exercise the rehydration
+ * path instead of handing `searchHybrid` a row it no longer receives.
+ */
+const keywordDoc = (doc: VectorDocument): KeywordIndexDocument => ({
+  id: doc.id,
+  content: doc.content,
+  embeddingDim: doc.metadata.embeddingDim ?? doc.embedding.length,
+  metadata: doc.metadata
+})
+
 describe("Vector Store - Advanced Tests", () => {
   beforeEach(async () => {
     await vectorDb.vectors.clear()
@@ -71,7 +86,12 @@ describe("Vector Store - Advanced Tests", () => {
 
       // Mock keyword search results
       vi.mocked(keywordIndexManager.search).mockReturnValue([
-        { id: 1, score: 10, document: doc1 as any, terms: ["apple"] }
+        {
+          id: 1,
+          score: 10,
+          document: keywordDoc(doc1 as never),
+          terms: ["apple"]
+        }
       ])
 
       // Perform hybrid search
@@ -105,7 +125,12 @@ describe("Vector Store - Advanced Tests", () => {
 
       // Keyword search finds doc1
       vi.mocked(keywordIndexManager.search).mockReturnValue([
-        { id: 1, score: 10, document: doc1 as any, terms: ["keyword"] }
+        {
+          id: 1,
+          score: 10,
+          document: keywordDoc(doc1 as never),
+          terms: ["keyword"]
+        }
       ])
 
       // Semantic search (via internal searchSimilarVectors) will find doc2 for embedding [1, 0]

--- a/src/lib/embeddings/keyword-index.ts
+++ b/src/lib/embeddings/keyword-index.ts
@@ -3,14 +3,47 @@ import { logger } from "@/lib/logger"
 import type { VectorDocument } from "./vector-store"
 
 /**
- * Keyword search result
+ * What the index retains per document.
+ *
+ * Deliberately not a `VectorDocument`: the full row carries `embedding` and
+ * `normalizedEmbedding`, two float arrays that a BM25 index never reads. The
+ * index held both for every document in the corpus, in JS `number[]` (float64,
+ * twice the width of the Float32Array copy the ANN backend already keeps), on
+ * top of MiniSearch's own stored content — the largest resident allocation in
+ * the extension, for data that is already in IndexedDB.
+ *
+ * `embeddingDim` is captured at add time because candidate filtering needs the
+ * dimension and `metadata.embeddingDim` is absent on older rows, where the
+ * fallback was `document.embedding.length`. Keeping it here is what lets
+ * filtering stay synchronous after the arrays are dropped.
+ */
+export interface KeywordIndexDocument {
+  id?: number
+  content: string
+  embeddingDim: number
+  metadata: VectorDocument["metadata"]
+}
+
+/**
+ * Keyword search result.
+ *
+ * `document` is the retained projection, not the stored row. Callers that need
+ * the vectors — reranking, fusion output — must rehydrate the surviving
+ * candidates from IndexedDB; see `hydrateKeywordCandidates` in `search.ts`.
  */
 export interface KeywordSearchResult {
   id: number
   score: number
-  document: VectorDocument
+  document: KeywordIndexDocument
   terms: string[] // Matched keywords
 }
+
+const toIndexDocument = (document: VectorDocument): KeywordIndexDocument => ({
+  id: document.id,
+  content: document.content,
+  embeddingDim: document.metadata.embeddingDim ?? document.embedding.length,
+  metadata: document.metadata
+})
 
 /**
  * Keyword Index for full-text search using BM25 algorithm
@@ -18,7 +51,9 @@ export interface KeywordSearchResult {
  */
 class KeywordIndexManager {
   private index: MiniSearch<{ id: number; content: string; timestamp: number }>
-  private documents: Map<number, VectorDocument> = new Map()
+  private documents: Map<number, KeywordIndexDocument> = new Map()
+  /** Running total of retained content, so stats never walk the corpus. */
+  private retainedContentChars = 0
 
   constructor() {
     this.index = new MiniSearch({
@@ -44,7 +79,9 @@ class KeywordIndexManager {
         this.removeDocument(id)
       }
 
-      this.documents.set(id, document)
+      const projected = toIndexDocument(document)
+      this.documents.set(id, projected)
+      this.retainedContentChars += projected.content.length
       this.index.add({
         id,
         content: content.toLowerCase(), // Normalize for better matching
@@ -101,13 +138,15 @@ class KeywordIndexManager {
    */
   removeDocument(id: number): void {
     try {
-      if (this.documents.has(id)) {
+      const existing = this.documents.get(id)
+      if (existing) {
         this.index.remove({ id } as {
           id: number
           content: string
           timestamp: number
         })
         this.documents.delete(id)
+        this.retainedContentChars -= existing.content.length
       }
     } catch (error) {
       logger.error(
@@ -124,19 +163,25 @@ class KeywordIndexManager {
   clear(): void {
     this.index.removeAll()
     this.documents.clear()
+    this.retainedContentChars = 0
     logger.verbose("Keyword index cleared", "KeywordIndex")
   }
 
   /**
-   * Get index statistics
+   * Get index statistics.
+   *
+   * `memorySizeMB` is estimated from a running character count. It used to
+   * `JSON.stringify` every retained document — including both embedding arrays,
+   * rendered as decimal text — which allocated a string several times the size
+   * of the corpus purely to produce a diagnostic number, on a path reached from
+   * search warm-up.
    */
   getStats() {
     return {
       documentCount: this.index.documentCount,
       termCount: this.documents.size,
       memorySizeMB:
-        (JSON.stringify(Array.from(this.documents.values())).length +
-          this.index.documentCount * 100) /
+        (this.retainedContentChars * 2 + this.index.documentCount * 100) /
         (1024 * 1024)
     }
   }

--- a/src/lib/embeddings/search.ts
+++ b/src/lib/embeddings/search.ts
@@ -339,6 +339,27 @@ export const searchSimilarVectors = async (
  * It uses Reciprocal Rank Fusion (implicit) by weighted scoring:
  * Final Score = (keywordWeight * normalizedBM25) + (semanticWeight * cosineSimilarity)
  */
+/**
+ * Reads stored rows for keyword candidates that survived filtering.
+ *
+ * Keyed by id via `bulkGet`, so the cost is proportional to the candidate
+ * count rather than the corpus. Missing ids are skipped: a vector deleted
+ * between indexing and this read is simply no longer a candidate.
+ */
+const hydrateKeywordCandidates = async (
+  ids: number[]
+): Promise<Map<number, VectorDocument>> => {
+  const hydrated = new Map<number, VectorDocument>()
+  if (ids.length === 0) return hydrated
+
+  const rows = await vectorDb.vectors.bulkGet(ids)
+  for (const row of rows) {
+    if (row?.id === undefined) continue
+    hydrated.set(row.id, row)
+  }
+  return hydrated
+}
+
 export const searchHybrid = async (
   queryText: string,
   queryEmbedding: number[],
@@ -374,7 +395,7 @@ export const searchHybrid = async (
     const queryDimension =
       searchOptions.embeddingDimension ?? queryEmbedding.length
     const documentDimension =
-      document.metadata.embeddingDim ?? document.embedding.length
+      document.metadata.embeddingDim ?? document.embeddingDim
     if (documentDimension !== queryDimension) return false
 
     const requestedModel = normalizeEmbeddingModelName(
@@ -430,13 +451,25 @@ export const searchHybrid = async (
   const scoreMap = new Map<number, number>()
   const docMap = new Map<number, VectorDocument>()
 
+  // The keyword index retains a projection with no vectors, so the surviving
+  // candidates are read back before fusion — reranking scores on
+  // `document.embedding`, and a document without one is silently given a
+  // neutral score rather than failing. Bounded by `limit * 3`, so this is a
+  // keyed lookup, not a table scan.
+  const hydratedKeywordDocs = await hydrateKeywordCandidates(
+    filteredKeywordResults.map((result) => result.id)
+  )
+
   for (let rank = 0; rank < filteredKeywordResults.length; rank++) {
     const result = filteredKeywordResults[rank]
+    const hydrated = hydratedKeywordDocs.get(result.id)
+    // A row deleted between indexing and this read has nothing to score.
+    if (!hydrated) continue
     scoreMap.set(
       result.id,
       (scoreMap.get(result.id) ?? 0) + keywordWeight / (RRF_K + rank + 1)
     )
-    docMap.set(result.id, result.document)
+    docMap.set(result.id, hydrated)
   }
 
   for (let rank = 0; rank < semanticResults.length; rank++) {

--- a/tools/check-bundle-size.ts
+++ b/tools/check-bundle-size.ts
@@ -186,7 +186,7 @@ const budgets: Budget[] = [
   {
     metric: "background",
     field: "gzipBytes",
-    max: isFirefox ? 210_000 : 193_000
+    max: isFirefox ? 210_000 : 194_000
   }
 ]
 


### PR DESCRIPTION
The BM25 index retained whole `VectorDocument`s — `embedding` and `normalizedEmbedding` both, in float64 — for every document in the corpus, duplicating what Dexie and the ANN backend already hold. Largest resident allocation in the extension, for data a keyword index never reads.

It now retains content, metadata and the dimension captured at add time. `searchHybrid` reads the surviving candidates back by id (`bulkGet`, bounded by `limit * 3`) before fusion — reranking scores on `document.embedding` and treats a missing one as *neutral* rather than failing, so a naive projection would have degraded ranking silently.

`getStats` no longer `JSON.stringify`s the corpus to estimate its own size.

Bundle budget raised to 194k: baseline was 78 bytes under the old cap.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces keyword-index memory use by retaining vector-free document projections and rehydrating keyword candidates from Dexie before hybrid fusion.
- Captures embedding dimensions in keyword-index projections so compatibility filtering remains synchronous.
- Replaces corpus serialization in index statistics with a running retained-content estimate.
- Adds tests for vector omission, candidate rehydration, deleted rows, and direct ID-based reads.
- Raises the Chrome background gzip budget from 193 kB to 194 kB.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security failures identified in the changed paths.

Keyword candidates remain partition-filtered, are restored from the authoritative Dexie rows before fusion, and deleted rows are intentionally omitted; the accompanying tests cover the principal behavioral changes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/embeddings/keyword-index.ts | Replaces retained VectorDocuments with vector-free projections and tracks retained content size incrementally. |
| src/lib/embeddings/search.ts | Rehydrates filtered keyword candidates by ID before reciprocal-rank fusion and safely skips deleted rows. |
| src/lib/embeddings/__tests__/search-hybrid.test.ts | Updates keyword fixtures to the projected shape and covers rehydration, deletion, and keyed lookup behavior. |
| tools/check-bundle-size.ts | Raises the Chrome background gzip budget by 1 kB. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant HS as Hybrid search
  participant KI as Keyword index
  participant DB as Dexie vectors
  participant SS as Semantic search
  HS->>KI: Search text (limit × 3)
  KI-->>HS: Projected candidates without vectors
  HS->>HS: Filter model/provider/dimension/scope
  HS->>SS: Search query embedding
  SS-->>HS: Semantic candidates
  HS->>DB: bulkGet(filtered keyword IDs)
  DB-->>HS: Full vector rows
  HS->>HS: Fuse hydrated keyword and semantic ranks
  HS-->>HS: Normalize, title-boost, and limit results
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: raise the Chrome background bundl..."](https://github.com/shishir435/ollama-client/commit/1a0f24e2db2be3708c0927552a0aa4fac6704106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53607964)</sub>

**Context used:**

- Knowledge Base — [Local RAG: File Upload, Chunking, Embedding, and Retrieval](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/knowledge-rag.md)

<!-- /greptile_comment -->