### PR TITLE
fix(codex): route image generation

### DIFF
--- a/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
+++ b/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
@@ -42,9 +42,11 @@ lines.on("line", (line) => {
     return
   }
   if (message.method === "thread/start") {
-    const isImage = message.params?.developerInstructions?.includes(
-      "built-in image generation tool"
-    )
+    const imageInstructions = message.params?.developerInstructions
+    const isImage =
+      imageInstructions?.includes("$imagegen") &&
+      imageInstructions?.includes("image_gen") &&
+      imageInstructions?.includes("do not complete the turn without an image")
     if (isImage) {
       const threadId =
         message.params?.model === "fake-codex-delayed"

--- a/packages/olc/src/backends/codex/index.ts
+++ b/packages/olc/src/backends/codex/index.ts
@@ -505,7 +505,7 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
       }
       const imageInstructions = [
         config.SYSTEM_PROMPT,
-        "Generate an image that fulfills the user's request. You must use the built-in image generation tool. Do not answer with only text."
+        "Use the $imagegen skill to generate an image that fulfills the user's request. Invoke the built-in image_gen tool and wait for its result. Do not merely announce, describe, or promise image generation, and do not complete the turn without an image result."
       ]
         .filter(Boolean)
         .join("\n\n")

--- a/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -192,6 +192,33 @@ describe("useChatStreaming", () => {
     )
   })
 
+  it("publishes generated images to the live assistant message", async () => {
+    const { options, spies } = mkOptions()
+    const { result } = renderHook(() => useChatStreaming(options))
+    result.current.currentStreamingMessageIdRef.current = 32
+    result.current.startStream({
+      durableTurn: {}
+    } as Parameters<typeof result.current.startStream>[0])
+    const images = [
+      {
+        imageId: "generated-1",
+        fileName: "generated-image.png",
+        mimeType: "image/png",
+        size: 3,
+        base64: "AQID",
+        origin: "model-generated" as const
+      }
+    ]
+
+    await capturedSetMessages?.([{ id: 32, content: "", images, done: true }])
+
+    expect(spies.updateMessage).toHaveBeenCalledWith(
+      32,
+      expect.objectContaining({ images, done: true }),
+      true
+    )
+  })
+
   it("beats liveness on a timer while streaming and stops when done", async () => {
     const { options } = mkOptions()
     const { result } = renderHook(() => useChatStreaming(options))

--- a/src/features/chat/hooks/use-chat-streaming.ts
+++ b/src/features/chat/hooks/use-chat-streaming.ts
@@ -115,6 +115,7 @@ export const useChatStreaming = ({
         {
           content: streamedMsg.content,
           thinking: streamedMsg.thinking,
+          images: streamedMsg.images,
           replayArtifact: streamedMsg.replayArtifact,
           metrics: streamedMsg.metrics,
           done: streamedMsg.done,
@@ -162,6 +163,7 @@ export const useChatStreaming = ({
         {
           content: streamedMsg.content,
           thinking: streamedMsg.thinking,
+          images: streamedMsg.images,
           replayArtifact: streamedMsg.replayArtifact,
           metrics: streamedMsg.metrics,
           done: true,

--- a/src/features/model/components/model-menu.tsx
+++ b/src/features/model/components/model-menu.tsx
@@ -222,6 +222,7 @@ export const ModelMenu = ({
         capabilityTags: targetModelData?.capabilityHints?.capabilityTags,
         contextLength: targetModelData?.capabilityHints?.contextLength,
         modalities: targetModelData?.capabilityHints?.modalities,
+        outputModalities: targetModelData?.capabilityHints?.outputModalities,
         supportedParameters:
           targetModelData?.capabilityHints?.supportedParameters,
         probed: getProbe(capabilityTarget.providerId, capabilityTarget.model)
@@ -237,6 +238,7 @@ export const ModelMenu = ({
         capabilityTags: targetModelData?.capabilityHints?.capabilityTags,
         contextLength: targetModelData?.capabilityHints?.contextLength,
         modalities: targetModelData?.capabilityHints?.modalities,
+        outputModalities: targetModelData?.capabilityHints?.outputModalities,
         supportedParameters:
           targetModelData?.capabilityHints?.supportedParameters,
         override: getOverride(

--- a/src/features/model/hooks/__tests__/use-model-capability-overrides.test.ts
+++ b/src/features/model/hooks/__tests__/use-model-capability-overrides.test.ts
@@ -1,0 +1,27 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type { ProviderModel } from "@/types"
+import { useModelCapabilityOverrides } from "../use-model-capability-overrides"
+
+vi.mock("@/hooks/use-setting", () => ({
+  useSetting: () => [{}, vi.fn()]
+}))
+
+describe("useModelCapabilityOverrides", () => {
+  it("preserves catalog-reported image output metadata", () => {
+    const model = {
+      name: "codex/image-generation",
+      model: "codex/image-generation",
+      providerId: "custom:openai:codex",
+      details: { family: "openai" },
+      capabilityHints: {
+        modalities: ["text"],
+        outputModalities: ["image"]
+      }
+    } as ProviderModel
+
+    const { result } = renderHook(() => useModelCapabilityOverrides())
+
+    expect(result.current.resolve(model).imageOutput).toBe(true)
+  })
+})

--- a/src/features/model/hooks/use-model-capability-overrides.ts
+++ b/src/features/model/hooks/use-model-capability-overrides.ts
@@ -54,6 +54,7 @@ export const useModelCapabilityOverrides = () => {
         capabilityTags: model.capabilityHints?.capabilityTags,
         contextLength: model.capabilityHints?.contextLength,
         modalities: model.capabilityHints?.modalities,
+        outputModalities: model.capabilityHints?.outputModalities,
         supportedParameters: model.capabilityHints?.supportedParameters,
         override: getOverride(providerId, model.name),
         probed: getProbe(providerId, model.name)

--- a/src/features/model/hooks/use-selected-model-capabilities.ts
+++ b/src/features/model/hooks/use-selected-model-capabilities.ts
@@ -51,6 +51,7 @@ export const useSelectedModelCapabilities = (): SelectedModelCapabilities => {
     capabilityTags: model?.capabilityHints?.capabilityTags,
     contextLength: model?.capabilityHints?.contextLength,
     modalities: model?.capabilityHints?.modalities,
+    outputModalities: model?.capabilityHints?.outputModalities,
     supportedParameters: model?.capabilityHints?.supportedParameters,
     override: getOverride(providerId, selectedModel)
   })

--- a/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
+++ b/src/features/sessions/stores/__tests__/chat-session-store-actions.test.ts
@@ -548,6 +548,34 @@ describe("updateMessage", () => {
     expect(mockRepo.updateMessage).not.toHaveBeenCalled()
   })
 
+  it("persists generated images through the atomic image writer", async () => {
+    const images = [
+      {
+        imageId: "generated-1",
+        fileName: "generated-image.png",
+        mimeType: "image/png",
+        size: 3,
+        base64: "AQID",
+        origin: "model-generated" as const
+      }
+    ]
+    mockRepo.updateMessageWithImages.mockResolvedValue(undefined as any)
+
+    await chatSessionStore
+      .getState()
+      .updateMessage(11, { content: "", images, done: true }, false)
+
+    expect(mockRepo.updateMessageWithImages).toHaveBeenCalledWith(
+      11,
+      { content: "", images, done: true },
+      images
+    )
+    expect(mockRepo.updateMessage).not.toHaveBeenCalled()
+    expect(chatSessionStore.getState().sessions[0]?.messages?.[0].images).toBe(
+      images
+    )
+  })
+
   it("updates the message content in store state", async () => {
     mockRepo.updateMessage.mockResolvedValue(undefined as any)
 

--- a/src/features/sessions/stores/chat-session-message-actions.ts
+++ b/src/features/sessions/stores/chat-session-message-actions.ts
@@ -319,7 +319,11 @@ export const createChatSessionMessageActions = (
     skipDb = false
   ) => {
     if (!skipDb) {
-      await repo.updateMessage(messageId, updates)
+      if (updates.images !== undefined) {
+        await repo.updateMessageWithImages(messageId, updates, updates.images)
+      } else {
+        await repo.updateMessage(messageId, updates)
+      }
       if (updates.content) {
         try {
           await deleteVectors({ messageId })


### PR DESCRIPTION
## Summary
- preserve catalog-reported image output modalities through model capability resolution
- route the synthetic Codex image model through the Images API instead of chat
- explicitly invoke the Codex `$imagegen` skill and `image_gen` tool
- add regression coverage for image-output metadata and Codex image instructions

## Verification
- `pnpm typecheck`
- changed-file Biome checks
- `pnpm test:run` (392 files, 3271 tests)
- pre-push Chrome package, bundle budgets, i18n, and docs build

## Note
Repository-wide Biome invocation is currently blocked by the unrelated nested `.worktrees/generated-image-output/biome.json`; all changed files pass Biome directly.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves catalog-declared image-output capabilities through UI model resolution and routes Codex image requests through its image-generation path.
- Propagates `outputModalities` through model capability consumers.
- Explicitly instructs Codex to invoke its image-generation skill and tool.
- Publishes and persists generated images on assistant messages.
- Adds regression coverage for capability resolution, streaming, and image persistence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/backends/codex/index.ts | Strengthens Codex image-generation instructions while retaining existing capability checks, model resolution, cancellation, and image-result validation. |
| src/features/chat/hooks/use-chat-streaming.ts | Propagates generated images into live assistant state and legacy terminal persistence while leaving durable persistence background-owned. |
| src/features/model/hooks/use-model-capability-overrides.ts | Includes catalog output modalities in effective capability resolution with existing override precedence intact. |
| src/features/model/hooks/use-selected-model-capabilities.ts | Aligns selected-model UI capabilities with the background router’s existing image-output metadata handling. |
| src/features/sessions/stores/chat-session-message-actions.ts | Routes image-bearing message updates through the existing atomic message-and-image repository operation. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Chat UI
  participant BG as Background Router
  participant Codex as Codex Backend
  participant DB as Message Repository
  UI->>BG: Submit image request
  BG->>BG: Resolve outputModalities
  BG->>Codex: generateImage(prompt, resolved model)
  Codex->>Codex: Invoke $imagegen / image_gen
  Codex-->>BG: Generated image artifact
  BG->>DB: Persist assistant message and images
  BG-->>UI: Stream assistant message with images
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(chat): retain generated images"](https://github.com/shishir435/ollama-client/commit/007f4d6aeb4f37ebce9ccc184a1cade0ff06b12a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55807898)</sub>

<!-- /greptile_comment -->