### PR TITLE
test(e2e): cover local provider streaming regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   # tagging a release, or after a flake — without opening a pull request.
   # Dispatch only becomes available once this file is on the default branch.
   workflow_dispatch:
+  schedule:
+    # Broader provider-stream parsing and failure coverage. The focused custom
+    # URL and #315 regressions remain blocking on ordinary pull requests.
+    - cron: "17 3 * * 1"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -412,6 +416,57 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-artifacts
+          path: artifacts/e2e
+          retention-days: 7
+          if-no-files-found: ignore
+
+  provider-e2e-full:
+    name: Provider stream matrix (scheduled)
+    needs: [checks, build]
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download packaged builds
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: chrome-e2e-builds
+          path: build
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run full provider stream matrix
+        run: pnpm e2e:chromium:provider-full
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: provider-e2e-artifacts
           path: artifacts/e2e
           retention-days: 7
           if-no-files-found: ignore

--- a/e2e/chromium/critical/__tests__/provider-streaming.spec.ts
+++ b/e2e/chromium/critical/__tests__/provider-streaming.spec.ts
@@ -1,0 +1,342 @@
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
+import { expect, test } from "../../fixtures/extension"
+import {
+  openPersistenceVerifyPage,
+  type VerifyCall,
+  waitForOpfsMarker
+} from "../../fixtures/persistence"
+
+const PROVIDERS = {
+  ollama: { id: "ollama", basePath: "/custom/ollama" },
+  lmStudio: { id: "lm studio", basePath: "/custom/lm-studio/v1" },
+  llamaCpp: { id: "llamacpp", basePath: "/custom/llama-cpp/v1" }
+} as const
+
+interface ProviderRequest {
+  body: Record<string, unknown>
+  path: string
+}
+
+const readBody = (request: import("node:http").IncomingMessage) =>
+  new Promise<Record<string, unknown>>((resolve, reject) => {
+    let body = ""
+    request.setEncoding("utf8")
+    request.on("data", (chunk) => {
+      body += chunk
+    })
+    request.on("end", () => {
+      try {
+        resolve(body ? (JSON.parse(body) as Record<string, unknown>) : {})
+      } catch (error) {
+        reject(error)
+      }
+    })
+  })
+
+const latestUserText = (body: Record<string, unknown>): string => {
+  const messages = Array.isArray(body.messages) ? body.messages : []
+  for (const message of [...messages].reverse()) {
+    if (!message || typeof message !== "object") continue
+    if (Reflect.get(message, "role") !== "user") continue
+    const content = Reflect.get(message, "content")
+    if (typeof content === "string") return content
+  }
+  return ""
+}
+
+const startMockProvider = async () => {
+  const requests: ProviderRequest[] = []
+  const server = createServer(async (request, response) => {
+    response.setHeader("Access-Control-Allow-Origin", "*")
+    response.setHeader("Access-Control-Allow-Headers", "*")
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204
+      response.end()
+      return
+    }
+
+    const path = request.url ?? ""
+    if (path.endsWith("/api/tags")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          models: [
+            {
+              name: "verify-model",
+              model: "verify-model",
+              modified_at: new Date(0).toISOString(),
+              size: 1,
+              digest: "verify",
+              details: { family: "verify", families: ["verify"] }
+            }
+          ]
+        })
+      )
+      return
+    }
+    if (path.endsWith("/api/show")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          capabilities: ["completion"],
+          details: { family: "verify" }
+        })
+      )
+      return
+    }
+    if (path.endsWith("/api/v0/models")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          data: [
+            {
+              id: "verify-model",
+              type: "llm",
+              arch: "verify",
+              capabilities: []
+            }
+          ]
+        })
+      )
+      return
+    }
+    if (path.endsWith("/v1/models")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          data: [{ id: "verify-model", meta: { n_params: 1_000_000_000 } }]
+        })
+      )
+      return
+    }
+
+    if (path.endsWith("/api/chat")) {
+      const body = await readBody(request)
+      requests.push({ body, path })
+      const prompt = latestUserText(body)
+      if (prompt.includes("http failure")) {
+        response.statusCode = 503
+        response.setHeader("Content-Type", "application/json")
+        response.end(JSON.stringify({ error: "mock unavailable" }))
+        return
+      }
+      response.setHeader("Content-Type", "application/x-ndjson")
+      response.write(
+        `${JSON.stringify({ message: { content: "custom " }, done: false })}\n`
+      )
+      response.end(
+        `${JSON.stringify({ message: { content: "ollama" }, done: false })}\n${JSON.stringify({ message: { content: "" }, done: true })}\n`
+      )
+      return
+    }
+
+    if (path.endsWith("/chat/completions")) {
+      const body = await readBody(request)
+      requests.push({ body, path })
+      const prompt = latestUserText(body)
+      if (prompt.includes("http failure")) {
+        response.statusCode = 503
+        response.setHeader("Content-Type", "application/json")
+        response.end(JSON.stringify({ error: { message: "mock unavailable" } }))
+        return
+      }
+
+      response.setHeader("Content-Type", "text/event-stream")
+      if (prompt.includes("fragmented sse")) {
+        response.write("data: {malformed-json}\n\n")
+        response.write('data: {"choices":[{"delta":{"content":"frag')
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        response.write('mented "},"finish_reason":null}]}\n\n')
+        response.write('data: {"choices":[{"delta":{"content":"stream"}')
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        response.end(',"finish_reason":"stop"}]}')
+        return
+      }
+
+      const providerText = path.includes("lm-studio")
+        ? "lm studio"
+        : "llama.cpp"
+      response.write(
+        `data: ${JSON.stringify({ choices: [{ delta: { content: "custom " }, finish_reason: null }] })}\n\n`
+      )
+      response.end(
+        `data: ${JSON.stringify({ choices: [{ delta: { content: providerText }, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`
+      )
+      return
+    }
+
+    response.statusCode = 404
+    response.setHeader("Content-Type", "application/json")
+    response.end(JSON.stringify({ error: "not found" }))
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const { port } = server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${port}`
+  let closed = false
+  return {
+    baseUrl: (path: string) => `${origin}${path}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve) => {
+        if (closed) {
+          resolve()
+          return
+        }
+        closed = true
+        server.close(() => resolve())
+        server.closeAllConnections()
+      })
+  }
+}
+
+const startTurn = (
+  call: VerifyCall,
+  turnId: string,
+  prompt: string,
+  providerId: string
+) => call("startDurableTurn", turnId, prompt, providerId)
+
+test("@critical built-in providers stream through fully custom base URLs", async ({
+  extension
+}) => {
+  test.setTimeout(120_000)
+  const mock = await startMockProvider()
+  try {
+    const { page, call } = await openPersistenceVerifyPage(extension)
+    await waitForOpfsMarker(call)
+
+    const cases = [
+      { ...PROVIDERS.ollama, expected: "custom ollama" },
+      { ...PROVIDERS.lmStudio, expected: "custom lm studio" },
+      { ...PROVIDERS.llamaCpp, expected: "custom llama.cpp" }
+    ]
+    for (const provider of cases) {
+      await call(
+        "configureFakeProvider",
+        provider.id,
+        mock.baseUrl(provider.basePath)
+      )
+      const assistantMessageId = (await startTurn(
+        call,
+        `custom-url-${provider.id}`,
+        `${provider.id} custom-url stream`,
+        provider.id
+      )) as number
+      await expect
+        .poll(
+          () =>
+            call(
+              "durableTurnResult",
+              `custom-url-${provider.id}`,
+              assistantMessageId
+            ),
+          { timeout: 30_000 }
+        )
+        .toEqual({
+          status: "completed",
+          content: provider.expected,
+          done: true
+        })
+    }
+
+    expect(mock.requests.map(({ path }) => path)).toEqual([
+      "/custom/ollama/api/chat",
+      "/custom/lm-studio/v1/chat/completions",
+      "/custom/llama-cpp/v1/chat/completions"
+    ])
+    await page.close()
+  } finally {
+    await mock.close()
+  }
+})
+
+test("@provider-full partial and malformed SSE still completes", async ({
+  extension
+}) => {
+  const mock = await startMockProvider()
+  try {
+    const { page, call } = await openPersistenceVerifyPage(extension)
+    await waitForOpfsMarker(call)
+    await call(
+      "configureFakeProvider",
+      PROVIDERS.llamaCpp.id,
+      mock.baseUrl(PROVIDERS.llamaCpp.basePath)
+    )
+
+    const assistantMessageId = (await startTurn(
+      call,
+      "fragmented-sse",
+      "fragmented sse",
+      PROVIDERS.llamaCpp.id
+    )) as number
+    await expect
+      .poll(
+        () => call("durableTurnResult", "fragmented-sse", assistantMessageId),
+        { timeout: 30_000 }
+      )
+      .toEqual({
+        status: "completed",
+        content: "fragmented stream",
+        done: true
+      })
+    await page.close()
+  } finally {
+    await mock.close()
+  }
+})
+
+test("@provider-full HTTP and connection failures reach the durable result", async ({
+  extension
+}) => {
+  const mock = await startMockProvider()
+  try {
+    const { page, call } = await openPersistenceVerifyPage(extension)
+    await waitForOpfsMarker(call)
+    await call(
+      "configureFakeProvider",
+      PROVIDERS.lmStudio.id,
+      mock.baseUrl(PROVIDERS.lmStudio.basePath)
+    )
+    const httpAssistantId = (await startTurn(
+      call,
+      "http-failure",
+      "http failure",
+      PROVIDERS.lmStudio.id
+    )) as number
+    await expect
+      .poll(
+        () => call("durableTurnResult", "http-failure", httpAssistantId),
+        { timeout: 30_000 }
+      )
+      .toMatchObject({ status: "failed", done: true })
+
+    const closedBaseUrl = mock.baseUrl("/closed-provider/v1")
+    await mock.close()
+    await call("configureFakeProvider", PROVIDERS.llamaCpp.id, closedBaseUrl)
+    const connectionAssistantId = (await startTurn(
+      call,
+      "connection-failure",
+      "connection failure",
+      PROVIDERS.llamaCpp.id
+    )) as number
+    await expect
+      .poll(
+        () =>
+          call(
+            "durableTurnResult",
+            "connection-failure",
+            connectionAssistantId
+          ),
+        { timeout: 30_000 }
+      )
+      .toMatchObject({ status: "failed", done: true })
+    await page.close()
+  } finally {
+    await mock.close()
+  }
+})

