### PR TITLE
feat(olc): add Codex backend and installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,64 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  olc-package:
+    name: olc distribution (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build registry-free bundle
+        run: pnpm proxy:bundle
+
+      - name: Package portable archives
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p release/olc/bin release/olc/dist
+          cp packages/olc/bin/olc packages/olc/bin/olc.cmd release/olc/bin/
+          cp packages/olc/dist/olc.mjs release/olc/dist/
+          cp -R packages/olc/dist/backends release/olc/dist/
+          cp packages/olc/README.md release/olc/
+          chmod +x release/olc/bin/olc release/olc/dist/olc.mjs
+          tar -C release -czf olc.tar.gz olc
+          (cd release && zip -qr ../olc.zip olc)
+          sha256sum olc.tar.gz > olc.tar.gz.sha256
+          sha256sum olc.zip > olc.zip.sha256
+          node packages/olc/dist/olc.mjs --help
+
+      - name: Verify Windows launcher and installer syntax
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & .\packages\olc\bin\olc.cmd --help
+          [scriptblock]::Create((Get-Content -Raw docs\public\olc.ps1)) | Out-Null
+
+      - name: Upload olc release package
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-package-olc
+          path: |
+            olc.tar.gz
+            olc.tar.gz.sha256
+            olc.zip
+            olc.zip.sha256
+          retention-days: 14
+          if-no-files-found: error
+
   persistence-migration:
     name: Persistence migration gates (chrome)
     # The evidence gate for retiring the legacy sql.js backend: a packaged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,16 @@ jobs:
             verified-release-artifacts/*-chrome.zip
             verified-release-artifacts/*-firefox.zip
             verified-release-artifacts/*-sources.zip
+            verified-release-artifacts/olc.tar.gz
+            verified-release-artifacts/olc.tar.gz.sha256
+            verified-release-artifacts/olc.zip
+            verified-release-artifacts/olc.zip.sha256
           )
 
-          # CI publishes one Chrome ZIP, one Firefox ZIP, and Firefox's required
-          # source ZIP. Refuse an incomplete or ambiguous set before touching a
-          # release.
-          if [ ${#ASSETS[@]} -ne 3 ]; then
-            echo "Expected exactly three verified release assets; found ${#ASSETS[@]}."
+          # CI publishes three extension packages plus two olc archives and their
+          # checksums. Refuse an incomplete or ambiguous set before touching a release.
+          if [ ${#ASSETS[@]} -ne 7 ]; then
+            echo "Expected exactly seven verified release assets; found ${#ASSETS[@]}."
             exit 1
           fi
           for asset in "${ASSETS[@]}"; do

--- a/docs/public/olc.ps1
+++ b/docs/public/olc.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repo = "Shishir435/ollama-client"
+$version = if ($env:OLC_VERSION) { $env:OLC_VERSION } else { "latest" }
+$installDir = if ($env:OLC_INSTALL_DIR) {
+  $env:OLC_INSTALL_DIR
+} else {
+  Join-Path $env:LOCALAPPDATA "Programs\olc"
+}
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  throw "Node.js 22.12 or newer is required: https://nodejs.org/"
+}
+$nodeVersion = [version](& node -p "process.versions.node")
+if ($nodeVersion -lt [version]"22.12.0") {
+  throw "Node.js 22.12 or newer is required; found $nodeVersion"
+}
+
+$baseUrl = if ($env:OLC_DOWNLOAD_BASE_URL) {
+  $env:OLC_DOWNLOAD_BASE_URL.TrimEnd("/")
+} elseif ($version -eq "latest") {
+  "https://github.com/$repo/releases/latest/download"
+} else {
+  "https://github.com/$repo/releases/download/$version"
+}
+$tempDir = Join-Path ([IO.Path]::GetTempPath()) ("olc-install-" + [guid]::NewGuid())
+$archive = Join-Path $tempDir "olc.zip"
+$checksum = Join-Path $tempDir "olc.zip.sha256"
+$parentDir = Split-Path -Parent $installDir
+$stageDir = Join-Path $parentDir (".olc-install-" + [guid]::NewGuid())
+$backupDir = Join-Path $parentDir (".olc-backup-" + [guid]::NewGuid())
+
+try {
+  New-Item -ItemType Directory -Force -Path $tempDir, $parentDir | Out-Null
+  Write-Host "Downloading olc ($version)..."
+  Invoke-WebRequest -UseBasicParsing "$baseUrl/olc.zip" -OutFile $archive
+  Invoke-WebRequest -UseBasicParsing "$baseUrl/olc.zip.sha256" -OutFile $checksum
+
+  $expected = ((Get-Content -Raw $checksum).Trim() -split "\s+")[0]
+  $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+  if ($actual -ne $expected.ToLowerInvariant()) {
+    throw "Checksum verification failed"
+  }
+
+  Expand-Archive -Path $archive -DestinationPath $tempDir -Force
+  $payload = Join-Path $tempDir "olc"
+  if (-not (Test-Path (Join-Path $payload "dist\olc.mjs"))) {
+    throw "Release archive is missing olc.mjs"
+  }
+  Move-Item $payload $stageDir
+  if (Test-Path $installDir) {
+    Move-Item $installDir $backupDir
+  }
+  try {
+    Move-Item $stageDir $installDir
+  } catch {
+    if (Test-Path $backupDir) { Move-Item $backupDir $installDir }
+    throw
+  }
+  if (Test-Path $backupDir) { Remove-Item -Recurse -Force $backupDir }
+
+  $binDir = Join-Path $installDir "bin"
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $pathParts = @($userPath -split ";" | Where-Object { $_ })
+  if ($pathParts -notcontains $binDir) {
+    [Environment]::SetEnvironmentVariable("Path", (($pathParts + $binDir) -join ";"), "User")
+  }
+  if (($env:Path -split ";") -notcontains $binDir) {
+    $env:Path = "$env:Path;$binDir"
+  }
+  Write-Host "Installed olc in $installDir"
+  Write-Host "Open a new terminal, then run: olc --help"
+} finally {
+  if (Test-Path $tempDir) { Remove-Item -Recurse -Force $tempDir }
+  if (Test-Path $stageDir) { Remove-Item -Recurse -Force $stageDir }
+}

--- a/docs/public/olc.sh
+++ b/docs/public/olc.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="Shishir435/ollama-client"
+install_dir="${OLC_INSTALL_DIR:-$HOME/.local/share/olc}"
+bin_dir="${OLC_BIN_DIR:-$HOME/.local/bin}"
+version="${OLC_VERSION:-latest}"
+
+fail() {
+  printf 'olc installer: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v node >/dev/null 2>&1 || fail "Node.js 22.12 or newer is required: https://nodejs.org/"
+node -e 'const [major, minor] = process.versions.node.split(".").map(Number); process.exit(major > 22 || (major === 22 && minor >= 12) ? 0 : 1)' || fail "Node.js 22.12 or newer is required"
+
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl --fail --silent --show-error --location "$1" --output "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget --quiet "$1" --output-document "$2"; }
+else
+  fail "curl or wget is required"
+fi
+
+if [ -n "${OLC_DOWNLOAD_BASE_URL:-}" ]; then
+  base_url=${OLC_DOWNLOAD_BASE_URL%/}
+else
+  case "$version" in
+    latest) base_url="https://github.com/$repo/releases/latest/download" ;;
+    *) base_url="https://github.com/$repo/releases/download/$version" ;;
+  esac
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/olc-install.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+archive="$temp_dir/olc.tar.gz"
+checksum="$temp_dir/olc.tar.gz.sha256"
+
+printf 'Downloading olc (%s)...\n' "$version"
+fetch "$base_url/olc.tar.gz" "$archive"
+fetch "$base_url/olc.tar.gz.sha256" "$checksum"
+
+expected=$(awk '{print $1; exit}' "$checksum")
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$archive" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+else
+  fail "sha256sum or shasum is required to verify the download"
+fi
+[ "$actual" = "$expected" ] || fail "checksum verification failed"
+
+tar -xzf "$archive" -C "$temp_dir"
+[ -f "$temp_dir/olc/dist/olc.mjs" ] || fail "release archive is missing olc.mjs"
+
+parent_dir=$(dirname "$install_dir")
+stage_dir="$parent_dir/.olc-install-$$"
+backup_dir="$parent_dir/.olc-backup-$$"
+mkdir -p "$parent_dir" "$bin_dir"
+mv "$temp_dir/olc" "$stage_dir"
+if [ -e "$install_dir" ]; then
+  mv "$install_dir" "$backup_dir"
+fi
+if ! mv "$stage_dir" "$install_dir"; then
+  [ ! -e "$backup_dir" ] || mv "$backup_dir" "$install_dir"
+  fail "could not install into $install_dir"
+fi
+rm -rf "$backup_dir"
+ln -sfn "$install_dir/bin/olc" "$bin_dir/olc"
+
+printf 'Installed olc in %s\n' "$install_dir"
+case ":$PATH:" in
+  *":$bin_dir:"*) printf 'Run: olc --help\n' ;;
+  *) printf 'Add %s to PATH, then run: olc --help\n' "$bin_dir" ;;
+esac

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -2,7 +2,8 @@
 
 An OpenAI-compatible HTTP front end for a local agent runtime, with a **tool
 bridge** so an OpenAI-compatible client can run its own tools inside the
-runtime's turn. The bundled backend serves [OpenCode](https://opencode.ai).
+runtime's turn. Bundled backends serve [OpenCode](https://opencode.ai) and the
+official [Codex CLI](https://developers.openai.com/codex/cli).
 
 Any client that already speaks `/v1/chat/completions` — Ollama Client's
 OpenAI-compatible provider, an SDK, `curl` — can use those models, tool calling
@@ -38,9 +39,28 @@ side channel, no client-side special cases.
 ## Install and run
 
 Requires Node ≥ 22.12. The OpenCode backend also needs the `opencode` binary on
-`PATH` (or `--opencode`).
+`PATH` (or `--opencode`). The Codex backend needs the `codex` binary on `PATH`
+(or `--codex`) and an existing `codex login`; olc never reads, stores, or proxies
+the user's OpenAI credentials.
 
-Nothing is published to a registry: clone the repository and run it.
+Nothing is published to a registry. Release bundles can be installed directly:
+
+```powershell
+# Windows PowerShell
+irm https://ollamaclient.in/olc.ps1 | iex
+```
+
+```bash
+# macOS / Linux
+curl -fsSL https://ollamaclient.in/olc.sh | sh
+```
+
+Both installers download a checksum-verified archive from the project's GitHub
+release. Set `OLC_VERSION` to install a specific tag, or `OLC_INSTALL_DIR` to
+change the destination. Node remains an explicit prerequisite; olc itself and
+its runtime dependency are bundled, so npm is not involved.
+
+To run from a clone instead:
 
 ```bash
 pnpm install
@@ -69,6 +89,18 @@ time. Publishing to npm later needs no changes: `package.json` already points
 
 If nothing is listening on the configured OpenCode URL, olc starts one itself in
 a temporary workspace and stops it on exit.
+
+To serve Codex instead:
+
+```bash
+codex login
+olc --backend codex
+```
+
+The adapter starts `codex app-server` over stdio, creates ephemeral read-only
+threads, and maps its streamed messages, reasoning, model catalog, and dynamic
+tool calls onto the same OpenAI-compatible API. Codex account entitlements and
+usage limits still apply.
 
 ### Versioning
 
@@ -154,6 +186,19 @@ inventory and its own approval flow; an agent quietly reaching for `bash` or
 `write` instead is neither visible nor wanted there. Opt individual tools back in
 by id, for example `--allow-opencode-tools websearch,webfetch`.
 
+### Codex backend
+
+| Option | Flag | Environment | Default |
+| --- | --- | --- | --- |
+| `CODEX_PATH` | `--codex` | `OLC_CODEX_PATH` (or `CODEX_PATH`) | `codex` |
+| `CODEX_PROJECT_DIR` | `--codex-project-dir` | `OLC_CODEX_PROJECT_DIR` | isolated temporary workspace |
+
+Codex runs with `approvalPolicy: never`, a read-only sandbox, and an ephemeral
+thread rooted in the dedicated workspace. The client-provided tools are exposed
+through App Server dynamic tools; every tool result still returns through the
+existing OLC/OpenAI tool-call round trip, so Ollama Client remains the approval
+and execution boundary. `--no-bridge` disables those dynamic tools.
+
 ## Endpoints
 
 | Route | Purpose |
@@ -182,6 +227,7 @@ The core is runtime-agnostic; everything OpenCode-specific lives in its backend.
 | `src/backends/registry.ts` | name → backend factory |
 | `src/backends/opencode/` | the OpenCode adapter: server supervision, catalog, plugin manifest, turn reading |
 | `src/backends/opencode/plugin/` | the plugin OpenCode loads; TypeScript, copied at run time and executed by OpenCode's runtime |
+| `src/backends/codex/` | the Codex App Server process, JSONL protocol, model and dynamic-tool mappings |
 
 ## Adding a backend
 

--- a/packages/olc/bin/olc
+++ b/packages/olc/bin/olc
@@ -3,7 +3,16 @@
 # when no bundle has been built yet.
 set -eu
 
-here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+script=$0
+while [ -h "$script" ]; do
+  link_dir=$(CDPATH='' cd -- "$(dirname -- "$script")" && pwd)
+  link_target=$(readlink "$script")
+  case "$link_target" in
+    /*) script=$link_target ;;
+    *) script=$link_dir/$link_target ;;
+  esac
+done
+here=$(CDPATH='' cd -- "$(dirname -- "$script")" && pwd)
 root=$(dirname "$here")
 
 if [ -f "$root/dist/olc.mjs" ]; then

--- a/packages/olc/bin/olc.cmd
+++ b/packages/olc/bin/olc.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+where node >nul 2>nul
+if errorlevel 1 (
+  echo olc: Node.js 22.12 or newer is required. 1>&2
+  exit /b 1
+)
+node "%~dp0..\dist\olc.mjs" %*

--- a/packages/olc/src/__tests__/cli.test.ts
+++ b/packages/olc/src/__tests__/cli.test.ts
@@ -11,14 +11,20 @@ describe("parseArgs", () => {
       "--opencode-url",
       "http://127.0.0.1:4444",
       "--allow-opencode-tools",
-      "websearch"
+      "websearch",
+      "--codex",
+      "/opt/codex",
+      "--codex-project-dir",
+      "/tmp/codex-empty"
     ])
 
     expect(options).toEqual({
       PORT: "9001",
       BIND_HOST: "0.0.0.0",
       OPENCODE_SERVER_URL: "http://127.0.0.1:4444",
-      ALLOW_OPENCODE_TOOLS: "websearch"
+      ALLOW_OPENCODE_TOOLS: "websearch",
+      CODEX_PATH: "/opt/codex",
+      CODEX_PROJECT_DIR: "/tmp/codex-empty"
     })
   })
 

--- a/packages/olc/src/backends/codex/__tests__/backend.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/backend.test.ts
@@ -1,0 +1,125 @@
+import { chmodSync, copyFileSync, mkdtempSync, rmSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { resolveConfig } from "../../../config.js"
+import { createCodexBackend } from "../index.js"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe("Codex backend", () => {
+  it("streams a turn across an App Server dynamic-tool suspension", async () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "olc-codex-test-"))
+    temporaryDirectories.push(directory)
+    const executable = path.join(directory, "codex")
+    copyFileSync(
+      fileURLToPath(new URL("./fixtures/fake-codex.mjs", import.meta.url)),
+      executable
+    )
+    chmodSync(executable, 0o755)
+
+    let suspend = () => {}
+    let releaseToolResult: ((output: string) => void) | undefined
+    const callClientTool = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          releaseToolResult = resolve
+          suspend()
+        })
+    )
+    const backend = createCodexBackend({
+      config: resolveConfig({ REQUEST_TIMEOUT_MS: 5_000 }),
+      options: {
+        CODEX_PATH: executable,
+        CODEX_PROJECT_DIR: path.join(directory, "workspace")
+      },
+      fileOptions: {},
+      log: vi.fn(),
+      retryAsync: (operation) => operation(),
+      callClientTool
+    })
+
+    try {
+      expect(await backend.listModels()).toMatchObject([
+        {
+          id: "codex/fake-codex",
+          capabilities: {
+            function_calling: true,
+            vision: true,
+            reasoning: true
+          }
+        }
+      ])
+      expect(await backend.resolveModel(undefined)).toEqual({
+        providerId: "codex",
+        modelId: "fake-codex"
+      })
+
+      const turn = await backend.startTurn({
+        requestId: "request-1",
+        model: { providerId: "codex", modelId: "fake-codex" },
+        messages: [
+          { role: "system", content: "Stay concise" },
+          { role: "user", content: "Use lookup" }
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Look up an answer",
+              parameters: { type: "object" }
+            }
+          }
+        ]
+      })
+      const suspended = new Promise<void>((resolve) => {
+        suspend = resolve
+      })
+      const text: string[] = []
+      const reasoning: string[] = []
+      const handlers = {
+        onText: (delta: string) => text.push(delta),
+        onReasoning: (delta: string) => reasoning.push(delta)
+      }
+
+      expect(
+        await turn.run(handlers, {
+          suspended,
+          hasUnannouncedToolCalls: () => true
+        })
+      ).toEqual({ status: "suspended" })
+      expect(callClientTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          turnId: "thread-1",
+          tool: "lookup",
+          args: { query: "answer" }
+        })
+      )
+
+      const outcome = await turn.resume([], handlers, {
+        suspended: new Promise(() => {}),
+        hasUnannouncedToolCalls: () => false,
+        releaseToolResults: () => releaseToolResult?.("42")
+      })
+      expect(outcome).toEqual({
+        status: "completed",
+        content: "Result: 42",
+        reasoning: "Checked. ",
+        finish: "stop"
+      })
+      expect(text).toEqual(["Result: 42"])
+      expect(reasoning).toEqual(["Checked. "])
+      await turn.dispose()
+    } finally {
+      await backend.shutdown()
+    }
+  })
+})

--- a/packages/olc/src/backends/codex/__tests__/backend.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/backend.test.ts
@@ -1,9 +1,17 @@
-import { chmodSync, copyFileSync, mkdtempSync, rmSync } from "node:fs"
+import {
+  chmodSync,
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync
+} from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { resolveConfig } from "../../../config.js"
+import { BackendInputError } from "../../types.js"
+import { CodexAppServerClient } from "../app-server-client.js"
 import { createCodexBackend } from "../index.js"
 
 const temporaryDirectories: string[] = []
@@ -62,6 +70,18 @@ describe("Codex backend", () => {
         modelId: "fake-codex"
       })
 
+      const unsupportedTurn = backend.startTurn({
+        requestId: "request-invalid-effort",
+        model: { providerId: "codex", modelId: "fake-codex" },
+        messages: [{ role: "user", content: "Think hard" }],
+        tools: [],
+        reasoningEffort: "high"
+      })
+      await expect(unsupportedTurn).rejects.toBeInstanceOf(BackendInputError)
+      await expect(unsupportedTurn).rejects.toThrow(
+        "Model 'codex/fake-codex' does not support reasoning effort 'high'. Supported efforts: medium."
+      )
+
       const turn = await backend.startTurn({
         requestId: "request-1",
         model: { providerId: "codex", modelId: "fake-codex" },
@@ -78,7 +98,8 @@ describe("Codex backend", () => {
               parameters: { type: "object" }
             }
           }
-        ]
+        ],
+        reasoningEffort: "medium"
       })
       const suspended = new Promise<void>((resolve) => {
         suspend = resolve
@@ -120,6 +141,46 @@ describe("Codex backend", () => {
       await turn.dispose()
     } finally {
       await backend.shutdown()
+    }
+  })
+
+  it("terminates a child whose initialization fails before retrying", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "olc-codex-leak-test-")
+    )
+    temporaryDirectories.push(directory)
+    const executable = path.join(directory, "codex")
+    const pidFile = path.join(directory, "pids")
+    copyFileSync(
+      fileURLToPath(new URL("./fixtures/fake-codex-hang.mjs", import.meta.url)),
+      executable
+    )
+    chmodSync(executable, 0o755)
+
+    const client = new CodexAppServerClient({
+      executable,
+      cwd: directory,
+      log: vi.fn(),
+      requestTimeoutMs: 500
+    })
+
+    try {
+      await expect(client.start()).rejects.toThrow(
+        "Codex app-server request 'initialize' timed out"
+      )
+      await expect(client.start()).rejects.toThrow(
+        "Codex app-server request 'initialize' timed out"
+      )
+      const pids = readFileSync(pidFile, "utf8").trim().split("\n").map(Number)
+      expect(pids).toHaveLength(2)
+      expect(new Set(pids).size).toBe(2)
+      for (const pid of pids) {
+        expect(() => process.kill(pid, 0)).toThrow(
+          expect.objectContaining({ code: "ESRCH" })
+        )
+      }
+    } finally {
+      await client.shutdown()
     }
   })
 })

--- a/packages/olc/src/backends/codex/__tests__/config.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { resolveCodexConfig } from "../config.js"
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+describe("resolveCodexConfig", () => {
+  it("uses the Codex binary on PATH and an isolated temporary workspace", () => {
+    const config = resolveCodexConfig()
+    expect(config.CODEX_PATH).toBe("codex")
+    expect(config.PROJECT_DIR).toContain("olc-codex-workspace")
+  })
+
+  it("keeps option, environment, file, default precedence", () => {
+    process.env.OLC_CODEX_PATH = "/env/codex"
+    expect(
+      resolveCodexConfig({ fileOptions: { CODEX_PATH: "/file/codex" } })
+        .CODEX_PATH
+    ).toBe("/env/codex")
+    expect(
+      resolveCodexConfig({
+        options: { CODEX_PATH: "/flag/codex" },
+        fileOptions: { CODEX_PATH: "/file/codex" }
+      }).CODEX_PATH
+    ).toBe("/flag/codex")
+  })
+
+  it("accepts the backend-specific project directory", () => {
+    process.env.OLC_CODEX_PROJECT_DIR = "/env/workspace"
+    expect(resolveCodexConfig().PROJECT_DIR).toBe("/env/workspace")
+    expect(
+      resolveCodexConfig({
+        options: { CODEX_PROJECT_DIR: "/flag/workspace" }
+      }).PROJECT_DIR
+    ).toBe("/flag/workspace")
+  })
+})

--- a/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex-hang.mjs
+++ b/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex-hang.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+fs.appendFileSync(path.join(process.cwd(), "pids"), `${process.pid}\n`)
+process.stdin.resume()

--- a/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
+++ b/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import readline from "node:readline"
+
+const lines = readline.createInterface({ input: process.stdin })
+const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`)
+
+lines.on("line", (line) => {
+  const message = JSON.parse(line)
+  if (message.method === "initialize") {
+    send({ id: message.id, result: { userAgent: "fake-codex" } })
+    return
+  }
+  if (message.method === "model/list") {
+    send({
+      id: message.id,
+      result: {
+        data: [
+          {
+            id: "fake-codex",
+            displayName: "Fake Codex",
+            inputModalities: ["text", "image"],
+            supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+            defaultReasoningEffort: "medium",
+            isDefault: true
+          }
+        ],
+        nextCursor: null
+      }
+    })
+    return
+  }
+  if (message.method === "thread/start") {
+    const valid =
+      message.params?.approvalPolicy === "never" &&
+      message.params?.sandbox === "read-only" &&
+      message.params?.ephemeral === true &&
+      message.params?.developerInstructions === "Stay concise" &&
+      message.params?.dynamicTools?.[0]?.name === "lookup"
+    if (!valid) {
+      send({
+        id: message.id,
+        error: { code: -32602, message: "invalid thread policy" }
+      })
+      return
+    }
+    send({ id: message.id, result: { thread: { id: "thread-1" } } })
+    return
+  }
+  if (message.method === "turn/start") {
+    send({ id: message.id, result: { turn: { id: "turn-1" } } })
+    send({
+      id: "dynamic-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "lookup",
+        arguments: { query: "answer" }
+      }
+    })
+    return
+  }
+  if (message.id === "dynamic-tool-1" && message.result) {
+    send({
+      method: "item/reasoning/summaryTextDelta",
+      params: { threadId: "thread-1", turnId: "turn-1", delta: "Checked. " }
+    })
+    send({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", delta: "Result: 42" }
+    })
+    send({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: { id: "turn-1", status: "completed", error: null }
+      }
+    })
+    return
+  }
+  if (message.id !== undefined) send({ id: message.id, result: {} })
+})

--- a/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
+++ b/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
@@ -47,6 +47,13 @@ lines.on("line", (line) => {
     return
   }
   if (message.method === "turn/start") {
+    if (message.params?.effort !== "medium") {
+      send({
+        id: message.id,
+        error: { code: -32602, message: "invalid reasoning effort" }
+      })
+      return
+    }
     send({ id: message.id, result: { turn: { id: "turn-1" } } })
     send({
       id: "dynamic-tool-1",

--- a/packages/olc/src/backends/codex/__tests__/wire.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/wire.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { mapCodexModel, normalizeCodexTools, toDynamicTools } from "../wire.js"
+import {
+  mapCodexModel,
+  normalizeCodexTools,
+  resolveCodexReasoningEffort,
+  toDynamicTools
+} from "../wire.js"
 
 describe("Codex wire mappings", () => {
   it("publishes model modalities and canonical reasoning efforts", () => {
@@ -36,6 +41,25 @@ describe("Codex wire mappings", () => {
     const mapped = mapCodexModel({ id: "codex-mini" }, false)
     expect(mapped.supported_parameters).not.toContain("tools")
     expect(mapped.capabilities.function_calling).toBe(false)
+  })
+
+  it("resolves only an exact model-advertised effort", () => {
+    const models = [
+      {
+        id: "gpt-5-codex",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "medium" }
+        ]
+      }
+    ]
+    expect(
+      resolveCodexReasoningEffort(models, "gpt-5-codex", "medium")
+    ).toEqual({ effort: "medium" })
+    expect(resolveCodexReasoningEffort(models, "gpt-5-codex", "high")).toEqual({
+      error:
+        "Model 'codex/gpt-5-codex' does not support reasoning effort 'high'. Supported efforts: low, medium."
+    })
   })
 
   it("turns unique OpenAI function tools into App Server dynamic tools", () => {

--- a/packages/olc/src/backends/codex/__tests__/wire.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/wire.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { mapCodexModel, normalizeCodexTools, toDynamicTools } from "../wire.js"
+
+describe("Codex wire mappings", () => {
+  it("publishes model modalities and canonical reasoning efforts", () => {
+    expect(
+      mapCodexModel({
+        id: "gpt-5-codex",
+        displayName: "GPT-5 Codex",
+        inputModalities: ["text", "image"],
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "medium" },
+          { reasoningEffort: "unsupported" }
+        ]
+      })
+    ).toMatchObject({
+      id: "codex/gpt-5-codex",
+      owned_by: "codex",
+      input_modalities: ["text", "image"],
+      supported_parameters: ["tools", "reasoning"],
+      capabilities: {
+        function_calling: true,
+        vision: true,
+        reasoning: true
+      },
+      reasoning: {
+        supported_efforts: ["low", "medium"],
+        default_effort: "medium"
+      }
+    })
+  })
+
+  it("does not advertise client tools when the bridge is disabled", () => {
+    const mapped = mapCodexModel({ id: "codex-mini" }, false)
+    expect(mapped.supported_parameters).not.toContain("tools")
+    expect(mapped.capabilities.function_calling).toBe(false)
+  })
+
+  it("turns unique OpenAI function tools into App Server dynamic tools", () => {
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "search_notes",
+          description: "Search notes",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } }
+          }
+        }
+      },
+      {
+        type: "function",
+        function: { name: "search_notes", description: "duplicate" }
+      },
+      { type: "function", function: { name: "" } }
+    ]
+
+    expect(normalizeCodexTools(tools)).toHaveLength(1)
+    expect(toDynamicTools(tools)).toEqual([
+      {
+        type: "function",
+        name: "search_notes",
+        description: "Search notes",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } }
+        }
+      }
+    ])
+  })
+})

--- a/packages/olc/src/backends/codex/app-server-client.ts
+++ b/packages/olc/src/backends/codex/app-server-client.ts
@@ -33,8 +33,9 @@ export class CodexAppServerClient {
   private nextId = 1
   private readonly pending = new Map<string, PendingRequest>()
   private readonly listeners = new Set<NotificationListener>()
+  private readonly intentionalStops =
+    new WeakSet<ChildProcessWithoutNullStreams>()
   private serverRequestHandler: ServerRequestHandler | null = null
-  private stopping = false
 
   constructor({
     executable,
@@ -63,7 +64,6 @@ export class CodexAppServerClient {
   }
 
   private async startInner(): Promise<void> {
-    this.stopping = false
     const child = spawn(this.executable, ["app-server", "--stdio"], {
       cwd: this.cwd,
       // npm exposes command-line packages as `.cmd` shims on Windows. Node cannot
@@ -78,15 +78,20 @@ export class CodexAppServerClient {
     const stderr = readline.createInterface({ input: child.stderr })
     stderr.on("line", (line) => this.log("Codex app-server stderr", { line }))
 
-    child.once("error", (error) => this.failAll(error))
+    child.once("error", (error) => {
+      if (this.process === child) this.failAll(error)
+    })
     child.once("exit", (code, signal) => {
       const error = new Error(
         `Codex app-server exited${code === null ? "" : ` with code ${code}`}${signal ? ` (${signal})` : ""}`
       )
+      // A failed attempt may finish exiting after a retry has already spawned.
+      // Never let that stale child clear or fail the new child's state.
+      if (this.process !== child) return
       this.process = null
       this.startPromise = null
       this.failAll(error)
-      if (!this.stopping) {
+      if (!this.intentionalStops.has(child)) {
         this.emit({
           method: "olc/appServerExited",
           params: { message: error.message }
@@ -94,18 +99,28 @@ export class CodexAppServerClient {
       }
     })
 
-    await this.request("initialize", {
-      clientInfo: {
-        name: "ollama_client_olc",
-        title: "Ollama Client OLC",
-        version: "1.0.0"
-      },
-      capabilities: {
-        experimentalApi: true,
-        requestAttestation: false
-      }
-    })
-    this.notify("initialized", {})
+    try {
+      await this.request("initialize", {
+        clientInfo: {
+          name: "ollama_client_olc",
+          title: "Ollama Client OLC",
+          version: "1.0.0"
+        },
+        capabilities: {
+          experimentalApi: true,
+          requestAttestation: false
+        }
+      })
+      this.notify("initialized", {})
+    } catch (error) {
+      await this.terminateChild(
+        child,
+        error instanceof Error
+          ? error
+          : new Error("Codex app-server initialization failed")
+      )
+      throw error
+    }
   }
 
   onNotification(listener: NotificationListener): () => void {
@@ -148,14 +163,65 @@ export class CodexAppServerClient {
   }
 
   async shutdown(): Promise<void> {
-    this.stopping = true
     const child = this.process
-    this.process = null
-    this.startPromise = null
     if (!child) return
-    this.failAll(new Error("Codex app-server is shutting down"))
-    child.stdin.end()
-    child.kill("SIGTERM")
+    await this.terminateChild(
+      child,
+      new Error("Codex app-server is shutting down")
+    )
+  }
+
+  private async terminateChild(
+    child: ChildProcessWithoutNullStreams,
+    reason: Error
+  ): Promise<void> {
+    this.intentionalStops.add(child)
+    if (this.process === child) {
+      this.process = null
+      this.startPromise = null
+      this.failAll(reason)
+    }
+    if (!child.stdin.destroyed) child.stdin.destroy()
+    if (child.exitCode !== null || child.signalCode !== null) return
+
+    const exitedAfterTerm = this.waitForExit(child, 1_000)
+    try {
+      child.kill("SIGTERM")
+    } catch {
+      return
+    }
+    if (await exitedAfterTerm) return
+
+    const exitedAfterKill = this.waitForExit(child, 1_000)
+    try {
+      child.kill("SIGKILL")
+    } catch {
+      return
+    }
+    await exitedAfterKill
+  }
+
+  private waitForExit(
+    child: ChildProcessWithoutNullStreams,
+    timeoutMs: number
+  ): Promise<boolean> {
+    return new Promise((resolve) => {
+      let settled = false
+      const finish = (exited: boolean) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        child.off("exit", onExit)
+        child.off("close", onExit)
+        resolve(exited)
+      }
+      const onExit = () => finish(true)
+      const timer = setTimeout(() => finish(false), timeoutMs)
+      if (typeof timer.unref === "function") timer.unref()
+      child.once("exit", onExit)
+      child.once("close", onExit)
+      if (child.exitCode !== null || child.signalCode !== null) finish(true)
+    })
   }
 
   private write(message: AppServerMessage): void {

--- a/packages/olc/src/backends/codex/app-server-client.ts
+++ b/packages/olc/src/backends/codex/app-server-client.ts
@@ -1,0 +1,242 @@
+/** Minimal JSONL JSON-RPC client for `codex app-server --stdio`. */
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process"
+import readline from "node:readline"
+import type { ProxyLogger } from "../../types.js"
+import { isRecord } from "../../util.js"
+
+export interface AppServerMessage {
+  id?: string | number
+  method?: string
+  params?: unknown
+  result?: unknown
+  error?: { code?: unknown; message?: unknown }
+}
+
+type NotificationListener = (message: AppServerMessage) => void
+type ServerRequestHandler = (
+  message: AppServerMessage
+) => Promise<unknown | undefined>
+
+interface PendingRequest {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout
+}
+
+export class CodexAppServerClient {
+  private readonly executable: string
+  private readonly cwd: string
+  private readonly log: ProxyLogger
+  private readonly requestTimeoutMs: number
+  private process: ChildProcessWithoutNullStreams | null = null
+  private startPromise: Promise<void> | null = null
+  private nextId = 1
+  private readonly pending = new Map<string, PendingRequest>()
+  private readonly listeners = new Set<NotificationListener>()
+  private serverRequestHandler: ServerRequestHandler | null = null
+  private stopping = false
+
+  constructor({
+    executable,
+    cwd,
+    log,
+    requestTimeoutMs = 30_000
+  }: {
+    executable: string
+    cwd: string
+    log: ProxyLogger
+    requestTimeoutMs?: number
+  }) {
+    this.executable = executable
+    this.cwd = cwd
+    this.log = log
+    this.requestTimeoutMs = requestTimeoutMs
+  }
+
+  start(): Promise<void> {
+    if (this.startPromise) return this.startPromise
+    this.startPromise = this.startInner().catch((error) => {
+      this.startPromise = null
+      throw error
+    })
+    return this.startPromise
+  }
+
+  private async startInner(): Promise<void> {
+    this.stopping = false
+    const child = spawn(this.executable, ["app-server", "--stdio"], {
+      cwd: this.cwd,
+      // npm exposes command-line packages as `.cmd` shims on Windows. Node cannot
+      // execute those directly, so let cmd.exe resolve the operator-selected binary.
+      shell: process.platform === "win32",
+      stdio: ["pipe", "pipe", "pipe"]
+    })
+    this.process = child
+
+    const stdout = readline.createInterface({ input: child.stdout })
+    stdout.on("line", (line) => this.handleLine(line))
+    const stderr = readline.createInterface({ input: child.stderr })
+    stderr.on("line", (line) => this.log("Codex app-server stderr", { line }))
+
+    child.once("error", (error) => this.failAll(error))
+    child.once("exit", (code, signal) => {
+      const error = new Error(
+        `Codex app-server exited${code === null ? "" : ` with code ${code}`}${signal ? ` (${signal})` : ""}`
+      )
+      this.process = null
+      this.startPromise = null
+      this.failAll(error)
+      if (!this.stopping) {
+        this.emit({
+          method: "olc/appServerExited",
+          params: { message: error.message }
+        })
+      }
+    })
+
+    await this.request("initialize", {
+      clientInfo: {
+        name: "ollama_client_olc",
+        title: "Ollama Client OLC",
+        version: "1.0.0"
+      },
+      capabilities: {
+        experimentalApi: true,
+        requestAttestation: false
+      }
+    })
+    this.notify("initialized", {})
+  }
+
+  onNotification(listener: NotificationListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  setServerRequestHandler(handler: ServerRequestHandler): void {
+    this.serverRequestHandler = handler
+  }
+
+  async request<T>(method: string, params: unknown): Promise<T> {
+    const id = this.nextId++
+    const key = String(id)
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(key)
+        reject(
+          new Error(
+            `Codex app-server request '${method}' timed out after ${this.requestTimeoutMs}ms`
+          )
+        )
+      }, this.requestTimeoutMs)
+      if (typeof timer.unref === "function") timer.unref()
+      this.pending.set(key, { resolve, reject, timer })
+    })
+    try {
+      this.write({ method, id, params })
+    } catch (error) {
+      const pending = this.pending.get(key)
+      if (pending) clearTimeout(pending.timer)
+      this.pending.delete(key)
+      throw error
+    }
+    return (await promise) as T
+  }
+
+  notify(method: string, params: unknown): void {
+    this.write({ method, params })
+  }
+
+  async shutdown(): Promise<void> {
+    this.stopping = true
+    const child = this.process
+    this.process = null
+    this.startPromise = null
+    if (!child) return
+    this.failAll(new Error("Codex app-server is shutting down"))
+    child.stdin.end()
+    child.kill("SIGTERM")
+  }
+
+  private write(message: AppServerMessage): void {
+    const child = this.process
+    if (!child || child.stdin.destroyed) {
+      throw new Error(
+        `Codex app-server is not running. Install Codex CLI and run 'codex login' first.`
+      )
+    }
+    child.stdin.write(`${JSON.stringify(message)}\n`)
+  }
+
+  private handleLine(line: string): void {
+    let message: AppServerMessage
+    try {
+      const parsed = JSON.parse(line)
+      if (!isRecord(parsed)) return
+      message = parsed as AppServerMessage
+    } catch {
+      this.log("Ignored non-JSON output from Codex app-server", { line })
+      return
+    }
+
+    if (message.id !== undefined && message.method) {
+      void this.handleServerRequest(message)
+      return
+    }
+
+    if (message.id !== undefined) {
+      const pending = this.pending.get(String(message.id))
+      if (!pending) return
+      clearTimeout(pending.timer)
+      this.pending.delete(String(message.id))
+      if (message.error) {
+        pending.reject(
+          new Error(
+            typeof message.error.message === "string"
+              ? message.error.message
+              : "Codex app-server request failed"
+          )
+        )
+      } else {
+        pending.resolve(message.result)
+      }
+      return
+    }
+
+    if (message.method) this.emit(message)
+  }
+
+  private async handleServerRequest(message: AppServerMessage): Promise<void> {
+    try {
+      const result = await this.serverRequestHandler?.(message)
+      if (result === undefined) {
+        this.write({
+          id: message.id,
+          error: {
+            code: -32601,
+            message: `OLC does not handle app-server request '${message.method}'`
+          }
+        })
+        return
+      }
+      this.write({ id: message.id, result })
+    } catch (error) {
+      this.write({
+        id: message.id,
+        error: { code: -32000, message: (error as Error).message }
+      })
+    }
+  }
+
+  private emit(message: AppServerMessage): void {
+    for (const listener of this.listeners) listener(message)
+  }
+
+  private failAll(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+}

