### PR TITLE
test(release): cover Ollama model reload regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Compatibility ledger
         run: pnpm check:compatibility
 
-      - name: Tests
-        run: pnpm test:run
+      - name: Tests and coverage thresholds
+        run: pnpm test:coverage
 
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, preview, "release/**"]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   # Lets the browser gates be re-run against any branch on demand — before
   # tagging a release, or after a flake — without opening a pull request.
   # Dispatch only becomes available once this file is on the default branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ permissions:
   contents: read
 
 jobs:
-  checks:
-    name: Typecheck, lint, test
+  static-checks:
+    name: Static checks
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -60,8 +60,71 @@ jobs:
       - name: Compatibility ledger
         run: pnpm check:compatibility
 
-      - name: Tests and coverage thresholds
-        run: pnpm test:coverage
+  test-shards:
+    name: Unit tests and coverage (shard ${{ matrix.shard }}/2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run test shard
+        run: pnpm exec vitest run --coverage --shard=${{ matrix.shard }}/2 --reporter=blob
+        env:
+          VITEST_COVERAGE_SHARD: "true"
+
+      - name: Upload test and coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vitest-report-${{ matrix.shard }}
+          path: .vitest-reports
+          include-hidden-files: true
+          retention-days: 1
+          if-no-files-found: error
+
+  checks:
+    # Preserve the stable check name used by branch protection while allowing
+    # static analysis and the two test shards to run at the same time.
+    name: Typecheck, lint, test
+    needs: [static-checks, test-shards]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download test and coverage reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: vitest-report-*
+          path: .vitest-reports
+          merge-multiple: true
+
+      - name: Merge reports and enforce coverage thresholds
+        run: pnpm exec vitest --merge-reports=.vitest-reports --coverage --reporter=default
 
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, preview]
+    branches: [main, preview, "release/**"]
   pull_request:
   # Lets the browser gates be re-run against any branch on demand — before
   # tagging a release, or after a flake — without opening a pull request.

--- a/docs/src/content/docs/guides/provider-setup.md
+++ b/docs/src/content/docs/guides/provider-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Provider Setup
-description: Configure Ollama, LM Studio, llama.cpp, OpenAI, OpenRouter, Anthropic, or compatible servers.
+description: Configure Ollama, LM Studio, llama.cpp, OpenAI, OpenRouter, Anthropic, Chinese frontier APIs, or compatible servers.
 ---
 
 Verified built-ins are Ollama, LM Studio, and llama.cpp. Add vLLM, LocalAI, KoboldCPP, or another compatible endpoint through **Add provider**. The OpenRouter preset uses its OpenAI-compatible Chat Completions API. Anthropic uses the native Messages API, while the generic Anthropic-compatible option also supports keyless local or LAN endpoints.
