### PR TITLE
feat(web-search): add native search routing

### DIFF
--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -188,7 +188,15 @@ Every tool id OpenCode reports is explicitly disabled per turn unless listed in
 `ALLOW_OPENCODE_TOOLS`. The client that talks to this proxy has its own tool
 inventory and its own approval flow; an agent quietly reaching for `bash` or
 `write` instead is neither visible nor wanted there. Opt individual tools back in
-by id, for example `--allow-opencode-tools websearch,webfetch`.
+by id with `--allow-opencode-tools`.
+
+`web_search` is also the client's per-turn search intent. Its execution policy
+can request client-managed, automatic, or native-only search. Automatic uses
+OpenCode's `websearch` when discovered and otherwise preserves the client tool as
+a SearXNG/Brave/Tavily fallback. Native-only removes that fallback and therefore
+fails closed when `websearch` is absent. Native `webfetch` remains off unless the
+operator explicitly lists it; a web-search request alone does not grant arbitrary
+URL fetching. Clients without a policy annotation retain automatic behavior.
 
 ### Codex backend
 
@@ -196,6 +204,7 @@ by id, for example `--allow-opencode-tools websearch,webfetch`.
 | --- | --- | --- | --- |
 | `CODEX_PATH` | `--codex` | `OLC_CODEX_PATH` (or `CODEX_PATH`) | `codex` |
 | `CODEX_PROJECT_DIR` | `--codex-project-dir` | `OLC_CODEX_PROJECT_DIR` | isolated temporary workspace |
+| `CODEX_WEB_SEARCH_MODE` | `--codex-web-search` | `OLC_CODEX_WEB_SEARCH_MODE` | `cached` |
 
 Codex runs with `approvalPolicy: never`, a read-only sandbox, and an ephemeral
 thread rooted in the dedicated workspace. The client-provided tools are exposed
@@ -206,6 +215,18 @@ Server reports native image generation, olc publishes a dedicated
 `codex/image-generation` model and exposes its result through the
 OpenAI-compatible Images endpoint. Ordinary Codex models remain text-output models;
 older Codex builds simply omit the image-generation model.
+
+For ordinary chat turns, an incoming `web_search` function is explicit per-turn
+intent. olc removes the duplicate dynamic tool and starts that Codex thread with
+search set to the client-requested `cached`, `indexed`, or `live` mode, capped by
+`CODEX_WEB_SEARCH_MODE`. A turn without the function—or one explicitly requesting
+client-managed execution—always starts with search `disabled`. Automatic mode
+preserves the client function as fallback when native search is operator-disabled;
+native-only removes it and fails closed. Image turns always disable search.
+Codex `webSearch` lifecycle items are forwarded as reasoning-status deltas, while
+commentary-phase messages stay in reasoning instead of being concatenated into
+the final answer. Debug mode reports the selected native mode and the number of
+observed search events, but never logs the query text.
 
 ## Endpoints
 

--- a/packages/olc/src/__tests__/cli.test.ts
+++ b/packages/olc/src/__tests__/cli.test.ts
@@ -15,7 +15,9 @@ describe("parseArgs", () => {
       "--codex",
       "/opt/codex",
       "--codex-project-dir",
-      "/tmp/codex-empty"
+      "/tmp/codex-empty",
+      "--codex-web-search",
+      "indexed"
     ])
 
     expect(options).toEqual({
@@ -24,7 +26,8 @@ describe("parseArgs", () => {
       OPENCODE_SERVER_URL: "http://127.0.0.1:4444",
       ALLOW_OPENCODE_TOOLS: "websearch",
       CODEX_PATH: "/opt/codex",
-      CODEX_PROJECT_DIR: "/tmp/codex-empty"
+      CODEX_PROJECT_DIR: "/tmp/codex-empty",
+      CODEX_WEB_SEARCH_MODE: "indexed"
     })
   })
 

--- a/packages/olc/src/backends/codex/__tests__/backend.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/backend.test.ts
@@ -113,6 +113,18 @@ describe("Codex backend", () => {
         ],
         reasoningEffort: "medium"
       })
+      const firstThreadStart = JSON.parse(
+        readFileSync(
+          path.join(directory, "workspace", "thread-starts.jsonl"),
+          "utf8"
+        )
+          .trim()
+          .split("\n")[0] as string
+      )
+      expect(firstThreadStart).toMatchObject({
+        config: { web_search: "disabled" },
+        dynamicTools: [{ name: "lookup" }]
+      })
       const suspended = new Promise<void>((resolve) => {
         suspend = resolve
       })
@@ -151,6 +163,68 @@ describe("Codex backend", () => {
       expect(text).toEqual(["Result: 42"])
       expect(reasoning).toEqual(["Checked. "])
       await turn.dispose()
+
+      const nativeSearchTurn = await backend.startTurn({
+        requestId: "request-native-search",
+        model: { providerId: "codex", modelId: "fake-codex" },
+        messages: [
+          { role: "system", content: "Stay concise" },
+          { role: "user", content: "Find current information" }
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              description: "Search the web",
+              parameters: { type: "object" }
+            }
+          },
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Look up an answer",
+              parameters: { type: "object" }
+            }
+          }
+        ],
+        reasoningEffort: "medium"
+      })
+      const threadStarts = readFileSync(
+        path.join(directory, "workspace", "thread-starts.jsonl"),
+        "utf8"
+      )
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+      expect(threadStarts[1]).toMatchObject({
+        config: { web_search: "cached" },
+        dynamicTools: [{ name: "lookup" }]
+      })
+      expect(threadStarts[1].developerInstructions).toContain(
+        "Native web search is enabled"
+      )
+      const nativeText: string[] = []
+      const nativeReasoning: string[] = []
+      const nativeOutcome = await nativeSearchTurn.run(
+        {
+          onText: (delta: string) => nativeText.push(delta),
+          onReasoning: (delta: string) => nativeReasoning.push(delta)
+        },
+        {
+          suspended: new Promise(() => {}),
+          hasUnannouncedToolCalls: () => false
+        }
+      )
+      expect(nativeOutcome).toMatchObject({
+        status: "completed",
+        content: "Verified answer."
+      })
+      expect(nativeText).toEqual(["Verified answer."])
+      expect(nativeReasoning.join("")).toContain("Checking sources.")
+      expect(nativeReasoning.join("")).toContain("Web search: current answer")
+      await nativeSearchTurn.dispose()
 
       await expect(
         backend.generateImage?.({

--- a/packages/olc/src/backends/codex/__tests__/config.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/config.test.ts
@@ -12,6 +12,7 @@ describe("resolveCodexConfig", () => {
     const config = resolveCodexConfig()
     expect(config.CODEX_PATH).toBe("codex")
     expect(config.PROJECT_DIR).toContain("olc-codex-workspace")
+    expect(config.WEB_SEARCH_MODE).toBe("cached")
   })
 
   it("keeps option, environment, file, default precedence", () => {
@@ -36,5 +37,17 @@ describe("resolveCodexConfig", () => {
         options: { CODEX_PROJECT_DIR: "/flag/workspace" }
       }).PROJECT_DIR
     ).toBe("/flag/workspace")
+  })
+
+  it("resolves and validates the native web-search mode", () => {
+    process.env.OLC_CODEX_WEB_SEARCH_MODE = "indexed"
+    expect(resolveCodexConfig().WEB_SEARCH_MODE).toBe("indexed")
+    expect(
+      resolveCodexConfig({ options: { CODEX_WEB_SEARCH_MODE: "live" } })
+        .WEB_SEARCH_MODE
+    ).toBe("live")
+    expect(() =>
+      resolveCodexConfig({ options: { CODEX_WEB_SEARCH_MODE: "surprise" } })
+    ).toThrow("Invalid Codex web-search mode 'surprise'")
   })
 })

