### PR TITLE
docs: polish release notes and layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [0.13.3]
 
+### Added
+
+- Web search can route through the selected agent runtime's native search tool.
+  Ollama Client still exposes one provider-neutral `web_search` tool and keeps
+  configured SearXNG, Brave, and Tavily backends available as explicit choices.
+- `olc` adds native Ollama lifecycle management with `--lan`, `--local`,
+  `--check`, and `--json`, safe app/service ownership checks, process-scoped
+  child environments, and strict option validation.
+
 ### Changed
 
 - All olc backends now detach by default. `--debug` implies foreground; explicit
@@ -19,10 +28,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `olc` now defaults to native Ollama on port 11434. Use `olc -b codex`
   for the Codex proxy on port 8083 or `olc -b opencode` for the OpenCode proxy
   on port 8084; `-b` aliases `--backend`.
-- Added native `--lan`, `--local`, `--check`, and `--json`, safe app/service
-  ownership checks, process-scoped child environments, and strict option
-  validation. olc never persists app, service, user, or machine environment;
-  an incompatible macOS app transitions to a standalone process safely.
+- Embedding requests use stricter cache identities, propagate cancellation
+  through provider and storage boundaries, retry rate limits without discarding
+  successful batches, and retain keyword context when dense embedding fails.
+- Embedding batches and search-cache retention are tuned against reproducible
+  performance benchmarks while preserving the extension bundle budgets.
+- olc never persists app, service, user, or machine environment; an incompatible
+  macOS app transitions to a standalone process safely.
+
+### Removed
+
+- The model-callable `selected_text` reader is removed. Pending page selections
+  remain an explicit, consumable composer handoff instead of silently becoming
+  live tool state, so stale selections cannot be read during a later turn.
 
 ### Development
 
@@ -34,11 +52,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   durable turns, while custom provider base URLs remain fully configurable.
 - Biome now enforces an initial cognitive-complexity ceiling so newly changed
   code cannot grow unchecked while the threshold is tightened incrementally.
+- Verification scripts are organized by purpose and the release gate now builds
+  each browser target once before reusing those artifacts for smoke, bundle,
+  migration, recovery, and critical browser checks.
+- Documentation articles remain centered on wide screens, terminal snippets use
+  recognizable red/yellow/green window controls, and the README no longer
+  advertises the removed selected-text tool.
 - Embedding generation from extension pages now crosses the validated,
   background-owned `embeddings.generate` RPC. The RPC preserves model/provider
   identity, forwards cancellation, and bounds stalled provider work with a
-  generous 15-minute deadline. Background RAG uses an application service seam;
-  full strategy/cache ownership migration continues in 0.13.3.
+  generous 15-minute deadline. Background RAG and UI maintenance use application
+  service seams instead of importing persistence adapters across ownership
+  boundaries.
 
 ## [0.13.2]
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ still live in IndexedDB through the embeddings storage layer.
 
 Ollama Client supports two context paths:
 
-- **Manual context**: select tabs, files, or images before sending.
+- **Manual context**: select tabs, selected text, files, or images before sending.
 - **Model-requested context**: tool-capable models can call tools during a response to inspect the current page, list/read open tabs, read permission-gated recently closed or synced-device sessions, search indexed files, search local chat memory, or search the live web when web search is enabled.
 
 Tool calls run inside the extension and are shown in the reasoning trace with status, inputs, sources, and trimmed output previews. They do not create extra chat-history rows; only the final answer and trace metadata are persisted.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Ollama Client gives you a browser-native chat workspace for local and bring-your
 - Use verified built-ins for Ollama, LM Studio, and llama.cpp; add other OpenAI-compatible servers or Anthropic from Settings.
 - Upload files and use local retrieval-augmented generation over your own content.
 - Attach images for vision-capable models.
-- Let tool-capable models read the current tab, selected text, open tabs, uploaded files, local memory, and optionally the live web when the prompt calls for it.
-- Capture selected page text into chat with the selection-button overlay.
+- Let tool-capable models read the current tab, open tabs, uploaded files, local memory, and optionally the live web when the prompt calls for it.
 - Keep chat history, sessions, files, settings, and embeddings on your machine by default.
 - Review all stored data, create a full backup, or wipe it from one Privacy screen.
 - Organize chats with tags; edit messages in place or fork an alternate branch.
@@ -61,8 +60,8 @@ still live in IndexedDB through the embeddings storage layer.
 
 Ollama Client supports two context paths:
 
