### PR TITLE
fix(embeddings): propagate cancellation end to end

### DIFF
--- a/src/background/handlers/handle-build-context.ts
+++ b/src/background/handlers/handle-build-context.ts
@@ -28,9 +28,11 @@ import type {
 export const resolveRetrievalToolsActive = async (
   modelId: string,
   providerId: string | undefined,
-  latestUserText: string
+  latestUserText: string,
+  signal?: AbortSignal
 ): Promise<boolean> => {
   try {
+    signal?.throwIfAborted()
     const provider = await ProviderFactory.getProviderForModel(
       modelId,
       providerId
@@ -39,10 +41,13 @@ export const resolveRetrievalToolsActive = async (
       modelId,
       providerId,
       provider,
-      latestUserText
+      latestUserText,
+      undefined,
+      signal
     )
     return hasRetrievalTool(resolved)
   } catch (error) {
+    if (signal?.aborted) throw error
     logger.debug(
       "Failed to resolve retrieval tools for context gating; auto-injecting",
       "handleBuildContext",
@@ -86,7 +91,8 @@ export const handleBuildContext = async (
     const retrievalToolsActive = await resolveRetrievalToolsActive(
       modelId,
       p.selectedModelRef?.providerId,
-      p.rawInput
+      p.rawInput,
+      controller.signal
     )
 
     const output = await new ContextService().build({

--- a/src/background/handlers/handle-chat-with-model.ts
+++ b/src/background/handlers/handle-chat-with-model.ts
@@ -245,7 +245,8 @@ export const handleChatWithModel = withErrorContext(
     const resolvedCapabilities = await resolveModelCapabilities(
       model,
       providerId,
-      provider
+      provider,
+      ac.signal
     )
     const { capabilities } = resolvedCapabilities
     const imageGenerator = capabilities.imageOutput
@@ -272,7 +273,8 @@ export const handleChatWithModel = withErrorContext(
           providerId,
           provider,
           latestUserText,
-          resolvedCapabilities
+          resolvedCapabilities,
+          ac.signal
         )
     const nativeTools =
       resolvedTools?.mode === "native" ? resolvedTools.tools : undefined

--- a/src/background/lib/__tests__/resolve-model-tools.test.ts
+++ b/src/background/lib/__tests__/resolve-model-tools.test.ts
@@ -149,6 +149,23 @@ describe("resolveModelTools", () => {
     expect(getModelDetails).toHaveBeenCalledTimes(2)
   })
 
+  it("passes cancellation to provider capability metadata", async () => {
+    const controller = new AbortController()
+    const getModelDetails = vi.fn(async () => ({ capabilities: ["tools"] }))
+    const provider = providerWithDetails(getModelDetails)
+
+    await resolveModelTools(
+      "qwen",
+      "ollama",
+      provider,
+      undefined,
+      undefined,
+      controller.signal
+    )
+
+    expect(getModelDetails).toHaveBeenCalledWith("qwen", controller.signal)
+  })
+
   it("offers all tools when every family is enabled (default)", async () => {
     await expect(
       resolveModelTools("qwen", "ollama", toolModel())

--- a/src/background/lib/resolve-model-tools.ts
+++ b/src/background/lib/resolve-model-tools.ts
@@ -40,6 +40,10 @@ interface CapabilityTagsCacheEntry {
 
 const capabilityTagsCache = new Map<string, CapabilityTagsCacheEntry>()
 
+const throwIfAborted = (signal?: AbortSignal): void => {
+  signal?.throwIfAborted()
+}
+
 export const clearModelToolCapabilityCache = () => {
   capabilityTagsCache.clear()
 }
@@ -61,8 +65,10 @@ export interface ResolvedModelCapabilities {
 export const resolveModelCapabilities = async (
   model: string,
   providerId: string | undefined,
-  provider: LLMProvider
+  provider: LLMProvider,
+  signal?: AbortSignal
 ): Promise<ResolvedModelCapabilities> => {
+  throwIfAborted(signal)
   const resolvedProviderId = providerId || DEFAULT_PROVIDER_ID
   const providerUrl = resolveProviderBaseUrl(provider.config)
   const cacheKey = `${resolvedProviderId}::${providerUrl}::${model}`
@@ -74,10 +80,11 @@ export const resolveModelCapabilities = async (
   if (cached && cached.expiresAt > Date.now()) {
     metadata = cached
   } else {
+    throwIfAborted(signal)
     let resolvedMetadata = false
     if (provider.getModelDetails) {
       try {
-        const details = await provider.getModelDetails(model)
+        const details = await provider.getModelDetails(model, signal)
         const tags = (details as { capabilities?: string[] } | null)
           ?.capabilities
         if (tags?.length) {
@@ -85,6 +92,7 @@ export const resolveModelCapabilities = async (
           resolvedMetadata = true
         }
       } catch (error) {
+        throwIfAborted(signal)
         logger.debug(
           "Failed to read model details for capability gating",
           "resolveModelCapabilities",
@@ -95,7 +103,7 @@ export const resolveModelCapabilities = async (
 
     if (!resolvedMetadata && provider.capabilities?.modelDiscovery) {
       try {
-        const { models } = await discoverProviderModels(provider)
+        const { models } = await discoverProviderModels(provider, signal)
         const servedModel = models.find((candidate) => candidate.name === model)
         if (servedModel) {
           metadata = {
@@ -111,6 +119,7 @@ export const resolveModelCapabilities = async (
           resolvedMetadata = true
         }
       } catch (error) {
+        throwIfAborted(signal)
         logger.debug(
           "Failed to read model catalog metadata for capability gating",
           "resolveModelCapabilities",
@@ -165,12 +174,14 @@ export const resolveModelTools = async (
   providerId: string | undefined,
   provider: LLMProvider,
   latestUserText?: string,
-  resolvedCapabilities?: ResolvedModelCapabilities
+  resolvedCapabilities?: ResolvedModelCapabilities,
+  signal?: AbortSignal
 ): Promise<ResolvedModelTools | undefined> => {
+  throwIfAborted(signal)
   const resolvedProviderId = providerId || DEFAULT_PROVIDER_ID
   const { capabilities, probed } =
     resolvedCapabilities ??
-    (await resolveModelCapabilities(model, providerId, provider))
+    (await resolveModelCapabilities(model, providerId, provider, signal))
 
   // Native when the model supports tool-calling; otherwise fall back to the
   // prompt-based path only if the user opted this model in. Off by default, so a

--- a/src/background/turns/turn-service-factory.ts
+++ b/src/background/turns/turn-service-factory.ts
@@ -32,6 +32,7 @@ export const withRetrievalToolState = async (
   submission: TurnSubmission,
   options: BuildRagContextOptions
 ): Promise<BuildRagContextOptions> => {
+  const signal = contextAbortSignal(submission.id)
   const context = submission.request.context
   const model =
     context.customModel ||
@@ -40,12 +41,13 @@ export const withRetrievalToolState = async (
   const retrievalToolsActive = await resolveRetrievalToolsActive(
     model,
     submission.providerId,
-    context.rawInput
+    context.rawInput,
+    signal
   )
   return {
     ...options,
     retrievalToolsActive,
-    signal: contextAbortSignal(submission.id)
+    signal
   }
 }
 

--- a/src/lib/embeddings/embedding-client.ts
+++ b/src/lib/embeddings/embedding-client.ts
@@ -177,8 +177,10 @@ export const generateEmbedding = async (
   config?: EmbeddingConfig,
   options: { plan?: EmbeddingPlan; signal?: AbortSignal } = {}
 ): Promise<EmbeddingResult | EmbeddingError> => {
+  options.signal?.throwIfAborted()
   const resolvedConfig = config ?? (await getEmbeddingConfig())
   const plan = options.plan ?? (await resolveEmbeddingPlan(modelName))
+  options.signal?.throwIfAborted()
   const contentHash = await hashContent(text)
   const cached = readCachedEmbedding(
     contentHash,

--- a/src/lib/embeddings/storage.ts
+++ b/src/lib/embeddings/storage.ts
@@ -485,7 +485,12 @@ export const fromDocuments = async (
   for (const doc of documents) {
     try {
       options.signal?.throwIfAborted()
-      const embeddingResult = await EmbeddingService.generate(doc.pageContent)
+      const embeddingResult = await EmbeddingService.generate(
+        doc.pageContent,
+        undefined,
+        undefined,
+        options.signal ? { signal: options.signal } : {}
+      )
       options.signal?.throwIfAborted()
 
       if ("error" in embeddingResult) {
@@ -538,10 +543,17 @@ export const storeChatMessage = async (
     chatId?: string
     title?: string
     messageId?: number
-  }
+  },
+  signal?: AbortSignal
 ): Promise<number> => {
   try {
-    const embeddingResult = await EmbeddingService.generate(content)
+    signal?.throwIfAborted()
+    const embeddingResult = await EmbeddingService.generate(
+      content,
+      undefined,
+      undefined,
+      signal ? { signal } : {}
+    )
 
     if ("error" in embeddingResult) {
       logger.error(
@@ -554,6 +566,7 @@ export const storeChatMessage = async (
       return 0
     }
 
+    signal?.throwIfAborted()
     return storeVector(content, embeddingResult.embedding, {
       ...metadata,
       type: "chat",

--- a/src/lib/knowledge/__tests__/knowledge-processor.test.ts
+++ b/src/lib/knowledge/__tests__/knowledge-processor.test.ts
@@ -98,4 +98,31 @@ describe("processKnowledgeBatch", () => {
     expect(results.get("f2")?.success).toBe(true)
     expect(chunker.chunkDocuments).toHaveBeenCalledTimes(2)
   })
+
+  it("propagates cancellation between files", async () => {
+    vi.mocked(chunker.chunkDocuments).mockResolvedValue([
+      { pageContent: "chunk", metadata: {} }
+    ])
+    vi.mocked(vectorStore.fromDocuments).mockResolvedValue([1])
+    const controller = new AbortController()
+    const onProgress = vi.fn((_fileId, progress) => {
+      if (progress.status === "completed") controller.abort()
+    })
+
+    await expect(
+      processKnowledgeBatch(
+        [
+          {
+            fileId: "f1",
+            fileName: "1.txt",
+            content: "c1",
+            contentType: "txt"
+          },
+          { fileId: "f2", fileName: "2.txt", content: "c2", contentType: "txt" }
+        ],
+        onProgress,
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: "AbortError" })
+  })
 })

--- a/src/lib/knowledge/knowledge-processor.ts
+++ b/src/lib/knowledge/knowledge-processor.ts
@@ -1,3 +1,4 @@
+import { abortableDelay } from "@/lib/abortable-delay"
 import { type ChunkDocument, chunkDocuments } from "@/lib/embeddings/chunker"
 import { getEmbeddingConfig } from "@/lib/embeddings/config"
 import { fromDocuments } from "@/lib/embeddings/vector-store"
@@ -158,6 +159,7 @@ export async function processKnowledge(
       chunkCount: chunks.length
     }
   } catch (error) {
+    if (signal?.aborted) throw error
     const errorMessage = getErrorMessage(error)
 
     logger.error("Error processing document", "processKnowledge", {
@@ -195,7 +197,8 @@ export async function processKnowledgeBatch(
     pages?: Array<{ pageNumber: number; text: string }>
     contentType: string
   }>,
-  onProgress?: (fileId: string, progress: ProcessingProgress) => void
+  onProgress?: (fileId: string, progress: ProcessingProgress) => void,
+  signal?: AbortSignal
 ): Promise<
   Map<string, { success: boolean; chunkCount: number; error?: string }>
 > {
@@ -205,8 +208,10 @@ export async function processKnowledgeBatch(
   >()
 
   for (const file of files) {
+    signal?.throwIfAborted()
     const result = await processKnowledge({
       ...file,
+      signal,
       onProgress: (progress) => onProgress?.(file.fileId, progress)
     })
 
@@ -217,7 +222,9 @@ export async function processKnowledgeBatch(
     })
 
     // Small delay between files to prevent overwhelming the system
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    if (file !== files[files.length - 1]) {
+      await abortableDelay(100, signal)
+    }
   }
 
   return results

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -758,7 +758,7 @@ export class AnthropicProvider implements LLMProvider {
     }
   }
 
-  async getModelDetails(): Promise<null> {
+  async getModelDetails(_model?: string, _signal?: AbortSignal): Promise<null> {
     return null
   }
 

--- a/src/lib/providers/openai-compatible.ts
+++ b/src/lib/providers/openai-compatible.ts
@@ -1125,7 +1125,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
       reader.releaseLock()
     }
   }
-  async getModelDetails(_model: string): Promise<null> {
+  async getModelDetails(_model: string, _signal?: AbortSignal): Promise<null> {
     return null
   }
 

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -192,7 +192,10 @@ export interface LLMProvider {
   ): Promise<void>
 
   getModels(signal?: AbortSignal): Promise<ProviderModel[]>
-  getModelDetails?(model: string): Promise<ProviderModelDetails | null>
+  getModelDetails?(
+    model: string,
+    signal?: AbortSignal
+  ): Promise<ProviderModelDetails | null>
   getEmbeddingSupport?(): Promise<EmbeddingSupport>
   embed?(text: string, model?: string, signal?: AbortSignal): Promise<number[]>
   embedBatch?(


### PR DESCRIPTION
## Summary
- propagate AbortSignal through embedding storage and knowledge batches
- cancel provider capability metadata/discovery before context and chat work proceeds
- preserve cancellation errors instead of converting them into fallback or ordinary failures
- add regression coverage for capability metadata and batch cancellation

## Validation
- pnpm typecheck
- pnpm lint:check
- 405 test files / 3389 tests passed
- extension and docs build hooks passed



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR propagates cancellation through capability discovery, retrieval-tool resolution, embedding storage, and knowledge ingestion so stopped work terminates promptly.
- Threads `AbortSignal` from background turn handlers through provider metadata and model discovery.
- Preserves cancellation errors instead of converting them into capability fallbacks or ordinary processing failures.
- Adds cancellation checkpoints around embedding generation, vector persistence, knowledge files, and inter-file delays.
- Extends provider model-detail contracts and regression coverage for capability and batch cancellation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/background/lib/resolve-model-tools.ts | Capability metadata and catalog discovery now receive the caller signal and preserve cancellation through both fallback catches. |
| src/background/handlers/handle-chat-with-model.ts | Chat preparation now passes the active turn signal through capability and tool resolution. |
| src/background/handlers/handle-build-context.ts | Context gating now propagates its abort signal and avoids converting cancellation into automatic retrieval fallback. |
| src/lib/embeddings/storage.ts | Document and chat-message embedding storage now forwards cancellation and checks it before persistence. |
| src/lib/knowledge/knowledge-processor.ts | Knowledge ingestion preserves abort errors, checks between files, and makes the inter-file delay abortable. |
| src/lib/providers/types.ts | The provider model-detail contract now accepts an optional AbortSignal consistently with implementations. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stop as Stop request
    participant Turn as Background turn
    participant Caps as Capability resolution
    participant Provider as Provider discovery
    participant Embed as Embedding/knowledge work
    Stop->>Turn: abort signal
    Turn->>Caps: pass AbortSignal
    Caps->>Provider: metadata/catalog request with signal
    Turn->>Embed: embedding/batch work with signal
    Provider-->>Caps: cancellation error
    Caps-->>Turn: rethrow cancellation
    Embed-->>Turn: rethrow cancellation
    Turn-->>Turn: terminate stopped work
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(embeddings): propagate cancellation ..."](https://github.com/shishir435/ollama-client/commit/503461d4c545d75e2d35c6efabdcaf4f1fd525d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58354538)</sub>

**Context used:**

- Knowledge Base — [Background turn execution](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/background-turn-execution.md)
- Knowledge Base — [Provider abstraction and compatibility](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/provider-abstraction.md)

<!-- /greptile_comment -->