### PR TITLE
feat: route embeddings through background RPC

### DIFF
--- a/packages/contracts/src/model-rpc.ts
+++ b/packages/contracts/src/model-rpc.ts
@@ -1,5 +1,32 @@
 import { z } from "zod"
 
+const EmbeddingVectorSchema = z.array(z.number().finite()).min(1).max(100_000)
+
+export const EmbeddingsGenerateRequestSchema = z
+  .object({
+    text: z.string().max(2_000_000),
+    model: z.string().min(1).max(500).optional()
+  })
+  .strict()
+
+export const EmbeddingsGenerateResultSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      embedding: EmbeddingVectorSchema,
+      model: z.string().min(1).max(500),
+      providerId: z.string().min(1).max(200)
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z.string().max(2_000),
+      code: z.string().max(100).optional()
+    })
+    .strict()
+])
+
 /**
  * Model lifecycle and catalog methods.
  *
@@ -217,4 +244,10 @@ export type EmbeddingsPrepareModelRequest = z.input<
 >
 export type EmbeddingsPrepareModelResult = z.infer<
   typeof EmbeddingsPrepareModelResultSchema
+>
+export type EmbeddingsGenerateRequest = z.input<
+  typeof EmbeddingsGenerateRequestSchema
+>
+export type EmbeddingsGenerateResult = z.infer<
+  typeof EmbeddingsGenerateResultSchema
 >

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -24,6 +24,7 @@ export enum RpcMethod {
   ModelsGetLibraryVariants = "models.getLibraryVariants",
   EmbeddingsCheckModel = "embeddings.checkModel",
   EmbeddingsPrepareModel = "embeddings.prepareModel",
+  EmbeddingsGenerate = "embeddings.generate",
   IngestionSubmit = "ingestions.submit",
   IngestionGet = "ingestions.get",
   IngestionCancel = "ingestions.cancel",

--- a/src/application/context/rag/__tests__/rag-pipeline.test.ts
+++ b/src/application/context/rag/__tests__/rag-pipeline.test.ts
@@ -4,7 +4,7 @@ import type { VectorDocument } from "@/lib/embeddings/types"
 import { formatEnhancedResults, retrieveContextEnhanced } from "../rag-pipeline"
 
 // ─── Mocks for retrieveContextEnhanced tests ─────────────────────────────────
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/application/embeddings/embedding-service", () => ({
   generateEmbedding: vi.fn()
 }))
 
@@ -31,8 +31,8 @@ vi.mock("@/lib/embeddings/feedback-service", () => ({
   feedbackService: { getFeedbackScore: vi.fn().mockResolvedValue(null) }
 }))
 
+import { generateEmbedding } from "@/application/embeddings/embedding-service"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { rerankerService } from "@/lib/embeddings/reranker"
 import { searchHybrid } from "@/lib/embeddings/search"

--- a/src/application/context/rag/__tests__/rag-retriever.test.ts
+++ b/src/application/context/rag/__tests__/rag-retriever.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/config/knowledge-config", () => ({
   }
 }))
 
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/application/embeddings/embedding-service", () => ({
   generateEmbedding: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
   generateEmbeddingsBatch: vi
     .fn()
@@ -186,7 +186,7 @@ describe("retrieveContextFromSources", () => {
 
   it("returns formatted results when embedding succeeds", async () => {
     const { generateEmbedding, generateEmbeddingsBatch } = await import(
-      "@/lib/embeddings/embedding-client"
+      "@/application/embeddings/embedding-service"
     )
     const { formatEnhancedResults } = await import("../rag-pipeline")
 
@@ -217,7 +217,7 @@ describe("retrieveContextFromSources", () => {
 
   it("falls back to keyword context when embedding fails", async () => {
     const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
+      "@/application/embeddings/embedding-service"
     )
 
     vi.mocked(generateEmbedding).mockResolvedValueOnce({ error: "failed" })

--- a/src/application/context/rag/rag-pipeline.ts
+++ b/src/application/context/rag/rag-pipeline.ts
@@ -1,5 +1,5 @@
+import { generateEmbedding } from "@/application/embeddings/embedding-service"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { feedbackService } from "@/lib/embeddings/feedback-service"
 import { rerankerService } from "@/lib/embeddings/reranker"
 import { searchHybrid } from "@/lib/embeddings/search"

--- a/src/application/context/rag/rag-retriever.ts
+++ b/src/application/context/rag/rag-retriever.ts
@@ -1,11 +1,11 @@
-import { knowledgeConfig } from "@/lib/config/knowledge-config"
-import { type ChunkDocument, chunkDocuments } from "@/lib/embeddings/chunker"
-import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import {
   cosineSimilarity,
   generateEmbedding,
   generateEmbeddingsBatch
-} from "@/lib/embeddings/embedding-client"
+} from "@/application/embeddings/embedding-service"
+import { knowledgeConfig } from "@/lib/config/knowledge-config"
+import { type ChunkDocument, chunkDocuments } from "@/lib/embeddings/chunker"
+import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import {
   getAllDocuments,
   type VectorDocument

--- a/src/application/embeddings/embedding-service.ts
+++ b/src/application/embeddings/embedding-service.ts
@@ -1,0 +1,23 @@
+import {
+  cosineSimilarity,
+  type EmbeddingError,
+  type EmbeddingResult,
+  generateEmbedding,
+  generateEmbeddingsBatch
+} from "@/lib/embeddings/embedding-client"
+
+/**
+ * Background embedding use-case seam.
+ *
+ * Strategy/cache migration will move behind this service incrementally. New
+ * background callers use this module; extension pages use typed RPC instead
+ * of resolving providers or credentials in-page.
+ */
+export const EmbeddingService = {
+  generate: generateEmbedding,
+  generateBatch: generateEmbeddingsBatch
+}
+
+export type { EmbeddingError, EmbeddingResult }
+// Named exports keep existing application seams stable while callers migrate.
+export { cosineSimilarity, generateEmbedding, generateEmbeddingsBatch }