@@ -23,6 +23,29 @@ Install [Ollama Client](https://chromewebstore.google.com/detail/ollama-client-c
 | Anthropic | `https://api.anthropic.com/v1` | Remote Claude Messages API; API key required. |
 | Anthropic-compatible | User configured | Native Messages wire; API key is optional for compatible self-hosted endpoints. |
 | OpenRouter | `https://openrouter.ai/api/v1` | OpenAI-compatible hosted gateway; API key required. Model IDs keep their provider prefix. |
+
+### Contract-tested hosted compatibility endpoints
+
+The following hosted providers use **OpenAI-compatible** in the Add provider
+dialog. The listed URLs are editable examples, not client-side restrictions;
+regional endpoints, enterprise gateways, and reverse proxies are supported.
+Their request and streaming-response shapes are covered by fixture-based
+contract tests sourced from the vendors' current API documentation. These tests
+do not spend API credits or assert that every model supports every capability;
+they protect endpoint joining, Bearer authentication, model IDs, streamed text
+and reasoning, usage, and standard function tool calls from client regressions.
+
+| Provider | Base URL | Wire contract |
+|---|---|---|
+| DeepSeek | `https://api.deepseek.com` | OpenAI Chat Completions, including `reasoning_content` and tools. |
+| Qwen / Alibaba Model Studio | `https://dashscope.aliyuncs.com/compatible-mode/v1` | DashScope's OpenAI-compatible Chat Completions endpoint. Use the endpoint for your account region when it differs. |
+| Kimi / Moonshot | `https://api.moonshot.ai/v1` | OpenAI-compatible Chat Completions, including streamed tool-call fragments. |
+| Z.AI / GLM | `https://api.z.ai/api/paas/v4` | OpenAI-compatible Chat Completions. China accounts may use the BigModel endpoint instead. |
+
+The provider's own model documentation remains authoritative for vision,
+reasoning, tools, context limits, and regional availability. A passing client
+contract test means Ollama Client preserves the documented wire shape; it is
+not a live service-health check.
 
 ## 3. Start Ollama (primary path)
 

--- a/e2e/chromium/critical/__tests__/persistence.spec.ts
+++ b/e2e/chromium/critical/__tests__/persistence.spec.ts
@@ -17,6 +17,14 @@ interface Counts {
 
 const startFakeOllama = async () => {
   const promptCalls = new Map<string, number>()
+  const runtimeSignatures: Array<{
+    keepAlive?: string | number
+    model: string
+    numBatch?: number
+    numCtx?: number
+    numGpu?: number
+    numThread?: number
+  }> = []
   const readBody = (request: import("node:http").IncomingMessage) =>
     new Promise<string>((resolve) => {
       let body = ""
@@ -76,8 +84,24 @@ const startFakeOllama = async () => {
     }
     if (request.url === "/api/chat") {
       const body = JSON.parse(await readBody(request)) as {
+        keep_alive?: string | number
+        model?: string
         messages?: Array<{ role?: string; content?: string }>
+        options?: {
+          num_batch?: number
+          num_ctx?: number
+          num_gpu?: number
+          num_thread?: number
+        }
       }
+      runtimeSignatures.push({
+        model: body.model ?? "",
+        keepAlive: body.keep_alive,
+        numCtx: body.options?.num_ctx,
+        numThread: body.options?.num_thread,
+        numGpu: body.options?.num_gpu,
+        numBatch: body.options?.num_batch
+      })
       const userPrompt =
         [...(body.messages ?? [])]
           .reverse()
@@ -156,6 +180,8 @@ const startFakeOllama = async () => {
   return {
     baseUrl: `http://127.0.0.1:${port}`,
     callsFor: (prompt: string) => promptCalls.get(prompt) ?? 0,
+    runtimeSignaturesFor: (model: string) =>
+      runtimeSignatures.filter((signature) => signature.model === model),
     close: () =>
       new Promise<void>((resolve) => {
         for (const timer of pending) clearTimeout(timer)
@@ -191,6 +217,61 @@ test("@critical fresh OPFS profile survives a browser restart", async ({
     messages: 2
   })
   await page.close()
+})
+
+test("@critical RAG rewrite preserves Ollama runtime options before chat", async ({
+  extension
+}) => {
+  test.setTimeout(120_000)
+  const fakeOllama = await startFakeOllama()
+  try {
+    const { page, call } = await openPersistenceVerifyPage(extension)
+    await waitForOpfsMarker(call)
+    await call("configureFakeOllama", fakeOllama.baseUrl)
+    await call("buildConfiguredRagContext", "verify-runtime-config")
+
+    const assistantMessageId = (await call(
+      "startDurableTurn",
+      "verify-runtime-config-turn",
+      "runtime consistency e2e"
+    )) as number
+    await expect
+      .poll(
+        () =>
+          call(
+            "durableTurnResult",
+            "verify-runtime-config-turn",
+            assistantMessageId
+          ),
+        { timeout: 30_000 }
+      )
+      .toEqual({ status: "completed", content: "recovered", done: true })
+
+    await expect
+      .poll(() => fakeOllama.runtimeSignaturesFor("verify-model"))
+      .toHaveLength(2)
+    expect(fakeOllama.runtimeSignaturesFor("verify-model")).toEqual([
+      {
+        model: "verify-model",
+        keepAlive: "15m",
+        numCtx: 8192,
+        numThread: 8,
+        numGpu: 20,
+        numBatch: 256
+      },
+      {
+        model: "verify-model",
+        keepAlive: "15m",
+        numCtx: 8192,
+        numThread: 8,
+        numGpu: 20,
+        numBatch: 256
+      }
+    ])
+    await page.close()
+  } finally {
+    await fakeOllama.close()
+  }
 })
 
 test("@critical a generating turn completes after browser restart", async ({

--- a/packages/olc/src/backends/codex/__tests__/backend.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/backend.test.ts
@@ -186,14 +186,24 @@ describe("Codex backend", () => {
       executable,
       cwd: directory,
       log: vi.fn(),
-      requestTimeoutMs: 500
+      // Leave enough room for the child process to be scheduled under the full
+      // parallel suite before testing the initialize-response timeout itself.
+      requestTimeoutMs: 2_000
     })
 
     try {
-      await expect(client.start()).rejects.toThrow(
+      const firstStart = client.start()
+      await vi.waitFor(() => {
+        expect(readFileSync(pidFile, "utf8").trim().split("\n")).toHaveLength(1)
+      })
+      await expect(firstStart).rejects.toThrow(
         "Codex app-server request 'initialize' timed out"
       )
-      await expect(client.start()).rejects.toThrow(
+      const secondStart = client.start()
+      await vi.waitFor(() => {
+        expect(readFileSync(pidFile, "utf8").trim().split("\n")).toHaveLength(2)
+      })
+      await expect(secondStart).rejects.toThrow(
         "Codex app-server request 'initialize' timed out"
       )
       const pids = readFileSync(pidFile, "utf8").trim().split("\n").map(Number)
@@ -207,7 +217,7 @@ describe("Codex backend", () => {
     } finally {
       await client.shutdown()
     }
-  })
+  }, 15_000)
 
   it("interrupts an image turn cancelled while turn/start is pending", async () => {
     const directory = mkdtempSync(

--- a/packages/olc/src/backends/opencode/__tests__/turn-events.test.ts
+++ b/packages/olc/src/backends/opencode/__tests__/turn-events.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest"
+import { createTurnReader, extractFromParts } from "../turn-events.js"
+
+const retryAsync = async <T>(operation: () => Promise<T>): Promise<T> =>
+  operation()
+
+const clientWith = ({
+  diffs = [],
+  events = [],
+  messages = []
+}: {
+  diffs?: unknown
+  events?: unknown[]
+  messages?: unknown
+} = {}) => ({
+  event: {
+    subscribe: vi.fn(async () => ({
+      stream: (async function* () {
+        for (const event of events) yield event
+      })()
+    }))
+  },
+  session: {
+    diff: vi.fn(async () => diffs),
+    messages: vi.fn(async () => messages)
+  }
+})
+
+describe("extractFromParts", () => {
+  it("returns empty output for a non-array payload", () => {
+    expect(extractFromParts(null)).toEqual({
+      content: "",
+      reasoning: "",
+      toolErrors: []
+    })
+  })
+
+  it("joins text and reasoning while summarizing failed tools", () => {
+    expect(
+      extractFromParts([
+        { type: "text", text: "hello " },
+        { type: "text", text: "world" },
+        { type: "reasoning", text: "thinking" },
+        {
+          type: "tool",
+          tool: "search",
+          state: { status: "error", error: "denied" }
+        },
+        {
+          type: "tool",
+          name: "write",
+          state: { status: "failed", output: "disk full" }
+        },
+        { type: "tool", state: { status: "completed" } }
+      ])
+    ).toEqual({
+      content: "hello world",
+      reasoning: "thinking",
+      toolErrors: [
+        { tool: "search", error: "denied" },
+        { tool: "write", error: "disk full" }
+      ]
+    })
+  })
+})
+
+describe("OpenCode turn reader", () => {
+  it("normalizes wrapped, direct, and invalid session diffs", async () => {
+    const wrapped = clientWith({ diffs: { data: [{ file: "a.ts" }] } })
+    const direct = clientWith({ diffs: [{ file: "b.ts" }] })
+    const invalid = clientWith({ diffs: { data: { file: "c.ts" } } })
+
+    await expect(
+      createTurnReader({
+        client: wrapped as never,
+        retryAsync
+      }).getSessionDiffs("s1", "m1")
+    ).resolves.toEqual([{ file: "a.ts" }])
+    await expect(
+      createTurnReader({ client: direct as never, retryAsync }).getSessionDiffs(
+        "s2"
+      )
+    ).resolves.toEqual([{ file: "b.ts" }])
+    await expect(
+      createTurnReader({
+        client: invalid as never,
+        retryAsync
+      }).getSessionDiffs("s3")
+    ).resolves.toEqual([])
+    expect(wrapped.session.diff).toHaveBeenCalledWith({
+      path: { id: "s1" },
+      query: { messageID: "m1" }
+    })
+  })
+
+  it("streams classified text and reasoning until a terminal event", async () => {
+    const client = clientWith({
+      events: [
+        {
+          type: "message.part.updated",
+          properties: {
+            part: { sessionID: "session-1", id: "text-1", type: "text" },
+            delta: "hello"
+          }
+        },
+        {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              sessionID: "session-1",
+              id: "reason-1",
+              type: "reasoning"
+            },
+            delta: "think"
+          }
+        },
+        {
+          type: "message.updated",
+          properties: { info: { sessionID: "session-1", finish: "stop" } }
+        }
+      ]
+    })
+    const onDelta = vi.fn()
+    const reader = createTurnReader({ client: client as never, retryAsync })
+
+    const stream = await reader.openEventStream("session-1", {
+      timeoutMs: 1000,
+      onDelta
+    })
+
+    await expect(stream.done).resolves.toEqual({
+      content: "hello",
+      reasoning: "think",
+      finish: "stop"
+    })
+    expect(onDelta.mock.calls).toEqual([
+      ["hello", false],
+      ["think", true]
+    ])
+    expect(stream.controller.signal.aborted).toBe(true)
+  })
+
+  it("announces each patch hash once with its session diff", async () => {
+    const patch = {
+      sessionID: "session-1",
+      id: "patch-1",
+      messageID: "message-1",
+      type: "patch",
+      hash: "hash-1",
+      files: ["a.ts"]
+    }
+    const client = clientWith({
+      diffs: { data: [{ path: "a.ts" }] },
+      events: [
+        { type: "message.part.updated", properties: { part: patch } },
+        { type: "message.part.updated", properties: { part: patch } },
+        {
+          type: "message.updated",
+          properties: { info: { sessionID: "session-1", finish: "stop" } }
+        }
+      ]
+    })
+    const onPatch = vi.fn()
+    const reader = createTurnReader({ client: client as never, retryAsync })
+
+    const { done } = await reader.openEventStream("session-1", {
+      timeoutMs: 1000,
+      onPatch
+    })
+    await done
+
+    expect(onPatch).toHaveBeenCalledOnce()
+    expect(onPatch).toHaveBeenCalledWith({
+      hash: "hash-1",
+      files: ["a.ts"],
+      diffs: [{ path: "a.ts" }]
+    })
+  })
+
+  it("polls the latest assistant, emits progress, patches, and tool errors", async () => {
+    const client = clientWith({
+      diffs: [{ path: "changed.ts" }],
+      messages: {
+        data: [
+          { info: { role: "user" }, parts: [{ type: "text", text: "q" }] },
+          {
+            info: { role: "assistant", finish: "stop" },
+            parts: [
+              { type: "text", text: "answer" },
+              { type: "reasoning", text: "thought" },
+              {
+                type: "tool",
+                tool: "search",
+                state: { status: "error", error: "failed" }
+              },
+              {
+                id: "patch-1",
+                type: "patch",
+                hash: "hash-1",
+                files: ["changed.ts"]
+              }
+            ]
+          }
+        ]
+      }
+    })
+    const onProgress = vi.fn()
+    const onPatch = vi.fn()
+    const reader = createTurnReader({
+      client: client as never,
+      retryAsync,
+      pollIntervalMs: 0
+    })
+
+    await expect(
+      reader.pollForAssistantResponse("session-1", {
+        timeoutMs: 1000,
+        requireFinalOrContent: true,
+        onProgress,
+        onPatch
+      })
+    ).resolves.toMatchObject({
+      content: "answer",
+      reasoning: "thought",
+      finish: "stop",
+      toolErrors: [{ tool: "search", error: "failed" }]
+    })
+    expect(onProgress).toHaveBeenCalledWith("answer", "thought")
+    expect(onPatch).toHaveBeenCalledWith({
+      hash: "hash-1",
+      files: ["changed.ts"],
+      diffs: [{ path: "changed.ts" }]
+    })
+  })
+
+  it("returns immediately when polling observes suspension", async () => {
+    const client = clientWith()
+    const reader = createTurnReader({ client: client as never, retryAsync })
+
+    await expect(
+      reader.pollForAssistantResponse("session-1", {
+        timeoutMs: 1000,
+        isSuspended: () => true
+      })
+    ).resolves.toEqual({
+      content: "",
+      reasoning: "",
+      toolErrors: [],
+      suspended: true
+    })
+    expect(client.session.messages).not.toHaveBeenCalled()
+  })
+
+  it("retries only polling timeouts", async () => {
+    const client = clientWith({ messages: [] })
+    const reader = createTurnReader({
+      client: client as never,
+      retryAsync,
+      pollIntervalMs: 0
+    })
+
+    await expect(
+      reader.pollForAssistantResponseWithRetries(
+        "session-1",
+        { timeoutMs: 1, intervalMs: 0 },
+        1
+      )
+    ).rejects.toThrow("Request timeout")
+    expect(client.session.messages.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/olc/src/backends/opencode/plugin/__tests__/bridge.test.ts
+++ b/packages/olc/src/backends/opencode/plugin/__tests__/bridge.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  jsonSchemaToZodShape: vi.fn(() => ({ converted: true })),
+  readFileSync: vi.fn(),
+  tool: Object.assign(
+    vi.fn((definition) => definition),
+    {
+      schema: { string: vi.fn() }
+    }
+  )
+}))
+
+vi.mock("node:fs", () => ({
+  default: { readFileSync: mocks.readFileSync }
+}))
+
+vi.mock("@opencode-ai/plugin", () => ({ tool: mocks.tool }))
+
+vi.mock("../json-schema.js", () => ({
+  jsonSchemaToZodShape: mocks.jsonSchemaToZodShape
+}))
+
+import { olcBridge } from "../bridge.js"
+
+const manifest = (tools: unknown[]) =>
+  JSON.stringify({
+    endpoint: "http://127.0.0.1:4567/bridge",
+    token: "secret",
+    tools
+  })
+
+const context = {
+  abort: new AbortController().signal,
+  messageID: "message-1",
+  sessionID: "session-1"
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal("fetch", vi.fn())
+})
+
+describe("OpenCode client-tool bridge", () => {
+  it("returns no tools when the manifest cannot be read", async () => {
+    mocks.readFileSync.mockImplementationOnce(() => {
+      throw new Error("missing")
+    })
+
+    await expect(olcBridge()).resolves.toEqual({ tool: {} })
+  })
+
+  it("registers named tools, skips invalid entries, and supplies defaults", async () => {
+    mocks.readFileSync.mockReturnValueOnce(
+      manifest([
+        {
+          name: "search",
+          description: "Search documents",
+          parameters: { type: "object" }
+        },
+        { name: "plain" },
+        { description: "missing name" }
+      ])
+    )
+
+    const result = (await olcBridge()) as {
+      tool: Record<string, { args: unknown; description: string }>
+    }
+
+    expect(Object.keys(result.tool)).toEqual(["search", "plain"])
+    expect(result.tool.search).toMatchObject({
+      args: { converted: true },
+      description: "Search documents"
+    })
+    expect(result.tool.plain.description).toBe("Client tool plain")
+    expect(mocks.jsonSchemaToZodShape).toHaveBeenCalledTimes(2)
+  })
+
+  it("posts execution context and returns a string output", async () => {
+    mocks.readFileSync.mockReturnValueOnce(manifest([{ name: "search" }]))
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ output: "found" }), { status: 200 })
+    )
+    const result = (await olcBridge()) as {
+      tool: Record<
+        string,
+        { execute: (args: unknown, runtime: typeof context) => Promise<string> }
+      >
+    }
+
+    await expect(
+      result.tool.search.execute({ query: "llama" }, context)
+    ).resolves.toBe("found")
+    expect(fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:4567/bridge",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-OLC-Token": "secret"
+        },
+        body: JSON.stringify({
+          tool: "search",
+          arguments: { query: "llama" },
+          sessionID: "session-1",
+          messageID: "message-1"
+        }),
+        signal: context.abort
+      })
+    )
+  })
+
+  it("serializes a non-string successful output", async () => {
+    mocks.readFileSync.mockReturnValueOnce(manifest([{ name: "search" }]))
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ output: { hits: 2 } }), { status: 200 })
+    )
+    const result = (await olcBridge()) as {
+      tool: Record<
+        string,
+        { execute: (args: unknown, runtime: typeof context) => Promise<string> }
+      >
+    }
+
+    await expect(result.tool.search.execute(undefined, context)).resolves.toBe(
+      JSON.stringify({ hits: 2 })
+    )
+  })
+
+  it("surfaces the bridge's structured HTTP error", async () => {
+    mocks.readFileSync.mockReturnValueOnce(manifest([{ name: "search" }]))
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "tool denied" }), { status: 403 })
+    )
+    const result = (await olcBridge()) as {
+      tool: Record<
+        string,
+        { execute: (args: unknown, runtime: typeof context) => Promise<string> }
+      >
+    }
+
+    await expect(result.tool.search.execute({}, context)).rejects.toThrow(
+      "tool denied"
+    )
+  })
+
+  it("uses the HTTP status when the error body is not JSON", async () => {
+    mocks.readFileSync.mockReturnValueOnce(manifest([{ name: "search" }]))
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("bad gateway", { status: 502 })
+    )
+    const result = (await olcBridge()) as {
+      tool: Record<
+        string,
+        { execute: (args: unknown, runtime: typeof context) => Promise<string> }
+      >
+    }
+
+    await expect(result.tool.search.execute({}, context)).rejects.toThrow(
+      "bridge returned HTTP 502"
+    )
+  })
+})