--- a/packages/olc/src/backends/codex/config.ts
+++ b/packages/olc/src/backends/codex/config.ts
@@ -1,0 +1,41 @@
+/** Configuration owned by the Codex app-server backend. */
+import os from "node:os"
+import path from "node:path"
+import { type ProxyOptions, stringOption } from "../../config.js"
+
+export const CODEX_DEFAULTS = {
+  CODEX_PATH: "codex",
+  PROJECT_DIR: path.join(os.tmpdir(), "olc-codex-workspace")
+} as const
+
+export interface CodexConfig {
+  CODEX_PATH: string
+  PROJECT_DIR: string
+}
+
+export const resolveCodexConfig = ({
+  options = {},
+  fileOptions = {}
+}: {
+  options?: ProxyOptions
+  fileOptions?: ProxyOptions
+} = {}): CodexConfig => {
+  const env = process.env
+  return {
+    CODEX_PATH: stringOption(
+      options.CODEX_PATH,
+      env.OLC_CODEX_PATH,
+      env.CODEX_PATH,
+      fileOptions.CODEX_PATH,
+      CODEX_DEFAULTS.CODEX_PATH
+    ),
+    PROJECT_DIR: stringOption(
+      options.CODEX_PROJECT_DIR,
+      options.PROJECT_DIR,
+      env.OLC_CODEX_PROJECT_DIR,
+      fileOptions.CODEX_PROJECT_DIR,
+      fileOptions.PROJECT_DIR,
+      CODEX_DEFAULTS.PROJECT_DIR
+    )
+  }
+}