--- a/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
+++ b/packages/olc/src/backends/codex/__tests__/fixtures/fake-codex.mjs
@@ -6,6 +6,7 @@ const lines = readline.createInterface({ input: process.stdin })
 const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`)
 const imageThreads = new Set()
 const delayedImageThreads = new Set()
+const nativeSearchThreads = new Set()
 const ONE_PIXEL_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nXsAAAAASUVORK5CYII="
 
@@ -49,6 +50,7 @@ const isImageThreadRequest = (message) => {
 }
 
 const handleThreadStart = (message) => {
+  appendFileSync("thread-starts.jsonl", `${JSON.stringify(message.params)}\n`)
   if (isImageThreadRequest(message)) {
     const threadId =
       message.params?.model === "fake-codex-delayed"
@@ -60,11 +62,12 @@ const handleThreadStart = (message) => {
     return
   }
 
+  const nativeSearch = message.params?.config?.web_search !== "disabled"
   const valid =
     message.params?.approvalPolicy === "never" &&
     message.params?.sandbox === "read-only" &&
     message.params?.ephemeral === true &&
-    message.params?.developerInstructions === "Stay concise" &&
+    message.params?.developerInstructions?.startsWith("Stay concise") &&
     message.params?.dynamicTools?.[0]?.name === "lookup"
   if (!valid) {
     send({
@@ -73,7 +76,99 @@ const handleThreadStart = (message) => {
     })
     return
   }
-  send({ id: message.id, result: { thread: { id: "thread-1" } } })
+  const threadId = nativeSearch ? "thread-search" : "thread-1"
+  if (nativeSearch) nativeSearchThreads.add(threadId)
+  send({ id: message.id, result: { thread: { id: threadId } } })
+}
+
+const completeNativeSearchTurn = (message) => {
+  const threadId = message.params?.threadId
+  send({ id: message.id, result: { turn: { id: "turn-search" } } })
+  send({
+    method: "item/started",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      item: {
+        type: "agentMessage",
+        id: "commentary-1",
+        phase: "commentary",
+        text: ""
+      }
+    }
+  })
+  send({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      itemId: "commentary-1",
+      delta: "Checking sources."
+    }
+  })
+  send({
+    method: "item/completed",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      item: {
+        type: "agentMessage",
+        id: "commentary-1",
+        phase: "commentary",
+        text: "Checking sources."
+      }
+    }
+  })
+  send({
+    method: "item/started",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      item: { type: "webSearch", id: "search-1", query: "", action: null }
+    }
+  })
+  send({
+    method: "item/completed",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      item: {
+        type: "webSearch",
+        id: "search-1",
+        query: "current answer",
+        action: { type: "search", query: "current answer" }
+      }
+    }
+  })
+  send({
+    method: "item/started",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      item: {
+        type: "agentMessage",
+        id: "final-1",
+        phase: "final_answer",
+        text: ""
+      }
+    }
+  })
+  send({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId,
+      turnId: "turn-search",
+      itemId: "final-1",
+      delta: "Verified answer."
+    }
+  })
+  send({
+    method: "turn/completed",
+    params: {
+      threadId,
+      turn: { id: "turn-search", status: "completed", error: null }
+    }
+  })
 }
 
 const completeImageTurn = (message) => {
@@ -117,6 +212,10 @@ const handleImageTurnStart = (message) => {
 const handleTurnStart = (message) => {
   if (imageThreads.has(message.params?.threadId)) {
     handleImageTurnStart(message)
+    return
+  }
+  if (nativeSearchThreads.has(message.params?.threadId)) {
+    completeNativeSearchTurn(message)
     return
   }
   if (message.params?.effort !== "medium") {

--- a/packages/olc/src/backends/codex/__tests__/wire.test.ts
+++ b/packages/olc/src/backends/codex/__tests__/wire.test.ts
@@ -4,10 +4,70 @@ import {
   mapCodexModel,
   normalizeCodexTools,
   resolveCodexReasoningEffort,
+  routeCodexWebSearch,
   toDynamicTools
 } from "../wire.js"
 
 describe("Codex wire mappings", () => {
+  it("maps web-search intent to native mode without bridging a duplicate tool", () => {
+    const lookup = {
+      type: "function",
+      function: { name: "lookup", parameters: { type: "object" } }
+    }
+    const search = {
+      type: "function",
+      function: { name: "web_search", parameters: { type: "object" } }
+    }
+
+    expect(routeCodexWebSearch([search, lookup], "indexed")).toEqual({
+      native: true,
+      bridgeTools: [lookup],
+      threadMode: "indexed"
+    })
+    expect(routeCodexWebSearch([search, lookup], "disabled")).toEqual({
+      native: false,
+      bridgeTools: [search, lookup],
+      threadMode: "disabled"
+    })
+    expect(routeCodexWebSearch([lookup], "live")).toEqual({
+      native: false,
+      bridgeTools: [lookup],
+      threadMode: "disabled"
+    })
+  })
+
+  it("honors client/native routing and caps requested freshness", () => {
+    const search = (source: "client" | "native", mode = "live") => ({
+      type: "function",
+      function: {
+        name: "web_search",
+        parameters: {
+          type: "object",
+          "x-ollama-client-web-search": { source, mode }
+        }
+      }
+    })
+    expect(routeCodexWebSearch([search("client")], "live")).toMatchObject({
+      native: false,
+      threadMode: "disabled"
+    })
+    expect(routeCodexWebSearch([search("native")], "indexed")).toEqual({
+      native: true,
+      bridgeTools: [],
+      threadMode: "indexed"
+    })
+    expect(routeCodexWebSearch([search("native")], "disabled")).toEqual({
+      native: false,
+      bridgeTools: [],
+      threadMode: "disabled"
+    })
+    expect(routeCodexWebSearch([search("native")], "live", false)).toEqual({
+      native: false,
+      bridgeTools: [],
+      threadMode: "disabled"
+    })
+  })
+
   it("publishes model modalities and canonical reasoning efforts", () => {
     expect(
       mapCodexModel({

--- a/packages/olc/src/backends/codex/config.ts
+++ b/packages/olc/src/backends/codex/config.ts
@@ -5,12 +5,23 @@ import { type ProxyOptions, stringOption } from "../../config.js"
 
 export const CODEX_DEFAULTS = {
   CODEX_PATH: "codex",
-  PROJECT_DIR: path.join(os.tmpdir(), "olc-codex-workspace")
+  PROJECT_DIR: path.join(os.tmpdir(), "olc-codex-workspace"),
+  WEB_SEARCH_MODE: "cached"
 } as const
+
+export type CodexWebSearchMode = "disabled" | "cached" | "indexed" | "live"
+
+const CODEX_WEB_SEARCH_MODES: readonly CodexWebSearchMode[] = [
+  "disabled",
+  "cached",
+  "indexed",
+  "live"
+]
 
 export interface CodexConfig {
   CODEX_PATH: string
   PROJECT_DIR: string
+  WEB_SEARCH_MODE: CodexWebSearchMode
 }
 
 export const resolveCodexConfig = ({
@@ -21,6 +32,18 @@ export const resolveCodexConfig = ({
   fileOptions?: ProxyOptions
 } = {}): CodexConfig => {
   const env = process.env
+  const webSearchMode = stringOption(
+    options.CODEX_WEB_SEARCH_MODE,
+    env.OLC_CODEX_WEB_SEARCH_MODE,
+    fileOptions.CODEX_WEB_SEARCH_MODE,
+    CODEX_DEFAULTS.WEB_SEARCH_MODE
+  )
+  if (!CODEX_WEB_SEARCH_MODES.includes(webSearchMode as CodexWebSearchMode)) {
+    throw new Error(
+      `Invalid Codex web-search mode '${webSearchMode}'. Expected disabled, cached, indexed, or live.`
+    )
+  }
+
   return {
     CODEX_PATH: stringOption(
       options.CODEX_PATH,
@@ -36,6 +59,7 @@ export const resolveCodexConfig = ({
       fileOptions.CODEX_PROJECT_DIR,
       fileOptions.PROJECT_DIR,
       CODEX_DEFAULTS.PROJECT_DIR
-    )
+    ),
+    WEB_SEARCH_MODE: webSearchMode as CodexWebSearchMode
   }
 }

--- a/packages/olc/src/backends/codex/index.ts
+++ b/packages/olc/src/backends/codex/index.ts
@@ -25,6 +25,7 @@ import {
   mapCodexImageGenerationModel,
   mapCodexModel,
   resolveCodexReasoningEffort,
+  routeCodexWebSearch,
   toDynamicTools
 } from "./wire.js"
 
@@ -43,6 +44,7 @@ interface ModelListResponse {
 
 interface ModelProviderCapabilities {
   imageGeneration?: boolean
+  webSearch?: boolean
 }
 
 type QueueResult =
@@ -100,6 +102,7 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
   let providerCapabilitiesCache: {
     expiresAt: number
     imageGeneration: boolean
+    webSearch: boolean
   } | null = null
 
   const unsubscribe = client.onNotification((message) => {
@@ -182,6 +185,7 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
 
   const loadProviderCapabilities = async (): Promise<{
     imageGeneration: boolean
+    webSearch: boolean
   }> => {
     if (
       providerCapabilitiesCache &&
@@ -191,21 +195,24 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
     }
     await client.start()
     let imageGeneration = false
+    let webSearch = false
     try {
       const capabilities = await client.request<ModelProviderCapabilities>(
         "modelProvider/capabilities/read",
         {}
       )
       imageGeneration = capabilities?.imageGeneration === true
+      webSearch = capabilities?.webSearch === true
     } catch (error) {
       // Older App Server builds do not expose provider capabilities. Absence is
       // treated conservatively: accept image input, but advertise no image output.
-      log("Codex image-generation capability is unavailable", {
+      log("Codex provider capabilities are unavailable", {
         message: (error as Error).message
       })
     }
     providerCapabilitiesCache = {
       imageGeneration,
+      webSearch,
       expiresAt: Date.now() + 30_000
     }
     return providerCapabilitiesCache
@@ -223,6 +230,8 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
     private started = false
     private content = ""
     private reasoning = ""
+    private readonly agentMessagePhases = new Map<string, string>()
+    private nativeWebSearchEvents = 0
     private readonly images: GeneratedImage[] = []
     private readonly imageItemIds = new Set<string>()
     private lastError: string | null = null
@@ -300,8 +309,50 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
       handlers: TurnStreamHandlers
     ): void {
       const delta = typeof params.delta === "string" ? params.delta : ""
+      const itemId = typeof params.itemId === "string" ? params.itemId : ""
+      if (this.agentMessagePhases.get(itemId) === "commentary") {
+        this.reasoning += delta
+        handlers.onReasoning(delta)
+        return
+      }
       this.content += delta
       handlers.onText(delta)
+    }
+
+    private handleStartedItem(
+      item: Record<string, unknown>,
+      handlers: TurnStreamHandlers
+    ): void {
+      if (
+        item.type === "agentMessage" &&
+        typeof item.id === "string" &&
+        typeof item.phase === "string"
+      ) {
+        this.agentMessagePhases.set(item.id, item.phase)
+      }
+      if (item.type === "webSearch") {
+        handlers.onReasoning("\nSearching the web…\n")
+        this.reasoning += "\nSearching the web…\n"
+      }
+    }
+
+    private handleWebSearchCompleted(
+      item: Record<string, unknown>,
+      handlers: TurnStreamHandlers
+    ): void {
+      this.nativeWebSearchEvents += 1
+      const action = isRecord(item.action) ? item.action : {}
+      const query =
+        (typeof item.query === "string" && item.query.trim()) ||
+        (typeof action.query === "string" && action.query.trim())
+      const url = typeof action.url === "string" ? action.url.trim() : ""
+      const trace = query
+        ? `Web search: ${query}\n`
+        : url
+          ? `Opened web source: ${url}\n`
+          : "Web search completed.\n"
+      this.reasoning += trace
+      handlers.onReasoning(trace)
     }
 
     private appendReasoningDelta(
@@ -320,9 +371,17 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
       if (
         item.type === "agentMessage" &&
         typeof item.text === "string" &&
+        item.phase !== "commentary" &&
         !this.content
       ) {
         this.content = item.text
+      }
+      if (item.type === "webSearch") {
+        this.handleWebSearchCompleted(item, handlers)
+        return
+      }
+      if (item.type === "agentMessage" && typeof item.id === "string") {
+        this.agentMessagePhases.delete(item.id)
       }
       if (item.type !== "imageGeneration" || typeof item.result !== "string")
         return
@@ -356,6 +415,10 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
     }
 
     private completedTurnResult(): TurnResult {
+      log("Codex turn native-search evidence", {
+        threadId: this.id,
+        webSearchEvents: this.nativeWebSearchEvents
+      })
       return {
         status: "completed",
         content: this.content,
@@ -387,6 +450,10 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
       handlers: TurnStreamHandlers
     ): TurnResult | null {
       switch (method) {
+        case "item/started":
+          if (isRecord(params.item))
+            this.handleStartedItem(params.item, handlers)
+          return null
         case "item/agentMessage/delta":
           this.appendTextDelta(params, handlers)
           return null
@@ -515,7 +582,33 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
         if ("error" in resolved) throw new BackendInputError(resolved.error)
       }
       const prompt = buildPromptParts(input.messages)
-      const tools = config.BRIDGE_ENABLED ? toDynamicTools(input.tools) : []
+      const requestedWebSearch = routeCodexWebSearch(
+        input.tools,
+        codex.WEB_SEARCH_MODE
+      )
+      const capabilities = requestedWebSearch.native
+        ? await loadProviderCapabilities()
+        : null
+      const webSearch = routeCodexWebSearch(
+        input.tools,
+        codex.WEB_SEARCH_MODE,
+        capabilities?.webSearch ?? true
+      )
+      log("Codex web-search route", {
+        nativeWebSearch: webSearch.native,
+        webSearchMode: webSearch.threadMode
+      })
+      const tools = config.BRIDGE_ENABLED
+        ? toDynamicTools(webSearch.bridgeTools)
+        : []
+      const developerInstructions = [
+        config.SYSTEM_PROMPT || prompt.system,
+        webSearch.native
+          ? "Native web search is enabled for this turn. When the user asks to search, browse, verify, look up, or use current information, use the built-in web search before answering. Do not claim you searched unless a webSearch event occurred, and cite the source URLs you used."
+          : ""
+      ]
+        .filter(Boolean)
+        .join("\n\n")
       const response = await client.request<ThreadStartResponse>(
         "thread/start",
         {
@@ -525,9 +618,8 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
           sandbox: "read-only",
           ephemeral: true,
           serviceName: "ollama_client_olc",
-          ...(config.SYSTEM_PROMPT || prompt.system
-            ? { developerInstructions: config.SYSTEM_PROMPT || prompt.system }
-            : {}),
+          config: { web_search: webSearch.threadMode },
+          ...(developerInstructions ? { developerInstructions } : {}),
           ...(tools.length > 0 ? { dynamicTools: tools } : {})
         }
       )
@@ -560,6 +652,7 @@ export const createCodexBackend = (context: BackendContext): AgentBackend => {
           sandbox: "read-only",
           ephemeral: true,
           serviceName: "ollama_client_olc",
+          config: { web_search: "disabled" },
           developerInstructions: imageInstructions
         }
       )

--- a/packages/olc/src/backends/codex/wire.ts
+++ b/packages/olc/src/backends/codex/wire.ts
@@ -1,5 +1,6 @@
 /** Codex app-server mappings kept separate from the backend lifecycle. */
 
+import { splitWebSearchIntent } from "../../core/openai-wire.js"
 import type {
   BridgeToolDefinition,
   OpenAIToolDefinition,
@@ -8,6 +9,7 @@ import type {
 import { REASONING_EFFORTS } from "../../types.js"
 import { isRecord } from "../../util.js"
 import type { CatalogModel } from "../types.js"
+import type { CodexWebSearchMode } from "./config.js"
 
 export interface CodexModel {
   id: string
@@ -144,3 +146,41 @@ export const toDynamicTools = (tools: unknown) =>
     description: tool.description,
     inputSchema: tool.parameters
   }))
+
+/** Map public web-search intent onto one Codex thread without tool-name clashes. */
+export const routeCodexWebSearch = (
+  tools: unknown,
+  mode: CodexWebSearchMode,
+  nativeAvailable = true
+): {
+  native: boolean
+  bridgeTools: unknown
+  threadMode: CodexWebSearchMode
+} => {
+  const intent = splitWebSearchIntent(tools)
+  if (!intent.requested) {
+    return { native: false, bridgeTools: tools, threadMode: "disabled" }
+  }
+  if (intent.source === "client") {
+    return { native: false, bridgeTools: tools, threadMode: "disabled" }
+  }
+  const native = mode !== "disabled" && nativeAvailable
+  const ranks: Record<Exclude<CodexWebSearchMode, "disabled">, number> = {
+    cached: 0,
+    indexed: 1,
+    live: 2
+  }
+  const requestedMode = intent.mode ?? (mode === "disabled" ? "cached" : mode)
+  const threadMode = native
+    ? ranks[requestedMode] <=
+      ranks[mode as Exclude<CodexWebSearchMode, "disabled">]
+      ? requestedMode
+      : mode
+    : "disabled"
+  return {
+    native,
+    bridgeTools:
+      native || intent.source === "native" ? intent.clientTools : tools,
+    threadMode
+  }
+}

--- a/packages/olc/src/backends/opencode/__tests__/web-search.test.ts
+++ b/packages/olc/src/backends/opencode/__tests__/web-search.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { routeOpencodeWebSearch } from "../web-search.js"
+
+const tool = (name: string) => ({
+  type: "function",
+  function: { name, parameters: { type: "object" } }
+})
+
+const searchTool = (source: "auto" | "client" | "native") => ({
+  type: "function",
+  function: {
+    name: "web_search",
+    parameters: {
+      type: "object",
+      "x-ollama-client-web-search": { source, mode: "live" }
+    }
+  }
+})
+
+describe("routeOpencodeWebSearch", () => {
+  it("uses native search when OpenCode reports it", () => {
+    const lookup = tool("lookup")
+    expect(
+      routeOpencodeWebSearch({
+        tools: [tool("web_search"), lookup],
+        discoveredIds: ["bash", "websearch", "webfetch"],
+        operatorAllowedTools: ["bash"]
+      })
+    ).toEqual({
+      native: true,
+      bridgeTools: [lookup],
+      allowedNativeTools: ["bash", "websearch"]
+    })
+  })
+
+  it("keeps the client search fallback when native search is absent", () => {
+    const tools = [tool("web_search")]
+    expect(
+      routeOpencodeWebSearch({
+        tools,
+        discoveredIds: ["bash"],
+        operatorAllowedTools: ["websearch", "webfetch"]
+      })
+    ).toEqual({
+      native: false,
+      bridgeTools: tools,
+      allowedNativeTools: []
+    })
+  })
+
+  it("disables search when the turn did not opt in", () => {
+    const lookup = tool("lookup")
+    expect(
+      routeOpencodeWebSearch({
+        tools: [lookup],
+        discoveredIds: ["websearch", "webfetch"],
+        operatorAllowedTools: ["websearch", "webfetch"]
+      })
+    ).toEqual({
+      native: false,
+      bridgeTools: [lookup],
+      allowedNativeTools: []
+    })
+  })
+
+  it("enables webfetch only after both turn and operator opt in", () => {
+    expect(
+      routeOpencodeWebSearch({
+        tools: [tool("web_search")],
+        discoveredIds: ["websearch", "webfetch"],
+        operatorAllowedTools: ["webfetch"]
+      }).allowedNativeTools
+    ).toEqual(["websearch", "webfetch"])
+  })
+
+  it("keeps client mode local and makes unavailable native mode fail closed", () => {
+    const client = searchTool("client")
+    expect(
+      routeOpencodeWebSearch({
+        tools: [client],
+        discoveredIds: ["websearch"],
+        operatorAllowedTools: []
+      })
+    ).toMatchObject({ native: false, bridgeTools: [client] })
+
+    expect(
+      routeOpencodeWebSearch({
+        tools: [searchTool("native")],
+        discoveredIds: [],
+        operatorAllowedTools: []
+      })
+    ).toMatchObject({ native: false, bridgeTools: [] })
+  })
+})

--- a/packages/olc/src/backends/opencode/index.ts
+++ b/packages/olc/src/backends/opencode/index.ts
@@ -45,6 +45,7 @@ import { resolveOpencodeConfig } from "./config.js"
 import { createBackendSupervisor } from "./server.js"
 import { ToolManifest } from "./tool-manifest.js"
 import { createTurnReader, type TurnOutcome } from "./turn-events.js"
+import { routeOpencodeWebSearch } from "./web-search.js"
 
 const TOOL_IDS_CACHE_TTL_MS = 60_000
 const MODEL_CATALOG_CACHE_TTL_MS = 30_000
@@ -371,11 +372,20 @@ export const createOpencodeBackend = (
         )
       }
 
-      const bridgeNames = await syncBridgeTools(input.tools, input.requestId)
+      const discoveredIds = await loadToolIds()
+      const webSearch = routeOpencodeWebSearch({
+        tools: input.tools,
+        discoveredIds,
+        operatorAllowedTools: opencode.ALLOW_OPENCODE_TOOLS
+      })
+      const bridgeNames = await syncBridgeTools(
+        webSearch.bridgeTools,
+        input.requestId
+      )
       const flags = buildToolFlags({
-        discoveredIds: await loadToolIds(),
+        discoveredIds,
         bridgeNames,
-        allowedNativeTools: opencode.ALLOW_OPENCODE_TOOLS
+        allowedNativeTools: webSearch.allowedNativeTools
       })
 
       let variant: string | undefined
@@ -411,6 +421,7 @@ export const createOpencodeBackend = (
         requestId: input.requestId,
         sessionId,
         model: `${input.model.providerId}/${input.model.modelId}`,
+        nativeWebSearch: webSearch.native,
         bridgeTools: bridgeNames,
         parts: parts.length
       })

--- a/packages/olc/src/backends/opencode/web-search.ts
+++ b/packages/olc/src/backends/opencode/web-search.ts
@@ -1,0 +1,57 @@
+/** Per-turn mapping from the public `web_search` function to OpenCode tools. */
+import { splitWebSearchIntent } from "../../core/openai-wire.js"
+
+const OPENCODE_SEARCH_TOOLS = new Set(["websearch", "webfetch"])
+
+export interface OpencodeWebSearchRoute {
+  native: boolean
+  bridgeTools: unknown
+  allowedNativeTools: string[]
+}
+
+/**
+ * Prefer OpenCode's hosted search when it is actually present in the discovered
+ * tool inventory. Otherwise preserve the client function so the extension can
+ * execute SearXNG, Brave, Tavily, or another configured implementation.
+ *
+ * Search tools are always removed from the operator allowlist when the request did
+ * not opt in. `webfetch` is additionally opt-in at the operator layer because it
+ * can retrieve arbitrary URLs; native search alone does not silently enable it.
+ */
+export const routeOpencodeWebSearch = ({
+  tools,
+  discoveredIds,
+  operatorAllowedTools
+}: {
+  tools: unknown
+  discoveredIds: string[]
+  operatorAllowedTools: string[]
+}): OpencodeWebSearchRoute => {
+  const intent = splitWebSearchIntent(tools)
+  const native =
+    intent.requested &&
+    intent.source !== "client" &&
+    discoveredIds.includes("websearch")
+  const allowedNativeTools = operatorAllowedTools.filter(
+    (id) => !OPENCODE_SEARCH_TOOLS.has(id)
+  )
+
+  if (native) {
+    allowedNativeTools.push("websearch")
+    if (
+      operatorAllowedTools.includes("webfetch") &&
+      discoveredIds.includes("webfetch")
+    ) {
+      allowedNativeTools.push("webfetch")
+    }
+  }
+
+  return {
+    native,
+    bridgeTools:
+      native || (intent.requested && intent.source === "native")
+        ? intent.clientTools
+        : tools,
+    allowedNativeTools
+  }
+}

--- a/packages/olc/src/cli.ts
+++ b/packages/olc/src/cli.ts
@@ -46,6 +46,8 @@ Codex backend options:
   --codex <path>           Path to the Codex CLI binary
   --codex-project-dir <path>
                            Empty workspace used for Codex turns
+  --codex-web-search <mode>
+                           disabled, cached, indexed, or live (default cached)
 `
 
 const FLAG_TO_OPTION: Record<string, string> = {
@@ -62,7 +64,8 @@ const FLAG_TO_OPTION: Record<string, string> = {
   "--allow-opencode-tools": "ALLOW_OPENCODE_TOOLS",
   "--plugin-dir": "PLUGIN_DIR",
   "--codex": "CODEX_PATH",
-  "--codex-project-dir": "CODEX_PROJECT_DIR"
+  "--codex-project-dir": "CODEX_PROJECT_DIR",
+  "--codex-web-search": "CODEX_WEB_SEARCH_MODE"
 }
 
 /** Parse argv into proxy options. Unknown flags are an error, not a silent no-op. */

--- a/packages/olc/src/core/__tests__/openai-wire.test.ts
+++ b/packages/olc/src/core/__tests__/openai-wire.test.ts
@@ -9,6 +9,7 @@ import {
   imageChunk,
   imageMimeFromUrl,
   normalizeMessageContent,
+  splitWebSearchIntent,
   toolCallsChunk
 } from "../openai-wire.js"
 
@@ -141,6 +142,56 @@ describe("buildToolFlags", () => {
         bridgeNames: ["read"]
       })
     ).toEqual({ read: true })