--- a/packages/olc/src/core/__tests__/models-route.test.ts
+++ b/packages/olc/src/core/__tests__/models-route.test.ts
@@ -1,0 +1,132 @@
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { AgentBackend, CatalogModel } from "../../backends/types.js"
+import { createRouter } from "../http.js"
+import { registerModelRoutes } from "../models-route.js"
+
+const models: CatalogModel[] = [
+  {
+    id: "opencode/model-a",
+    object: "model",
+    created: 1,
+    owned_by: "opencode",
+    name: "Model A",
+    input_modalities: ["text"],
+    supported_parameters: ["tools"],
+    capabilities: {
+      function_calling: true,
+      vision: false,
+      reasoning: false
+    }
+  },
+  {
+    id: "model-b",
+    object: "model",
+    created: 2,
+    owned_by: "local",
+    name: "Model B",
+    input_modalities: ["text"],
+    supported_parameters: [],
+    capabilities: {
+      function_calling: false,
+      vision: false,
+      reasoning: false
+    }
+  }
+]
+
+const backend = (listModels = vi.fn(async () => models)): AgentBackend => ({
+  id: "fake",
+  ensureReady: vi.fn(async () => {}),
+  listModels,
+  resolveModel: vi.fn(async () => ({ providerId: "fake", modelId: "a" })),
+  startTurn: vi.fn(async () => {
+    throw new Error("not used")
+  }),
+  findTurn: () => undefined,
+  shutdown: vi.fn(async () => {})
+})
+
+describe("model catalog routes", () => {
+  let server: Server | null = null
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server?.close(() => resolve()))
+      server = null
+    }
+  })
+
+  const start = async (activeBackend: AgentBackend, log = vi.fn()) => {
+    const router = createRouter()
+    registerModelRoutes(router, { backend: activeBackend, log })
+    server = createServer((request, response) => {
+      void router.handle(request, response)
+    })
+    await new Promise<void>((resolve) =>
+      server?.listen(0, "127.0.0.1", resolve)
+    )
+    const { port } = server.address() as AddressInfo
+    return { baseUrl: `http://127.0.0.1:${port}`, log }
+  }
+
+  it("returns the complete backend catalog", async () => {
+    const { baseUrl, log } = await start(backend())
+
+    const response = await fetch(`${baseUrl}/v1/models`)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ object: "list", data: models })
+    expect(log).toHaveBeenCalledWith("GET /v1/models ok", { count: 2 })
+  })
+
+  it("finds a model by its full id", async () => {
+    const { baseUrl } = await start(backend())
+
+    const response = await fetch(`${baseUrl}/v1/models/model-b`)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ id: "model-b" })
+  })
+
+  it("finds a provider-prefixed model by its short id", async () => {
+    const { baseUrl } = await start(backend())
+
+    const response = await fetch(`${baseUrl}/v1/models/model-a`)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ id: "opencode/model-a" })
+  })
+
+  it("returns 404 for an unknown model", async () => {
+    const { baseUrl } = await start(backend())
+
+    const response = await fetch(`${baseUrl}/v1/models/missing`)
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({
+      error: { message: "Model not found" }
+    })
+  })
+
+  it.each([
+    "/v1/models",
+    "/v1/models/model-a"
+  ])("maps backend catalog failures on %s to 502", async (path) => {
+    const listModels = vi.fn(async () => {
+      throw new Error("catalog offline")
+    })
+    const { baseUrl } = await start(backend(listModels))
+
+    const response = await fetch(`${baseUrl}${path}`)
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Could not read the model catalog: catalog offline",
+        type: "CatalogError"
+      }
+    })
+  })
+})

--- a/src/application/context/__tests__/build-context.test.ts
+++ b/src/application/context/__tests__/build-context.test.ts
@@ -646,6 +646,17 @@ describe("prompt stats", () => {
 describe("query reformulation provider call", () => {
   it("invokeModelOnce is wired with the streaming provider when reformulation runs", async () => {
     ragsetOn()
+    mockedStorageGet
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce({
+        "ollama::llama3": {
+          num_ctx: 8192,
+          num_thread: 8,
+          num_gpu: 20,
+          num_batch: 256,
+          keep_alive: "15m"
+        }
+      } as never)
     mockedGetActiveKnowledgeSet.mockResolvedValueOnce({
       id: "ks-1",
       name: "K",
@@ -699,7 +710,12 @@ describe("query reformulation provider call", () => {
         temperature: 0.2,
         num_predict: 64,
         stop: ["\n"],
-        think: false
+        think: false,
+        num_ctx: 8192,
+        num_thread: 8,
+        num_gpu: 20,
+        num_batch: 256,
+        keep_alive: "15m"
       }),
       expect.any(Function),
       expect.any(AbortSignal)

--- a/src/application/context/__tests__/build-context.test.ts
+++ b/src/application/context/__tests__/build-context.test.ts
@@ -723,6 +723,66 @@ describe("query reformulation provider call", () => {
     // The reformulated value ("pong") should be the query sent to retrieve.
     expect(mockedRetrieve.mock.calls[0]?.[0]).toBe("pong")
   })
+
+  it("preserves legacy bare runtime config during query reformulation", async () => {
+    ragsetOn()
+    mockedStorageGet
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce({
+        llama3: {
+          num_ctx: 32768,
+          num_thread: 4,
+          num_gpu: 0,
+          num_batch: 128,
+          keep_alive: 0
+        }
+      } as never)
+    mockedGetActiveKnowledgeSet.mockResolvedValueOnce({
+      id: "ks-1",
+      name: "K",
+      questionPrompt: "QP"
+    } as never)
+    mockedReformulate.mockImplementationOnce(async (_q, _hist, invoke) =>
+      invoke("ping")
+    )
+
+    const fakeProvider = {
+      id: "ollama",
+      config: {
+        id: "ollama",
+        type: "ollama",
+        enabled: true,
+        baseUrl: "http://localhost:11434",
+        name: "Ollama"
+      },
+      streamChat: vi.fn(async (_req, onChunk) => {
+        onChunk({ delta: "pong" })
+      })
+    }
+    mockedGetProvider.mockResolvedValueOnce(fakeProvider as never)
+
+    await buildRagContext(
+      defaults({
+        messages: [
+          { role: "user", content: "x" },
+          { role: "assistant", content: "y", done: true }
+        ]
+      })
+    )
+
+    expect(fakeProvider.streamChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "llama3",
+        num_ctx: 32768,
+        num_thread: 4,
+        num_gpu: 0,
+        num_batch: 128,
+        keep_alive: 0
+      }),
+      expect.any(Function),
+      expect.any(AbortSignal)
+    )
+  })
 })
 
 describe("conversation-memory recall (file-independent)", () => {

--- a/src/application/context/build-context.ts
+++ b/src/application/context/build-context.ts
@@ -22,6 +22,10 @@ import {
   type KnowledgeSetRecord
 } from "@/lib/knowledge/knowledge-sets"
 import { logger } from "@/lib/logger"
+import {
+  getStoredModelConfig,
+  resolveModelConfig
+} from "@/lib/model-config-utils"
 import { ProviderFactory } from "@/lib/providers/factory"
 import { assertProviderEnabled } from "@/lib/providers/provider-policy"
 import { readSetting } from "@/lib/storage/setting-access"
@@ -178,6 +182,14 @@ export const buildRagContext = async (
         selectedModelRef?.providerId
       )
       assertProviderEnabled(provider, modelId)
+      const modelConfigMap = await readSetting(SETTINGS.MODEL_CONFIGS)
+      const modelParams = resolveModelConfig(
+        getStoredModelConfig(
+          modelConfigMap,
+          modelId,
+          selectedModelRef?.providerId
+        )
+      )
       let response = ""
       await withTimeoutSignal(
         (signal) =>
@@ -188,7 +200,12 @@ export const buildRagContext = async (
               temperature: 0.2,
               num_predict: 64,
               stop: ["\n"],
-              think: false
+              think: false,
+              num_ctx: modelParams.num_ctx,
+              num_thread: modelParams.num_thread,
+              num_gpu: modelParams.num_gpu,
+              num_batch: modelParams.num_batch,
+              keep_alive: modelParams.keep_alive
             },
             (chunk) => {
               if (chunk.delta) response += chunk.delta

--- a/src/background/__tests__/persistence-readiness.test.ts
+++ b/src/background/__tests__/persistence-readiness.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  ensureMigrated: vi.fn(),
+  ensurePersistenceOwnerReady: vi.fn(),
+  registerChromiumPersistenceControl: vi.fn(),
+  registerPersistenceHost: vi.fn()
+}))
+
+vi.mock("@/lib/persistence/chromium-owner", () => ({
+  ensurePersistenceOwnerReady: mocks.ensurePersistenceOwnerReady,
+  registerChromiumPersistenceControl: mocks.registerChromiumPersistenceControl
+}))
+
+vi.mock("@/lib/persistence/owner-host", () => ({
+  ensureMigrated: mocks.ensureMigrated,
+  registerPersistenceHost: mocks.registerPersistenceHost
+}))
+
+const loadTopology = async ({
+  firefox = false,
+  ownerAvailable = true,
+  spike = false
+}: {
+  firefox?: boolean
+  ownerAvailable?: boolean
+  spike?: boolean
+} = {}) => {
+  vi.resetModules()
+  vi.stubGlobal("__FIREFOX_BG_OWNER__", firefox)
+  vi.stubGlobal("__SPIKE_OPFS_OWNER__", spike)
+  vi.stubGlobal("__SPIKE_OPFS_OWNER_MV2__", false)
+  chrome.runtime.onMessage = (ownerAvailable
+    ? { addListener: vi.fn() }
+    : undefined) as unknown as typeof chrome.runtime.onMessage
+  return import("../persistence-readiness")
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.ensureMigrated.mockResolvedValue(undefined)
+  mocks.ensurePersistenceOwnerReady.mockResolvedValue(undefined)
+  document.body.innerHTML = ""
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("startPersistenceTopology", () => {
+  it("is a no-op when the runtime has no owner topology", async () => {
+    const { startPersistenceTopology } = await loadTopology({
+      ownerAvailable: false
+    })
+
+    await expect(startPersistenceTopology()).resolves.toBeUndefined()
+    expect(mocks.registerChromiumPersistenceControl).not.toHaveBeenCalled()
+    expect(mocks.registerPersistenceHost).not.toHaveBeenCalled()
+  })
+
+  it("is a no-op in the benchmark build that owns the offscreen slot", async () => {
+    const { startPersistenceTopology } = await loadTopology({ spike: true })
+
+    await expect(startPersistenceTopology()).resolves.toBeUndefined()
+    expect(mocks.registerChromiumPersistenceControl).not.toHaveBeenCalled()
+  })
+
+  it("shares one Chromium startup across concurrent callers", async () => {
+    let releaseOwner: (() => void) | undefined
+    mocks.ensurePersistenceOwnerReady.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseOwner = resolve
+        })
+    )
+    const { startPersistenceTopology } = await loadTopology()
+
+    const first = startPersistenceTopology()
+    const second = startPersistenceTopology()
+
+    expect(first).toBe(second)
+    await vi.waitFor(() => {
+      expect(mocks.registerChromiumPersistenceControl).toHaveBeenCalledOnce()
+      expect(mocks.ensurePersistenceOwnerReady).toHaveBeenCalledOnce()
+    })
+
+    releaseOwner?.()
+    await expect(first).resolves.toBeUndefined()
+  })
+
+  it("clears a failed startup so the next caller can retry", async () => {
+    mocks.ensurePersistenceOwnerReady
+      .mockRejectedValueOnce(new Error("offscreen creation failed"))
+      .mockResolvedValueOnce(undefined)
+    const { startPersistenceTopology } = await loadTopology()
+
+    await expect(startPersistenceTopology()).rejects.toThrow(
+      "offscreen creation failed"
+    )
+    await expect(startPersistenceTopology()).resolves.toBeUndefined()
+
+    expect(mocks.registerChromiumPersistenceControl).toHaveBeenCalledTimes(2)
+    expect(mocks.ensurePersistenceOwnerReady).toHaveBeenCalledTimes(2)
+  })
+
+  it("starts the Firefox in-process owner and installs one ingestion host", async () => {
+    const append = vi
+      .spyOn(document.body, "append")
+      .mockImplementation(() => {})
+    const { startPersistenceTopology } = await loadTopology({ firefox: true })
+
+    await startPersistenceTopology()
+    await startPersistenceTopology()
+
+    expect(mocks.registerPersistenceHost).toHaveBeenCalledOnce()
+    expect(mocks.ensureMigrated).toHaveBeenCalledOnce()
+    expect(append).toHaveBeenCalledOnce()
+    const frame = append.mock.calls[0]?.[0] as HTMLIFrameElement
+    expect(frame.id).toBe("ingestion-processor-host")
+    expect(frame.hidden).toBe(true)
+    expect(frame.src).toBe(
+      "chrome-extension://test/ingestion-processor.html?host=1"
+    )
+  })
+})

--- a/src/background/handlers/__tests__/small-handlers.test.ts
+++ b/src/background/handlers/__tests__/small-handlers.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  notifyJobComplete: vi.fn(),
+  queryTabs: vi.fn(),
+  resolveToolConfirmation: vi.fn(),
+  safeSendResponse: vi.fn(),
+  startDurableTurn: vi.fn()
+}))
+
+vi.mock("@/background/lib/notify", () => ({
+  notifyJobComplete: mocks.notifyJobComplete
+}))
+
+vi.mock("@/background/lib/runtime-delivery", () => ({
+  safeSendResponse: mocks.safeSendResponse
+}))
+
+vi.mock("@/background/lib/tool-confirmation-registry", () => ({
+  resolveToolConfirmation: mocks.resolveToolConfirmation
+}))
+
+vi.mock("@/background/durable-turn-runtime", () => ({
+  startDurableTurn: mocks.startDurableTurn
+}))
+
+vi.mock("@/background/lib/error-handler", () => ({
+  withErrorContext:
+    (
+      handler: (...args: unknown[]) => unknown,
+      context: {
+        resolveDiagnosticSessionId?: (message: unknown) => string | undefined
+      }
+    ) =>
+    (...args: unknown[]) => {
+      context.resolveDiagnosticSessionId?.(args[0])
+      return handler(...args)
+    }
+}))
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: { tabs: { query: mocks.queryTabs } }
+}))
+
+import {
+  handleJobCompleteNotification,
+  handleKeepToolLoopAlive
+} from "../handle-app-messages"
+import { handleOpenTabs } from "../handle-browser-messages"
+import { handleStartTurn } from "../handle-start-turn"
+import { handleToolConfirmation } from "../handle-tool-confirmation"
+
+const sendResponse = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("application message handlers", () => {
+  it("acknowledges the tool-loop keepalive synchronously", () => {
+    expect(handleKeepToolLoopAlive(sendResponse)).toBeUndefined()
+    expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+      success: true
+    })
+  })
+
+  it("rejects an invalid job-notification payload", () => {
+    const result = handleJobCompleteNotification(
+      { type: "notify", payload: { title: 42 } } as never,
+      sendResponse
+    )
+
+    expect(result).toBe(true)
+    expect(mocks.notifyJobComplete).not.toHaveBeenCalled()
+    expect(mocks.safeSendResponse).toHaveBeenCalledWith(
+      sendResponse,
+      expect.objectContaining({
+        success: false,
+        error: { status: 400, message: "Invalid message payload" }
+      })
+    )
+  })
+
+  it("returns the notification result and optional id", async () => {
+    mocks.notifyJobComplete.mockResolvedValueOnce({ sent: true })
+
+    expect(
+      handleJobCompleteNotification(
+        {
+          type: "notify",
+          payload: { id: "job-1", title: "Done", message: "Finished" }
+        } as never,
+        sendResponse
+      )
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(mocks.notifyJobComplete).toHaveBeenCalledWith({
+        id: "job-1",
+        title: "Done",
+        message: "Finished"
+      })
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+        success: true,
+        data: { sent: true },
+        error: undefined
+      })
+    })
+  })
+
+  it("reports a skipped notification with its reason", async () => {
+    mocks.notifyJobComplete.mockResolvedValueOnce({
+      sent: false,
+      reason: "permission denied"
+    })
+
+    handleJobCompleteNotification(
+      {
+        type: "notify",
+        payload: { title: "Done", message: "Finished" }
+      } as never,
+      sendResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(
+        sendResponse,
+        expect.objectContaining({
+          success: false,
+          error: { status: 0, message: "permission denied" }
+        })
+      )
+    })
+  })
+
+  it("converts a notification rejection into an error response", async () => {
+    mocks.notifyJobComplete.mockRejectedValueOnce(new Error("notify failed"))
+
+    handleJobCompleteNotification(
+      {
+        type: "notify",
+        payload: { title: "Done", message: "Finished" }
+      } as never,
+      sendResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+        success: false,
+        error: { status: 0, message: "notify failed" }
+      })
+    })
+  })
+})
+
+describe("browser message handlers", () => {
+  it("returns the queried tabs", async () => {
+    const tabs = [{ id: 1, title: "One" }]
+    mocks.queryTabs.mockResolvedValueOnce(tabs)
+
+    expect(handleOpenTabs(sendResponse)).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(mocks.queryTabs).toHaveBeenCalledWith({})
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+        success: true,
+        tabs
+      })
+    })
+  })
+
+  it("returns the browser query error", async () => {
+    mocks.queryTabs.mockRejectedValueOnce(new Error("tabs unavailable"))
+
+    handleOpenTabs(sendResponse)
+
+    await vi.waitFor(() => {
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+        success: false,
+        error: { status: 0, message: "tabs unavailable" }
+      })
+    })
+  })
+
+  it("uses a stable fallback for non-Error query failures", async () => {
+    mocks.queryTabs.mockRejectedValueOnce("closed")
+
+    handleOpenTabs(sendResponse)
+
+    await vi.waitFor(() => {
+      expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+        success: false,
+        error: { status: 0, message: "Failed to query tabs" }
+      })
+    })
+  })
+})
+
+describe("tool confirmation handler", () => {
+  it.each([
+    "session",
+    "always"
+  ] as const)("forwards an approved %s scope", (scope) => {
+    expect(
+      handleToolConfirmation(
+        {
+          type: "confirm",
+          payload: { callId: "call-1", approved: true, scope }
+        } as never,
+        sendResponse
+      )
+    ).toBeUndefined()
+
+    expect(mocks.resolveToolConfirmation).toHaveBeenCalledWith(
+      "call-1",
+      true,
+      scope
+    )
+    expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+      success: true
+    })
+  })
+
+  it("drops an invalid scope but preserves the decision", () => {
+    handleToolConfirmation(
+      {
+        type: "confirm",
+        payload: { callId: "call-2", approved: false, scope: "global" }
+      } as never,
+      sendResponse
+    )
+
+    expect(mocks.resolveToolConfirmation).toHaveBeenCalledWith(
+      "call-2",
+      false,
+      undefined
+    )
+  })
+
+  it("rejects a missing call id without touching the registry", () => {
+    handleToolConfirmation(
+      { type: "confirm", payload: { approved: true } } as never,
+      sendResponse
+    )
+
+    expect(mocks.resolveToolConfirmation).not.toHaveBeenCalled()
+    expect(mocks.safeSendResponse).toHaveBeenCalledWith(sendResponse, {
+      success: false
+    })
+  })
+})
+
+describe("durable turn adapter", () => {
+  it("forwards the durable submission and stream lifecycle", async () => {
+    const port = { postMessage: vi.fn() }
+    const isPortClosed = vi.fn(() => false)
+    const submission = { sessionId: "session-1", rawInput: "hello" }
+
+    await handleStartTurn(
+      {
+        type: "start-turn",
+        payload: {
+          assistantMessageId: 22,
+          start: { submission, userMessageId: 11 }
+        }
+      } as never,
+      port as never,
+      isPortClosed
+    )
+
+    expect(mocks.startDurableTurn).toHaveBeenCalledWith(submission, 11, 22, {
+      port,
+      isPortClosed
+    })
+  })
+})

