### PR TITLE
fix(rag): prevent model reload during query rewrite

### DIFF
--- a/src/application/context/__tests__/build-context.test.ts
+++ b/src/application/context/__tests__/build-context.test.ts
@@ -646,6 +646,17 @@ describe("prompt stats", () => {
 describe("query reformulation provider call", () => {
   it("invokeModelOnce is wired with the streaming provider when reformulation runs", async () => {
     ragsetOn()
+    mockedStorageGet
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce({
+        "ollama::llama3": {
+          num_ctx: 8192,
+          num_thread: 8,
+          num_gpu: 20,
+          num_batch: 256,
+          keep_alive: "15m"
+        }
+      } as never)
     mockedGetActiveKnowledgeSet.mockResolvedValueOnce({
       id: "ks-1",
       name: "K",
@@ -699,7 +710,12 @@ describe("query reformulation provider call", () => {
         temperature: 0.2,
         num_predict: 64,
         stop: ["\n"],
-        think: false
+        think: false,
+        num_ctx: 8192,
+        num_thread: 8,
+        num_gpu: 20,
+        num_batch: 256,
+        keep_alive: "15m"
       }),
       expect.any(Function),
       expect.any(AbortSignal)

--- a/src/application/context/build-context.ts
+++ b/src/application/context/build-context.ts
@@ -22,6 +22,10 @@ import {
   type KnowledgeSetRecord
 } from "@/lib/knowledge/knowledge-sets"
 import { logger } from "@/lib/logger"
+import {
+  getStoredModelConfig,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { readSetting } from "@/lib/storage/setting-access"
@@ -178,6 +182,14 @@ export const buildRagContext = async (
         selectedModelRef?.providerId
       )
       assertProviderEnabled(provider, modelId)
+      const modelConfigMap = await readSetting(SETTINGS.MODEL_CONFIGS)
+      const modelParams = resolveModelConfig(
+        getStoredModelConfig(
+          modelConfigMap,
+          modelId,
+          selectedModelRef?.providerId
+        )
+      )
       let response = ""
       await withTimeoutSignal(
         (signal) =>
@@ -188,7 +200,12 @@ export const buildRagContext = async (
               temperature: 0.2,
               num_predict: 64,
               stop: ["\n"],
-              think: false
+              think: false,
+              num_ctx: modelParams.num_ctx,
+              num_thread: modelParams.num_thread,
+              num_gpu: modelParams.num_gpu,
+              num_batch: modelParams.num_batch,
+              keep_alive: modelParams.keep_alive
             },
             (chunk) => {
               if (chunk.delta) response += chunk.delta


### PR DESCRIPTION
## Summary

- reuse the selected model's provider-scoped runtime configuration for RAG query-rewrite calls
- keep `num_ctx`, GPU/thread/batch allocation, and `keep_alive` consistent with the main chat request
- prevent Ollama from alternating between its 4K default runner and the configured context runner
- add regression coverage for the forwarded runtime settings

## Testing

- `pnpm test src/application/context/__tests__/build-context.test.ts --run` — 26 passed
- `pnpm lint:check` — passed
- `pnpm typecheck` — passed
- `pnpm test:run` — 3272 passed; one unrelated Codex image-cancellation test timed out during the full parallel run and passed when rerun alone

Closes #315

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes RAG query reformulation reuse the selected model’s provider-scoped runtime configuration, keeping its Ollama runner settings aligned with the subsequent chat request.

- Reads and resolves the stored model configuration before query rewriting.
- Forwards context, thread, GPU, batch, and keep-alive settings to the rewrite request.
- Adds regression coverage for the forwarded values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the query-rewrite request now consistently using the selected model’s runtime configuration.

The rewrite and main chat paths use matching provider-scoped configuration semantics, unsupported adapters omit the added fields, and storage failures continue through the existing rewrite fallback.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/application/context/build-context.ts | Resolves the same provider-scoped model configuration used by normal chat and forwards its runtime settings during query reformulation; no changed-code defect was identified. |
| src/application/context/__tests__/build-context.test.ts | Extends rewrite-call regression coverage to assert forwarding of context, thread, GPU, batch, and keep-alive settings. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant RAG as RAG Context Builder
  participant S as Settings Storage
  participant F as Provider Factory
  participant P as Selected Provider
  RAG->>S: Read provider-scoped model config
  S-->>RAG: Runtime settings
  RAG->>F: Resolve model and provider
  F-->>RAG: Provider adapter
  RAG->>P: Rewrite query with runtime settings
  P-->>RAG: Standalone retrieval query
  RAG->>RAG: Retrieve and assemble context
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rag): preserve model runtime config ..."](https://github.com/shishir435/ollama-client/commit/6eeedf69b86fc3ec7da456755d38abef0a555e05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56275138)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Knowledge ingestion and retrieval](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/knowledge-retrieval.md)
- Knowledge Base — [Model connectivity](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/model-connectivity.md)
- Knowledge Base — [Provider abstraction and compatibility](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/provider-abstraction.md)
</details>


<!-- /greptile_comment -->