+  })
+})
+
+describe("splitWebSearchIntent", () => {
+  it("removes only the web_search function and preserves other tools", () => {
+    const lookup = {
+      type: "function",
+      function: { name: "lookup", parameters: { type: "object" } }
+    }
+    const webSearch = {
+      type: "function",
+      function: { name: "web_search", parameters: { type: "object" } }
+    }
+
+    expect(splitWebSearchIntent([lookup, webSearch])).toEqual({
+      requested: true,
+      clientTools: [lookup],
+      source: "auto"
+    })
+  })
+
+  it("does not infer intent from malformed or absent tools", () => {
+    expect(splitWebSearchIntent(undefined)).toEqual({
+      requested: false,
+      clientTools: [],
+      source: "auto"
+    })
+    expect(splitWebSearchIntent([{ name: "web_search" }])).toEqual({
+      requested: false,
+      clientTools: [{ name: "web_search" }],
+      source: "auto"
+    })
+  })
+
+  it("reads the client web-search execution policy", () => {
+    const search = {
+      type: "function",
+      function: {
+        name: "web_search",
+        parameters: {
+          type: "object",
+          "x-ollama-client-web-search": { source: "native", mode: "live" }
+        }
+      }
+    }
+    expect(splitWebSearchIntent([search])).toMatchObject({
+      requested: true,
+      source: "native",
+      mode: "live"
+    })
   })
 })
 