--- a/src/contents/__tests__/content-config.test.ts
+++ b/src/contents/__tests__/content-config.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getEffectiveConfig: vi.fn(),
+  readSetting: vi.fn(),
+  readStoredSetting: vi.fn()
+}))
+
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  DEFAULT_CONTENT_EXTRACTION_CONFIG: {
+    contentScraper: "auto",
+    enabled: true,
+    excludedUrlPatterns: [],
+    maxWaitTime: 1000,
+    scrollDepth: 0.8,
+    scrollStrategy: "incremental",
+    siteOverrides: {}
+  }
+}))
+
+vi.mock("@/lib/content-extractor", () => ({
+  getEffectiveConfig: mocks.getEffectiveConfig
+}))
+
+vi.mock("@/lib/storage/setting-access", () => ({
+  readSetting: mocks.readSetting,
+  readStoredSetting: mocks.readStoredSetting
+}))
+
+import { resolveActiveConfig } from "../content-config"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.readStoredSetting.mockResolvedValue(undefined)
+  mocks.readSetting.mockResolvedValue([])
+  mocks.getEffectiveConfig.mockImplementation((_url, config) => config)
+})
+
+describe("resolveActiveConfig", () => {
+  it("uses the stored config and detects a matching regex override", async () => {
+    mocks.readStoredSetting.mockResolvedValueOnce({
+      contentScraper: "readability",
+      enabled: true,
+      excludedUrlPatterns: ["private"],
+      siteOverrides: {
+        "example\\.com/articles": { contentScraper: "defuddle" }
+      }
+    })
+
+    const result = await resolveActiveConfig(
+      "https://example.com/articles/testing"
+    )
+
+    expect(mocks.readSetting).not.toHaveBeenCalled()
+    expect(mocks.getEffectiveConfig).toHaveBeenCalledWith(
+      "https://example.com/articles/testing",
+      expect.objectContaining({
+        excludedUrlPatterns: ["private"],
+        siteOverrides: expect.objectContaining({
+          "example\\.com/articles": { contentScraper: "defuddle" }
+        })
+      }),
+      expect.any(Object)
+    )
+    expect(result.hasSiteOverride).toBe(true)
+  })
+
+  it("migrates legacy exclusion patterns when the stored list is empty", async () => {
+    mocks.readStoredSetting.mockResolvedValueOnce({
+      enabled: false,
+      excludedUrlPatterns: [],
+      siteOverrides: undefined
+    })
+    mocks.readSetting.mockResolvedValueOnce(["legacy-private"])
+
+    await resolveActiveConfig("https://example.com")
+
+    expect(mocks.getEffectiveConfig).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        enabled: false,
+        excludedUrlPatterns: ["legacy-private"],
+        siteOverrides: {}
+      }),
+      expect.any(Object)
+    )
+  })
+
+  it("builds from defaults when no stored extraction config exists", async () => {
+    mocks.readSetting.mockResolvedValueOnce(["blocked.example"])
+
+    const result = await resolveActiveConfig("https://public.example")
+
+    expect(mocks.getEffectiveConfig).toHaveBeenCalledWith(
+      "https://public.example",
+      expect.objectContaining({
+        contentScraper: "auto",
+        enabled: true,
+        excludedUrlPatterns: ["blocked.example"]
+      }),
+      expect.any(Object)
+    )
+    expect(result.hasSiteOverride).toBe(false)
+  })
+
+  it("falls back to substring matching for an invalid regex override", async () => {
+    mocks.readStoredSetting.mockResolvedValueOnce({
+      enabled: true,
+      excludedUrlPatterns: ["keep-current"],
+      siteOverrides: { "[broken": { enabled: false } }
+    })
+
+    const result = await resolveActiveConfig(
+      "https://example.com/path/[broken/page"
+    )
+
+    expect(result.hasSiteOverride).toBe(true)
+  })
+})

--- a/src/contents/__tests__/page-content-handler.test.ts
+++ b/src/contents/__tests__/page-content-handler.test.ts
@@ -146,6 +146,67 @@ describe("handleGetPageContent", () => {
     expect(mocks.extractReadableContent).not.toHaveBeenCalled()
   })
 
