### PR TITLE
fix(rag): index filenames in keyword search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- File RAG keyword search now indexes filenames, so questions referencing
+  hyphenated filenames such as `ChatGPT-Memory.txt` retrieve their contents.
+
 - RAG query reformulation now reuses the selected model's context, thread, GPU,
   batch, and keep-alive settings. Ollama no longer restarts the runner between a
   rewrite request using its default 4K context and a chat request using the

--- a/src/lib/embeddings/__tests__/keyword-index.test.ts
+++ b/src/lib/embeddings/__tests__/keyword-index.test.ts
@@ -116,6 +116,28 @@ describe("Keyword Index Manager", () => {
       )
     })
 
+    it("should find documents by hyphenated filename", () => {
+      const document: VectorDocument = {
+        id: 6,
+        content: "Notes about long-term memory",
+        embedding: [0.1, 0.2, 0.3],
+        metadata: {
+          source: "ChatGPT-Memory.txt",
+          title: "ChatGPT-Memory.txt",
+          type: "file",
+          timestamp: Date.now()
+        }
+      }
+
+      keywordIndexManager.addDocument(6, document.content, document)
+
+      const results = keywordIndexManager.search("ChatGPT-Memory.txt", {
+        combineWith: "AND"
+      })
+
+      expect(results.some((result) => result.id === 6)).toBe(true)
+    })
+
     it("should be case-insensitive", () => {
       const results1 = keywordIndexManager.search("python")
       const results2 = keywordIndexManager.search("PYTHON")

--- a/src/lib/embeddings/keyword-index.ts
+++ b/src/lib/embeddings/keyword-index.ts
@@ -50,14 +50,22 @@ const toIndexDocument = (document: VectorDocument): KeywordIndexDocument => ({
  * Provides fast exact keyword matching to complement semantic search
  */
 class KeywordIndexManager {
-  private index: MiniSearch<{ id: number; content: string; timestamp: number }>
+  private index: MiniSearch<{
+    id: number
+    content: string
+    searchText: string
+    timestamp: number
+  }>
   private documents: Map<number, KeywordIndexDocument> = new Map()
   /** Running total of retained content, so stats never walk the corpus. */
   private retainedContentChars = 0
 
   constructor() {
     this.index = new MiniSearch({
-      fields: ["content"], // Fields to index
+      // Include source/title so filename-only questions can retrieve their
+      // chunks. Keep content separately for the stored projection returned to
+      // callers.
+      fields: ["searchText"],
       storeFields: ["content", "timestamp"], // Fields to store
       idField: "id",
       searchOptions: {
@@ -82,9 +90,16 @@ class KeywordIndexManager {
       const projected = toIndexDocument(document)
       this.documents.set(id, projected)
       this.retainedContentChars += projected.content.length
+      const searchableMetadata = [
+        projected.metadata.source,
+        projected.metadata.title
+      ]
+        .filter(Boolean)
+        .join(" ")
       this.index.add({
         id,
         content: content.toLowerCase(), // Normalize for better matching
+        searchText: `${content} ${searchableMetadata}`.toLowerCase(),
         timestamp: document.metadata.timestamp
       })
     } catch (error) {
@@ -143,6 +158,7 @@ class KeywordIndexManager {
         this.index.remove({ id } as {
           id: number
           content: string
+          searchText: string
           timestamp: number
         })
         this.documents.delete(id)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the local keyword index to search file source and title metadata alongside chunk content, allowing filename-based RAG queries to retrieve file chunks.
- Adds a combined searchable projection while preserving the stored content projection.
- Covers retrieval by a hyphenated filename.
- Documents the filename-search correction in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with filename indexing covered by a focused test and no concrete correctness or security defect identified.

The searchable projection now includes content, source, and title while preserving existing result storage, scoping, hydration, and hybrid-ranking behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/embeddings/keyword-index.ts | Adds source and title metadata to each document's searchable text while retaining content and timestamp for result projection. |
| src/lib/embeddings/__tests__/keyword-index.test.ts | Adds focused coverage proving that a hyphenated filename can retrieve its indexed document. |
| CHANGELOG.md | Accurately records the user-visible filename keyword-search fix. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Chunk content] --> D[Combined searchText]
  B[Metadata source] --> D
  C[Metadata title] --> D
  D --> E[MiniSearch keyword index]
  F[Filename or content query] --> E
  E --> G[Scoped keyword candidates]
  G --> H[Durable-row hydration]
  H --> I[Hybrid ranking]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rag): index filenames in keyword sea..."](https://github.com/shishir435/ollama-client/commit/56db71cf671d6ce8db098f95ba368602bf4a5be3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58329128)</sub>

**Context used:**

- Knowledge Base — [Embedding indexes and search](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/embedding-and-search.md)
- Knowledge Base — [Knowledge ingestion and retrieval](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/knowledge-retrieval.md)

<!-- /greptile_comment -->