--- a/src/background/__tests__/rpc-server.test.ts
+++ b/src/background/__tests__/rpc-server.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   probeModelCapabilities: vi.fn(),
   checkEmbeddingModelExists: vi.fn(),
   prepareEmbeddingModel: vi.fn(),
+  generateEmbedding: vi.fn(),
   info: vi.fn(),
   error: vi.fn()
 }))
@@ -34,6 +35,10 @@ vi.mock("@/lib/logger", () => ({
 vi.mock("@/background/handlers/handle-embedding-download", () => ({
   checkEmbeddingModelExists: mocks.checkEmbeddingModelExists,
   prepareEmbeddingModel: mocks.prepareEmbeddingModel
+}))
+
+vi.mock("@/application/embeddings/embedding-service", () => ({
+  EmbeddingService: { generate: mocks.generateEmbedding }
 }))
 
 import {
@@ -92,6 +97,11 @@ beforeEach(() => {
   mocks.prepareEmbeddingModel.mockResolvedValue({
     ready: true,
     prepared: false
+  })
+  mocks.generateEmbedding.mockResolvedValue({
+    embedding: [0.1, 0.2],
+    model: "embed-model",
+    providerId: "ollama"
   })
 })
 
@@ -280,6 +290,40 @@ describe("RPC server", () => {
     expect(mocks.prepareEmbeddingModel).toHaveBeenCalledWith(
       { model: "embed-model", providerId: "ollama" },
       expect.any(AbortSignal)
+    )
+  })
+
+  it("dispatches embedding generation through background service", async () => {
+    const envelope = request(RpcMethod.EmbeddingsGenerate, {
+      text: "hello",
+      model: "embed-model"
+    })
+    const sendResponse = vi.fn()
+
+    await handleRpcRequest(
+      envelope,
+      extensionSender,
+      extensionId,
+      extensionPrefix,
+      sendResponse
+    )
+
+    expect(mocks.generateEmbedding).toHaveBeenCalledWith(
+      "hello",
+      "embed-model",
+      undefined,
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        result: {
+          ok: true,
+          embedding: [0.1, 0.2],
+          model: "embed-model",
+          providerId: "ollama"
+        }
+      })
     )
   })
 

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -11,6 +11,7 @@ import {
 import { CancellationRegistry } from "@ollama-client/runtime-core/cancellation"
 import { classifyRuntimeSender } from "@ollama-client/runtime-core/runtime-sender"
 import type { Runtime } from "webextension-polyfill"
+import { EmbeddingService } from "@/application/embeddings/embedding-service"
 import {
   checkEmbeddingModelExists,
   prepareEmbeddingModel
@@ -73,6 +74,24 @@ const handlers = {
   },
   [RpcMethod.EmbeddingsPrepareModel]: async (request, signal) =>
     prepareEmbeddingModel(request, signal),
+  [RpcMethod.EmbeddingsGenerate]: async (request, signal) => {
+    const result = await EmbeddingService.generate(
+      request.text,
+      request.model,
+      undefined,
+      {
+        signal
+      }
+    )
+    if ("error" in result) {
+      return {
+        ok: false as const,
+        error: result.failure?.userMessage ?? "Embedding generation failed",
+        ...(result.code ? { code: result.code } : {})
+      }
+    }
+    return { ok: true as const, ...result }
+  },
   [RpcMethod.IngestionSubmit]: async (request) =>
     IngestionService.submit(request),
   [RpcMethod.IngestionGet]: async (request) =>

--- a/src/background/rpc-server.ts
+++ b/src/background/rpc-server.ts
@@ -299,10 +299,10 @@ export const handleRpcRequest = async (
 
   const controller = new AbortController()
   activeRequests.set(requestId, controller)
-  const serverTimeoutId = setTimeout(
-    () => controller.abort(),
-    definition.timeoutMs
-  )
+  const serverTimeoutId =
+    definition.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => controller.abort(), definition.timeoutMs)
 
   let status = "success"
   let errorCode: RpcErrorCode | undefined
@@ -341,7 +341,7 @@ export const handleRpcRequest = async (
       })
     }
   } finally {
-    clearTimeout(serverTimeoutId)
+    if (serverTimeoutId !== undefined) clearTimeout(serverTimeoutId)
     if (activeRequests.get(requestId) === controller) {
       activeRequests.clear(requestId)
     }

--- a/src/features/chat/hooks/__tests__/use-auto-embed-messages.test.ts
+++ b/src/features/chat/hooks/__tests__/use-auto-embed-messages.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/hooks/use-setting", () => ({
   useSetting: vi.fn()
 }))
 
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/protocol/embedding-client", () => ({
   generateEmbedding: vi.fn()
 }))
 