+  it("returns a useful YouTube response even when no transcript exists", async () => {
+    mocks.isYouTubeVideoPage.mockReturnValueOnce(true)
+    mocks.getYouTubeVideoId.mockReturnValueOnce("video-404")
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    const response = sendResponse.mock.calls[0]?.[0] as { html: string }
+    expect(response.html).toContain(
+      "No transcript found for this YouTube video."
+    )
+    expect(response.html).toContain("Transcript:")
+    expect(mocks.extractReadableContent).not.toHaveBeenCalled()
+  })
+
+  it("returns a Udemy transcript without regular page extraction", async () => {
+    mocks.isUdemyLecturePage.mockReturnValueOnce(true)
+    mocks.getTranscript.mockResolvedValueOnce("Lecture transcript")
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: "Lecture transcript",
+        title: "Resolved title"
+      })
+    )
+    expect(mocks.extractContentWithLoading).not.toHaveBeenCalled()
+    expect(mocks.extractReadableContent).not.toHaveBeenCalled()
+  })
+
+  it("falls back to page extraction when a Udemy transcript is missing", async () => {
+    mocks.isUdemyLecturePage.mockReturnValueOnce(true)
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(mocks.extractContentWithLoading).toHaveBeenCalled()
+    expect(mocks.extractReadableContent).toHaveBeenCalled()
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true })
+    )
+  })
+
+  it("skips enhanced extraction when it is disabled by configuration", async () => {
+    mocks.resolveActiveConfig.mockResolvedValueOnce({
+      effectiveConfig: { ...extractionConfig, enabled: false },
+      hasSiteOverride: true
+    })
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(mocks.extractContentWithLoading).not.toHaveBeenCalled()
+    expect(mocks.extractReadableContent).toHaveBeenCalledWith(document, "auto")
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true })
+    )
+  })
+
   it("falls back to readable extraction when enhanced extraction fails", async () => {
     mocks.extractContentWithLoading.mockRejectedValueOnce(
       new Error("provider unavailable")

--- a/src/contents/__tests__/page-content-handler.test.ts
+++ b/src/contents/__tests__/page-content-handler.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  extractContentWithLoading: vi.fn(),
+  extractReadableContent: vi.fn(),
+  getTranscript: vi.fn(),
+  getYouTubeVideoId: vi.fn(),
+  isExcludedUrl: vi.fn(),
+  isUdemyLecturePage: vi.fn(),
+  isYouTubeVideoPage: vi.fn(),
+  readSetting: vi.fn(),
+  resolveActiveConfig: vi.fn(),
+  resolvePageTitle: vi.fn()
+}))
+
+vi.mock("@/lib/content-extractor", () => ({
+  extractContentWithLoading: mocks.extractContentWithLoading
+}))
+
+vi.mock("@/lib/storage/setting-access", () => ({
+  readSetting: mocks.readSetting
+}))
+
+vi.mock("@/lib/transcript-extractor", () => ({
+  getTranscript: mocks.getTranscript
+}))
+
+vi.mock("@/lib/youtube-url", () => ({
+  getYouTubeVideoId: mocks.getYouTubeVideoId
+}))
+
+vi.mock("../content-config", () => ({
+  resolveActiveConfig: mocks.resolveActiveConfig
+}))
+
+vi.mock("../content-extraction", () => ({
+  extractReadableContent: mocks.extractReadableContent,
+  resolvePageTitle: mocks.resolvePageTitle
+}))
+
+vi.mock("../page-platforms", () => ({
+  isUdemyLecturePage: mocks.isUdemyLecturePage,
+  isYouTubeVideoPage: mocks.isYouTubeVideoPage
+}))
+
+vi.mock("../url-filter", () => ({
+  isExcludedUrl: mocks.isExcludedUrl
+}))
+
+import { handleGetPageContent } from "../page-content-handler"
+
+const extractionConfig = {
+  contentScraper: "auto",
+  enabled: true,
+  maxWaitTime: 1000,
+  scrollDepth: 0.8,
+  scrollStrategy: "incremental"
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.head.innerHTML = ""
+  document.body.innerHTML = ""
+  document.title = "Page title"
+  window.history.replaceState({}, "", "/article")
+  mocks.readSetting.mockResolvedValue(true)
+  mocks.isExcludedUrl.mockResolvedValue(false)
+  mocks.isYouTubeVideoPage.mockReturnValue(false)
+  mocks.isUdemyLecturePage.mockReturnValue(false)
+  mocks.resolveActiveConfig.mockResolvedValue({
+    effectiveConfig: extractionConfig,
+    hasSiteOverride: false
+  })
+  mocks.extractContentWithLoading.mockResolvedValue({
+    metrics: { duration: 12, scrollSteps: 2 }
+  })
+  mocks.extractReadableContent.mockReturnValue({
+    pageTitle: "Extracted title",
+    readableText: "Useful article text. ".repeat(8),
+    selectedExtractor: "defuddle",
+    selectedReason: "defuddle-markdown"
+  })
+  mocks.resolvePageTitle.mockReturnValue("Resolved title")
+  mocks.getTranscript.mockResolvedValue(null)
+  mocks.getYouTubeVideoId.mockReturnValue(null)
+})
+
+describe("handleGetPageContent", () => {
+  it("fails closed before extraction when tab access is disabled", async () => {
+    mocks.readSetting.mockResolvedValueOnce(false)
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      html: "Tab access is disabled by the user.",
+      title: "Page title"
+    })
+    expect(mocks.resolveActiveConfig).not.toHaveBeenCalled()
+    expect(mocks.extractReadableContent).not.toHaveBeenCalled()
+  })
+
+  it("rejects an excluded URL before resolving extraction config", async () => {
+    mocks.isExcludedUrl.mockResolvedValueOnce(true)
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      html: "This page is excluded by your settings.",
+      title: "Page title"
+    })
+    expect(mocks.resolveActiveConfig).not.toHaveBeenCalled()
+  })
+
+  it("returns canonical YouTube metadata and transcript without scraping the page", async () => {
+    mocks.isYouTubeVideoPage.mockReturnValueOnce(true)
+    mocks.getYouTubeVideoId.mockReturnValueOnce("video-123")
+    mocks.getTranscript.mockResolvedValueOnce("First line\nSecond line")
+    document.body.innerHTML = `
+      <div id="channel-name"><a> Test Channel </a></div>
+      <div id="top-level-buttons-computed">
+        <button aria-label="1,234 likes"></button>
+        <button aria-label="5 dislikes"></button>
+      </div>
+    `
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledOnce()
+    const response = sendResponse.mock.calls[0]?.[0] as {
+      html: string
+      title: string
+    }
+    expect(response.title).toBe("Resolved title")
+    expect(response.html).toContain(
+      "Video URL: https://www.youtube.com/watch?v=video-123"
+    )
+    expect(response.html).toContain("Channel: Test Channel")
+    expect(response.html).toContain("Likes: 1,234 likes")
+    expect(response.html).toContain("First line\nSecond line")
+    expect(mocks.extractContentWithLoading).not.toHaveBeenCalled()
+    expect(mocks.extractReadableContent).not.toHaveBeenCalled()
+  })
+
+  it("falls back to readable extraction when enhanced extraction fails", async () => {
+    mocks.extractContentWithLoading.mockRejectedValueOnce(
+      new Error("provider unavailable")
+    )
+    mocks.getTranscript.mockResolvedValueOnce("Transcript text")
+    const sendResponse = vi.fn()
+
+    await handleGetPageContent(sendResponse)
+
+    expect(mocks.extractReadableContent).toHaveBeenCalledWith(document, "auto")
+    expect(sendResponse).toHaveBeenCalledOnce()
+    const response = sendResponse.mock.calls[0]?.[0] as {
+      extractionDebug: Record<string, unknown>
+      html: string
+      success: boolean
+      title: string
+    }
+    expect(response).toMatchObject({
+      success: true,
+      title: "Resolved title"
+    })
+    expect(response.html).toContain("Transcript text")
+    expect(response.html).toContain("Useful article text")
+    expect(response.extractionDebug).toMatchObject({
+      hasTranscript: true,
+      selectedExtractor: "defuddle",
+      selectedReason: "defuddle-markdown"
+    })
+  })
+
+  it("rejects content too short to be meaningful", async () => {
+    mocks.extractReadableContent.mockReturnValueOnce({
+      pageTitle: "Short",
+      readableText: "too short",
+      selectedExtractor: "basic",
+      selectedReason: "fallback-basic"
+    })
+
+    await expect(handleGetPageContent(vi.fn())).rejects.toThrow(
+      "Failed to extract meaningful content"
+    )
+  })
+})

--- a/src/entrypoints/persistence-verify/main.ts
+++ b/src/entrypoints/persistence-verify/main.ts
@@ -14,6 +14,10 @@ import {
   STORAGE_KEYS
 } from "@/lib/constants"
 import {
+  ensureDefaultKnowledgeSet,
+  updateKnowledgeSet
+} from "@/lib/knowledge/knowledge-sets"
+import {
   invalidateBackendCache,
   readPersistenceBackend
 } from "@/lib/persistence/backend"
@@ -37,6 +41,8 @@ import {
   query
 } from "@/lib/sqlite/db"
 import { LATEST_SCHEMA_VERSION } from "@/lib/sqlite/migrations/migration-runner"
+import { writeSetting } from "@/lib/storage/setting-access"
+import { SETTINGS } from "@/lib/storage/settings"
 import {
   CHAT_STREAM_EVENT_TYPES,
   STREAM_PROTOCOL_VERSION
@@ -86,6 +92,76 @@ const connectTurn = (turnId: string, afterSeq?: number): VerifyStream => {
   }
   return stream
 }