--- a/packages/olc/src/backends/codex/index.ts
+++ b/packages/olc/src/backends/codex/index.ts
@@ -13,12 +13,18 @@ import type {
   TurnRunSignals,
   TurnStreamHandlers
 } from "../types.js"
+import { BackendInputError } from "../types.js"
 import {
   type AppServerMessage,
   CodexAppServerClient
 } from "./app-server-client.js"
 import { resolveCodexConfig } from "./config.js"
-import { type CodexModel, mapCodexModel, toDynamicTools } from "./wire.js"
+import {
+  type CodexModel,
+  mapCodexModel,
+  resolveCodexReasoningEffort,
+  toDynamicTools
+} from "./wire.js"
 
 interface ThreadStartResponse {
   thread?: { id?: string }
@@ -344,6 +350,14 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
     },
     startTurn: async (input) => {
       await client.start()
+      if (input.reasoningEffort) {
+        const resolved = resolveCodexReasoningEffort(
+          await loadRawModels(),
+          input.model.modelId,
+          input.reasoningEffort
+        )
+        if ("error" in resolved) throw new BackendInputError(resolved.error)
+      }
       const prompt = buildPromptParts(input.messages)
       const tools = config.BRIDGE_ENABLED ? toDynamicTools(input.tools) : []
       const response = await client.request<ThreadStartResponse>(

--- a/packages/olc/src/backends/codex/index.ts
+++ b/packages/olc/src/backends/codex/index.ts
@@ -1,0 +1,378 @@
+/** Codex app-server adapter for OLC's runtime-neutral backend port. */
+import fs from "node:fs"
+import { buildPromptParts } from "../../core/openai-wire.js"
+import type { ToolResultMessage } from "../../types.js"
+import { isRecord } from "../../util.js"
+import type {
+  AgentBackend,
+  BackendContext,
+  BackendTurn,
+  CatalogModel,
+  StartTurnInput,
+  TurnResult,
+  TurnRunSignals,
+  TurnStreamHandlers
+} from "../types.js"
+import {
+  type AppServerMessage,
+  CodexAppServerClient
+} from "./app-server-client.js"
+import { resolveCodexConfig } from "./config.js"
+import { type CodexModel, mapCodexModel, toDynamicTools } from "./wire.js"
+
+interface ThreadStartResponse {
+  thread?: { id?: string }
+}
+
+interface TurnStartResponse {
+  turn?: { id?: string }
+}
+
+interface ModelListResponse {
+  data?: CodexModel[]
+  nextCursor?: string | null
+}
+
+type QueueResult =
+  | { type: "message"; message: AppServerMessage }
+  | { type: "suspended" }
+
+class MessageQueue {
+  private readonly messages: AppServerMessage[] = []
+  private readonly waiters = new Set<(message: AppServerMessage) => void>()
+
+  push(message: AppServerMessage): void {
+    const waiter = this.waiters.values().next().value
+    if (waiter) {
+      this.waiters.delete(waiter)
+      waiter(message)
+      return
+    }
+    this.messages.push(message)
+  }
+
+  async next(suspended: Promise<void>): Promise<QueueResult> {
+    const queued = this.messages.shift()
+    if (queued) return { type: "message", message: queued }
+
+    let waiter: ((message: AppServerMessage) => void) | undefined
+    const message = new Promise<AppServerMessage>((resolve) => {
+      waiter = resolve
+      this.waiters.add(resolve)
+    })
+    const result = await Promise.race([
+      message.then((value) => ({ type: "message" as const, message: value })),
+      suspended.then(() => ({ type: "suspended" as const }))
+    ])
+    if (waiter) this.waiters.delete(waiter)
+    return result
+  }
+}
+
+export const createCodexBackend = (context: BackendContext): AgentBackend => {
+  const { config, log } = context
+  const codex = resolveCodexConfig({
+    options: context.options,
+    fileOptions: context.fileOptions
+  })
+  fs.mkdirSync(codex.PROJECT_DIR, { recursive: true })
+
+  const client = new CodexAppServerClient({
+    executable: codex.CODEX_PATH,
+    cwd: codex.PROJECT_DIR,
+    log,
+    requestTimeoutMs: Math.min(config.REQUEST_TIMEOUT_MS, 60_000)
+  })
+  const turns = new Map<string, CodexTurn>()
+  let catalogCache: { expiresAt: number; raw: CodexModel[] } | null = null
+
+  const unsubscribe = client.onNotification((message) => {
+    const params = isRecord(message.params) ? message.params : {}
+    const threadId =
+      typeof params.threadId === "string" ? params.threadId : undefined
+    if (threadId) turns.get(threadId)?.push(message)
+    if (message.method === "olc/appServerExited") {
+      for (const turn of turns.values()) turn.push(message)
+    }
+  })
+
+  client.setServerRequestHandler(async (message) => {
+    const params = isRecord(message.params) ? message.params : {}
+    if (message.method === "item/tool/call") {
+      const threadId = String(params.threadId ?? "")
+      const turn = turns.get(threadId)
+      if (!turn) throw new Error("Codex requested a tool for an unknown turn")
+      try {
+        const output = await context.callClientTool({
+          turnId: turn.id,
+          tool: String(params.tool ?? "tool"),
+          args: params.arguments ?? {},
+          signal: turn.signal
+        })
+        return {
+          contentItems: [{ type: "inputText", text: output }],
+          success: true
+        }
+      } catch (error) {
+        return {
+          contentItems: [
+            {
+              type: "inputText",
+              text: `Tool failed: ${(error as Error).message}`
+            }
+          ],
+          success: false
+        }
+      }
+    }
+
+    if (message.method === "item/commandExecution/requestApproval") {
+      return { decision: "decline" }
+    }
+    if (message.method === "item/fileChange/requestApproval") {
+      return { decision: "decline" }
+    }
+    if (message.method === "execCommandApproval") {
+      return { decision: "denied" }
+    }
+    if (message.method === "applyPatchApproval") {
+      return { decision: "denied" }
+    }
+    return undefined
+  })
+
+  const loadRawModels = async (): Promise<CodexModel[]> => {
+    if (catalogCache && catalogCache.expiresAt > Date.now()) {
+      return catalogCache.raw
+    }
+    await client.start()
+    const models: CodexModel[] = []
+    let cursor: string | null = null
+    do {
+      const page: ModelListResponse = await client.request<ModelListResponse>(
+        "model/list",
+        {
+          limit: 100,
+          includeHidden: false,
+          ...(cursor ? { cursor } : {})
+        }
+      )
+      if (Array.isArray(page?.data)) models.push(...page.data)
+      cursor = typeof page?.nextCursor === "string" ? page.nextCursor : null
+    } while (cursor)
+    catalogCache = { raw: models, expiresAt: Date.now() + 30_000 }
+    return models
+  }
+
+  class CodexTurn implements BackendTurn {
+    readonly id: string
+    readonly signal: AbortSignal
+    private readonly abortController = new AbortController()
+    private readonly queue = new MessageQueue()
+    private readonly input: StartTurnInput
+    private codexTurnId: string | null = null
+    private started = false
+    private content = ""
+    private reasoning = ""
+    private lastError: string | null = null
+
+    constructor(threadId: string, input: StartTurnInput) {
+      this.id = threadId
+      this.input = input
+      this.signal = this.abortController.signal
+    }
+
+    push(message: AppServerMessage): void {
+      this.queue.push(message)
+    }
+
+    async run(
+      handlers: TurnStreamHandlers,
+      signals: TurnRunSignals
+    ): Promise<TurnResult> {
+      if (!this.started) {
+        this.started = true
+        const prompt = buildPromptParts(this.input.messages)
+        const response = await client.request<TurnStartResponse>("turn/start", {
+          threadId: this.id,
+          input: prompt.parts.map((part) =>
+            part.type === "file"
+              ? { type: "image", url: part.url }
+              : { type: "text", text: part.text, text_elements: [] }
+          ),
+          ...(this.input.reasoningEffort
+            ? { effort: this.input.reasoningEffort }
+            : {})
+        })
+        const turnId = response?.turn?.id
+        if (!turnId) throw new Error("Codex did not return a turn id")
+        this.codexTurnId = turnId
+      }
+      return await this.readLeg(handlers, signals)
+    }
+
+    async resume(
+      _results: ToolResultMessage[],
+      handlers: TurnStreamHandlers,
+      signals: TurnRunSignals
+    ): Promise<TurnResult> {
+      signals.releaseToolResults?.()
+      return await this.readLeg(handlers, signals)
+    }
+
+    async abort(): Promise<void> {
+      this.abortController.abort()
+      if (!this.codexTurnId) return
+      try {
+        await client.request("turn/interrupt", {
+          threadId: this.id,
+          turnId: this.codexTurnId
+        })
+      } catch (error) {
+        log("Codex turn interrupt failed", {
+          threadId: this.id,
+          message: (error as Error).message
+        })
+      }
+    }
+
+    async dispose(): Promise<void> {
+      turns.delete(this.id)
+      try {
+        await client.request("thread/delete", { threadId: this.id })
+      } catch (error) {
+        log("Codex thread cleanup failed", {
+          threadId: this.id,
+          message: (error as Error).message
+        })
+      }
+    }
+
+    private async readLeg(
+      handlers: TurnStreamHandlers,
+      signals: TurnRunSignals
+    ): Promise<TurnResult> {
+      while (true) {
+        const next = await this.queue.next(signals.suspended)
+        if (next.type === "suspended") return { status: "suspended" }
+        const { method } = next.message
+        const params = isRecord(next.message.params) ? next.message.params : {}
+
+        if (method === "item/agentMessage/delta") {
+          const delta = typeof params.delta === "string" ? params.delta : ""
+          this.content += delta
+          handlers.onText(delta)
+          continue
+        }
+        if (method === "item/reasoning/summaryTextDelta") {
+          const delta = typeof params.delta === "string" ? params.delta : ""
+          this.reasoning += delta
+          handlers.onReasoning(delta)
+          continue
+        }
+        if (method === "item/completed" && isRecord(params.item)) {
+          if (
+            params.item.type === "agentMessage" &&
+            typeof params.item.text === "string" &&
+            !this.content
+          ) {
+            this.content = params.item.text
+          }
+          continue
+        }
+        if (method === "error") {
+          const error = isRecord(params.error) ? params.error : {}
+          if (typeof error.message === "string") this.lastError = error.message
+          continue
+        }
+        if (method === "olc/appServerExited") {
+          return {
+            status: "failed",
+            error: {
+              type: "CodexAppServerExited",
+              message: String(params.message ?? "Codex app-server exited")
+            }
+          }
+        }
+        if (method !== "turn/completed" || !isRecord(params.turn)) continue
+
+        const status = String(params.turn.status ?? "failed")
+        if (status === "completed") {
+          return {
+            status: "completed",
+            content: this.content,
+            reasoning: this.reasoning,
+            finish: "stop"
+          }
+        }
+        const turnError = isRecord(params.turn.error) ? params.turn.error : {}
+        return {
+          status: "failed",
+          error: {
+            type: status === "interrupted" ? "CodexInterrupted" : "CodexError",
+            message:
+              (typeof turnError.message === "string" && turnError.message) ||
+              this.lastError ||
+              `Codex turn ended with status '${status}'`
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    id: "codex",
+    ensureReady: () => client.start(),
+    listModels: async (): Promise<CatalogModel[]> =>
+      (await loadRawModels()).map((model) =>
+        mapCodexModel(model, config.BRIDGE_ENABLED)
+      ),
+    resolveModel: async (requested) => {
+      const models = await loadRawModels()
+      const raw = typeof requested === "string" ? requested.trim() : ""
+      const wanted = raw.startsWith("codex/") ? raw.slice("codex/".length) : raw
+      const match = wanted
+        ? models.find((model) => model.id === wanted || model.model === wanted)
+        : (models.find((model) => model.isDefault) ?? models[0])
+      return match
+        ? { providerId: "codex", modelId: match.id }
+        : {
+            error: wanted
+              ? `Codex model '${wanted}' is not available`
+              : "Codex returned no available models"
+          }
+    },
+    startTurn: async (input) => {
+      await client.start()
+      const prompt = buildPromptParts(input.messages)
+      const tools = config.BRIDGE_ENABLED ? toDynamicTools(input.tools) : []
+      const response = await client.request<ThreadStartResponse>(
+        "thread/start",
+        {
+          model: input.model.modelId,
+          cwd: codex.PROJECT_DIR,
+          approvalPolicy: "never",
+          sandbox: "read-only",
+          ephemeral: true,
+          serviceName: "ollama_client_olc",
+          ...(config.SYSTEM_PROMPT || prompt.system
+            ? { developerInstructions: config.SYSTEM_PROMPT || prompt.system }
+            : {}),
+          ...(tools.length > 0 ? { dynamicTools: tools } : {})
+        }
+      )
+      const threadId = response?.thread?.id
+      if (!threadId) throw new Error("Codex did not return a thread id")
+      const turn = new CodexTurn(threadId, input)
+      turns.set(threadId, turn)
+      return turn
+    },
+    findTurn: (turnId) => turns.get(turnId),
+    shutdown: async () => {
+      unsubscribe()
+      await Promise.allSettled([...turns.values()].map((turn) => turn.abort()))
+      turns.clear()
+      await client.shutdown()
+    }
+  }
+}

--- a/packages/olc/src/backends/codex/wire.ts
+++ b/packages/olc/src/backends/codex/wire.ts
@@ -1,0 +1,97 @@
+/** Codex app-server mappings kept separate from the backend lifecycle. */
+
+import type {
+  BridgeToolDefinition,
+  OpenAIToolDefinition,
+  ReasoningEffort
+} from "../../types.js"
+import { REASONING_EFFORTS } from "../../types.js"
+import { isRecord } from "../../util.js"
+import type { CatalogModel } from "../types.js"
+
+export interface CodexModel {
+  id: string
+  model?: string
+  displayName?: string
+  hidden?: boolean
+  supportedReasoningEfforts?: Array<{
+    reasoningEffort?: string
+    description?: string
+  }>
+  defaultReasoningEffort?: string
+  inputModalities?: string[]
+  isDefault?: boolean
+}
+
+const isReasoningEffort = (value: string): value is ReasoningEffort =>
+  REASONING_EFFORTS.includes(value as ReasoningEffort)
+
+export const mapCodexModel = (
+  model: CodexModel,
+  supportsTools = true
+): CatalogModel => {
+  const efforts = (model.supportedReasoningEfforts ?? [])
+    .map((option) => option.reasoningEffort ?? "")
+    .filter(isReasoningEffort)
+  const defaultEffort = model.defaultReasoningEffort
+  const modalities = model.inputModalities?.length
+    ? model.inputModalities
+    : ["text", "image"]
+  return {
+    id: `codex/${model.id}`,
+    object: "model",
+    created: 0,
+    owned_by: "codex",
+    name: model.displayName || model.id,
+    input_modalities: modalities,
+    supported_parameters: [
+      ...(supportsTools ? ["tools"] : []),
+      ...(efforts.length > 0 ? ["reasoning"] : [])
+    ],
+    capabilities: {
+      function_calling: supportsTools,
+      vision: modalities.includes("image"),
+      reasoning: efforts.length > 0
+    },
+    ...(efforts.length > 0
+      ? {
+          reasoning: {
+            supported_efforts: efforts,
+            ...(defaultEffort && isReasoningEffort(defaultEffort)
+              ? { default_effort: defaultEffort }
+              : {})
+          }
+        }
+      : {})
+  }
+}
+
+export const normalizeCodexTools = (tools: unknown): BridgeToolDefinition[] => {
+  if (!Array.isArray(tools)) return []
+  const definitions: BridgeToolDefinition[] = []
+  const names = new Set<string>()
+  for (const entry of tools as OpenAIToolDefinition[]) {
+    const fn = isRecord(entry) ? entry.function : undefined
+    const name =
+      isRecord(fn) && typeof fn.name === "string" ? fn.name.trim() : ""
+    if (!name || names.has(name)) continue
+    names.add(name)
+    definitions.push({
+      name,
+      description:
+        isRecord(fn) && typeof fn.description === "string"
+          ? fn.description
+          : "",
+      parameters: isRecord(fn) && isRecord(fn.parameters) ? fn.parameters : {}
+    })
+  }
+  return definitions
+}
+
+export const toDynamicTools = (tools: unknown) =>
+  normalizeCodexTools(tools).map((tool) => ({
+    type: "function" as const,
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.parameters
+  }))

--- a/packages/olc/src/backends/codex/wire.ts
+++ b/packages/olc/src/backends/codex/wire.ts
@@ -26,13 +26,35 @@ export interface CodexModel {
 const isReasoningEffort = (value: string): value is ReasoningEffort =>
   REASONING_EFFORTS.includes(value as ReasoningEffort)
 
+export const codexReasoningEfforts = (model: CodexModel): ReasoningEffort[] =>
+  (model.supportedReasoningEfforts ?? [])
+    .map((option) => option.reasoningEffort ?? "")
+    .filter(isReasoningEffort)
+
+export const resolveCodexReasoningEffort = (
+  models: CodexModel[],
+  modelId: string,
+  effort: ReasoningEffort
+): { effort: ReasoningEffort } | { error: string } => {
+  const model = models.find(
+    (candidate) => candidate.id === modelId || candidate.model === modelId
+  )
+  const supported = model ? codexReasoningEfforts(model) : []
+  if (supported.includes(effort)) return { effort }
+  const id = `codex/${modelId}`
+  return {
+    error:
+      supported.length > 0
+        ? `Model '${id}' does not support reasoning effort '${effort}'. Supported efforts: ${supported.join(", ")}.`
+        : `Model '${id}' does not report any selectable reasoning-effort variants.`
+  }
+}
+
 export const mapCodexModel = (
   model: CodexModel,
   supportsTools = true
 ): CatalogModel => {
-  const efforts = (model.supportedReasoningEfforts ?? [])
-    .map((option) => option.reasoningEffort ?? "")
-    .filter(isReasoningEffort)
+  const efforts = codexReasoningEfforts(model)
   const defaultEffort = model.defaultReasoningEffort
   const modalities = model.inputModalities?.length
     ? model.inputModalities

--- a/packages/olc/src/backends/registry.ts
+++ b/packages/olc/src/backends/registry.ts
@@ -5,10 +5,12 @@
  * `src/core/` changes. The name is what `--backend` and `OLC_BACKEND` select.
  */
 
+import { createCodexBackend } from "./codex/index.js"
 import { createOpencodeBackend } from "./opencode/index.js"
 import type { BackendContext, BackendFactory } from "./types.js"
 
 const BACKENDS: Record<string, BackendFactory> = {
+  codex: createCodexBackend,
   opencode: createOpencodeBackend
 }
 

--- a/packages/olc/src/cli.ts
+++ b/packages/olc/src/cli.ts
@@ -41,6 +41,11 @@ OpenCode backend options:
   --allow-opencode-tools <ids>
                            Comma-separated OpenCode tools to leave enabled
   --plugin-dir <path>      Where to generate the bridge plugin
+
+Codex backend options:
+  --codex <path>           Path to the Codex CLI binary
+  --codex-project-dir <path>
+                           Empty workspace used for Codex turns
 `
 
 const FLAG_TO_OPTION: Record<string, string> = {
@@ -55,7 +60,9 @@ const FLAG_TO_OPTION: Record<string, string> = {
   "--agent": "OPENCODE_AGENT",
   "--project-dir": "PROJECT_DIR",
   "--allow-opencode-tools": "ALLOW_OPENCODE_TOOLS",
-  "--plugin-dir": "PLUGIN_DIR"
+  "--plugin-dir": "PLUGIN_DIR",
+  "--codex": "CODEX_PATH",
+  "--codex-project-dir": "CODEX_PROJECT_DIR"
 }
 
 /** Parse argv into proxy options. Unknown flags are an error, not a silent no-op. */


### PR DESCRIPTION
## Summary

- add a Codex CLI backend over the official `codex app-server` JSONL protocol
- expose Codex models, vision, reasoning efforts, streaming, cancellation, and dynamic client tools through OLC's existing OpenAI-compatible API
- run Codex turns as ephemeral, read-only threads with approvals disabled and authentication delegated to `codex login`
- add checksum-verified PowerShell and POSIX installers without publishing to npm
- publish portable OLC archives from CI and smoke-test the Windows launcher and installer syntax on `windows-latest`

## Verification

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run` — 3,248 tests passed
- `pnpm docs:build`
- `pnpm generate:resources`
- `pnpm proxy:bundle`
- `pnpm package`
- `pnpm bundle:check`
- fake App Server integration test covering dynamic-tool suspend/resume and streamed completion
- live `/v1/models` catalog smoke against the installed Codex CLI, without an inference request
- offline checksum/install/launcher smoke for the POSIX release bundle

## Note

The base branch's pre-push production audit currently reports an existing `defuddle@0.9.0` advisory. This branch does not change `package.json` or `pnpm-lock.yaml`; all remaining pre-push gates were run successfully before pushing.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a Codex App Server backend and portable, checksum-verified OLC distribution installers.
- Maps Codex model metadata, streamed text and reasoning, dynamic client tools, cancellation, and ephemeral thread lifecycle onto OLC’s existing backend interface.
- Adds POSIX and PowerShell installers, platform launchers, release archives, checksums, and CI smoke tests.
- The latest changes terminate failed Codex startup attempts before retrying and validate requested reasoning effort against the selected model’s advertised variants.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the two previously reported lifecycle and model-effort issues are addressed by the current code.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/backends/codex/app-server-client.ts | Implements JSONL RPC process supervision and now terminates a child whose initialization fails before permitting a retry. |
| packages/olc/src/backends/codex/index.ts | Implements Codex model discovery, ephemeral thread and turn lifecycle, dynamic-tool bridging, streaming, cancellation, cleanup, and model-specific effort validation. |
| packages/olc/src/backends/codex/wire.ts | Maps Codex model metadata, canonical reasoning efforts, and OpenAI function definitions to OLC and App Server wire contracts. |
| docs/public/olc.sh | Adds the POSIX installer with Node prerequisite checks, verified archive download, staged replacement, rollback, and launcher symlink creation. |
| docs/public/olc.ps1 | Adds the Windows installer with checksum verification, staged replacement and rollback, and user PATH configuration. |
| .github/workflows/ci.yml | Builds portable OLC archives and smoke-tests the Windows launcher and PowerShell installer syntax. |
| .github/workflows/release.yml | Includes both portable archives and their checksums in the verified release asset set. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as OpenAI-compatible client
  participant OLC as OLC proxy
  participant Backend as Codex backend
  participant Codex as codex app-server
  Client->>OLC: Chat completion request
  OLC->>Backend: startTurn(model, messages, tools, effort)
  Backend->>Codex: initialize / model/list
  Backend->>Codex: thread/start (ephemeral, read-only)
  Backend->>Codex: turn/start
  Codex-->>Backend: streamed reasoning and text
  opt Dynamic client tool
    Codex->>Backend: item/tool/call
    Backend-->>OLC: suspend with tool call
    OLC-->>Client: tool_calls completion
    Client->>OLC: tool result
    OLC->>Backend: resume
    Backend-->>Codex: tool result
  end
  Codex-->>Backend: turn/completed
  Backend-->>OLC: normalized completion
  OLC-->>Client: OpenAI-compatible stream
  Backend->>Codex: thread/delete
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(olc): enforce Codex lifecycle constr..."](https://github.com/shishir435/ollama-client/commit/9334cdc5ce7d39ecc88e51d6b43907f0e1521436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55732978)</sub>

<!-- /greptile_comment -->