-- **Manual context**: select tabs, selected text, files, or images before sending.
-- **Model-requested context**: tool-capable models can call tools during a response to inspect the current page, list/read open tabs, read permission-gated recently closed or synced-device sessions, search indexed files, search local chat memory, use the most recent selected text, or search the live web when web search is enabled.
+- **Manual context**: select tabs, files, or images before sending.
+- **Model-requested context**: tool-capable models can call tools during a response to inspect the current page, list/read open tabs, read permission-gated recently closed or synced-device sessions, search indexed files, search local chat memory, or search the live web when web search is enabled.
 
 Tool calls run inside the extension and are shown in the reasoning trace with status, inputs, sources, and trimmed output previews. They do not create extra chat-history rows; only the final answer and trace metadata are persisted.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ollama Client gives you a browser-native chat workspace for local and bring-your
 - Upload files and use local retrieval-augmented generation over your own content.
 - Attach images for vision-capable models.
 - Let tool-capable models read the current tab, open tabs, uploaded files, local memory, and optionally the live web when the prompt calls for it.
+- Capture selected page text into chat with the selection-button overlay.
 - Keep chat history, sessions, files, settings, and embeddings on your machine by default.
 - Review all stored data, create a full backup, or wipe it from one Privacy screen.
 - Organize chats with tags; edit messages in place or fork an alternate branch.

--- a/docs/src/styles/starlight-overrides.css
+++ b/docs/src/styles/starlight-overrides.css
@@ -31,6 +31,13 @@ body {
   line-height: 1.6;
 }
 
+/* Keep the article centered in the reading pane on wide screens. */
+@media (min-width: 72rem) {
+  [data-has-sidebar][data-has-toc] .main-pane .sl-container {
+    margin-inline: auto;
+  }
+}
+
 /* Heading hierarchy — tighter tracking, normal weight, more breathing room. */
 .sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
   font-weight: 600;
