### PR TITLE
docs: document olc 0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -979,7 +979,8 @@ No functional changes: this release is store metadata only.
 
 - Comprehensive docs refresh for v0.6.0, including RAG and WXT migration updates.
 
-[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.13.0...HEAD
+[Unreleased]: https://github.com/Shishir435/ollama-client/compare/0.13.2...HEAD
+[0.13.2]: https://github.com/Shishir435/ollama-client/compare/0.13.1...0.13.2
 [0.13.0]: https://github.com/Shishir435/ollama-client/compare/0.12.8...0.13.0
 [0.12.8]: https://github.com/Shishir435/ollama-client/compare/0.12.7...0.12.8
 [0.12.7]: https://github.com/Shishir435/ollama-client/compare/0.12.6...0.12.7

--- a/README.md
+++ b/README.md
@@ -112,6 +112,42 @@ Firefox development:
 pnpm dev:firefox
 ```
 
+### Install `olc` local proxy
+
+`olc` exposes OpenCode or Codex through an OpenAI-compatible local API. It
+requires Node.js 22.12 or newer and the selected runtime on `PATH`.
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://ollamaclient.in/olc.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://ollamaclient.in/olc.ps1 | iex
+```
+
+To pin version `0.13.2` on macOS / Linux:
+
+```bash
+export OLC_VERSION=0.13.2
+curl -fsSL https://ollamaclient.in/olc.sh | sh
+```
+
+To pin version `0.13.2` in Windows PowerShell:
+
+```powershell
+$env:OLC_VERSION = "0.13.2"
+irm https://ollamaclient.in/olc.ps1 | iex
+```
+
+Then run `olc --help`.
+Configure Ollama Client with a custom OpenAI-compatible provider at
+`http://127.0.0.1:8083/v1`. See the [OLC developer guide](https://www.ollamaclient.in/developers/)
+for backend setup, authentication, and tool-calling details.
+
 ## Common Commands
 
 ```bash

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -9,11 +9,36 @@ The project does include **olc**, a local command-line proxy that exposes an age
 
 ## Quickstart
 
-olc currently runs from a repository checkout and requires Node.js 22.12 or
-newer plus the selected runtime on `PATH`: OpenCode, or Codex CLI with an
-existing `codex login`.
+olc requires Node.js 22.12 or newer plus the selected runtime on `PATH`:
+OpenCode, or Codex CLI with an existing `codex login`.
+
+Install the published release bundle directly:
+
+```powershell
+# Windows PowerShell
+irm https://ollamaclient.in/olc.ps1 | iex
+```
 
 ```bash
+# macOS / Linux
+curl -fsSL https://ollamaclient.in/olc.sh | sh
+```
+
+Both installers download checksum-verified archives from the GitHub release.
+Pin version `0.13.2` with the shell-specific commands below:
+
+```bash
+export OLC_VERSION=0.13.2
+curl -fsSL https://ollamaclient.in/olc.sh | sh
+```
+
+```powershell
+$env:OLC_VERSION = "0.13.2"
+irm https://ollamaclient.in/olc.ps1 | iex
+```
+
+```bash
+# Source checkout alternative
 git clone https://github.com/Shishir435/ollama-client.git
 cd ollama-client
 pnpm install
@@ -28,7 +53,8 @@ Use `pnpm proxy:opencode:debug` or `pnpm proxy:codex:debug` for verbose proxy
 logging. The existing `pnpm proxy` and `pnpm proxy:debug` commands remain
 OpenCode aliases.
 
-The CLI is part of the source distribution but is not yet published to npm, PyPI, or Homebrew. Do not tell users to install an `olc` package from a public registry unless an official release announcement links it.
+The CLI is distributed as release archives, not through npm, PyPI, or Homebrew.
+Do not tell users to install an `olc` package from a public registry.
 
 ## Authentication and browser access
 


### PR DESCRIPTION
Release-readiness documentation fixes for 0.13.2.

## Changes
- document macOS/Linux and Windows olc installers in README
- update developer guide from checkout-only to published release bundles
- correct 0.13.2 and Unreleased changelog comparison links

## Validation
- generated docs artifacts
- Astro docs build passed (91 pages)
- git diff --check passed



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates release-readiness documentation for olc 0.13.2.
- Adds macOS/Linux and Windows installer instructions with working shell-specific version pinning.
- Updates the developer guide to describe published release bundles while retaining source-checkout instructions.
- Corrects the 0.13.2 and Unreleased changelog comparison links.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Updates comparison links so Unreleased starts at 0.13.2 and adds the missing 0.13.2 release comparison. |
| README.md | Documents olc installation, shell-specific version pinning, runtime requirements, and local provider configuration. |
| docs/src/content/docs/developers.md | Promotes published release bundles as the primary quickstart and documents correct installer commands for both supported shell families. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: document olc 0.13.2 installers"](https://github.com/shishir435/ollama-client/commit/1be4f7bf1ef7239ab7dc4e06d08c3323bde7dda7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331379)</sub>

<!-- /greptile_comment -->