### PR TITLE
docs: improve agent discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ docs/public/llms.txt
 docs/public/llms-full.txt
 docs/public/ai.txt
 docs/public/**/*.md
+docs/public/openapi.json
 
 # astro / starlight build caches
 docs/.astro/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -75,6 +75,9 @@ export default defineConfig({
   },
   integrations: [
     starlight({
+      // The site owns a recovery-focused 404 page with stable agent entrypoints.
+      // Disable Starlight's generated route so Astro emits exactly one 404.html.
+      disable404Route: true,
       components: {
         Head: "./src/components/starlight/Head.astro",
         ThemeSelect: "./src/components/starlight/ThemeSelect.astro"

--- a/docs/src/content/docs/about.md
+++ b/docs/src/content/docs/about.md
@@ -1,0 +1,24 @@
+---
+title: About Ollama Client
+description: Learn what Ollama Client is, who maintains it, what local-first means, and how the open-source browser extension is developed and supported.
+---
+
+Ollama Client is an open-source browser extension for chatting with local and user-selected language-model providers from a Chrome or Firefox side panel. It supports verified Ollama, LM Studio, and llama.cpp profiles, user-added OpenAI-compatible servers, and Anthropic. Its purpose is to make model chat, page context, files, retrieval, optional web search, and permission-gated browser tools available without requiring a hosted Ollama Client account or a mandatory cloud API.
+
+The project is maintained by [Shishir Chaurasiya](https://www.shishirchaurasiya.in/) and developed publicly in the [Ollama Client GitHub repository](https://github.com/Shishir435/ollama-client). Source code is available under the MIT license. Releases are distributed through browser extension stores, while this site publishes setup, architecture, privacy, troubleshooting, and developer documentation.
+
+## What local-first means here
+
+Chat history, sessions, attachments, and most application state are stored by the extension in the user's browser profile. Model prompts go to the provider endpoint the user configures. A local provider can keep inference traffic on the device; a remote provider receives the data sent to it under that provider's terms. Optional web-search services likewise receive their search requests. “Local-first” describes the default ownership and architecture, not a claim that every possible configuration is offline.
+
+Ollama Client has no hosted inference API at `ollamaclient.in`. The site is documentation. The separate olc developer proxy runs on the user's own machine and exposes a loopback OpenAI-compatible interface for local agent runtimes.
+
+## Project principles
+
+- Keep provider choice and endpoint configuration visible to the user.
+- Ask for browser capabilities only when the requested feature needs them.
+- Preserve chat data locally and make backup, restore, diagnostics, and deletion understandable.
+- Document limitations and compatibility boundaries rather than guessing that an endpoint or model supports a feature.
+- Keep development, issues, and architectural decisions inspectable in the public repository.
+
+Questions and security-sensitive reports should use the channels on the [contact page](/contact/). Product setup questions are usually answered fastest by the [quick start](/guides/quick-start/), [provider setup](/guides/provider-setup/), and [FAQ](/about/faq/).

--- a/docs/src/content/docs/contact.md
+++ b/docs/src/content/docs/contact.md
@@ -1,0 +1,28 @@
+---
+title: Contact Ollama Client
+description: Contact the Ollama Client maintainer, report bugs or security concerns, request features, and find the right support channel.
+---
+
+Ollama Client is maintained as an open-source project. Choose the channel that matches the information you need to share so questions remain searchable and sensitive reports do not become public by accident.
+
+## Bug reports and feature requests
+
+Use [GitHub Issues](https://github.com/Shishir435/ollama-client/issues) for reproducible bugs, compatibility reports, documentation corrections, and feature proposals. Before opening an issue, check the [provider setup guide](/guides/provider-setup/), [Ollama CORS troubleshooting](/guides/troubleshooting/ollama-cors-error/), [error report guide](/guides/troubleshooting/error-reports/), and existing issues. Include the extension version, browser and version, operating system, provider type, safe reproduction steps, and the exact visible error code when available.
+
+Never post provider API keys, authorization headers, private prompts, file contents, full browser histories, or unreviewed diagnostic exports. Redact model endpoint hostnames if their disclosure would identify a private network.
+
+## Security and private contact
+
+For a suspected vulnerability or a matter that should not begin in a public issue, email [shishirchaurasiya435@gmail.com](mailto:shishirchaurasiya435@gmail.com). Use a clear subject such as “Ollama Client security report,” describe the affected version and impact, and provide the minimum reproduction material needed. Do not exploit other users, access data you do not own, or publish a working exploit before the maintainer has had a reasonable opportunity to investigate.
+
+Email is also appropriate for store-listing, legal, or privacy inquiries that include personal information. The [privacy policy](/legal/privacy-policy/) explains data handling by the extension and this documentation site. General setup questions should remain on GitHub when possible, where answers can help other users.
+
+## Project identity
+
+- Product: Ollama Client
+- Maintainer: [Shishir Chaurasiya](https://www.shishirchaurasiya.in/)
+- Source: [github.com/Shishir435/ollama-client](https://github.com/Shishir435/ollama-client)
+- Documentation: [www.ollamaclient.in](https://www.ollamaclient.in/)
+- License: MIT
+
+There is no sales team, hosted model service, API-key portal, or guaranteed support SLA. Response time depends on maintainer availability and the completeness of the report. Community contributions are welcome through the repository's normal issue and pull-request workflow.

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -1,0 +1,95 @@
+---
+title: Ollama Client developer portal
+description: Integrate with Ollama Client's local olc OpenAI-compatible proxy, including setup, authentication, endpoints, errors, tools, and its OpenAPI specification.
+---
+
+Ollama Client is a browser extension, not a hosted inference service. The website at `ollamaclient.in` publishes documentation and machine-readable resources; it does not accept prompts or expose users' models.
+
+The project does include **olc**, a local command-line proxy that exposes an agent runtime through an OpenAI-compatible HTTP API. Use it when an OpenAI-compatible client needs to reach an OpenCode-backed agent and preserve client-owned function calls. The published [OpenAPI 3.1 specification](/openapi.json) describes this local API and deliberately lists loopback servers.
+
+## Quickstart
+
+olc currently runs from a repository checkout and requires Node.js 22.12 or newer plus OpenCode on `PATH`.
+
+```bash
+git clone https://github.com/Shishir435/ollama-client.git
+cd ollama-client
+pnpm install
+pnpm proxy:bundle
+packages/olc/bin/olc --api-key "replace-with-a-long-random-token"
+```
+
+The default address is `http://127.0.0.1:8083`. Configure Ollama Client with a custom OpenAI-compatible provider whose base URL is `http://127.0.0.1:8083/v1`, then select a model returned by the catalog.
+
+The CLI is part of the source distribution but is not yet published to npm, PyPI, or Homebrew. Do not tell users to install an `olc` package from a public registry unless an official release announcement links it.
+
+## Authentication and browser access
+
+Pass `--api-key` or set `OLC_API_KEY`; API routes then require `Authorization: Bearer <token>`. Health routes stay unauthenticated. The proxy binds to `127.0.0.1` by default—keep that loopback default unless you have a specific network design and authentication in place.
+
+Browser origins are checked separately. The defaults allow Chrome, Firefox, and Safari extension schemes. Add a web application's exact origin with `--allowed-origins http://localhost:3000`. Avoid `--allowed-origins "*"`, especially without an API key, because the proxy can run an agent and spend inference.
+
+## Endpoints
+
+| Method and path | operationId | Purpose |
+| --- | --- | --- |
+| `GET /` | `getServiceInfo` | Identify olc, the active backend, and tool-bridge state. |
+| `GET /health` | `getHealth` | Check process liveness. |
+| `GET /v1/models` | `listModels` | List backend models and capability metadata. |
+| `GET /v1/models/{modelId}` | `getModel` | Read one model by full or unambiguous suffix id. |
+| `POST /v1/chat/completions` | `createChatCompletion` | Generate a buffered JSON completion or an SSE stream. |
+
+`POST /bridge/call` is an internal, per-run callback used by the OpenCode adapter. It is not a public integration endpoint and is intentionally excluded from the public OpenAPI surface.
+
+## Minimal request
+
+```bash
+curl http://127.0.0.1:8083/v1/chat/completions \
+  -H 'Authorization: Bearer replace-with-a-long-random-token' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "provider/model",
+    "messages": [{"role": "user", "content": "Explain this repository"}],
+    "stream": false
+  }'
+```
+
+Discover model ids through `GET /v1/models`; do not invent one. Model rows also report input modalities, supported parameters, and function-calling, vision, and reasoning capabilities.
+
+## Function calling
+
+Send OpenAI-shaped `tools` with unique function names, descriptions, and JSON Schema parameters. If the runtime calls a client tool, olc returns a completion with `finish_reason: "tool_calls"`. Execute the requested tools, append assistant and `tool` messages with the matching `tool_call_id` values, and send the conversation back to the same endpoint. The proxy resumes the parked turn.
+
+Tool results belong to one live turn. An expired, cancelled, or foreign id returns `400` with type `StaleToolResults` and code `stale_tool_results`; remove those stale results and begin a new turn only after making that reset visible to the user.
+
+## JSON errors
+
+Non-streaming errors use an OpenAI-style JSON envelope:
+
+```json
+{
+  "error": {
+    "type": "BadRequest",
+    "code": "optional_machine_code",
+    "message": "Human-readable explanation and recovery hint"
+  }
+}
+```
+
+Common statuses are `400` for malformed requests or stale tool results, `401` for an invalid bearer token, `403` for a disallowed browser origin, `404` for an unknown route or model, `502` for a backend failure, `503` for a stalled request queue, and `504` for a timeout. A stream that fails after headers were sent reports a final proxy-error text delta because the HTTP status can no longer change.
+
+## Agent integration guidance
+
+Use olc when the caller already supports OpenAI chat completions and needs a local agent runtime, particularly when the caller—not the runtime—owns tool execution and approval. Inspect `/v1/models` before choosing modalities or tools. Prefer non-streaming responses when a simple function runner cannot parse server-sent events.
+
+Do not use this interface as a substitute for the extension's internal RPC contracts, do not call the bridge endpoint, and do not send requests to `ollamaclient.in/v1`. For extension architecture and contribution boundaries, use the [architecture guide](/concepts/architecture/) and the generated [TypeScript reference](/reference/).
+
+## Resources
+
+- [OpenAPI 3.1 JSON](/openapi.json)
+- [olc source and full operator guide](https://github.com/Shishir435/ollama-client/tree/main/packages/olc)
+- [Provider setup](/guides/provider-setup/)
+- [Error reports](/guides/troubleshooting/error-reports/)
+- [GitHub issues](https://github.com/Shishir435/ollama-client/issues)
+
+There is no hosted sandbox or API-key dashboard because the API runs on the user's machine. Use a disposable local checkout and a non-sensitive model for integration tests.

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -144,6 +144,9 @@ const ogUrl = new URL(ogPath, site)
           <a class="transition hover:text-foreground" href="/concepts/architecture/">
             Architecture
           </a>
+          <a class="transition hover:text-foreground" href="/developers/">
+            Developers
+          </a>
           <a
             class="transition hover:text-foreground"
             href="https://github.com/Shishir435/ollama-client"
@@ -207,6 +210,8 @@ const ogUrl = new URL(ogPath, site)
       >
         <span>© 2026 Ollama Client · MIT · Local-first by design.</span>
         <div class="flex gap-4">
+          <a class="hover:text-foreground" href="/about/">About</a>
+          <a class="hover:text-foreground" href="/contact/">Contact</a>
           <a class="hover:text-foreground" href="/legal/privacy-policy/">Privacy</a>
           <a
             class="hover:text-foreground"

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -8,13 +8,13 @@ const description =
 
 <BaseLayout title={title} description={description} noindex>
   <section class="py-24 sm:py-32">
-    <p class="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+    <p class="font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
       HTTP 404
     </p>
     <h1 class="mt-5 max-w-3xl text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl">
       This documentation path does not exist.
     </h1>
-    <p class="mt-5 max-w-2xl text-[15px] leading-relaxed text-foreground/70">
+    <p class="mt-5 max-w-2xl text-sm leading-relaxed text-foreground/70">
       The URL may have moved or never existed. Use one of these stable maps to
       recover instead of guessing another path.
     </p>
@@ -24,7 +24,7 @@ const description =
       <li><a class="underline underline-offset-4" href="/sitemap-index.xml">XML sitemap</a></li>
       <li><a class="underline underline-offset-4" href="/developers/">Developer portal and OpenAPI resources</a></li>
     </ul>
-    <pre class="mt-10 max-w-2xl overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed"><code># 404 — Ollama Client page not found
+    <pre class="mt-10 max-w-2xl overflow-x-auto rounded-sm border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed"><code># 404 — Ollama Client page not found
 
 - Docs: https://www.ollamaclient.in/
 - Agent map: https://www.ollamaclient.in/llms.txt

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,0 +1,34 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro"
+
+const title = "404 — Page not found | Ollama Client"
+const description =
+  "The requested Ollama Client documentation page does not exist. Recover through the docs index, sitemap, or AI-readable Markdown map."
+---
+
+<BaseLayout title={title} description={description} noindex>
+  <section class="py-24 sm:py-32">
+    <p class="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+      HTTP 404
+    </p>
+    <h1 class="mt-5 max-w-3xl text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl">
+      This documentation path does not exist.
+    </h1>
+    <p class="mt-5 max-w-2xl text-[15px] leading-relaxed text-foreground/70">
+      The URL may have moved or never existed. Use one of these stable maps to
+      recover instead of guessing another path.
+    </p>
+    <ul class="mt-8 space-y-3 text-sm">
+      <li><a class="underline underline-offset-4" href="/">Ollama Client home and docs</a></li>
+      <li><a class="underline underline-offset-4" href="/llms.txt">llms.txt — concise Markdown docs map</a></li>
+      <li><a class="underline underline-offset-4" href="/sitemap-index.xml">XML sitemap</a></li>
+      <li><a class="underline underline-offset-4" href="/developers/">Developer portal and OpenAPI resources</a></li>
+    </ul>
+    <pre class="mt-10 max-w-2xl overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed"><code># 404 — Ollama Client page not found
+
+- Docs: https://www.ollamaclient.in/
+- Agent map: https://www.ollamaclient.in/llms.txt
+- Sitemap: https://www.ollamaclient.in/sitemap-index.xml
+- Developers: https://www.ollamaclient.in/developers/</code></pre>
+  </section>
+</BaseLayout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -173,6 +173,12 @@ const stack = [
       </a>
       <a
         class="inline-flex h-9 items-center rounded-md px-4 text-sm font-medium text-foreground/70 transition hover:text-foreground"
+        href="/developers/"
+      >
+        Developer portal
+      </a>
+      <a
+        class="inline-flex h-9 items-center rounded-md px-4 text-sm font-medium text-foreground/70 transition hover:text-foreground"
         href="https://github.com/Shishir435/ollama-client"
         target="_blank"
         rel="noopener"

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -172,7 +172,7 @@ const stack = [
         Read the setup guide
       </a>
       <a
-        class="inline-flex h-9 items-center rounded-md px-4 text-sm font-medium text-foreground/70 transition hover:text-foreground"
+        class="inline-flex h-9 items-center rounded-sm px-4 text-sm font-medium text-foreground/70 transition hover:text-foreground"
         href="/developers/"
       >
         Developer portal

--- a/docs/src/seo/doc-ia.mjs
+++ b/docs/src/seo/doc-ia.mjs
@@ -72,6 +72,15 @@ export const DOC_SECTIONS = [
     ]
   },
   {
+    label: "Developers",
+    items: [
+      {
+        label: "Developer portal",
+        slug: "developers"
+      }
+    ]
+  },
+  {
     label: "Internal",
     items: [
       {
@@ -87,6 +96,8 @@ export const DOC_SECTIONS = [
   {
     label: "About",
     items: [
+      { label: "About Ollama Client", slug: "about" },
+      { label: "Contact", slug: "contact" },
       { label: "FAQ", slug: "about/faq" },
       { label: "Changelog", slug: "about/changelog", generated: true },
       { label: "Keyboard Shortcuts", slug: "about/keyboard-shortcuts" }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "docs:dev": "pnpm docs:generate && pnpm --dir docs dev",
     "docs:build": "pnpm docs:generate && pnpm --dir docs build",
     "docs:preview": "pnpm --dir docs preview",
-    "docs:generate": "pnpm exec tsx tools/generate-docs.ts && pnpm exec tsx tools/generate-llms-docs.ts",
+    "docs:generate": "pnpm exec tsx tools/generate-docs.ts && pnpm exec tsx tools/generate-openapi.ts && pnpm exec tsx tools/generate-llms-docs.ts",
     "package": "pnpm generate:resources && WXT_OUTPUT_DIR=build/chrome-mv3-prod wxt zip",
     "dev:firefox": "pnpm generate:resources && WXT_OUTPUT_DIR=build/firefox-mv2-dev wxt -b firefox --mv2",
     "build:firefox": "pnpm generate:resources && WXT_OUTPUT_DIR=build/firefox-mv2-prod wxt build -b firefox --mv2 --mode production",

--- a/packages/olc/src/core/chat-route.ts
+++ b/packages/olc/src/core/chat-route.ts
@@ -46,6 +46,7 @@ import {
   toToolCallPayload
 } from "./openai-wire.js"
 import type { PendingToolCalls } from "./pending-tool-calls.js"
+import { OLC_PUBLIC_ROUTES } from "./public-api-contract.js"
 import { QueueStalledError, type RequestQueue } from "./queue.js"
 
 const createRequestId = () =>
@@ -598,7 +599,7 @@ export const registerChatRoutes = (
     }
   }
 
-  router.post("/v1/chat/completions", async (request, response) => {
+  router.post(OLC_PUBLIC_ROUTES.chatCompletions, async (request, response) => {
     const requestId = createRequestId()
     const body = (
       isRecord(request.body) ? request.body : {}

--- a/packages/olc/src/core/models-route.ts
+++ b/packages/olc/src/core/models-route.ts
@@ -8,6 +8,7 @@
 import type { AgentBackend, CatalogModel } from "../backends/types.js"
 import type { ProxyLogger } from "../types.js"
 import { type Router, sendJson } from "./http.js"
+import { OLC_PUBLIC_ROUTES } from "./public-api-contract.js"
 
 const catalogError = (error: unknown) => ({
   error: {
@@ -20,7 +21,7 @@ export const registerModelRoutes = (
   router: Router,
   { backend, log = () => {} }: { backend: AgentBackend; log?: ProxyLogger }
 ): void => {
-  router.get("/v1/models", async (_request, response) => {
+  router.get(OLC_PUBLIC_ROUTES.models, async (_request, response) => {
     try {
       const models = await backend.listModels()
       log("GET /v1/models ok", { count: models.length })
@@ -31,7 +32,7 @@ export const registerModelRoutes = (
     }
   })
 
-  router.get("/v1/models/:modelId", async (request, response) => {
+  router.get(OLC_PUBLIC_ROUTES.model, async (request, response) => {
     try {
       const models: CatalogModel[] = await backend.listModels()
       const requested = request.params.modelId ?? ""

--- a/packages/olc/src/core/public-api-contract.ts
+++ b/packages/olc/src/core/public-api-contract.ts
@@ -1,0 +1,13 @@
+/**
+ * Public olc HTTP routes shared by the server and generated OpenAPI document.
+ *
+ * Backend-only callbacks such as the OpenCode bridge are deliberately absent:
+ * they use per-run credentials and are not a client integration surface.
+ */
+export const OLC_PUBLIC_ROUTES = {
+  serviceInfo: "/",
+  health: "/health",
+  models: "/v1/models",
+  model: "/v1/models/:modelId",
+  chatCompletions: "/v1/chat/completions"
+} as const

--- a/packages/olc/src/proxy.ts
+++ b/packages/olc/src/proxy.ts
@@ -14,6 +14,7 @@ import { createClientToolInvoker } from "./core/client-tools.js"
 import { createRouter, sendJson } from "./core/http.js"
 import { registerModelRoutes } from "./core/models-route.js"
 import { PendingToolCalls } from "./core/pending-tool-calls.js"
+import { OLC_PUBLIC_ROUTES } from "./core/public-api-contract.js"
 import { createRequestQueue } from "./core/queue.js"
 import type { ProxyConfig, ProxyLogger } from "./types.js"
 import { createRetryAsync } from "./util.js"
@@ -81,14 +82,14 @@ export const createProxy = ({
     }
   })
 
-  router.get("/", (_request, response) =>
+  router.get(OLC_PUBLIC_ROUTES.serviceInfo, (_request, response) =>
     sendJson(response, 200, {
       service: "olc",
       backend: backend.id,
       toolBridge: config.BRIDGE_ENABLED ? "enabled" : "disabled"
     })
   )
-  router.get("/health", (_request, response) =>
+  router.get(OLC_PUBLIC_ROUTES.health, (_request, response) =>
     sendJson(response, 200, { status: "ok", backend: backend.id })
   )
 

--- a/src/lib/__tests__/agent-docs.test.ts
+++ b/src/lib/__tests__/agent-docs.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { OLC_PUBLIC_ROUTES } from "../../../packages/olc/src/core/public-api-contract"
+import { buildOlcOpenApi } from "../../../tools/generate-openapi"
+
+const REPO_ROOT = join(__dirname, "../../..")
+const readRepoFile = (path: string) =>
+  readFileSync(join(REPO_ROOT, path), "utf-8")
+
+const openApi = buildOlcOpenApi() as {
+  openapi: string
+  info: { title: string; version: string; description: string }
+  servers: Array<{ url: string }>
+  paths: Record<
+    string,
+    Record<
+      string,
+      {
+        operationId?: string
+        description?: string
+        parameters?: Array<{ schema?: unknown }>
+        responses?: Record<string, unknown>
+      }
+    >
+  >
+}
+
+describe("agent-facing documentation", () => {
+  it("publishes a function-calling-compatible local OpenAPI surface", () => {
+    const packageVersion = JSON.parse(
+      readRepoFile("packages/olc/package.json")
+    ).version
+    const operations = Object.values(openApi.paths).flatMap((path) =>
+      Object.values(path)
+    )
+    const operationIds = operations.map((operation) => operation.operationId)
+
+    expect(openApi.openapi).toBe("3.1.0")
+    expect(openApi.info.title).toContain("Ollama Client")
+    expect(openApi.info.version).toBe(packageVersion)
+    expect(openApi.info.description).toContain("does not host")
+    expect(Object.keys(openApi.paths)).toEqual([
+      OLC_PUBLIC_ROUTES.serviceInfo,
+      OLC_PUBLIC_ROUTES.health,
+      OLC_PUBLIC_ROUTES.models,
+      OLC_PUBLIC_ROUTES.model.replace(":modelId", "{modelId}"),
+      OLC_PUBLIC_ROUTES.chatCompletions
+    ])
+    expect(openApi.servers).not.toHaveLength(0)
+    expect(
+      openApi.servers.every(({ url }) =>
+        /^http:\/\/(127\.0\.0\.1|localhost)/.test(url)
+      )
+    ).toBe(true)
+    expect(operationIds.every(Boolean)).toBe(true)
+    expect(new Set(operationIds).size).toBe(operationIds.length)
+    expect(
+      operations.every((operation) => Boolean(operation.description))
+    ).toBe(true)
+    expect(operations.every((operation) => Boolean(operation.responses))).toBe(
+      true
+    )
+    expect(
+      operations
+        .flatMap((operation) => operation.parameters ?? [])
+        .every((parameter) => Boolean(parameter.schema))
+    ).toBe(true)
+  })
+
+  it("keeps trust pages substantive and product-specific", () => {
+    for (const path of [
+      "docs/src/content/docs/about.md",
+      "docs/src/content/docs/contact.md",
+      "docs/src/content/docs/legal/privacy-policy.md"
+    ]) {
+      const content = readRepoFile(path)
+      const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim()
+
+      expect(body.length, path).toBeGreaterThanOrEqual(500)
+      expect(content, path).toContain("Ollama Client")
+    }
+  })
+
+  it("configures Markdown negotiation without hiding response variants", () => {
+    const config = JSON.parse(readRepoFile("vercel.json")) as {
+      rewrites: Array<{
+        source: string
+        destination: string
+        has?: Array<{ type: string; key: string; value?: string }>
+      }>
+      headers: Array<{
+        source: string
+        headers: Array<{ key: string; value: string }>
+      }>
+    }
+    const markdownRewrite = config.rewrites.find(
+      ({ source, destination }) =>
+        source === "/:path((?!.*\\.).*)" && destination === "/:path*.md"
+    )
+    const vary = config.headers
+      .flatMap(({ headers }) => headers)
+      .find(({ key }) => key.toLowerCase() === "vary")
+
+    expect(markdownRewrite?.has).toContainEqual({
+      type: "header",
+      key: "Accept",
+      value: ".*text/markdown.*"
+    })
+    expect(vary?.value).toContain("Accept")
+    expect(vary?.value).toContain("Accept-Encoding")
+  })
+
+  it("provides a custom 404 with stable recovery links", () => {
+    const page = readRepoFile("docs/src/pages/404.astro")
+
+    expect(page).toContain("HTTP 404")
+    expect(page).toContain("/llms.txt")
+    expect(page).toContain("/sitemap-index.xml")
+    expect(page).toContain("/developers/")
+  })
+})

--- a/src/lib/__tests__/agent-docs.test.ts
+++ b/src/lib/__tests__/agent-docs.test.ts
@@ -98,7 +98,8 @@ describe("agent-facing documentation", () => {
     }
     const markdownRewrite = config.rewrites.find(
       ({ source, destination }) =>
-        source === "/:path((?!.*\\.).*)" && destination === "/:path*.md"
+        source === "/:path((?!reference(?:/|$))(?!.*\\.).*)" &&
+        destination === "/:path*.md"
     )
     const vary = config.headers
       .flatMap(({ headers }) => headers)
@@ -109,6 +110,14 @@ describe("agent-facing documentation", () => {
       key: "Accept",
       value: ".*text/markdown.*"
     })
+    const routePattern = markdownRewrite?.source.match(/^\/:path\((.*)\)$/)?.[1]
+    expect(routePattern).toBeDefined()
+    const negotiatedPath = new RegExp(`^${routePattern}$`)
+    expect(negotiatedPath.test("developers")).toBe(true)
+    expect(negotiatedPath.test("guides/provider-setup")).toBe(true)
+    expect(negotiatedPath.test("reference")).toBe(false)
+    expect(negotiatedPath.test("reference/lib/providers")).toBe(false)
+    expect(negotiatedPath.test("openapi.json")).toBe(false)
     expect(vary?.value).toContain("Accept")
     expect(vary?.value).toContain("Accept-Encoding")
   })

--- a/tools/generate-llms-docs.ts
+++ b/tools/generate-llms-docs.ts
@@ -284,12 +284,26 @@ function writeLlmsTxt(pages: DocPage[]) {
 
 Ollama Client is a local-first browser extension for private LLM chat, provider management, and local RAG workflows.
 
+## When to use Ollama Client
+
+- Use it when a person wants to chat with Ollama, LM Studio, llama.cpp, Anthropic, or an OpenAI-compatible server from a Chrome or Firefox side panel.
+- Use it for local-first conversations, file and knowledge-base retrieval, current-page context, optional web search, and browser tools whose permissions remain visible to the user.
+- Use the local **olc** proxy when an OpenAI-compatible client needs to call an OpenCode-backed agent runtime, including client-owned function tools.
+
+## When not to use Ollama Client
+
+- Do not treat ollamaclient.in as a hosted inference API. The website publishes documentation; model requests go to endpoints configured by the user.
+- Do not assume a model, provider, web-search backend, or browser permission is available. Ask the user or inspect their configuration first.
+- Do not send sensitive data to a remote provider without the user's informed approval.
+
 ## Docs
 
 ${lines.join("\n")}
 
 ## Reference
 
+- [Developer Portal](${SITE_URL}/developers/): Local proxy quickstart, authentication, endpoints, errors, and integration guidance.
+- [OpenAPI 3.1 Specification](${SITE_URL}/openapi.json): Machine-readable schema for the local olc proxy; its servers are loopback addresses, not this website.
 - [API Reference](${SITE_URL}/reference/): Generated TypeScript API reference.
 - [Full Markdown Docs](${SITE_URL}/llms-full.txt): All public docs in one Markdown file.
 - [GitHub Repository](https://github.com/Shishir435/ollama-client): Source code and issue tracker.
@@ -326,6 +340,15 @@ Primary AI docs index: ${SITE_URL}/llms.txt
 Full Markdown docs: ${SITE_URL}/llms-full.txt
 Sitemap: ${SITE_URL}/sitemap-index.xml
 Repository: https://github.com/Shishir435/ollama-client
+Developer portal: ${SITE_URL}/developers/
+OpenAPI specification: ${SITE_URL}/openapi.json
+
+When to use Ollama Client:
+- A user wants a local-first Chrome or Firefox interface for their configured LLM provider.
+- An OpenAI-compatible client needs the local olc proxy to reach an OpenCode-backed agent runtime.
+- The task benefits from user-controlled page context, local files, retrieval, web search, or permission-gated browser tools.
+
+Do not treat this documentation host as a model API. The olc OpenAPI servers are loopback URLs, and the extension sends requests only to provider endpoints the user configures.
 
 Preferred fetch order:
 1. Fetch /llms.txt for the docs map.

--- a/tools/generate-openapi.ts
+++ b/tools/generate-openapi.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env tsx
+/** Generate the public OpenAPI artifact from the olc runtime contract. */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { OLC_PUBLIC_ROUTES } from "../packages/olc/src/core/public-api-contract.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, "..")
+const TEMPLATE_PATH = join(
+  REPO_ROOT,
+  "tools/openapi/olc-openapi.template.json"
+)
+const OUTPUT_PATH = join(REPO_ROOT, "docs/public/openapi.json")
+
+type HttpMethod = "get" | "post"
+type OpenApiOperation = {
+  operationId?: string
+  [key: string]: unknown
+}
+type OpenApiDocument = {
+  info: { version: string; [key: string]: unknown }
+  paths: Record<string, Partial<Record<HttpMethod, OpenApiOperation>>>
+  [key: string]: unknown
+}
+
+const ROUTE_OPERATIONS = {
+  serviceInfo: { method: "get", operationId: "getServiceInfo" },
+  health: { method: "get", operationId: "getHealth" },
+  models: { method: "get", operationId: "listModels" },
+  model: { method: "get", operationId: "getModel" },
+  chatCompletions: {
+    method: "post",
+    operationId: "createChatCompletion"
+  }
+} as const satisfies Record<
+  keyof typeof OLC_PUBLIC_ROUTES,
+  { method: HttpMethod; operationId: string }
+>
+
+const toOpenApiPath = (route: string) =>
+  route.replace(/:([A-Za-z0-9_]+)/g, "{$1}")
+
+const readJson = <T>(path: string): T =>
+  JSON.parse(readFileSync(path, "utf-8")) as T
+
+const operationsById = (template: OpenApiDocument) => {
+  const operations = new Map<string, OpenApiOperation>()
+
+  for (const pathItem of Object.values(template.paths)) {
+    for (const operation of Object.values(pathItem)) {
+      if (!operation?.operationId) continue
+      if (operations.has(operation.operationId)) {
+        throw new Error(
+          `Duplicate OpenAPI operationId: ${operation.operationId}`
+        )
+      }
+      operations.set(operation.operationId, operation)
+    }
+  }
+
+  return operations
+}
+
+export function buildOlcOpenApi(): OpenApiDocument {
+  const template = readJson<OpenApiDocument>(TEMPLATE_PATH)
+  const packageJson = readJson<{ version: string }>(
+    join(REPO_ROOT, "packages/olc/package.json")
+  )
+  const operations = operationsById(template)
+  const paths: OpenApiDocument["paths"] = {}
+
+  for (const routeName of Object.keys(
+    ROUTE_OPERATIONS
+  ) as (keyof typeof ROUTE_OPERATIONS)[]) {
+    const runtimeRoute = OLC_PUBLIC_ROUTES[routeName]
+    const { method, operationId } = ROUTE_OPERATIONS[routeName]
+    const operation = operations.get(operationId)
+    if (!operation) {
+      throw new Error(
+        `OpenAPI template is missing operationId: ${operationId}`
+      )
+    }
+    const path = toOpenApiPath(runtimeRoute)
+    paths[path] = { ...paths[path], [method]: operation }
+    operations.delete(operationId)
+  }
+
+  if (operations.size > 0) {
+    throw new Error(
+      `OpenAPI template has operations with no public runtime route: ${[
+        ...operations.keys()
+      ].join(", ")}`
+    )
+  }
+
+  return {
+    ...template,
+    info: { ...template.info, version: packageJson.version },
+    paths
+  }
+}
+
+export function writeOlcOpenApi() {
+  const document = buildOlcOpenApi()
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(document, null, 2)}\n`, "utf-8")
+  return OUTPUT_PATH
+}
+
+function main() {
+  console.log("Generating olc OpenAPI specification...")
+  writeOlcOpenApi()
+  console.log("Generated docs/public/openapi.json")
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main()
+}

--- a/tools/openapi/olc-openapi.template.json
+++ b/tools/openapi/olc-openapi.template.json
@@ -1,0 +1,630 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Ollama Client olc Local Proxy API",
+    "version": "generated-from-packages/olc/package.json",
+    "description": "OpenAI-compatible HTTP API exposed by the local olc CLI. This API runs on the user's machine; ollamaclient.in is documentation and does not host these endpoints.",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "externalDocs": {
+    "description": "Ollama Client developer portal",
+    "url": "https://www.ollamaclient.in/developers/"
+  },
+  "servers": [
+    {
+      "url": "http://127.0.0.1:8083",
+      "description": "Default loopback address"
+    },
+    {
+      "url": "http://localhost:{port}",
+      "description": "Locally configured olc instance",
+      "variables": {
+        "port": {
+          "default": "8083",
+          "description": "Port selected with --port or OLC_PORT"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Service",
+      "description": "Local proxy identity and liveness"
+    },
+    {
+      "name": "Models",
+      "description": "Backend model discovery and capability metadata"
+    },
+    {
+      "name": "Chat",
+      "description": "OpenAI-compatible chat completions and client-owned function calls"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getServiceInfo",
+        "summary": "Identify the local proxy",
+        "description": "Returns the olc service name, active backend id, and whether the client tool bridge is enabled. This liveness route does not require the optional bearer token.",
+        "tags": ["Service"],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The local proxy is running.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceInfo"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenOrigin"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "getHealth",
+        "summary": "Check local proxy liveness",
+        "description": "Returns a small JSON response when the olc process and selected backend adapter are reachable. It does not prove that a model can complete a request.",
+        "tags": ["Service"],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The local proxy process is healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Health"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenOrigin"
+          }
+        }
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "operationId": "listModels",
+        "summary": "List backend models",
+        "description": "Returns models from the selected local runtime with modalities, supported parameters, and empirical capability flags. Call this before selecting a model or enabling tools or images.",
+        "tags": ["Models"],
+        "security": [{"bearerAuth": []}, {}],
+        "responses": {
+          "200": {
+            "description": "A model catalog, which may be empty.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelList"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "502": {
+            "$ref": "#/components/responses/BackendFailure"
+          }
+        }
+      }
+    },
+    "/v1/models/{modelId}": {
+      "get": {
+        "operationId": "getModel",
+        "summary": "Get one backend model",
+        "description": "Returns one model by full id or an unambiguous suffix id. Use the exact id returned by listModels when possible.",
+        "tags": ["Models"],
+        "security": [{"bearerAuth": []}, {}],
+        "parameters": [
+          {
+            "name": "modelId",
+            "in": "path",
+            "required": true,
+            "description": "URL-encoded full model id or unambiguous suffix from the catalog.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "example": "openai/gpt-5"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The matching model and its capability metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Model"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "404": {
+            "description": "No model matched. Refresh the catalog and retry with an exact id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                },
+                "example": {
+                  "error": {
+                    "message": "Model not found"
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "$ref": "#/components/responses/BackendFailure"
+          }
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "operationId": "createChatCompletion",
+        "summary": "Create or resume a chat completion",
+        "description": "Starts an agent-runtime turn, or resumes its parked client-tool call when trailing tool messages carry live tool_call_id values. With stream=true the success response is server-sent events ending in [DONE]; otherwise it is one JSON completion.",
+        "tags": ["Chat"],
+        "security": [{"bearerAuth": []}, {}],
+        "requestBody": {
+          "required": true,
+          "description": "OpenAI-compatible chat input. Discover the model id and capabilities through /v1/models first.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequest"
+              },
+              "examples": {
+                "buffered": {
+                  "summary": "Non-streaming text completion",
+                  "value": {
+                    "model": "provider/model",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Summarize this project."
+                      }
+                    ],
+                    "stream": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A JSON completion when stream is false, or an SSE stream when stream is true. A tool call uses finish_reason=tool_calls and must be continued with matching tool messages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatCompletion"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "OpenAI-compatible data events followed by data: [DONE]."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The JSON shape, messages, model, or tool-result correlation is invalid. The error message includes a recovery direction; stale tool results also include code stale_tool_results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProxyFailure"
+          },
+          "502": {
+            "$ref": "#/components/responses/BackendFailure"
+          },
+          "503": {
+            "description": "The serialized request queue is stalled. Back off until the named active turn stops.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The turn exceeded the configured request deadline. Retry only after considering whether the operation is safe to repeat.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Optional token configured with --api-key or OLC_API_KEY. When no token is configured, API routes permit unauthenticated non-browser clients."
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "The configured bearer token is missing or invalid. Supply Authorization: Bearer <token>.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "error": {
+                "message": "Unauthorized"
+              }
+            }
+          }
+        }
+      },
+      "ForbiddenOrigin": {
+        "description": "The request carries a browser Origin that is not in OLC_ALLOWED_ORIGINS. Add the exact trusted origin or call from a non-browser client.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "BackendFailure": {
+        "description": "The selected local runtime failed. Check its process, model catalog, and olc logs before retrying.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "ProxyFailure": {
+        "description": "olc could not complete the request. Read error.type and message, then inspect local logs without exposing secrets.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "ServiceInfo": {
+        "type": "object",
+        "required": ["service", "backend", "toolBridge"],
+        "properties": {
+          "service": {
+            "const": "olc"
+          },
+          "backend": {
+            "type": "string"
+          },
+          "toolBridge": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Health": {
+        "type": "object",
+        "required": ["status", "backend"],
+        "properties": {
+          "status": {
+            "const": "ok"
+          },
+          "backend": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ModelList": {
+        "type": "object",
+        "required": ["object", "data"],
+        "properties": {
+          "object": {
+            "const": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Model"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Model": {
+        "type": "object",
+        "required": ["id", "object", "created", "owned_by", "name", "input_modalities", "supported_parameters", "capabilities"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "object": {
+            "const": "model"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "owned_by": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "context_length": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "input_modalities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "supported_parameters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "required": ["function_calling", "vision", "reasoning"],
+            "properties": {
+              "function_calling": {
+                "type": "boolean"
+              },
+              "vision": {
+                "type": "boolean"
+              },
+              "reasoning": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "ChatCompletionRequest": {
+        "type": "object",
+        "required": ["model", "messages"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact id from GET /v1/models."
+          },
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            }
+          },
+          "stream": {
+            "type": "boolean",
+            "default": false
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolDefinition"
+            }
+          },
+          "tool_choice": {
+            "description": "OpenAI-compatible tool choice value. Backend support may vary.",
+            "oneOf": [
+              {"type": "string"},
+              {"type": "object", "additionalProperties": true}
+            ]
+          }
+        },
+        "additionalProperties": true
+      },
+      "ChatMessage": {
+        "type": "object",
+        "required": ["role"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["system", "developer", "user", "assistant", "tool"]
+          },
+          "content": {
+            "description": "Text, null, or OpenAI-compatible content parts including text and image_url.",
+            "oneOf": [
+              {"type": "string"},
+              {"type": "array", "items": {"type": "object", "additionalProperties": true}},
+              {"type": "null"}
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "tool_call_id": {
+            "type": "string"
+          },
+          "tool_calls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "ToolDefinition": {
+        "type": "object",
+        "required": ["type", "function"],
+        "properties": {
+          "type": {
+            "const": "function"
+          },
+          "function": {
+            "type": "object",
+            "required": ["name", "parameters"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "object",
+                "description": "JSON Schema for function arguments.",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "ToolCall": {
+        "type": "object",
+        "required": ["id", "type", "function"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "function"
+          },
+          "function": {
+            "type": "object",
+            "required": ["name", "arguments"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "string",
+                "description": "JSON-encoded function arguments."
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      },
+      "ChatCompletion": {
+        "type": "object",
+        "required": ["id", "object", "created", "model", "choices"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "const": "chat.completion"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["index", "message", "finish_reason"],
+              "properties": {
+                "index": {
+                  "type": "integer"
+                },
+                "message": {
+                  "$ref": "#/components/schemas/ChatMessage"
+                },
+                "finish_reason": {
+                  "type": ["string", "null"]
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["message"],
+            "properties": {
+              "message": {
+                "type": "string",
+                "minLength": 1
+              },
+              "type": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
       "destination": "/llms.txt"
     },
     {
-      "source": "/:path((?!.*\\.).*)",
+      "source": "/:path((?!reference(?:/|$))(?!.*\\.).*)",
       "has": [
         {
           "type": "header",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,66 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm docs:build",
   "outputDirectory": "docs/dist",
-  "installCommand": "pnpm install --frozen-lockfile"
+  "installCommand": "pnpm install --frozen-lockfile",
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "Accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/llms.txt"
+    },
+    {
+      "source": "/:path((?!.*\\.).*)",
+      "has": [
+        {
+          "type": "header",
+          "key": "Accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/:path*.md"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "Accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/:path*",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.md",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- publish a developer portal, substantive trust pages, and a recovery-focused 404
- generate the OpenAPI 3.1 artifact from shared olc route constants and the package version
- add Markdown content negotiation plus explicit agent use and safety guidance

## Verification

- pnpm typecheck
- pnpm lint:check
- pnpm test:run (3209 tests)
- pnpm docs:build
- pre-push release hooks, extension package, and bundle budgets



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves agent and developer discoverability across the documentation site.
- Adds substantive developer, project identity, contact, and recovery pages.
- Publishes generated OpenAPI and Markdown documentation artifacts.
- Centralizes olc public routes and configures Markdown content negotiation.
- Adds navigation, tests, and agent-specific usage and safety guidance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| vercel.json | Adds Markdown content negotiation while correctly excluding generated reference routes and dot-bearing assets. |
| docs/src/pages/404.astro | Adds a recovery-focused 404 page and resolves the previously flagged design-token usage. |
| docs/src/pages/index.astro | Adds a developer portal entry point using the repository’s permitted radius token. |
| tools/generate-llms-docs.ts | Expands generated agent documentation with usage boundaries, safety guidance, and developer resources. |
| tools/generate-openapi.ts | Generates the public OpenAPI artifact from shared route constants and package metadata. |
| packages/olc/src/core/public-api-contract.ts | Centralizes olc public route literals for runtime and documentation generation. |
| src/lib/__tests__/agent-docs.test.ts | Covers the OpenAPI surface, trust-page content, Markdown negotiation exclusions, and 404 recovery links. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): scope Markdown negotiation"](https://github.com/shishir435/ollama-client/commit/d76312e1046ff4d08e5209263a4efd76541306e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55707874)</sub>

<!-- /greptile_comment -->