@@ -211,6 +218,20 @@ starlight-toc nav a[aria-current="true"] {
 .expressive-code .frame .header {
   font-family: var(--sl-font-mono);
   font-size: 0.6875rem !important;
+}
+
+/* Expressive Code uses monochrome title-bar dots by default. Give terminal
+ * frames the familiar macOS close/minimize/zoom colors instead. */
+.expressive-code .frame.is-terminal .header::before {
+  width: 2.1rem;
+  height: 0.56rem;
+  background:
+    radial-gradient(circle at 0.28rem 50%, #ff5f57 0 0.25rem, transparent 0.27rem),
+    radial-gradient(circle at 1.05rem 50%, #febc2e 0 0.25rem, transparent 0.27rem),
+    radial-gradient(circle at 1.82rem 50%, #28c840 0 0.25rem, transparent 0.27rem);
+  opacity: 1;
+  -webkit-mask-image: none;
+  mask-image: none;
 }
 
 @media (max-width: 50rem) {

--- a/docs/src/styles/starlight-overrides.css
+++ b/docs/src/styles/starlight-overrides.css
@@ -4,7 +4,9 @@
  * Goals:
  *   - Pure neutrals (white / zinc-950) with hairline borders.
  *   - Accent (extension's primary blue) used only on links and the
- *     active sidebar item. No accent panels, no decorative tints.
+ *     active sidebar item. No accent panels, no decorative tints. The
+ *     one exception is the terminal window-control dots, which are the
+ *     recognizable macOS colors and are tokenized as such.
  *   - Geist Sans / Geist Mono throughout. Slightly larger body type
  *     and tighter heading line-height than Starlight defaults.
  *   - Code blocks: github-light + github-dark-dimmed (configured in
@@ -31,10 +33,16 @@ body {
   line-height: 1.6;
 }
 
-/* Keep the article centered in the reading pane on wide screens. */
+/*
+ * Keep the article centered in the reading pane on wide screens.
+ * Starlight sets `--sl-content-margin-inline: auto 0` for the
+ * sidebar-plus-TOC layout, which is the only case where the article is
+ * not centered; overriding the variable rather than the property leaves
+ * the container rule to Starlight.
+ */
 @media (min-width: 72rem) {
-  [data-has-sidebar][data-has-toc] .main-pane .sl-container {
-    margin-inline: auto;
+  [data-has-sidebar][data-has-toc] .main-pane {
+    --sl-content-margin-inline: auto;
   }
 }
 
@@ -220,18 +228,22 @@ starlight-toc nav a[aria-current="true"] {
   font-size: 0.6875rem !important;
 }
 
-/* Expressive Code uses monochrome title-bar dots by default. Give terminal
- * frames the familiar macOS close/minimize/zoom colors instead. */
+/*
+ * Expressive Code paints monochrome title-bar dots by masking a flat
+ * background color. Repaint that background with a three-stop gradient so
+ * the dots take the familiar macOS close/minimize/zoom colors while their
+ * size and spacing stay whatever the mask says. The stops sit at 33% and
+ * 66% of the mask's 60-unit viewBox (units 19.8 and 39.6), inside the gaps
+ * between its circles.
+ */
 .expressive-code .frame.is-terminal .header::before {
-  width: 2.1rem;
-  height: 0.56rem;
-  background:
-    radial-gradient(circle at 0.28rem 50%, #ff5f57 0 0.25rem, transparent 0.27rem),
-    radial-gradient(circle at 1.05rem 50%, #febc2e 0 0.25rem, transparent 0.27rem),
-    radial-gradient(circle at 1.82rem 50%, #28c840 0 0.25rem, transparent 0.27rem);
+  background: linear-gradient(
+    to right,
+    var(--sl-color-terminal-dot-red) 0 33%,
+    var(--sl-color-terminal-dot-amber) 0 66%,
+    var(--sl-color-terminal-dot-green) 0
+  );
   opacity: 1;
-  -webkit-mask-image: none;
-  mask-image: none;
 }
 
 @media (max-width: 50rem) {

--- a/docs/src/styles/tokens.css
+++ b/docs/src/styles/tokens.css
@@ -48,6 +48,16 @@
   --sl-color-accent: oklch(0.37 0.013 285.805);
   --sl-color-accent-high: oklch(0.274 0.006 286.033);
 
+  /*
+   * Terminal window-control dots. The only non-neutral hues in the docs
+   * palette: they are the recognizable macOS close/minimize/zoom colors,
+   * so they are identical in both themes and are not part of the accent
+   * scale.
+   */
+  --sl-color-terminal-dot-red: oklch(0.694 0.196 26.36);
+  --sl-color-terminal-dot-amber: oklch(0.835 0.161 80.91);
+  --sl-color-terminal-dot-green: oklch(0.728 0.217 144.71);
+
   --sl-content-width: 48rem;
   --sl-sidebar-width: 16.5rem;
   --sl-text-h1: 2.25rem;


### PR DESCRIPTION
## Summary

Reconcile the 0.13.3 changelog with the commits already on the release branch, remove stale selected-text tool claims from the README, and polish the docs reading layout and terminal-window controls.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Docs
- [ ] Build / tooling / CI
- [ ] Breaking change (storage format, message protocol, manifest permissions, public API)

## Quality gates

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm format:check`
- [x] `pnpm test:run` (3,549 tests)
- [x] `pnpm test:coverage`
- [x] `pnpm build` (Chrome MV3)
- [x] `pnpm build:firefox` (Firefox MV2)
- [x] `pnpm verify:release`
- [x] `pnpm verify:browser-smoke`
- [x] `pnpm generate:resources`
- [x] Docs layout checked at a 1600px viewport

## Surface area / risk

- [ ] Touches chat history persistence
- [ ] Touches the content script
- [ ] Touches background-worker routing
- [ ] Touches a provider implementation
- [ ] Touches CSP / manifest / permissions
- [ ] Adds a new dependency

Documentation-only change. No runtime, storage, permission, dependency, or network behavior changes.

## Privacy / local-first

No change.

## Screenshots / GIFs

Not attached. The rendered Ollama Cloud guide was checked locally at a 1600px viewport; the article was centered in its reading pane and terminal controls resolved to red/yellow/green.

## Notes

- The repository has no plain `release` branch, so this PR targets `release/0.13.3`.
- Workspace package versions are consistently `0.13.3`, the changelog comparison links are correct, and the current-version release metadata test passes.
- The pre-push production audit (`pnpm audit --prod --audit-level high`) passes its threshold, reporting 8 existing low/moderate advisories. A full workspace `pnpm audit` reports 43 existing advisories (7 low, 24 moderate, 11 high, 1 critical) in dependency/tooling chains; this PR does not change dependencies.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR reconciles the 0.13.3 release notes and clarifies that selected text remains available through manual composer handoff rather than a model-callable tool.
- Updates the changelog for web search, Ollama lifecycle management, embeddings, verification, and documentation changes.
- Removes stale model-requested selected-text claims while preserving documentation of the manual selection workflow.
- Centers documentation articles on wide screens and adds tokenized terminal window-control colors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Expands and reorganizes the 0.13.3 release notes, including an accurate distinction between the removed selected-text tool and retained composer handoff. |
| README.md | Removes selected text from model-callable tool lists while continuing to document the manual selection workflow. |
| docs/src/styles/starlight-overrides.css | Centers wide-screen article content and applies tokenized red, amber, and green terminal controls. |
| docs/src/styles/tokens.css | Defines theme-independent color tokens for terminal window controls. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: tokenize terminal dots, use starli..."](https://github.com/shishir435/ollama-client/commit/1497ef8129c0100b41fb16711ec6581df9e2e0c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59146117)</sub>

<!-- /greptile_comment -->