+
+const buildContextThroughRuntime = (requestId: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const port = browser.runtime.connect({
+      name: MESSAGE_KEYS.PROVIDER.STREAM_RESPONSE
+    })
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error("Context build did not settle"))
+    }, 30_000)
+    const cleanup = () => {
+      clearTimeout(timer)
+      port.onMessage.removeListener(onMessage)
+      port.disconnect()
+    }
+    const onMessage = (event: unknown) => {
+      if (!event || typeof event !== "object") return
+      if (Reflect.get(event, "requestId") !== requestId) return
+      const type = Reflect.get(event, "type")
+      if (type === CHAT_STREAM_EVENT_TYPES.CONTEXT_RESULT) {
+        cleanup()
+        resolve()
+        return
+      }
+      if (type !== CHAT_STREAM_EVENT_TYPES.CONTEXT_ERROR) return
+      const failure = Reflect.get(event, "failure")
+      cleanup()
+      reject(
+        new Error(
+          failure && typeof failure === "object"
+            ? String(
+                Reflect.get(failure, "userMessage") ??
+                  Reflect.get(failure, "message") ??
+                  "Context build failed"
+              )
+            : "Context build failed"
+        )
+      )
+    }
+    port.onMessage.addListener(onMessage)
+    port.postMessage({
+      version: STREAM_PROTOCOL_VERSION,
+      type: MESSAGE_KEYS.PROVIDER.BUILD_CONTEXT,
+      payload: {
+        requestId,
+        turnId: requestId,
+        rawInput: "What does the document say about model loading?",
+        messages: [
+          { role: "user", content: "Remember the runtime settings." },
+          {
+            role: "assistant",
+            content: "I will preserve them.",
+            done: true
+          }
+        ],
+        hasTabContext: false,
+        contextText: "",
+        tabDocuments: [],
+        memoryEnabled: false,
+        maxTabContextChars: 1_000,
+        maxRagContextChars: 1_000,
+        groundedOnlyMode: false,
+        selectedModel: "verify-model",
+        selectedModelRef: {
+          providerId: ProviderId.OLLAMA,
+          modelId: "verify-model"
+        }
+      }
+    })
+  })
 
 /**
  * Resolve once the tab has committed its requested document. onUpdated is
@@ -406,6 +482,29 @@ const verifyApi = {
       baseUrl,
       customModels: ["verify-model"]
     })
+  },
+
+  /** Reproduce the #315 sequence through the packaged background: RAG query
+   * rewriting calls the selected model before the durable chat call. Both
+   * requests must carry the same model-loading options or Ollama unloads and
+   * reloads the model between them. */
+  async buildConfiguredRagContext(requestId: string): Promise<void> {
+    await writeSetting(SETTINGS.USE_RAG, true)
+    await writeSetting(SETTINGS.MODEL_CONFIGS, {
+      [`${ProviderId.OLLAMA}::verify-model`]: {
+        num_ctx: 8192,
+        num_thread: 8,
+        num_gpu: 20,
+        num_batch: 256,
+        keep_alive: "15m"
+      }
+    })
+    const knowledgeSet = await ensureDefaultKnowledgeSet()
+    await updateKnowledgeSet(knowledgeSet.id, {
+      questionPrompt:
+        "Rewrite the question as one standalone search query: {question}"
+    })
+    await buildContextThroughRuntime(requestId)
   },
 
   /** Submit through the real durable port contract. Only row creation mirrors

--- a/src/features/chat/hooks/__tests__/use-image-attachments.test.ts
+++ b/src/features/chat/hooks/__tests__/use-image-attachments.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useImageAttachments } from "../use-image-attachments"
+
+const file = (name: string, type: string, contents = "abc"): File =>
+  new File([contents], name, { type })
+
+describe("useImageAttachments", () => {
+  const onReject = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    [file("photo.heic", "image/jpeg"), "heic"],
+    [file("photo.jpg", "image/heic"), "heic"],
+    [file("notes.txt", "text/plain"), "type"]
+  ] as const)("rejects %s as %s", async (input, reason) => {
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 100, onReject })
+    )
+
+    await expect(result.current.fileToAttachment(input)).resolves.toBeNull()
+    expect(onReject).toHaveBeenCalledWith(reason, input)
+  })
+
+  it("rejects an image above the configured byte limit", async () => {
+    const input = file("large.png", "image/png", "12345")
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 4, onReject })
+    )
+
+    await expect(result.current.fileToAttachment(input)).resolves.toBeNull()
+    expect(onReject).toHaveBeenCalledWith("size", input)
+  })
+
+  it("silently rejects when notification is disabled", async () => {
+    const input = file("notes.txt", "text/plain")
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 100, onReject })
+    )
+
+    await expect(
+      result.current.fileToAttachment(input, false)
+    ).resolves.toBeNull()
+    expect(onReject).not.toHaveBeenCalled()
+  })
+
+  it("converts an accepted image to a base64 attachment", async () => {
+    const input = file("photo.png", "image/png")
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 100, onReject })
+    )
+
+    await expect(result.current.fileToAttachment(input)).resolves.toMatchObject(
+      {
+        imageId: expect.stringMatching(/^img-/),
+        fileName: "photo.png",
+        mimeType: "image/png",
+        size: 3,
+        base64: "YWJj"
+      }
+    )
+    expect(onReject).not.toHaveBeenCalled()
+  })
+
+  it("stages only accepted files", async () => {
+    const accepted = file("photo.png", "image/png")
+    const rejected = file("notes.txt", "text/plain")
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 100, onReject })
+    )
+
+    await act(async () => {
+      await result.current.addFiles([accepted, rejected])
+    })
+
+    expect(result.current.images).toHaveLength(1)
+    expect(result.current.images[0]).toMatchObject({ fileName: "photo.png" })
+    expect(onReject).toHaveBeenCalledWith("type", rejected)
+  })
+
+  it("removes one image and clears the remainder", async () => {
+    const { result } = renderHook(() =>
+      useImageAttachments({ maxSizeBytes: 100, onReject })
+    )
+    await act(async () => {
+      await result.current.addFiles([
+        file("one.png", "image/png"),
+        file("two.png", "image/png")
+      ])
+    })
+    const firstId = result.current.images[0].imageId
+
+    act(() => result.current.remove(firstId))
+    expect(result.current.images.map((image) => image.fileName)).toEqual([
+      "two.png"
+    ])
+
+    act(() => result.current.clear())
+    expect(result.current.images).toEqual([])
+  })
+})

--- a/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
+++ b/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
@@ -1,6 +1,14 @@
 import { readFileSync } from "node:fs"
 import { createRequire } from "node:module"
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest"
 import { type ChatDbEngine, createChatDbEngine } from "../chat-db-engine"
 import type { IntegrityReport } from "../durable-tables"
 import {
@@ -37,6 +45,7 @@ beforeAll(() => {
 })
 
 const errors: string[] = []
+const engines: ChatDbEngine[] = []
 
 /** A fresh owner. Creating one models a browser session starting. */
 const bootEngine = async (
@@ -46,6 +55,7 @@ const bootEngine = async (
     wasmBinary: Promise.resolve(wasmBinary),
     onError: (message) => errors.push(message)
   })
+  engines.push(engine)
   await engine.submit({ op: "setBackend", backend: "legacy", integrity })
   return engine
 }