@@ -44,9 +44,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should embed a user message", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { storeVector } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -69,9 +67,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip system messages", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     const { result } = renderHook(() => useAutoEmbedMessages())
 
@@ -84,9 +80,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip app-owned permission notices", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { result } = renderHook(() => useAutoEmbedMessages())
 
     await result.current.embedMessage(
@@ -110,9 +104,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip short messages", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     const { result } = renderHook(() => useAutoEmbedMessages())
 
@@ -125,9 +117,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip incomplete assistant messages", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     const { result } = renderHook(() => useAutoEmbedMessages())
 
@@ -140,9 +130,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should embed complete assistant messages", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { storeVector } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -165,9 +153,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should handle embedding errors gracefully", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
       error: "Embedding failed"
@@ -196,9 +182,7 @@ describe("useAutoEmbedMessages", () => {
       { isLoading: false }
     ])
 
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     const { result } = renderHook(() => useAutoEmbedMessages())
 
@@ -211,9 +195,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should embed multiple messages", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
       embedding: [0.1, 0.2, 0.3],
@@ -240,9 +222,7 @@ describe("useAutoEmbedMessages", () => {
   })
 
   it("should skip embedding when streaming", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     const { result } = renderHook(() => useAutoEmbedMessages())
 

--- a/src/features/chat/hooks/__tests__/use-chat.test.ts
+++ b/src/features/chat/hooks/__tests__/use-chat.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: toastMock })
 }))
 
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/protocol/embedding-client", () => ({
   generateEmbedding: vi.fn()
 }))
 