--- a/packages/olc/src/core/openai-wire.ts
+++ b/packages/olc/src/core/openai-wire.ts
@@ -315,6 +315,65 @@ export const buildToolFlags = ({
   return flags
 }
 
+const toolFunctionName = (entry: unknown): string => {
+  if (!isRecord(entry) || !isRecord(entry.function)) return ""
+  return typeof entry.function.name === "string"
+    ? entry.function.name.trim()
+    : ""
+}
+
+export type WebSearchIntentSource = "auto" | "client" | "native"
+export type WebSearchIntentMode = "cached" | "indexed" | "live"
+
+const webSearchPolicy = (
+  entry: unknown
+): { source: WebSearchIntentSource; mode?: WebSearchIntentMode } => {
+  if (!isRecord(entry) || !isRecord(entry.function)) return { source: "auto" }
+  const parameters = entry.function.parameters
+  if (!isRecord(parameters)) return { source: "auto" }
+  const annotation = parameters["x-ollama-client-web-search"]
+  if (!isRecord(annotation)) return { source: "auto" }
+  const source = ["auto", "client", "native"].includes(
+    String(annotation.source)
+  )
+    ? (annotation.source as WebSearchIntentSource)
+    : "auto"
+  const mode = ["cached", "indexed", "live"].includes(String(annotation.mode))
+    ? (annotation.mode as WebSearchIntentMode)
+    : undefined
+  return { source, ...(mode ? { mode } : {}) }
+}
+
+/**
+ * Separate the extension's web-search intent from tools the runtime must bridge.
+ *
+ * `web_search` remains an ordinary OpenAI function on the public wire. A backend
+ * with native search consumes that function as per-turn intent and bridges every
+ * other tool unchanged. A backend without native search keeps the original array,
+ * allowing the connected client to execute its configured search provider.
+ */
+export const splitWebSearchIntent = (
+  tools: unknown
+): {
+  requested: boolean
+  clientTools: unknown[]
+  source: WebSearchIntentSource
+  mode?: WebSearchIntentMode
+} => {
+  const entries = Array.isArray(tools) ? tools : []
+  const search = entries.find(
+    (entry) => toolFunctionName(entry) === "web_search"
+  )
+  const policy = webSearchPolicy(search)
+  return {
+    requested: search !== undefined,
+    clientTools: entries.filter(
+      (entry) => toolFunctionName(entry) !== "web_search"
+    ),
+    ...policy
+  }
+}
+
 /** OpenAI `tool_calls` entry for one parked bridge call. */
 export const toToolCallPayload = (call: PendingToolCall, index: number) => ({
   index,

--- a/src/background/lib/__tests__/resolve-model-tools.test.ts
+++ b/src/background/lib/__tests__/resolve-model-tools.test.ts
@@ -53,6 +53,22 @@ const baseDefinitions: ToolDefinition[] = [
 // Mutable so a test can swap in a vision-only tool; reset in afterEach.
 let definitions: ToolDefinition[] = baseDefinitions
 
+const definitionsWithWebSearchPolicy = () =>
+  definitions.map((definition) =>
+    definition.name === "web_search"
+      ? {
+          ...definition,
+          parameters: {
+            ...definition.parameters,
+            "x-ollama-client-web-search": {
+              source: "client" as const,
+              mode: "cached" as const
+            }
+          }
+        }
+      : definition
+  )
+
 const captureScreenshotTool: ToolDefinition = {
   name: "capture_screenshot",
   description: "Screenshot the tab",
@@ -145,7 +161,10 @@ describe("resolveModelTools", () => {
 
     await expect(
       resolveModelTools("qwen", "ollama", provider)
-    ).resolves.toEqual({ tools: definitions, mode: "native" })
+    ).resolves.toEqual({
+      tools: definitionsWithWebSearchPolicy(),
+      mode: "native"
+    })
     expect(getModelDetails).toHaveBeenCalledTimes(2)
   })
 
@@ -169,7 +188,10 @@ describe("resolveModelTools", () => {
   it("offers all tools when every family is enabled (default)", async () => {
     await expect(
       resolveModelTools("qwen", "ollama", toolModel())
-    ).resolves.toEqual({ tools: definitions, mode: "native" })
+    ).resolves.toEqual({
+      tools: definitionsWithWebSearchPolicy(),
+      mode: "native"
+    })
   })
 
   it("offers no tools when the master switch is off", async () => {
@@ -259,7 +281,10 @@ describe("resolveModelTools", () => {
 
     expect(getModelDetails).toHaveBeenCalledOnce()
     expect(getModels).toHaveBeenCalledOnce()
-    expect(resolved).toEqual({ tools: definitions, mode: "native" })
+    expect(resolved).toEqual({
+      tools: definitionsWithWebSearchPolicy(),
+      mode: "native"
+    })
   })
 
   it("returns no tools for a non-tool-calling model without the fallback opt-in", async () => {
@@ -278,7 +303,10 @@ describe("resolveModelTools", () => {
     )
     await expect(
       resolveModelTools("plain", "ollama", nonToolModel)
-    ).resolves.toEqual({ tools: definitions, mode: "non-native" })
+    ).resolves.toEqual({
+      tools: definitionsWithWebSearchPolicy(),
+      mode: "non-native"
+    })
   })
 
   it("uses alternating user-role results when the probe detects that mode", async () => {
@@ -293,7 +321,10 @@ describe("resolveModelTools", () => {
 
     await expect(
       resolveModelTools("gemma", "llamacpp", nonToolModel)
-    ).resolves.toEqual({ tools: definitions, mode: "native-user-results" })
+    ).resolves.toEqual({
+      tools: definitionsWithWebSearchPolicy(),
+      mode: "native-user-results"
+    })
   })
 
   it("still honors family governance in non-native mode", async () => {

--- a/src/background/lib/resolve-model-tools.ts
+++ b/src/background/lib/resolve-model-tools.ts
@@ -17,6 +17,8 @@ import {
   getEffectiveToolFamilySettings,
   getToolModelOverride
 } from "@/lib/tools/tool-model-overrides"
+import { getWebSearchConfig } from "@/lib/tools/web-search"
+import { withWebSearchExecutionPolicy } from "@/lib/tools/web-search/web-search-tool"
 import { filterToolsForTurn } from "./tool-exposure-policy"
 
 /**
@@ -225,5 +227,12 @@ export const resolveModelTools = async (
   // browser-data tools are not sent to any provider unless their optional
   // permission is already granted and this request explicitly asks for them.
   const allowed = await filterToolsForTurn(governed, latestUserText)
-  return allowed.length > 0 ? { tools: allowed, mode } : undefined
+  if (allowed.length === 0) return undefined
+  const webSearchConfig = await getWebSearchConfig()
+  return {
+    tools: allowed.map((definition) =>
+      withWebSearchExecutionPolicy(definition, webSearchConfig)
+    ),
+    mode
+  }
 }

--- a/src/features/web-search/__tests__/web-search-settings.test.tsx
+++ b/src/features/web-search/__tests__/web-search-settings.test.tsx
@@ -89,6 +89,47 @@ describe("WebSearchSettings", () => {
     expect(updateConfig).toHaveBeenCalledWith({ enabled: true })
   })
 
+  it("shows the execution source and client privacy disclosure", () => {
+    render(<WebSearchSettings />)
+
+    expect(
+      screen.getByLabelText("settings.web_search.execution_source.label")
+    ).toHaveTextContent("settings.web_search.execution_source.client")
+    expect(
+      screen.getByText("settings.web_search.privacy.client")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("settings.web_search.native_mode.label")
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows native freshness and disclosure for native-only search", () => {
+    config.executionSource = "native"
+    config.nativeMode = "live"
+    render(<WebSearchSettings />)
+
+    expect(
+      screen.getByLabelText("settings.web_search.native_mode.label")
+    ).toHaveTextContent("settings.web_search.native_mode.live")
+    expect(
+      screen.getByText("settings.web_search.privacy.native")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("settings.web_search.provider.label")
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows friendly provider and safety labels while selects are closed", () => {
+    render(<WebSearchSettings />)
+
+    expect(
+      screen.getByLabelText("settings.web_search.provider.label")
+    ).toHaveTextContent("settings.web_search.providers.searxng")
+    expect(
+      screen.getByLabelText("settings.web_search.safe_search.label")
+    ).toHaveTextContent("settings.web_search.safe_search.moderate")
+  })
+
   it("validates config before test search", async () => {
     config = {
       provider: "brave",

--- a/src/features/web-search/components/web-search-settings.tsx
+++ b/src/features/web-search/components/web-search-settings.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Loader2, Search, TriangleAlert } from "lucide-react"
+import { CheckCircle, Info, Loader2, Search, TriangleAlert } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -22,7 +22,9 @@ import {
   BRAVE_SEARCH_ENDPOINT,
   getWebSearchBackend,
   listWebSearchBackends,
+  type NativeWebSearchMode,
   TAVILY_SEARCH_ENDPOINT,
+  type WebSearchExecutionSource,
   type WebSearchProviderConfig,
   type WebSearchProviderId,
   type WebSearchSafeSearch
@@ -41,6 +43,12 @@ const providerFields: Record<
 }
 
 const safeSearchValues: WebSearchSafeSearch[] = ["off", "moderate", "strict"]
+const executionSources: WebSearchExecutionSource[] = [
+  "native",
+  "auto",
+  "client"
+]
+const nativeModes: NativeWebSearchMode[] = ["cached", "indexed", "live"]
 
 const providerBaseUrls: Partial<Record<WebSearchProviderId, string>> = {
   brave: BRAVE_SEARCH_ENDPOINT,
@@ -60,6 +68,8 @@ export const WebSearchSettings = () => {
   }, [])
 
   const backend = getWebSearchBackend(config.provider)
+  const executionSource = config.executionSource ?? "client"
+  const nativeMode = config.nativeMode ?? "cached"
   const visibleFields = providerFields[config.provider] ?? []
   const providerBaseUrl = providerBaseUrls[config.provider]
 
@@ -135,24 +145,30 @@ export const WebSearchSettings = () => {
 
       <div className="grid gap-4 md:grid-cols-2">
         <SettingsFormField
-          htmlFor="web-search-provider"
-          label={t("settings.web_search.provider.label")}
-          description={t("settings.web_search.provider.description")}
+          htmlFor="web-search-execution-source"
+          label={t("settings.web_search.execution_source.label")}
+          description={t("settings.web_search.execution_source.description")}
           className="min-w-0"
-          focusId="web-search-provider">
+          focusId="web-search-execution-source">
           <Select
-            value={config.provider}
-            onValueChange={(provider) =>
-              update({ provider: provider as WebSearchProviderId })
+            value={executionSource}
+            onValueChange={(executionSource) =>
+              update({
+                executionSource: executionSource as WebSearchExecutionSource
+              })
             }>
-            <SelectTrigger id="web-search-provider" className="w-full">
-              <SelectValue />
+            <SelectTrigger id="web-search-execution-source" className="w-full">
+              <SelectValue>
+                {() =>
+                  t(`settings.web_search.execution_source.${executionSource}`)
+                }
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                {listWebSearchBackends().map((item) => (
-                  <SelectItem key={item.id} value={item.id}>
-                    {t(item.labelKey)}
+                {executionSources.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {t(`settings.web_search.execution_source.${value}`)}
                   </SelectItem>
                 ))}
               </SelectGroup>
@@ -160,132 +176,209 @@ export const WebSearchSettings = () => {
           </Select>
         </SettingsFormField>
 
-        <SettingsFormField
-          htmlFor="web-search-safe-search"
-          label={t("settings.web_search.safe_search.label")}
-          description={t("settings.web_search.safe_search.description")}
-          className="min-w-0"
-          focusId="web-search-safe-search">
-          <Select
-            value={config.safeSearch}
-            onValueChange={(safeSearch) =>
-              update({ safeSearch: safeSearch as WebSearchSafeSearch })
-            }>
-            <SelectTrigger id="web-search-safe-search" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {safeSearchValues.map((value) => (
-                  <SelectItem key={value} value={value}>
-                    {t(`settings.web_search.safe_search.${value}`)}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </SettingsFormField>
+        {executionSource !== "client" && (
+          <SettingsFormField
+            htmlFor="web-search-native-mode"
+            label={t("settings.web_search.native_mode.label")}
+            description={t("settings.web_search.native_mode.description")}
+            className="min-w-0"
+            focusId="web-search-native-mode">
+            <Select
+              value={nativeMode}
+              onValueChange={(nativeMode) =>
+                update({ nativeMode: nativeMode as NativeWebSearchMode })
+              }>
+              <SelectTrigger id="web-search-native-mode" className="w-full">
+                <SelectValue>
+                  {() => t(`settings.web_search.native_mode.${nativeMode}`)}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {nativeModes.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {t(`settings.web_search.native_mode.${value}`)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingsFormField>
+        )}
       </div>
 
-      {visibleFields.includes("endpoint") && (
-        <SettingsFormField
-          htmlFor="web-search-endpoint"
-          label={t("settings.web_search.endpoint.label")}
-          description={t("settings.web_search.endpoint.description")}
-          focusId="web-search-endpoint">
-          <Input
-            id="web-search-endpoint"
-            type="url"
-            value={config.endpoint ?? ""}
-            placeholder="http://localhost:8080"
-            onChange={(event) => update({ endpoint: event.target.value })}
-          />
-        </SettingsFormField>
-      )}
-
-      {providerBaseUrl && (
-        <SettingsFormField
-          label={t("settings.web_search.base_url.label")}
-          description={t("settings.web_search.base_url.description")}>
-          <div className="rounded-control border border-border bg-muted/20 px-3 py-2 font-mono text-xs text-muted-foreground">
-            {providerBaseUrl}
-          </div>
-        </SettingsFormField>
-      )}
-
-      {visibleFields.includes("apiKey") && (
-        <SettingsFormField
-          htmlFor="web-search-api-key"
-          label={t("settings.web_search.api_key.label")}
-          description={t("settings.web_search.api_key.description")}
-          focusId="web-search-api-key">
-          <Input
-            id="web-search-api-key"
-            type="password"
-            autoComplete="off"
-            value={config.apiKey ?? ""}
-            onChange={(event) => update({ apiKey: event.target.value })}
-          />
-        </SettingsFormField>
-      )}
-
-      {config.provider === "searxng" && (
-        <SettingsSliderField
-          label={t("settings.web_search.searxng_pages.label")}
-          description={t("settings.web_search.searxng_pages.description")}
-          value={config.searxngPages ?? 1}
-          min={1}
-          max={3}
-          step={1}
-          onValueChange={(searxngPages) => update({ searxngPages })}
-          valueLabel={t("settings.web_search.searxng_pages.value", {
-            count: config.searxngPages ?? 1
-          })}
-        />
-      )}
-
-      <SettingsSliderField
-        focusId="web-search-result-count"
-        label={t("settings.web_search.result_count.label")}
-        description={t("settings.web_search.result_count.description")}
-        value={config.count ?? 5}
-        min={1}
-        max={10}
-        step={1}
-        onValueChange={(count) => update({ count })}
-        valueLabel={t("settings.web_search.result_count.value", {
-          count: config.count ?? 5
-        })}
+      <StatusAlert
+        variant="info"
+        icon={Info}
+        title={t("settings.web_search.privacy.title")}
+        description={t(`settings.web_search.privacy.${executionSource}`)}
       />
 
-      <div className="flex items-center gap-3">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={testSearch}
-          disabled={isTesting || !backend}>
-          {isTesting ? (
-            <Loader2 className="icon-md animate-spin" />
-          ) : (
-            <Search className="icon-md" />
-          )}
-          {t("settings.web_search.test.button")}
-        </Button>
-      </div>
+      {executionSource !== "native" && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2">
+            <SettingsFormField
+              htmlFor="web-search-provider"
+              label={t("settings.web_search.provider.label")}
+              description={t("settings.web_search.provider.description")}
+              className="min-w-0"
+              focusId="web-search-provider">
+              <Select
+                value={config.provider}
+                onValueChange={(provider) =>
+                  update({ provider: provider as WebSearchProviderId })
+                }>
+                <SelectTrigger id="web-search-provider" className="w-full">
+                  <SelectValue>
+                    {() => (backend ? t(backend.labelKey) : config.provider)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {listWebSearchBackends().map((item) => (
+                      <SelectItem key={item.id} value={item.id}>
+                        {t(item.labelKey)}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </SettingsFormField>
 
-      {testState === "success" && (
-        <StatusAlert
-          variant="success"
-          icon={CheckCircle}
-          title={t("settings.web_search.test.success_title")}
-        />
-      )}
-      {testState === "error" && (
-        <StatusAlert
-          variant="destructive"
-          icon={TriangleAlert}
-          title={t("settings.web_search.test.error_title")}
-        />
+            <SettingsFormField
+              htmlFor="web-search-safe-search"
+              label={t("settings.web_search.safe_search.label")}
+              description={t("settings.web_search.safe_search.description")}
+              className="min-w-0"
+              focusId="web-search-safe-search">
+              <Select
+                value={config.safeSearch}
+                onValueChange={(safeSearch) =>
+                  update({ safeSearch: safeSearch as WebSearchSafeSearch })
+                }>
+                <SelectTrigger id="web-search-safe-search" className="w-full">
+                  <SelectValue>
+                    {() =>
+                      t(
+                        `settings.web_search.safe_search.${config.safeSearch ?? "moderate"}`
+                      )
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {safeSearchValues.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {t(`settings.web_search.safe_search.${value}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </SettingsFormField>
+          </div>
+
+          {visibleFields.includes("endpoint") && (
+            <SettingsFormField
+              htmlFor="web-search-endpoint"
+              label={t("settings.web_search.endpoint.label")}
+              description={t("settings.web_search.endpoint.description")}
+              focusId="web-search-endpoint">
+              <Input
+                id="web-search-endpoint"
+                type="url"
+                value={config.endpoint ?? ""}
+                placeholder="http://localhost:8080"
+                onChange={(event) => update({ endpoint: event.target.value })}
+              />
+            </SettingsFormField>
+          )}
+
+          {providerBaseUrl && (
+            <SettingsFormField
+              label={t("settings.web_search.base_url.label")}
+              description={t("settings.web_search.base_url.description")}>
+              <div className="rounded-control border border-border bg-muted/20 px-3 py-2 font-mono text-xs text-muted-foreground">
+                {providerBaseUrl}
+              </div>
+            </SettingsFormField>
+          )}
+
+          {visibleFields.includes("apiKey") && (
+            <SettingsFormField
+              htmlFor="web-search-api-key"
+              label={t("settings.web_search.api_key.label")}
+              description={t("settings.web_search.api_key.description")}
+              focusId="web-search-api-key">
+              <Input
+                id="web-search-api-key"
+                type="password"
+                autoComplete="off"
+                value={config.apiKey ?? ""}
+                onChange={(event) => update({ apiKey: event.target.value })}
+              />
+            </SettingsFormField>
+          )}
+
+          {config.provider === "searxng" && (
+            <SettingsSliderField
+              label={t("settings.web_search.searxng_pages.label")}
+              description={t("settings.web_search.searxng_pages.description")}
+              value={config.searxngPages ?? 1}
+              min={1}
+              max={3}
+              step={1}
+              onValueChange={(searxngPages) => update({ searxngPages })}
+              valueLabel={t("settings.web_search.searxng_pages.value", {
+                count: config.searxngPages ?? 1
+              })}
+            />
+          )}
+
+          <SettingsSliderField
+            focusId="web-search-result-count"
+            label={t("settings.web_search.result_count.label")}
+            description={t("settings.web_search.result_count.description")}
+            value={config.count ?? 5}
+            min={1}
+            max={10}
+            step={1}
+            onValueChange={(count) => update({ count })}
+            valueLabel={t("settings.web_search.result_count.value", {
+              count: config.count ?? 5
+            })}
+          />
+
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={testSearch}
+              disabled={isTesting || !backend}>
+              {isTesting ? (
+                <Loader2 className="icon-md animate-spin" />
+              ) : (
+                <Search className="icon-md" />
+              )}
+              {t("settings.web_search.test.button")}
+            </Button>
+          </div>
+
+          {testState === "success" && (
+            <StatusAlert
+              variant="success"
+              icon={CheckCircle}
+              title={t("settings.web_search.test.success_title")}
+            />
+          )}
+          {testState === "error" && (
+            <StatusAlert
+              variant="destructive"
+              icon={TriangleAlert}
+              title={t("settings.web_search.test.error_title")}
+            />
+          )}
+        </>
       )}
     </div>
   )

--- a/src/lib/tools/types.ts
+++ b/src/lib/tools/types.ts
@@ -14,6 +14,11 @@ export interface ToolParameterSchema {
   type: "object"
   properties: Record<string, unknown>
   required?: string[]
+  /** Client-owned annotations. JSON Schema consumers ignore unknown keywords. */
+  "x-ollama-client-web-search"?: {
+    source: "auto" | "client" | "native"
+    mode: "cached" | "indexed" | "live"
+  }
 }
 
 export type ToolCategory =

--- a/src/lib/tools/web-search/__tests__/config.test.ts
+++ b/src/lib/tools/web-search/__tests__/config.test.ts
@@ -57,6 +57,28 @@ describe("WebSearchProviderConfigSchema", () => {
     )
   })
 
+  it("preserves native execution policy and rejects invalid policy values", () => {
+    expect(
+      WebSearchProviderConfigSchema.parse({
+        executionSource: "native",
+        nativeMode: "live"
+      })
+    ).toEqual(
+      expect.objectContaining({ executionSource: "native", nativeMode: "live" })
+    )
+    expect(
+      WebSearchProviderConfigSchema.parse({
+        executionSource: "remote",
+        nativeMode: "unlimited"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        executionSource: "client",
+        nativeMode: "cached"
+      })
+    )
+  })
+
   it("rejects non-object persisted values", () => {
     expect(WebSearchProviderConfigSchema.safeParse("broken").success).toBe(
       false

--- a/src/lib/tools/web-search/__tests__/web-search-tool.test.ts
+++ b/src/lib/tools/web-search/__tests__/web-search-tool.test.ts
@@ -53,6 +53,7 @@ vi.mock("../registry", () => ({
 
 describe("web_search tool", () => {
   beforeEach(() => {
+    lastQuery.current = null
     configState.current = {
       provider: "searxng",
       enabled: false,
@@ -86,6 +87,22 @@ describe("web_search tool", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["web_search"])
   })
 
+  it("lists native intent without requiring a client backend", async () => {
+    configState.current = {
+      provider: "brave",
+      enabled: true,
+      executionSource: "native",
+      nativeMode: "live"
+    }
+    const { createWebSearchToolSource } = await import(
+      "../web-search-tool-source"
+    )
+
+    await expect(createWebSearchToolSource().listTools()).resolves.toHaveLength(
+      1
+    )
+  })
+
   it("returns normalized content with sources", async () => {
     configState.current.enabled = true
     const { runWebSearch } = await import("../web-search-tool")
@@ -104,6 +121,17 @@ describe("web_search tool", () => {
         used: true
       }
     ])
+  })
+
+  it("fails closed when native-only intent reaches the client executor", async () => {
+    configState.current.enabled = true
+    configState.current.executionSource = "native"
+    const { runWebSearch } = await import("../web-search-tool")
+
+    await expect(runWebSearch({ query: "private query" }, {})).resolves.toEqual(
+      expect.objectContaining({ isError: true })
+    )
+    expect(lastQuery.current).toBeNull()
   })
 
   it("marks results beyond the cap as unused and only sends the cap to the model", async () => {

--- a/src/lib/tools/web-search/config.ts
+++ b/src/lib/tools/web-search/config.ts
@@ -19,6 +19,8 @@ export const DEFAULT_WEB_SEARCH_CONFIG: WebSearchProviderConfig = {
   // search returns an actionable error to the model/user rather than the
   // feature being invisible.
   enabled: true,
+  executionSource: "client",
+  nativeMode: "cached",
   count: 5,
   searxngPages: 1,
   safeSearch: "moderate"
@@ -51,7 +53,12 @@ const StoredWebSearchProviderConfigSchema = z.object({
   count: z.number().finite().optional().catch(undefined),
   searxngPages: z.number().finite().optional().catch(undefined),
   safeSearch: z.enum(["off", "moderate", "strict"]).optional().catch(undefined),
-  enabled: z.boolean().optional().catch(undefined)
+  enabled: z.boolean().optional().catch(undefined),
+  executionSource: z
+    .enum(["auto", "client", "native"])
+    .optional()
+    .catch(undefined),
+  nativeMode: z.enum(["cached", "indexed", "live"]).optional().catch(undefined)
 })
 
 /**

--- a/src/lib/tools/web-search/types.ts
+++ b/src/lib/tools/web-search/types.ts
@@ -2,6 +2,10 @@ export type WebSearchProviderId = "searxng" | "brave" | "tavily"
 
 export type WebSearchSafeSearch = "off" | "moderate" | "strict"
 
+export type WebSearchExecutionSource = "auto" | "client" | "native"
+
+export type NativeWebSearchMode = "cached" | "indexed" | "live"
+
 /** Recency window for time-sensitive queries. Supported by all backends. */
 export type WebSearchTimeRange = "day" | "week" | "month" | "year"
 
@@ -35,6 +39,10 @@ export interface WebSearchProviderConfig {
   searxngPages?: number
   safeSearch?: WebSearchSafeSearch
   enabled?: boolean
+  /** Where the public `web_search` intent should execute. */
+  executionSource?: WebSearchExecutionSource
+  /** Requested provider-native search freshness; the runtime may cap it. */
+  nativeMode?: NativeWebSearchMode
 }
 
 export interface WebSearchConfigValidation {

--- a/src/lib/tools/web-search/web-search-tool-source.ts
+++ b/src/lib/tools/web-search/web-search-tool-source.ts
@@ -11,6 +11,11 @@ export const createWebSearchToolSource = (): ToolSource => ({
     // this device's chats (the composer toggle).
     if (!config.enabled) return []
     if (!(await getWebSearchActive())) return []
+    // Native/automatic modes must not require a configured client backend just
+    // to express intent. Automatic fallback validates only if it actually runs.
+    if ((config.executionSource ?? "client") !== "client") {
+      return [webSearchDefinition]
+    }
     const backend = getWebSearchBackend(config.provider)
     if (!backend) return []
     if (!backend.validateConfig(config).ok) return []

--- a/src/lib/tools/web-search/web-search-tool.ts
+++ b/src/lib/tools/web-search/web-search-tool.ts
@@ -7,7 +7,7 @@ import {
 } from "./backends/shared"
 import { getWebSearchConfig } from "./config"
 import { getWebSearchBackend } from "./registry"
-import type { WebSearchResult } from "./types"
+import type { WebSearchProviderConfig, WebSearchResult } from "./types"
 
 const PER_SNIPPET_CHAR_LIMIT = 500
 const TOOL_OUTPUT_CHAR_LIMIT = 6000
@@ -57,6 +57,24 @@ export const webSearchDefinition: ToolDefinition = {
       }
     },
     required: ["query"]
+  }
+}
+
+/** Attach per-turn execution intent without coupling provider adapters to OLC. */
+export const withWebSearchExecutionPolicy = (
+  definition: ToolDefinition,
+  config: WebSearchProviderConfig
+): ToolDefinition => {
+  if (definition.name !== webSearchDefinition.name) return definition
+  return {
+    ...definition,
+    parameters: {
+      ...definition.parameters,
+      "x-ollama-client-web-search": {
+        source: config.executionSource ?? "client",
+        mode: config.nativeMode ?? "cached"
+      }
+    }
   }
 }
 
@@ -201,6 +219,13 @@ export const runWebSearch = async (
   const config = await getWebSearchConfig()
   if (!config.enabled) {
     return { content: "Web search is not enabled.", isError: true }
+  }
+  if (config.executionSource === "native") {
+    return {
+      content:
+        "Native-only web search was requested, but the selected model runtime did not consume the search intent.",
+      isError: true
+    }
   }
 
   const backend = getWebSearchBackend(config.provider)

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1371,14 +1371,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1224,14 +1224,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -1216,14 +1216,34 @@
     },
     "web_search": {
       "title": "Web Search",
-      "description": "Let tool-capable models search the live web through a configured search provider.",
+      "description": "Let supported models search the web using built-in or configured search.",
+      "execution_source": {
+        "label": "Search source",
+        "description": "Choose the model's built-in search or a provider you configure.",
+        "client": "Configured provider",
+        "auto": "Built-in, then configured fallback",
+        "native": "Model's built-in search"
+      },
+      "native_mode": {
+        "label": "Search freshness",
+        "description": "How fresh built-in search should be. The runtime may enforce a stricter limit.",
+        "cached": "Cached (fastest)",
+        "indexed": "Indexed (balanced)",
+        "live": "Live (freshest)"
+      },
+      "privacy": {
+        "title": "Query destination",
+        "client": "Queries go only to the configured SearXNG, Brave, or Tavily backend.",
+        "auto": "Queries use the model's built-in search when available, otherwise the configured provider.",
+        "native": "Queries may leave this device through the selected model provider or its search partner. If built-in search is unavailable, the request fails instead of silently using the configured provider."
+      },
       "enable": {
         "label": "Enable web search",
-        "description": "Expose a web_search tool to supported models when the provider config is valid."
+        "description": "Allow supported models to search when the chat web toggle is on."
       },
       "provider": {
-        "label": "Provider",
-        "description": "Choose the backend used behind the single web_search tool."
+        "label": "Configured provider",
+        "description": "Used directly, or as fallback after built-in search."
       },
       "providers": {
         "searxng": "SearXNG",

--- a/tools/check-bundle-size.ts
+++ b/tools/check-bundle-size.ts
@@ -187,10 +187,11 @@ const budgets: Budget[] = [
     metric: "background",
     field: "gzipBytes",
     // Generated-image responses plus embedding route validation, cancellation,
-    // cache safeguards, retry metadata, and the complexity-helper split live
+    // cache safeguards, retry metadata, native web-search routing, and the
+    // complexity-helper split live
     // in the background owner. Keep Chrome narrow while leaving deterministic
     // build headroom.
-    max: isFirefox ? 210_000 : 202_150
+    max: isFirefox ? 210_000 : 202_400
   }
 ]
 


### PR DESCRIPTION
## Summary
- add native web-search routing for Codex and OpenCode backends
- preserve client-managed search as the default
- add explicit execution policy, native mode controls, and fallback behavior
- add tests, localized settings, and OLC documentation
- update the measured background bundle budget for native-search routing

## Validation
- 407 test files / 3413 tests passed
- typecheck, lint, formatting, i18n drift, production build, bundle check, and docs build passed

Target: release/0.13.3



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable native web-search routing for Codex and OpenCode while retaining client-managed search as the default and automatic fallback.
- Adds per-turn execution-source and freshness policy annotations.
- Routes eligible searches through native backend capabilities while suppressing duplicate bridged tools.
- Adds settings UI, localization, backend tests, CLI configuration, documentation, and an updated bundle budget.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/backends/codex/index.ts | Adds capability-gated native-search routing, per-thread search configuration, and native-search stream event handling. |
| packages/olc/src/backends/codex/wire.ts | Maps public web-search intent to Codex native modes while retaining client fallback under automatic routing. |
| packages/olc/src/backends/opencode/web-search.ts | Selects OpenCode native search per turn and limits native tool access to discovered and explicitly allowed tools. |
| packages/olc/src/core/openai-wire.ts | Extracts execution policy from the web_search definition and separates it from tools bridged to native backends. |
| src/background/lib/resolve-model-tools.ts | Annotates exposed web-search definitions with the configured execution policy before provider dispatch. |
| src/features/web-search/components/web-search-settings.tsx | Adds execution-source, native freshness, fallback, and privacy controls to web-search settings. |
| src/lib/tools/web-search/config.ts | Defines backward-compatible defaults and normalization for execution-source and native-search mode settings. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Chat request with web_search tool] --> Policy{Execution source}
  Policy -->|client| Client[Client-managed search]
  Policy -->|auto| Capability{Native search available?}
  Policy -->|native| NativeCapability{Native search available?}
  Capability -->|yes| Native[Backend-native search]
  Capability -->|no| Client
  NativeCapability -->|yes| Native
  NativeCapability -->|no| Closed[Search disabled / fail closed]
  Native --> Backend{Selected backend}
  Backend --> Codex[Codex web_search mode]
  Backend --> OpenCode[OpenCode websearch tool]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["build: allow native search bundle headro..."](https://github.com/shishir435/ollama-client/commit/8851aa1ab05c7aed87e6d0f014cdc56016de4b3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58697509)</sub>

<!-- /greptile_comment -->