@@ -82,6 +92,17 @@ const afterDebounce = (): Promise<void> =>
 beforeEach(async () => {
   errors.length = 0
   await deleteLegacyBlob()
+})
+
+afterEach(async () => {
+  // Cancel every backend's pending debounce before the next test clears the
+  // shared fake IndexedDB store. Without this, an earlier engine can wake a
+  // second later and overwrite the next fixture, especially under coverage.
+  await Promise.all(
+    engines
+      .splice(0)
+      .map((engine) => engine.submit({ op: "flush" }).catch(() => undefined))
+  )
 })
 
 describe("legacy blob backend", () => {

--- a/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
+++ b/src/lib/persistence/__tests__/legacy-blob-backend.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs"
 import { createRequire } from "node:module"
-import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { type ChatDbEngine, createChatDbEngine } from "../chat-db-engine"
 import type { IntegrityReport } from "../durable-tables"
 import {
@@ -85,6 +85,46 @@ beforeEach(async () => {
 })
 
 describe("legacy blob backend", () => {
+  it("resolves a blob write only after its transaction commits", async () => {
+    const putRequest = {} as IDBRequest
+    const transaction = {
+      error: null,
+      objectStore: vi.fn(() => ({ put: vi.fn(() => putRequest) })),
+      onabort: null,
+      oncomplete: null,
+      onerror: null
+    } as unknown as IDBTransaction
+    const database = {
+      close: vi.fn(),
+      transaction: vi.fn(() => transaction)
+    } as unknown as IDBDatabase
+    const openRequest = {
+      result: database,
+      onerror: null,
+      onupgradeneeded: null,
+      onsuccess: null
+    } as unknown as IDBOpenDBRequest
+    const open = vi.spyOn(indexedDB, "open").mockReturnValue(openRequest)
+
+    try {
+      let resolved = false
+      const write = writeLegacyBlob(new Uint8Array([1, 2, 3])).then(() => {
+        resolved = true
+      })
+
+      openRequest.onsuccess?.(new Event("success"))
+      await Promise.resolve()
+      expect(resolved).toBe(false)
+
+      transaction.oncomplete?.(new Event("complete"))
+      await write
+      expect(resolved).toBe(true)
+      expect(database.close).toHaveBeenCalledOnce()
+    } finally {
+      open.mockRestore()
+    }
+  })
+
   it("creates the full schema when IndexedDB holds no database", async () => {
     const engine = await bootEngine()
 

--- a/src/lib/persistence/legacy-blob-db.ts
+++ b/src/lib/persistence/legacy-blob-db.ts
@@ -67,11 +67,11 @@ export interface LegacyBlobDb {
  * `deleteDatabase` fire `onblocked` and the reset path then waits on a delete
  * that never lands.
  */
-const withBlobStore = <T>(
+const withBlobStore = (
   mode: IDBTransactionMode,
-  work: (store: IDBObjectStore, done: (value: T) => void) => void
-): Promise<T> =>
-  new Promise<T>((resolve, reject) => {
+  work: (store: IDBObjectStore) => void
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
     const request = indexedDB.open(SQLITE_DB_NAME, 1)
     request.onerror = () => reject(request.error)
     request.onupgradeneeded = (event) => {
@@ -84,14 +84,21 @@ const withBlobStore = <T>(
       const database = request.result
       try {
         const transaction = database.transaction([SQLITE_DB_STORE], mode)
-        work(transaction.objectStore(SQLITE_DB_STORE), (value) => {
+        transaction.oncomplete = () => {
           database.close()
-          resolve(value)
-        })
+          resolve()
+        }
         transaction.onerror = () => {
           database.close()
           reject(transaction.error)
         }
+        transaction.onabort = () => {
+          database.close()
+          reject(
+            transaction.error ?? new Error("IndexedDB transaction aborted")
+          )
+        }
+        work(transaction.objectStore(SQLITE_DB_STORE))
       } catch (error) {
         database.close()
         reject(error)
@@ -106,8 +113,8 @@ const withBlobStore = <T>(
 export { readLegacyBlobBytes as readLegacyBlob } from "./legacy-blob-reader"
 
 export const writeLegacyBlob = (bytes: Uint8Array): Promise<void> =>
-  withBlobStore<void>("readwrite", (store, done) => {
-    store.put(bytes, SQLITE_DB_KEY).onsuccess = () => done(undefined)
+  withBlobStore("readwrite", (store) => {
+    store.put(bytes, SQLITE_DB_KEY)
   })
 
 export const deleteLegacyBlob = (): Promise<void> =>

--- a/src/lib/providers/__tests__/provider-contract-china.test.ts
+++ b/src/lib/providers/__tests__/provider-contract-china.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { OpenAICompatibleProvider } from "../openai-compatible"
+import { ProviderType } from "../types"
+import {
+  collectChunks,
+  openAIStream,
+  requestBody,
+  streamResponse,
+  weatherTool
+} from "./provider-contract-fixtures"
+
+interface HostedCompatibilityCase {
+  name: string
+  baseUrl: string
+  model: string
+}
+
+const providers: HostedCompatibilityCase[] = [
+  {
+    name: "DeepSeek",
+    baseUrl: "https://gateway.test/deepseek/v1",
+    model: "deepseek-v4-flash"
+  },
+  {
+    name: "Qwen / DashScope",
+    baseUrl: "https://gateway.test/qwen/compatible-mode/v1",
+    model: "qwen3.5-plus"
+  },
+  {
+    name: "Kimi / Moonshot",
+    baseUrl: "https://gateway.test/kimi/v1",
+    model: "kimi-k2.6"
+  },
+  {
+    name: "Z.AI / GLM",
+    baseUrl: "https://gateway.test/glm/api/paas/v4",
+    model: "glm-5.3"
+  }
+]
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("Chinese frontier provider OpenAI compatibility contracts", () => {
+  it.each(
+    providers
+  )("$name preserves its endpoint, model id, auth, reasoning, tools, and usage", async ({
+    name,
+    baseUrl,
+    model
+  }) => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(streamResponse(openAIStream()))
+    const collected = collectChunks()
+
+    await new OpenAICompatibleProvider({
+      id: `custom:openai:${name.toLowerCase().replaceAll(/\W+/g, "-")}`,
+      type: ProviderType.OPENAI,
+      enabled: true,
+      name,
+      baseUrl,
+      apiKey: "sk-provider-test"
+    }).streamChat(
+      {
+        model,
+        messages: [{ role: "user", content: "Weather?" }],
+        num_predict: 128,
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseUrl}/chat/completions`,
+      expect.objectContaining({ method: "POST" })
+    )
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer sk-provider-test"
+    })
+    expect(requestBody(fetchMock)).toMatchObject({
+      model,
+      stream: true,
+      max_tokens: 128,
+      tools: [
+        {
+          type: "function",
+          function: expect.objectContaining({ name: "get_weather" })
+        }
+      ]
+    })
+    expect(requestBody(fetchMock).stream_options).toBeUndefined()
+    expect(collected.chunks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ thinkingDelta: "plan" }),
+        expect.objectContaining({ delta: "done" }),
+        expect.objectContaining({
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "get_weather",
+              arguments: { city: "Paris" }
+            }
+          ]
+        }),
+        expect.objectContaining({
+          done: true,
+          metrics: expect.objectContaining({
+            prompt_eval_count: 7,
+            eval_count: 3
+          })
+        })
+      ])
+    )
+  })
+})

--- a/src/lib/providers/__tests__/provider-contract-fixtures.ts
+++ b/src/lib/providers/__tests__/provider-contract-fixtures.ts
@@ -1,0 +1,102 @@
+import { vi } from "vitest"
+
+import type { ToolDefinition } from "@/lib/tools/types"
+import type { ChatStreamMessage } from "@/types"
+
+const encoder = new TextEncoder()
+
+export const weatherTool: ToolDefinition = {
+  name: "get_weather",
+  description: "Get the weather",
+  parameters: {
+    type: "object",
+    properties: { city: { type: "string" } },
+    required: ["city"]
+  }
+}
+
+export const streamResponse = (chunks: string[]): Response => {
+  let index = 0
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: vi.fn(async () =>
+          index < chunks.length
+            ? { done: false, value: encoder.encode(chunks[index++]) }
+            : { done: true, value: undefined }
+        ),
+        cancel: vi.fn(async () => undefined),
+        releaseLock: vi.fn()
+      })
+    },
+    text: async () => ""
+  } as unknown as Response
+}
+
+export const jsonResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  })
+
+export const requestBody = (
+  fetchMock: ReturnType<typeof vi.spyOn>,
+  call = 0
+): Record<string, unknown> =>
+  JSON.parse((fetchMock.mock.calls[call]?.[1] as RequestInit).body as string)
+
+export const collectChunks = () => {
+  const chunks: ChatStreamMessage[] = []
+  return {
+    chunks,
+    onChunk: (chunk: ChatStreamMessage) => chunks.push(chunk)
+  }
+}
+
+export const openAIStream = ({
+  reasoning = "plan",
+  content = "done",
+  includeTool = true
+}: {
+  reasoning?: string
+  content?: string
+  includeTool?: boolean
+} = {}): string[] => [
+  `data: ${JSON.stringify({
+    choices: [{ delta: { reasoning_content: reasoning } }]
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    choices: [{ delta: { content } }]
+  })}\n\n`,
+  ...(includeTool
+    ? [
+        `data: ${JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call-1",
+                    type: "function",
+                    function: {
+                      name: "get_weather",
+                      arguments: '{"city":"Paris"}'
+                    }
+                  }
+                ]
+              },
+              finish_reason: "tool_calls"
+            }
+          ]
+        })}\n\n`
+      ]
+    : []),
+  `data: ${JSON.stringify({
+    choices: [],
+    usage: { prompt_tokens: 7, completion_tokens: 3 }
+  })}\n\n`,
+  "data: [DONE]\n\n"
+]

--- a/src/lib/providers/__tests__/provider-contract-frontier.test.ts
+++ b/src/lib/providers/__tests__/provider-contract-frontier.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AnthropicProvider } from "../anthropic"
+import { OpenAICompatibleProvider } from "../openai-compatible"
+import { ProviderServiceProfile, ProviderType } from "../types"
+import {
+  collectChunks,
+  openAIStream,
+  requestBody,
+  streamResponse,
+  weatherTool
+} from "./provider-contract-fixtures"
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("frontier provider wire contracts", () => {
+  it("uses OpenAI's hosted token field, auth, vision, tools, and usage stream", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(streamResponse(openAIStream()))
+    const collected = collectChunks()
+
+    await new OpenAICompatibleProvider({
+      id: "custom:openai:openai",
+      type: ProviderType.OPENAI,
+      serviceProfile: ProviderServiceProfile.OPENAI,
+      enabled: true,
+      name: "OpenAI",
+      // A service profile selects the wire dialect; users may route it through
+      // a regional, enterprise, or reverse-proxy URL.
+      baseUrl: "https://gateway.test/openai/v1",
+      apiKey: "sk-openai-test"
+    }).streamChat(
+      {
+        model: "gpt-5.6",
+        messages: [
+          {
+            role: "user",
+            content: "What is shown?",
+            images: [{ mimeType: "image/png", base64: "aW1hZ2U=" }]
+          }
+        ],
+        num_predict: 256,
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.test/openai/v1/chat/completions",
+      expect.objectContaining({ method: "POST" })
+    )
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer sk-openai-test"
+    })
+    expect(requestBody(fetchMock)).toMatchObject({
+      model: "gpt-5.6",
+      max_completion_tokens: 256,
+      stream_options: { include_usage: true },
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is shown?" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,aW1hZ2U=" }
+            }
+          ]
+        }
+      ]
+    })
+    expect(requestBody(fetchMock).max_tokens).toBeUndefined()
+    expect(collected.chunks.at(-1)).toMatchObject({
+      done: true,
+      metrics: expect.objectContaining({
+        prompt_eval_count: 7,
+        eval_count: 3
+      })
+    })
+  })
+
+  it("preserves OpenRouter attribution, prefixed model ids, and SSE comments", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        streamResponse([": OPENROUTER PROCESSING\n\n", ...openAIStream()])
+      )
+    const collected = collectChunks()
+
+    await new OpenAICompatibleProvider({
+      id: "custom:openai:openrouter",
+      type: ProviderType.OPENAI,
+      serviceProfile: ProviderServiceProfile.OPENROUTER,
+      enabled: true,
+      name: "OpenRouter",
+      baseUrl: "https://gateway.test/openrouter/api/v1",
+      apiKey: "sk-or-test"
+    }).streamChat(
+      {
+        model: "anthropic/claude-sonnet-4.6",
+        messages: [{ role: "user", content: "Weather?" }],
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.test/openrouter/api/v1/chat/completions",
+      expect.objectContaining({ method: "POST" })
+    )
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer sk-or-test",
+      "HTTP-Referer": "https://www.ollamaclient.in",
+      "X-OpenRouter-Title": "Ollama Client"
+    })
+    expect(requestBody(fetchMock)).toMatchObject({
+      model: "anthropic/claude-sonnet-4.6",
+      stream_options: { include_usage: true }
+    })
+    expect(collected.chunks).toContainEqual(
+      expect.objectContaining({ thinkingDelta: "plan" })
+    )
+  })
+
+  it("uses Anthropic's native Messages stream and tool blocks", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        streamResponse([
+          'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":7,"output_tokens":1}}}\n\n',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking"}}\n\n',
+          'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call-1","name":"get_weather"}}\n\n',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":\\"Paris\\"}"}}\n\n',
+          'event: message_delta\ndata: {"type":"message_delta","usage":{"output_tokens":3}}\n\n',
+          'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+        ])
+      )
+    const collected = collectChunks()
+
+    await new AnthropicProvider({
+      id: "custom:anthropic:anthropic",
+      type: ProviderType.ANTHROPIC,
+      serviceProfile: ProviderServiceProfile.ANTHROPIC,
+      enabled: true,
+      name: "Anthropic",
+      baseUrl: "https://gateway.test/anthropic/v1",
+      apiKey: "sk-ant-test"
+    }).streamChat(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "system", content: "Be concise." },
+          { role: "user", content: "Weather?" }
+        ],
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.test/anthropic/v1/messages",
+      expect.objectContaining({ method: "POST" })
+    )
+    expect(request.headers).toMatchObject({
+      "x-api-key": "sk-ant-test",
+      "anthropic-version": "2023-06-01",
+      "anthropic-dangerous-direct-browser-access": "true"
+    })
+    expect(requestBody(fetchMock)).toMatchObject({
+      model: "claude-sonnet-4-6",
+      system: "Be concise.",
+      stream: true,
+      tools: [
+        {
+          name: "get_weather",
+          input_schema: weatherTool.parameters
+        }
+      ]
+    })
+    expect(
+      collected.chunks.find((chunk) => chunk.toolCalls)?.toolCalls
+    ).toEqual([
+      {
+        id: "call-1",
+        name: "get_weather",
+        arguments: { city: "Paris" }
+      }
+    ])
+  })
+})

--- a/src/lib/providers/__tests__/provider-contract-frontier.test.ts
+++ b/src/lib/providers/__tests__/provider-contract-frontier.test.ts
@@ -37,7 +37,15 @@ describe("frontier provider wire contracts", () => {
           {
             role: "user",
             content: "What is shown?",
-            images: [{ mimeType: "image/png", base64: "aW1hZ2U=" }]
+            images: [
+              {
+                imageId: "vision-fixture",
+                fileName: "fixture.png",
+                mimeType: "image/png",
+                size: 5,
+                base64: "aW1hZ2U="
+              }
+            ]
           }
         ],
         num_predict: 256,

--- a/src/lib/providers/__tests__/provider-contract-local.test.ts
+++ b/src/lib/providers/__tests__/provider-contract-local.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { LlamaCppProvider } from "../llama-cpp"
+import { LMStudioProvider } from "../lm-studio"
+import { OllamaProvider } from "../ollama"
+import { ProviderId, ProviderType } from "../types"
+import {
+  collectChunks,
+  jsonResponse,
+  openAIStream,
+  requestBody,
+  streamResponse,
+  weatherTool
+} from "./provider-contract-fixtures"
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("local provider wire contracts", () => {
+  it("keeps Ollama on its native chat stream including thinking and tools", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      streamResponse([
+        `${JSON.stringify({ message: { thinking: "plan" }, done: false })}\n`,
+        `${JSON.stringify({ message: { content: "done" }, done: false })}\n`,
+        `${JSON.stringify({
+          message: {
+            tool_calls: [
+              {
+                id: "call-1",
+                function: {
+                  name: "get_weather",
+                  arguments: { city: "Paris" }
+                }
+              }
+            ]
+          },
+          done: true,
+          prompt_eval_count: 7,
+          eval_count: 3
+        })}\n`
+      ])
+    )
+    const collected = collectChunks()
+
+    await new OllamaProvider({
+      id: ProviderId.OLLAMA,
+      type: ProviderType.OLLAMA,
+      enabled: true,
+      name: "Ollama",
+      baseUrl: "http://localhost:11434"
+    }).streamChat(
+      {
+        model: "qwen3.5:latest",
+        messages: [{ role: "user", content: "Weather?" }],
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:11434/api/chat",
+      expect.objectContaining({ method: "POST" })
+    )
+    expect(requestBody(fetchMock)).toMatchObject({
+      model: "qwen3.5:latest",
+      stream: true,
+      tools: [
+        {
+          type: "function",
+          function: expect.objectContaining({ name: "get_weather" })
+        }
+      ]
+    })
+    expect(collected.chunks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ thinkingDelta: "plan" }),
+        expect.objectContaining({ delta: "done" }),
+        expect.objectContaining({
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "get_weather",
+              arguments: { city: "Paris" }
+            }
+          ]
+        }),
+        expect.objectContaining({
+          done: true,
+          metrics: expect.objectContaining({
+            prompt_eval_count: 7,
+            eval_count: 3
+          })
+        })
+      ])
+    )
+  })
+
+  it("keeps LM Studio on OpenAI chat while requesting streamed usage", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(streamResponse(openAIStream()))
+    const collected = collectChunks()
+
+    await new LMStudioProvider({
+      id: ProviderId.LM_STUDIO,
+      type: ProviderType.OPENAI,
+      enabled: true,
+      name: "LM Studio",
+      baseUrl: "http://localhost:1234/v1"
+    }).streamChat(
+      {
+        model: "qwen3-8b",
+        messages: [{ role: "user", content: "Weather?" }],
+        tools: [weatherTool]
+      },
+      collected.onChunk
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:1234/v1/chat/completions",
+      expect.objectContaining({ method: "POST" })
+    )
+    expect(requestBody(fetchMock)).toMatchObject({
+      model: "qwen3-8b",
+      stream: true,
+      stream_options: { include_usage: true }
+    })
+    expect(
+      collected.chunks.find((chunk) => chunk.toolCalls)?.toolCalls
+    ).toEqual([
+      {
+        id: "call-1",
+        name: "get_weather",
+        arguments: { city: "Paris" }
+      }
+    ])
+  })
+
+  it("accepts llama.cpp's hybrid model catalog metadata", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        data: [
+          {
+            id: "Qwen3.5-9B-Q4_K_M.gguf",
+            created: 1_700_000_000,
+            meta: {
+              n_params: 9_000_000_000,
+              n_ctx_train: 262_144,
+              size: "6123456789"
+            }
+          }
+        ]
+      })
+    )
+
+    const models = await new LlamaCppProvider({
+      id: ProviderId.LLAMA_CPP,
+      type: ProviderType.OPENAI,
+      enabled: true,
+      name: "llama.cpp",
+      baseUrl: "http://localhost:8000/v1"
+    }).getModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/v1/models",
+      undefined
+    )
+    expect(models).toEqual([
+      expect.objectContaining({
+        name: "Qwen3.5-9B-Q4_K_M.gguf",
+        size: 6_123_456_789,
+        details: expect.objectContaining({
+          family: "llama-cpp",
+          parameter_size: "9B"
+        }),
+        capabilityHints: { contextLength: 262_144 }
+      })
+    ])
+  })
+})

--- a/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
+++ b/src/lib/repositories/__tests__/chat-durability.smoke.test.ts
@@ -50,6 +50,7 @@ import {
  */
 
 const TIMEOUT = 25_000
+const owners: ReturnType<typeof createChatDbEngine>[] = []
 
 const require = createRequire(import.meta.url)
 const wasmPath = require.resolve("@sqlite.org/sqlite-wasm/sqlite3.wasm")
@@ -76,6 +77,7 @@ beforeAll(() => {
  */
 const installOwner = () => {
   const engine = createChatDbEngine({ wasmBinary: Promise.resolve(wasmBuffer) })
+  owners.push(engine)
   const ready = engine.submit({ op: "setBackend", backend: "legacy" })
   globalThis.__persistenceHostCall = async (request) => {
     await ready
@@ -137,9 +139,18 @@ beforeEach(async () => {
   await clearSqliteStore()
 }, TIMEOUT)
 
-afterEach(() => {
+afterEach(async () => {
+  // A test that ends after a mutation can otherwise leave the legacy
+  // backend's one-second save timer alive. Under coverage instrumentation that
+  // timer may fire after the next test has cleared IndexedDB and overwrite its
+  // fixture with the previous test's image.
+  await Promise.all(
+    owners
+      .splice(0)
+      .map((engine) => engine.submit({ op: "flush" }).catch(() => undefined))
+  )
   globalThis.__persistenceHostCall = undefined
-})
+}, TIMEOUT)
 
 // Re-import the facade fresh and stand up a new owner. The owner is what a
 // restart actually restarts: the engine's in-memory database goes with it while

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -110,16 +110,22 @@ afterEach(() => {
  * reading a name their factory does not define throws rather than yielding
  * undefined. Those suites stub the config outright and need no reset.
  */
-beforeEach(async () => {
-  try {
-    const embeddingConfig = (await import("@/lib/embeddings/config")) as {
-      resetEmbeddingConfigCache?: () => void
+beforeEach(
+  async () => {
+    try {
+      const embeddingConfig = (await import("@/lib/embeddings/config")) as {
+        resetEmbeddingConfigCache?: () => void
+      }
+      embeddingConfig.resetEmbeddingConfigCache?.()
+    } catch {
+      // Module is mocked without the reset export.
     }
-    embeddingConfig.resetEmbeddingConfigCache?.()
-  } catch {
-    // Module is mocked without the reset export.
-  }
-})
+  },
+  // vmThreads can pause a worker while recycling another memory-limited VM.
+  // Keep the shared cache-reset hook from turning that scheduler delay into a
+  // random suite failure; individual tests retain Vitest's normal timeout.
+  25_000
+)
 
 /** Reset per-test IndexedDB state supplied by fake-indexeddb. */
 beforeEach(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import path from "node:path"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vitest/config"
 
+const COVERAGE_MODE = process.argv.includes("--coverage")
+const COVERAGE_TEST_TIMEOUT_MS = 30_000
+
 const THREAD_TEST_PATTERNS = [
   "src/features/chat/hooks/__tests__/use-embedding-migration.test.ts",
   "src/lib/__tests__/backup-service.test.ts",
@@ -23,8 +26,9 @@ export default defineConfig({
         test: {
           name: "unit-vm",
           pool: "vmThreads",
-          maxWorkers: 6,
+          maxWorkers: COVERAGE_MODE ? 4 : 6,
           vmMemoryLimit: "256MB",
+          testTimeout: COVERAGE_MODE ? COVERAGE_TEST_TIMEOUT_MS : 5_000,
           include: [
             "src/**/*.{test,spec}.{ts,tsx}",
             "config/**/*.{test,spec}.ts"
@@ -37,7 +41,8 @@ export default defineConfig({
         test: {
           name: "persistence",
           pool: "threads",
-          maxWorkers: 6,
+          maxWorkers: COVERAGE_MODE ? 4 : 6,
+          testTimeout: COVERAGE_MODE ? COVERAGE_TEST_TIMEOUT_MS : 5_000,
           include: THREAD_TEST_PATTERNS
         }
       },
@@ -45,7 +50,8 @@ export default defineConfig({
         test: {
           name: "packages",
           environment: "node",
-          maxWorkers: 6,
+          maxWorkers: COVERAGE_MODE ? 4 : 6,
+          testTimeout: COVERAGE_MODE ? COVERAGE_TEST_TIMEOUT_MS : 5_000,
           include: ["packages/*/src/**/*.test.ts"]
         }
       }
@@ -58,8 +64,22 @@ export default defineConfig({
         "src/**/*.{test,spec}.{ts,tsx}",
         "packages/*/src/**/*.{test,spec}.{ts,tsx}",
         "src/**/*.d.ts",
-        "packages/*/src/**/*.d.ts"
-      ]
+        "packages/*/src/**/*.d.ts",
+        // Browser composition roots are executed only inside packaged
+        // extensions. Counting them as unit-test misses obscures the logic
+        // coverage beneath them; the browser gates own these files instead.
+        "src/entrypoints/**",
+        "src/contents/index.ts",
+        "src/contents/debug-init.ts",
+        "src/lib/persistence/chat-db-worker.ts",
+        "src/spike/**"
+      ],
+      thresholds: {
+        branches: 67,
+        functions: 75,
+        lines: 80,
+        statements: 78
+      }
     }
   },
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vitest/config"
 
 const COVERAGE_MODE = process.argv.includes("--coverage")
+const COVERAGE_SHARD = process.env.VITEST_COVERAGE_SHARD === "true"
 const COVERAGE_TEST_TIMEOUT_MS = 30_000
 
 const THREAD_TEST_PATTERNS = [
@@ -63,6 +64,8 @@ export default defineConfig({
       exclude: [
         "src/**/*.{test,spec}.{ts,tsx}",
         "packages/*/src/**/*.{test,spec}.{ts,tsx}",
+        "src/**/__tests__/**",
+        "packages/*/src/**/__tests__/**",
         "src/**/*.d.ts",
         "packages/*/src/**/*.d.ts",
         // Browser composition roots are executed only inside packaged
@@ -74,12 +77,17 @@ export default defineConfig({
         "src/lib/persistence/chat-db-worker.ts",
         "src/spike/**"
       ],
-      thresholds: {
-        branches: 67,
-        functions: 75,
-        lines: 80,
-        statements: 78
-      }
+      // A shard cannot satisfy global thresholds alone. Its V8 data is stored
+      // in the blob report, then the merge job applies these floors to the
+      // complete cross-shard coverage map.
+      thresholds: COVERAGE_SHARD
+        ? undefined
+        : {
+            branches: 67,
+            functions: 75,
+            lines: 80,
+            statements: 78
+          }
     }
   },
   resolve: {


### PR DESCRIPTION
## Summary

- include the fix for #315 so RAG query rewriting preserves the selected model's runtime configuration
- add unit coverage for provider-scoped and legacy bare model runtime settings
- add a packaged-Chromium regression that sends a RAG rewrite and durable chat through the real background/provider paths and asserts both Ollama `/api/chat` calls use the same `num_ctx`, thread, GPU, batch, and `keep_alive` values
- run CI for pushes to `release/**`, giving release commits an exact-SHA Actions result

## Why this catches #315

Before the fix, the query-rewrite call omitted the saved model-loading options while the following chat call included them. Ollama can reload the same model when those runtime options change. The fake Ollama server records both wire requests, so the E2E fails if their model-loading signatures differ.

## Verification

- `vitest run --testTimeout=20000 --hookTimeout=20000`: 392 files, 3,274 tests passed
- TypeScript typecheck passed
- Biome passed
- Chrome production and benchmark builds passed
- the new Playwright case is left for GitHub Actions because this workspace has no Playwright Chromium executable

Closes #315













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves selected-model runtime configuration during RAG query rewriting and adds regression coverage through unit and packaged-browser paths.

- Propagates Ollama context, thread, GPU, batch, and keep-alive settings to query-rewrite requests.
- Adds provider-contract, persistence, background, content, and OLC backend test coverage.
- Splits unit coverage across CI shards, merges reports for threshold enforcement, and runs CI on release branches.
- Waits for legacy IndexedDB blob transactions to commit before reporting successful writes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the reviewed changes or available prior findings.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/application/context/build-context.ts | Resolves the selected model’s stored configuration and forwards its runtime loading options to the RAG rewrite request. |
| src/application/context/__tests__/build-context.test.ts | Covers provider-scoped and legacy bare model configurations for query rewriting. |
| e2e/chium/critical/__tests__/persistence.spec.ts | Adds a packaged-extension regression test comparing the rewrite and durable-chat Ollama request signatures. |
| src/lib/persistence/legacy-blob-db.ts | Resolves writes after IndexedDB transaction completion and rejects aborted transactions. |
| .github/workflows/ci.yml | Adds release-branch CI and parallel test shards whose blob reports are merged before enforcing coverage thresholds. |
| vitest.config.ts | Configures coverage-mode timeouts, worker limits, shard report paths, and merged global thresholds. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Chat as Durable chat
  participant RAG as RAG context builder
  participant Settings as Model settings
  participant Ollama as Ollama provider
  Chat->>RAG: Build context for selected model
  RAG->>Settings: Resolve provider-scoped or legacy config
  Settings-->>RAG: Runtime loading options
  RAG->>Ollama: Rewrite query with runtime options
  Ollama-->>RAG: Rewritten query
  Chat->>Ollama: Generate response with same runtime options
```
</details>

<sub>Reviews (7): Last reviewed commit: ["test: complete vision attachment fixture"](https://github.com/shishir435/ollama-client/commit/3d663c06b0a19eba32f8869c27fff485fc4456fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56287305)</sub>

<!-- /greptile_comment -->