--- a/src/features/chat/hooks/__tests__/use-embedding-migration.test.ts
+++ b/src/features/chat/hooks/__tests__/use-embedding-migration.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/embeddings/vector-store", () => ({
   storeVector: mocks.storeVector
 }))
 
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/protocol/embedding-client", () => ({
   generateEmbedding: mocks.generateEmbedding
 }))
 

--- a/src/features/chat/hooks/__tests__/use-semantic-chat-search.test.ts
+++ b/src/features/chat/hooks/__tests__/use-semantic-chat-search.test.ts
@@ -11,7 +11,7 @@ vi.mock("@plasmohq/storage/hook", () => ({
   ])
 }))
 
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/protocol/embedding-client", () => ({
   generateEmbedding: vi.fn()
 }))
 
@@ -45,9 +45,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should perform search with results", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -86,9 +84,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should handle search errors", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
       error: "Embedding failed"
@@ -105,9 +101,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should set searching state during search", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
 
     let resolveEmbedding: any
@@ -146,9 +140,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should filter by session ID", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -177,9 +169,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should use custom limit and similarity", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -209,9 +199,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should identify assistant messages correctly", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
 
     vi.mocked(generateEmbedding).mockResolvedValue({
@@ -249,9 +237,7 @@ describe("useSemanticChatSearch", () => {
   })
 
   it("should handle keyword index build failure gracefully", async () => {
-    const { generateEmbedding } = await import(
-      "@/lib/embeddings/embedding-client"
-    )
+    const { generateEmbedding } = await import("@/protocol/embedding-client")
     const { searchHybrid } = await import("@/lib/embeddings/vector-store")
     const { ensureKeywordIndexBuilt } = await import(
       "@/lib/embeddings/auto-index"

--- a/src/features/chat/hooks/use-auto-embed-messages.ts
+++ b/src/features/chat/hooks/use-auto-embed-messages.ts
@@ -3,10 +3,10 @@ import { useSetting } from "@/hooks/use-setting"
 import { chunkTextAsync } from "@/lib/embeddings/chunker"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { assessContentQuality } from "@/lib/embeddings/content-quality-filter"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { storeVector, vectorDb } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
 import { SETTINGS } from "@/lib/storage/settings"
+import { generateEmbedding } from "@/protocol/embedding-client"
 import type { ChatMessage } from "@/types"
 
 /**

--- a/src/features/chat/hooks/use-embedding-migration.ts
+++ b/src/features/chat/hooks/use-embedding-migration.ts
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react"
 
 import { chunkTextAsync } from "@/lib/embeddings/chunker"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { storeVector, vectorDb } from "@/lib/embeddings/vector-store"
 import { logger } from "@/lib/logger"
 import {
   countMessages,
   getMessagesPaginated
 } from "@/lib/repositories/chat-history"
+import { generateEmbedding } from "@/protocol/embedding-client"
 import type { Role } from "@/types"
 
 export const useEmbeddingMigration = () => {

--- a/src/features/chat/hooks/use-semantic-chat-search.ts
+++ b/src/features/chat/hooks/use-semantic-chat-search.ts
@@ -1,13 +1,13 @@
 import { useCallback, useState } from "react"
 import { useSetting } from "@/hooks/use-setting"
 import { ensureKeywordIndexBuilt } from "@/lib/embeddings/auto-index"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
 import { searchHybrid } from "@/lib/embeddings/vector-store"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
 import { SETTINGS } from "@/lib/storage/settings"
+import { generateEmbedding } from "@/protocol/embedding-client"
 
 export interface ChatSearchResult {
   result: SearchResult

--- a/src/features/file-upload/hooks/__tests__/use-file-search.test.ts
+++ b/src/features/file-upload/hooks/__tests__/use-file-search.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useFileSearch } from "../use-file-search"
 
 // Mock dependencies
-vi.mock("@/lib/embeddings/embedding-client", () => ({
+vi.mock("@/protocol/embedding-client", () => ({
   generateEmbedding: vi.fn()
 }))
 
@@ -15,9 +15,9 @@ vi.mock("@/lib/plasmo-global-storage", () => ({
   getPlasmoStoredValue: vi.fn()
 }))
 
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { searchSimilarVectors } from "@/lib/embeddings/vector-store"
 import { getPlasmoStoredValue } from "@/lib/plasmo-global-storage"
+import { generateEmbedding } from "@/protocol/embedding-client"
 
 describe("useFileSearch", () => {
   beforeEach(() => {

--- a/src/features/file-upload/hooks/use-file-search.ts
+++ b/src/features/file-upload/hooks/use-file-search.ts
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import type { SearchResult } from "@/lib/embeddings/vector-store"
 import { searchSimilarVectors } from "@/lib/embeddings/vector-store"
 import { getDisplayErrorMessage } from "@/lib/error-display"
 import { createAppError } from "@/lib/error-utils"
 import { logger } from "@/lib/logger"
+import { generateEmbedding } from "@/protocol/embedding-client"
 
 export interface FileSearchResult {
   result: SearchResult

--- a/src/features/model/components/embedding-config/embedding-test-generation.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-generation.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from "react-i18next"
 import { SettingsCard } from "@/components/settings"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/class-names"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import { getDisplayErrorMessage } from "@/lib/error-display"
+import { generateEmbedding } from "@/protocol/embedding-client"
 
 export interface EmbeddingTestGenerationProps {
   modelExists: boolean

--- a/src/features/model/components/embedding-config/embedding-test-search.tsx
+++ b/src/features/model/components/embedding-config/embedding-test-search.tsx
@@ -5,11 +5,11 @@ import { SettingsCard } from "@/components/settings"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { generateEmbedding } from "@/lib/embeddings/embedding-client"
 import {
   type SearchResult,
   searchSimilarVectors
 } from "@/lib/embeddings/vector-store"
+import { generateEmbedding } from "@/protocol/embedding-client"
 
 export interface EmbeddingTestSearchProps {
   modelExists: boolean

--- a/src/protocol/__tests__/rpc-registry.test.ts
+++ b/src/protocol/__tests__/rpc-registry.test.ts
@@ -19,6 +19,7 @@ describe("RPC method registry", () => {
     RpcMethod.ModelsSearchLibrary,
     RpcMethod.ModelsGetLibraryVariants,
     RpcMethod.EmbeddingsCheckModel,
+    RpcMethod.EmbeddingsGenerate,
     RpcMethod.IngestionGet,
     RpcMethod.ModelPullGet,
     RpcMethod.ModelPullListActive,

--- a/src/protocol/__tests__/rpc-registry.test.ts
+++ b/src/protocol/__tests__/rpc-registry.test.ts
@@ -53,6 +53,15 @@ describe("RPC method registry", () => {
     }
   })
 
+  it("allows cold embedding work the same deadline as preparation", () => {
+    expect(RPC_METHOD_DEFINITIONS[RpcMethod.EmbeddingsGenerate].timeoutMs).toBe(
+      300_000
+    )
+    expect(
+      RPC_METHOD_DEFINITIONS[RpcMethod.EmbeddingsPrepareModel].timeoutMs
+    ).toBe(300_000)
+  })
+
   it("requires explicit review before classifying a method as a query", () => {
     // Metadata cannot prove an implementation is side-effect free. Keeping the
     // complete query set here makes adding or relabelling one a deliberate

--- a/src/protocol/__tests__/rpc-registry.test.ts
+++ b/src/protocol/__tests__/rpc-registry.test.ts
@@ -38,7 +38,11 @@ describe("RPC method registry", () => {
     expect(definition.request).toBeDefined()
     expect(definition.response).toBeDefined()
     expect(definition.allowedSources.length).toBeGreaterThan(0)
-    expect(definition.timeoutMs).toBeGreaterThan(0)
+    if (method === RpcMethod.EmbeddingsGenerate) {
+      expect(definition.timeoutMs).toBeUndefined()
+    } else {
+      expect(definition.timeoutMs).toBeGreaterThan(0)
+    }
     expect(["query", "command"]).toContain(definition.operation)
   })
 
@@ -53,13 +57,10 @@ describe("RPC method registry", () => {
     }
   })
 
-  it("allows cold embedding work the same deadline as preparation", () => {
+  it("leaves embedding generation deadline-free", () => {
     expect(RPC_METHOD_DEFINITIONS[RpcMethod.EmbeddingsGenerate].timeoutMs).toBe(
-      300_000
+      undefined
     )
-    expect(
-      RPC_METHOD_DEFINITIONS[RpcMethod.EmbeddingsPrepareModel].timeoutMs
-    ).toBe(300_000)
   })
 
   it("requires explicit review before classifying a method as a query", () => {

--- a/src/protocol/__tests__/rpc-registry.test.ts
+++ b/src/protocol/__tests__/rpc-registry.test.ts
@@ -38,11 +38,7 @@ describe("RPC method registry", () => {
     expect(definition.request).toBeDefined()
     expect(definition.response).toBeDefined()
     expect(definition.allowedSources.length).toBeGreaterThan(0)
-    if (method === RpcMethod.EmbeddingsGenerate) {
-      expect(definition.timeoutMs).toBeUndefined()
-    } else {
-      expect(definition.timeoutMs).toBeGreaterThan(0)
-    }
+    expect(definition.timeoutMs).toBeGreaterThan(0)
     expect(["query", "command"]).toContain(definition.operation)
   })
 
@@ -57,9 +53,9 @@ describe("RPC method registry", () => {
     }
   })
 
-  it("leaves embedding generation deadline-free", () => {
+  it("gives slow embedding generation a bounded cancellation window", () => {
     expect(RPC_METHOD_DEFINITIONS[RpcMethod.EmbeddingsGenerate].timeoutMs).toBe(
-      undefined
+      900_000
     )
   })
 

--- a/src/protocol/embedding-client.ts
+++ b/src/protocol/embedding-client.ts
@@ -1,0 +1,43 @@
+import type {
+  EmbeddingsGenerateRequest,
+  EmbeddingsGenerateResult
+} from "@ollama-client/contracts/model-rpc"
+import { RpcMethod } from "@ollama-client/contracts/rpc"
+import { extensionRpcClient } from "./extension-client"
+
+export interface EmbeddingResult {
+  embedding: number[]
+  model: string
+  providerId: string
+}
+
+export interface EmbeddingError {
+  error: string
+  code?: string
+}
+
+/** Page-side embedding client. Provider resolution stays background-owned. */
+export const generateEmbedding = async (
+  text: string,
+  model?: string
+): Promise<EmbeddingResult | EmbeddingError> => {
+  const request: EmbeddingsGenerateRequest = {
+    text,
+    ...(model ? { model } : {})
+  }
+  const result: EmbeddingsGenerateResult = await extensionRpcClient.call(
+    RpcMethod.EmbeddingsGenerate,
+    request
+  )
+  if (!result.ok) {
+    return {
+      error: result.error,
+      ...(result.code ? { code: result.code } : {})
+    }
+  }
+  return {
+    embedding: result.embedding,
+    model: result.model,
+    providerId: result.providerId
+  }
+}

--- a/src/protocol/extension-client.ts
+++ b/src/protocol/extension-client.ts
@@ -63,15 +63,20 @@ export const extensionRpcClient = {
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     try {
-      const rawResponse = await Promise.race([
-        browser.runtime.sendMessage(envelope),
-        new Promise<never>((_resolve, reject) => {
-          timeoutId = setTimeout(() => {
-            cancelRpcRequest(requestId)
-            reject(timeoutError(method))
-          }, definition.timeoutMs)
-        })
-      ])
+      const responsePromises: Promise<unknown>[] = [
+        browser.runtime.sendMessage(envelope)
+      ]
+      if (definition.timeoutMs !== undefined) {
+        responsePromises.push(
+          new Promise<never>((_resolve, reject) => {
+            timeoutId = setTimeout(() => {
+              cancelRpcRequest(requestId)
+              reject(timeoutError(method))
+            }, definition.timeoutMs)
+          })
+        )
+      }
+      const rawResponse = await Promise.race(responsePromises)
       const responseSchema = createRpcResponseEnvelopeSchema(
         definition.response
       )

--- a/src/protocol/rpc-map.ts
+++ b/src/protocol/rpc-map.ts
@@ -29,6 +29,8 @@ import type {
 import type {
   EmbeddingsCheckModelRequest,
   EmbeddingsCheckModelResult,
+  EmbeddingsGenerateRequest,
+  EmbeddingsGenerateResult,
   EmbeddingsPrepareModelRequest,
   EmbeddingsPrepareModelResult,
   ModelsGetDetailsRequest,
@@ -129,6 +131,10 @@ export interface RpcMap {
   [RpcMethod.EmbeddingsPrepareModel]: RpcDefinition<
     EmbeddingsPrepareModelRequest,
     EmbeddingsPrepareModelResult
+  >
+  [RpcMethod.EmbeddingsGenerate]: RpcDefinition<
+    EmbeddingsGenerateRequest,
+    EmbeddingsGenerateResult
   >
   [RpcMethod.IngestionSubmit]: RpcDefinition<
     IngestionSubmitRequest,

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -52,7 +52,7 @@ export interface RpcMethodDefinition {
   request: z.ZodType
   response: z.ZodType
   allowedSources: readonly RpcSource[]
-  timeoutMs: number
+  timeoutMs?: number
   operation: "query" | "command"
 }
 
@@ -63,7 +63,7 @@ const extensionPagesOnly = ["extension-page"] as const
  * operation rather than a global default: model warmup and embedding prepare
  * may perform cold-start or pull work, while ordinary queries stay bounded.
  */
-export const RPC_METHOD_DEFINITIONS = {
+export const RPC_METHOD_DEFINITIONS: Record<RpcMethod, RpcMethodDefinition> = {
   [RpcMethod.ProvidersList]: {
     request: ProvidersListRequestSchema,
     response: ProvidersListResultSchema,
@@ -189,10 +189,6 @@ export const RPC_METHOD_DEFINITIONS = {
     request: EmbeddingsGenerateRequestSchema,
     response: EmbeddingsGenerateResultSchema,
     allowedSources: extensionPagesOnly,
-    // Cold embedding models can take as long as model preparation. Keep the
-    // page request bounded, but do not abort valid migration or indexing work
-    // before the preparation RPC's 300-second ceiling.
-    timeoutMs: 300_000,
     operation: "query"
   },
   [RpcMethod.IngestionSubmit]: {
@@ -272,7 +268,7 @@ export const RPC_METHOD_DEFINITIONS = {
     timeoutMs: 5_000,
     operation: "command"
   }
-} as const satisfies Record<RpcMethod, RpcMethodDefinition>
+}
 
 import {
   DiagnosticsClearRequestSchema,

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -11,6 +11,8 @@ import {
 import {
   EmbeddingsCheckModelRequestSchema,
   EmbeddingsCheckModelResultSchema,
+  EmbeddingsGenerateRequestSchema,
+  EmbeddingsGenerateResultSchema,
   EmbeddingsPrepareModelRequestSchema,
   EmbeddingsPrepareModelResultSchema,
   ModelsGetDetailsRequestSchema,
@@ -182,6 +184,13 @@ export const RPC_METHOD_DEFINITIONS = {
     // Preparing can mean pulling the model.
     timeoutMs: 300_000,
     operation: "command"
+  },
+  [RpcMethod.EmbeddingsGenerate]: {
+    request: EmbeddingsGenerateRequestSchema,
+    response: EmbeddingsGenerateResultSchema,
+    allowedSources: extensionPagesOnly,
+    timeoutMs: 120_000,
+    operation: "query"
   },
   [RpcMethod.IngestionSubmit]: {
     request: IngestionSubmitRequestSchema,

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -189,6 +189,10 @@ export const RPC_METHOD_DEFINITIONS: Record<RpcMethod, RpcMethodDefinition> = {
     request: EmbeddingsGenerateRequestSchema,
     response: EmbeddingsGenerateResultSchema,
     allowedSources: extensionPagesOnly,
+    // Embedding generation may include a cold start or a large migration
+    // chunk. Keep a generous bound so a provider that accepts but never
+    // completes still releases both page and background resources.
+    timeoutMs: 900_000,
     operation: "query"
   },
   [RpcMethod.IngestionSubmit]: {

--- a/src/protocol/rpc-registry.ts
+++ b/src/protocol/rpc-registry.ts
@@ -189,7 +189,10 @@ export const RPC_METHOD_DEFINITIONS = {
     request: EmbeddingsGenerateRequestSchema,
     response: EmbeddingsGenerateResultSchema,
     allowedSources: extensionPagesOnly,
-    timeoutMs: 120_000,
+    // Cold embedding models can take as long as model preparation. Keep the
+    // page request bounded, but do not abort valid migration or indexing work
+    // before the preparation RPC's 300-second ceiling.
+    timeoutMs: 300_000,
     operation: "query"
   },
   [RpcMethod.IngestionSubmit]: {


### PR DESCRIPTION
## Summary
- add typed embeddings.generate RPC contract with runtime validation
- route UI embedding generation through background-owned dispatch
- expose application EmbeddingService seam for background RAG
- preserve cancellation and add RPC regression coverage

## Verification
- pnpm typecheck
- pnpm lint:check
- pnpm test:run (404 files, 3378 tests)
- Chrome production package and bundle budget checks
- docs build

## Scope
This is first 0.13.3 embedding-ownership slice. Full strategy/cache extraction remains follow-up work.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a validated embeddings.generate RPC and routes page-side embedding generation through a background-owned service.
- Adds shared request and result schemas plus RPC registry and map entries.
- Introduces page-side and application embedding-service seams.
- Threads cancellation into background embedding generation and migrates search, diagnostics, migration, and automatic-embedding callers.
- Adds RPC dispatch and registry regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/contracts/src/model-rpc.ts | Adds strict, bounded schemas for embedding generation requests and results. |
| src/protocol/embedding-client.ts | Introduces the page-side adapter that calls the typed background embedding RPC. |
| src/protocol/rpc-registry.ts | Registers embeddings.generate with extension-page authorization and query metadata. |
| src/background/rpc-server.ts | Dispatches embedding generation through the application service and propagates cancellation. |
| src/application/embeddings/embedding-service.ts | Exposes a background-facing application seam over the existing embedding implementation. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Extension page
  participant Client as Embedding RPC client
  participant RPC as Background RPC server
  participant Service as EmbeddingService
  participant Provider as Embedding provider
  UI->>Client: generateEmbedding(text, model)
  Client->>RPC: embeddings.generate
  RPC->>Service: generate(text, model, signal)
  Service->>Provider: embed(text, model, signal)
  Provider-->>Service: embedding result
  Service-->>RPC: validated result
  RPC-->>Client: RPC response
  Client-->>UI: embedding or error
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: bound embedding rpc lifetime"](https://github.com/shishir435/ollama-client/commit/cb6f83e5aafa659627faeb824430726e562dda8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58337890)</sub>

**Context used:**

- Knowledge Base — [Runtime messaging and RPC](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/runtime-messaging.md)
- Knowledge Base — [Embedding indexes and search](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/embedding-and-search.md)

<!-- /greptile_comment -->