--- a/e2e/chromium/critical/__tests__/provider-streaming.spec.ts
+++ b/e2e/chromium/critical/__tests__/provider-streaming.spec.ts
@@ -309,10 +309,9 @@ test("@provider-full HTTP and connection failures reach the durable result", asy
       PROVIDERS.lmStudio.id
     )) as number
     await expect
-      .poll(
-        () => call("durableTurnResult", "http-failure", httpAssistantId),
-        { timeout: 30_000 }
-      )
+      .poll(() => call("durableTurnResult", "http-failure", httpAssistantId), {
+        timeout: 30_000
+      })
       .toMatchObject({ status: "failed", done: true })
 
     const closedBaseUrl = mock.baseUrl("/closed-provider/v1")

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "e2e:release": "pnpm e2e:build:release && pnpm e2e:chromium:critical && pnpm verify:sw-turn-recovery && pnpm verify:opfs-migration && pnpm verify:firefox-opfs-migration",
     "e2e:chromium": "playwright test",
     "e2e:chromium:critical": "playwright test --grep @critical",
+    "e2e:chromium:provider-critical": "playwright test provider-streaming.spec.ts --grep @critical",
+    "e2e:chromium:provider-full": "playwright test provider-streaming.spec.ts",
     "e2e:headed": "E2E_HEADFUL=1 playwright test --grep @critical",
     "e2e:report": "playwright show-report artifacts/e2e/html",
     "verify": "pnpm typecheck && pnpm lint:check && pnpm check:dead && pnpm check:i18n && pnpm test:run && pnpm check:generated && pnpm check:compatibility",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
       "chromium-persistence",
       "**/persistence.spec.ts",
       "build/chrome-mv3-benchmark"
+    ),
+    chromiumProject(
+      "chromium-provider-streaming",
+      "**/provider-streaming.spec.ts",
+      "build/chrome-mv3-benchmark"
     )
   ]
 })

--- a/src/entrypoints/persistence-verify/main.ts
+++ b/src/entrypoints/persistence-verify/main.ts
@@ -198,7 +198,10 @@ const waitForTabComplete = (tabId: number): Promise<void> =>
       })
   })
 
-const makeTurnRequest = (prompt: string) => ({
+const makeTurnRequest = (
+  prompt: string,
+  providerId: string = ProviderId.OLLAMA
+) => ({
   version: 1 as const,
   context: {
     rawInput: prompt,
@@ -212,7 +215,7 @@ const makeTurnRequest = (prompt: string) => ({
     groundedOnlyMode: false,
     selectedModel: "verify-model",
     selectedModelRef: {
-      providerId: ProviderId.OLLAMA,
+      providerId,
       modelId: "verify-model"
     }
   },
@@ -477,7 +480,14 @@ const verifyApi = {
   },
 
   async configureFakeOllama(baseUrl: string): Promise<void> {
-    await ProviderManager.updateProviderConfig(ProviderId.OLLAMA, {
+    await this.configureFakeProvider(ProviderId.OLLAMA, baseUrl)
+  },
+
+  async configureFakeProvider(
+    providerId: string,
+    baseUrl: string
+  ): Promise<void> {
+    await ProviderManager.updateProviderConfig(providerId, {
       enabled: true,
       baseUrl,
       customModels: ["verify-model"]
@@ -509,10 +519,14 @@ const verifyApi = {
 
   /** Submit through the real durable port contract. Only row creation mirrors
    * the UI; lifecycle ownership begins when START_TURN reaches background. */
-  async startDurableTurn(turnId: string, prompt: string): Promise<number> {
+  async startDurableTurn(
+    turnId: string,
+    prompt: string,
+    providerId: string = ProviderId.OLLAMA
+  ): Promise<number> {
     const now = Date.now()
     const sessionId = `session-${turnId}`
-    const request = makeTurnRequest(prompt)
+    const request = makeTurnRequest(prompt, providerId)
     await chatHistory.addSession({
       id: sessionId,
       title: `verify ${turnId}`,
@@ -547,7 +561,7 @@ const verifyApi = {
             sessionId,
             mode: "new",
             model: "verify-model",
-            providerId: ProviderId.OLLAMA,
+            providerId,
             request,
             createdAt: now
           },

--- a/tools/verify-firefox-opfs-migration.ts
+++ b/tools/verify-firefox-opfs-migration.ts
@@ -516,6 +516,11 @@ const runScenarios = async (): Promise<void> => {
       await reloadServer.close()
     }
 
+    const providerRegressionCounts = await call<{
+      sessions: number
+      messages: number
+    }>(driver, "counts")
+
     // ---- 2. Concurrent facade writes from two tabs, exact counts ----
     const secondTab = await openVerifyTab(driver)
 
@@ -533,8 +538,14 @@ const runScenarios = async (): Promise<void> => {
     )
     record(
       "concurrent-facade-writes",
-      afterWrites.sessions === 2 && afterWrites.messages === APPENDS * 2,
-      { expected: APPENDS * 2, ...afterWrites }
+      afterWrites.sessions === providerRegressionCounts.sessions + 2 &&
+        afterWrites.messages ===
+          providerRegressionCounts.messages + APPENDS * 2,
+      {
+        baseline: providerRegressionCounts,
+        expectedAppendedMessages: APPENDS * 2,
+        ...afterWrites
+      }
     )
 
     await driver.switchTo().window(secondTab)

--- a/tools/verify-firefox-opfs-migration.ts
+++ b/tools/verify-firefox-opfs-migration.ts
@@ -55,6 +55,8 @@
  */
 
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { Builder, type WebDriver } from "selenium-webdriver"
@@ -335,6 +337,114 @@ const waitForOpfsMarker = async (
   }
 }
 
+const startReloadRegressionServer = async () => {
+  const signatures: Array<Record<string, unknown>> = []
+  const server = createServer((request, response) => {
+    response.setHeader("Access-Control-Allow-Origin", "*")
+    response.setHeader("Access-Control-Allow-Headers", "*")
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204
+      response.end()
+      return
+    }
+    if (request.url?.endsWith("/api/tags")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          models: [
+            {
+              name: "verify-model",
+              model: "verify-model",
+              modified_at: new Date(0).toISOString(),
+              size: 1,
+              digest: "verify",
+              details: { family: "verify", families: ["verify"] }
+            }
+          ]
+        })
+      )
+      return
+    }
+    if (request.url?.endsWith("/api/show")) {
+      response.setHeader("Content-Type", "application/json")
+      response.end(
+        JSON.stringify({
+          capabilities: ["completion"],
+          details: { family: "verify" }
+        })
+      )
+      return
+    }
+    if (!request.url?.endsWith("/api/chat")) {
+      response.statusCode = 404
+      response.end(JSON.stringify({ error: "not found" }))
+      return
+    }
+
+    let rawBody = ""
+    request.setEncoding("utf8")
+    request.on("data", (chunk) => {
+      rawBody += chunk
+    })
+    request.on("end", () => {
+      const body = JSON.parse(rawBody) as {
+        keep_alive?: string | number
+        model?: string
+        options?: Record<string, unknown>
+      }
+      signatures.push({
+        model: body.model,
+        keepAlive: body.keep_alive,
+        numCtx: body.options?.num_ctx,
+        numThread: body.options?.num_thread,
+        numGpu: body.options?.num_gpu,
+        numBatch: body.options?.num_batch
+      })
+      response.setHeader("Content-Type", "application/x-ndjson")
+      response.end(
+        `${JSON.stringify({ message: { content: "firefox" }, done: false })}\n${JSON.stringify({ message: { content: "" }, done: true })}\n`
+      )
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const { port } = server.address() as AddressInfo
+  return {
+    baseUrl: `http://127.0.0.1:${port}/custom/ollama`,
+    signatures,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+        server.closeAllConnections()
+      })
+  }
+}
+
+const waitForTurnResult = async (
+  driver: WebDriver,
+  turnId: string,
+  assistantMessageId: number,
+  timeoutMs = 30000
+): Promise<{ status?: string; content?: string; done?: boolean }> => {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const result = await call<{
+      status?: string
+      content?: string
+      done?: boolean
+    }>(driver, "durableTurnResult", turnId, assistantMessageId)
+    if (["completed", "failed", "cancelled"].includes(result.status ?? "")) {
+      return result
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Turn ${turnId} did not settle: ${JSON.stringify(result)}`)
+    }
+    await sleep(250)
+  }
+}
+
 const runScenarios = async (): Promise<void> => {
   if (!existsSync(resolve(buildPath, "persistence-verify.html"))) {
     throw new Error(
@@ -366,6 +476,45 @@ const runScenarios = async (): Promise<void> => {
       freshCounts.sessions === 0 && freshCounts.messages === 0,
       { freshMarker, freshCounts }
     )
+
+    // #315 crossed two production paths: RAG rewrite followed by durable chat.
+    // Firefox must preserve the same runner settings across both requests too.
+    const reloadServer = await startReloadRegressionServer()
+    try {
+      await call<void>(driver, "configureFakeOllama", reloadServer.baseUrl)
+      await call<void>(driver, "buildConfiguredRagContext", "firefox-315-rag")
+      const assistantMessageId = await call<number>(
+        driver,
+        "startDurableTurn",
+        "firefox-315-chat",
+        "firefox runtime consistency"
+      )
+      const result = await waitForTurnResult(
+        driver,
+        "firefox-315-chat",
+        assistantMessageId
+      )
+      const expected = {
+        model: "verify-model",
+        keepAlive: "15m",
+        numCtx: 8192,
+        numThread: 8,
+        numGpu: 20,
+        numBatch: 256
+      }
+      record(
+        "provider-runtime-config-consistent-firefox",
+        result.status === "completed" &&
+          result.content === "firefox" &&
+          reloadServer.signatures.length === 2 &&
+          reloadServer.signatures.every(
+            (signature) => JSON.stringify(signature) === JSON.stringify(expected)
+          ),
+        { baseUrl: reloadServer.baseUrl, result, signatures: reloadServer.signatures }
+      )
+    } finally {
+      await reloadServer.close()
+    }
 
     // ---- 2. Concurrent facade writes from two tabs, exact counts ----
     const secondTab = await openVerifyTab(driver)


### PR DESCRIPTION
## Summary

- exercise Ollama, LM Studio, and llama.cpp through the packaged extension → runtime port → background durable-turn → ProviderFactory → provider adapter path
- run each built-in against a loopback mock server configured with a nonstandard path-prefixed base URL
- preserve the existing Chromium #315 regression and add its packaged Firefox MV2 mirror
- cover fragmented/malformed SSE plus HTTP and connection failures in a broader scheduled/manual matrix
- keep the focused custom-URL smoke blocking on normal PRs while the full stream matrix runs weekly or on workflow dispatch

## #315 root cause and regression boundary

With RAG enabled, query reformulation omitted the selected model's stored Ollama runtime settings. Ollama used its default 4K context for that request, then the durable chat used the configured 65,536-token context and saved thread/GPU/batch/keep-alive values. That configuration change restarted the runner and could evict the embedding model.

PR #317 already added a packaged-Chromium assertion comparing those two Ollama wire signatures. This PR does not duplicate its unit-contract coverage. It adds the missing Firefox mirror and verifies the actual extension path across all three built-in local providers.

## Coverage

### Blocking on ordinary PRs

- Chromium: Ollama, LM Studio, and llama.cpp stream text through fully configurable custom base URLs
- Chromium: existing #315 RAG rewrite → durable chat runtime-signature regression
- Firefox: #315 RAG rewrite → durable chat runtime-signature regression in the packaged MV2 production topology

### Scheduled/manual full matrix

- malformed SSE event ignored without losing subsequent valid content
- JSON records split across HTTP chunks
- final partial SSE record without a trailing newline
- HTTP 503 surfaced as a failed durable turn
- connection refusal surfaced as a failed durable turn

Tool-call streaming is not part of #315's failure mechanism; PR #317's provider contract tests already cover native and fragmented OpenAI-compatible tool-call transport, so this PR avoids duplicating that isolated wire coverage.

## CI impact

The focused provider smoke reuses existing packaged benchmark builds and browser jobs. Expected incremental runtime is ~15–30 seconds on Chromium and ~20–45 seconds inside the already-running Firefox job. The broader matrix is isolated to weekly schedule/manual dispatch and runs in parallel with the other post-build browser gates.

## Verification

GitHub Actions run 32772604403 is green:

- static checks: typecheck, lint, format, dead code, generated resources, i18n, compatibility
- two parallel unit/coverage shards plus merged threshold enforcement
- Chrome and Firefox production packages and bundle budgets
- Chromium critical browser gates, including all three custom-URL providers and #315
- packaged Firefox MV2 #315 regression
- Chromium and Firefox persistence migration gates
- OLC distribution checks on Linux and Windows
