### PR TITLE
fix(olc): give the macOS app time to finish quitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - olc never persists app, service, user, or machine environment; an incompatible
   macOS app transitions to a standalone process safely.
 
+### Fixed
+
+- The macOS Ollama app now gets a full minute to finish quitting before olc
+  gives up, and an exit during the final poll is treated as an exit rather than
+  a timeout. Previously a slower-than-ten-second quit aborted the transition
+  after the app had already been signalled, leaving no server running and no
+  replacement started.
+
 ### Removed
 
 - The model-callable `selected_text` reader is removed. Pending page selections
@@ -58,6 +66,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Documentation articles remain centered on wide screens, terminal snippets use
   recognizable red/yellow/green window controls, and the README no longer
   advertises the removed selected-text tool.
+- The olc installation docs now document a pinned, checksum-verified path that
+  does not pipe a remote script into a shell, and every place that shows the
+  one-line installer links to it.
 - Embedding generation from extension pages now crosses the validated,
   background-owned `embeddings.generate` RPC. The RPC preserves model/provider
   identity, forwards cancellation, and bounds stalled provider work with a

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ $env:OLC_VERSION = "0.13.2"
 irm https://ollamaclient.in/olc.ps1 | iex
 ```
 
+These commands pipe a remote script into your shell. To pin the release and
+verify it before running anything, see
+[installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell).
+
 Then run `olc` for native Ollama, or `olc --help` for all short/long options.
 All modes detach by default; `--debug` or `--foreground` stays attached.
 For Codex/OpenCode, configure Ollama Client with a custom OpenAI-compatible provider at

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -38,6 +38,56 @@ $env:OLC_VERSION = "0.13.2"
 irm https://ollamaclient.in/olc.ps1 | iex
 ```
 
+### Install without piping to a shell
+
+`ollamaclient.in/olc.sh` and `olc.ps1` are mutable convenience wrappers. Both
+verify the archive they download against its published `sha256`, but the wrapper
+itself is fetched and executed in one step, so there is nothing to inspect or
+authenticate first. Two alternatives avoid that.
+
+Fetch the wrapper, read it, then run it:
+
+```bash
+curl -fsSL https://ollamaclient.in/olc.sh -o olc-install.sh
+less olc-install.sh
+sh olc-install.sh
+```
+
+```powershell
+irm https://ollamaclient.in/olc.ps1 -OutFile olc-install.ps1
+Get-Content olc-install.ps1
+./olc-install.ps1
+```
+
+Or skip the wrapper and take the pinned release archive directly. `olc.tar.gz`
+and `olc.tar.gz.sha256` are immutable per tag, so this is the same artifact the
+wrapper would install, verified before anything runs:
+
+```bash
+tag=0.13.3
+base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
+curl -fsSL "$base/olc.tar.gz" -o olc.tar.gz
+curl -fsSL "$base/olc.tar.gz.sha256" -o olc.tar.gz.sha256
+shasum -a 256 -c olc.tar.gz.sha256
+tar -xzf olc.tar.gz
+node olc/dist/olc.mjs --help
+```
+
+```powershell
+$tag = "0.13.3"
+$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+irm "$base/olc.tar.gz" -OutFile olc.tar.gz
+irm "$base/olc.tar.gz.sha256" -OutFile olc.tar.gz.sha256
+$expected = (Get-Content olc.tar.gz.sha256).Split(" ")[0]
+if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+tar -xzf olc.tar.gz
+node olc/dist/olc.mjs --help
+```
+
+Move the extracted `olc` directory wherever you keep tools and put `olc.mjs`
+on `PATH` under whatever name you prefer; the wrapper's only extra job is
+choosing those locations for you.
+
 ```bash
 # Source checkout alternative
 git clone https://github.com/Shishir435/ollama-client.git

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -59,9 +59,9 @@ Get-Content olc-install.ps1
 ./olc-install.ps1
 ```
 
-Or skip the wrapper and take the pinned release archive directly. `olc.tar.gz`
-and `olc.tar.gz.sha256` are immutable per tag, so this is the same artifact the
-wrapper would install, verified before anything runs:
+Or skip the wrapper and take the release archive for a chosen tag directly. This
+is the same artifact the wrapper would install, checked against its published
+`sha256` before anything runs:
 
 ```bash
 tag=0.13.3
@@ -83,6 +83,13 @@ if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) { throw "che
 tar -xzf olc.tar.gz
 node olc/dist/olc.mjs --help
 ```
+
+The checksum is published beside the archive on the same release, so it shows
+the download arrived intact — not that the file behind a tag is still the one you
+reviewed. The release workflow never overwrites a published asset (a re-run on a
+moved tag uploads only what is missing), but release assets can still be changed
+by hand. For a pin that does not depend on that, record the hash of a release you
+have checked and compare against it on later installs.
 
 Move the extracted `olc` directory wherever you keep tools and put `olc.mjs`
 on `PATH` under whatever name you prefer; the wrapper's only extra job is

--- a/docs/src/content/docs/guides/provider-setup.md
+++ b/docs/src/content/docs/guides/provider-setup.md
@@ -66,6 +66,8 @@ curl -fsSL https://ollamaclient.in/olc.sh | sh
 irm https://ollamaclient.in/olc.ps1 | iex
 ```
 
+These installers pipe a remote script into your shell. To pin the release and verify it first, see [installing without piping to a shell](/developers/#install-without-piping-to-a-shell).
+
 Start or reuse native Ollama with extension origins enabled:
 
 ```bash

--- a/docs/src/content/docs/guides/quick-start.md
+++ b/docs/src/content/docs/guides/quick-start.md
@@ -79,6 +79,9 @@ olc --check --json
 On Windows PowerShell, install with `irm https://ollamaclient.in/olc.ps1 | iex`,
 then run the same olc commands.
 
+These installers pipe a remote script into your shell. To pin the release and verify it first, see [installing without piping to a shell](/developers/#install-without-piping-to-a-shell).
+
+
 **Manual setup without olc:** stop the current Ollama app/server, set
 `OLLAMA_ORIGINS`, and start it again:
 

--- a/docs/src/content/docs/guides/troubleshooting/ollama-cors-error.md
+++ b/docs/src/content/docs/guides/troubleshooting/ollama-cors-error.md
@@ -30,6 +30,8 @@ olc
 olc --check --json
 ```
 
+These installers pipe a remote script into your shell. To pin the release and verify it first, see [installing without piping to a shell](/developers/#install-without-piping-to-a-shell).
+
 Ollama itself must already be installed. `olc --debug` provides foreground
 diagnostics. Use `olc --lan` only when trusted-network access is intended;
 Ollama has no native API authentication. olc passes `OLLAMA_*` only to a

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -236,7 +236,12 @@ An already-compatible macOS app, systemd service, Windows tray process, or other
 managed server is reused unchanged. When the macOS app needs a different bind or
 origin, olc gracefully quits the app, waits for its verified listener to exit,
 and starts a standalone child with process-scoped settings. It does not relaunch
-or reconfigure the app. Other incompatible managed services remain untouched and
+or reconfigure the app. The app gets a minute to finish quitting, far longer than
+the ten seconds a CLI `SIGTERM` is given: while the wait lasts Ollama is still
+serving, whereas giving up early would abandon an app that was already asked to
+quit and never start its replacement. If the listener is still up when that
+deadline passes, no replacement is started and the running server is left as it
+is. Other incompatible managed services remain untouched and
 must be stopped for a standalone session or configured through their owner.
 Standalone Unix processes are identity-checked before `SIGTERM`; olc never
 escalates to a force-kill. Detached logs go to `~/.ollama/olc.log`.

--- a/packages/olc/src/__tests__/ollama-process.test.ts
+++ b/packages/olc/src/__tests__/ollama-process.test.ts
@@ -302,6 +302,54 @@ describe("manager ownership", () => {
     child.emit("exit", 0, null)
     await expect(run.session?.finished).resolves.toBe(0)
   })
+  it("treats an exit during the final poll as an exit, not a timeout", async () => {
+    vi.spyOn(process, "getuid").mockReturnValue(1000)
+    vi.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGTERM") return true
+      throw Object.assign(new Error("missing"), { code: "ESRCH" })
+    })
+    let checks = 0
+    mocks.execute.mockImplementation(async () => {
+      checks += 1
+      /** Identity survives every polled check and disappears only after the last delay. */
+      if (checks > 41) throw new Error("process exited")
+      return { stdout: identity }
+    })
+    await expect(stopListener(listener)).resolves.toBeUndefined()
+    expect(mocks.delay).toHaveBeenCalledTimes(40)
+  })
+  it("waits past the CLI deadline while the macOS app finishes quitting", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" })
+    const child = Object.assign(new EventEmitter(), { kill: vi.fn() })
+    mocks.spawn.mockReturnValue(child)
+    vi.spyOn(process, "getuid").mockReturnValue(1000)
+    let checks = 0
+    mocks.execute.mockImplementation(async () => {
+      checks += 1
+      if (checks === 2) return { stdout: appIdentity }
+      /** Slower than the 10s CLI deadline, well inside the app's own. */
+      if (checks > 60) throw new Error("process exited")
+      return { stdout: identity }
+    })
+    vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (pid === appProcess.pid && signal === "SIGTERM") return true
+      throw Object.assign(new Error("missing"), { code: "ESRCH" })
+    })
+    const run = await applyManager(
+      { kind: "mac-app", appPath: "/Applications/Ollama.app", appProcess },
+      resolveOllamaOptions({ FOREGROUND: true }, {}, {}),
+      {},
+      listener
+    )
+    expect(mocks.delay.mock.calls.length).toBeGreaterThan(40)
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "ollama",
+      ["serve"],
+      expect.any(Object)
+    )
+    child.emit("exit", 0, null)
+    await expect(run.session?.finished).resolves.toBe(0)
+  })
   it("uses a standalone process when no managed listener is running", async () => {
     Object.defineProperty(process, "platform", { value: "linux" })
     expect(await detectManager()).toEqual({ kind: "cli" })

--- a/packages/olc/src/ollama/manager.ts
+++ b/packages/olc/src/ollama/manager.ts
@@ -9,6 +9,7 @@ import {
 } from "../foreground-process.js"
 import { bindAddress, type OllamaOptions } from "./config.js"
 import {
+  APP_EXIT_TIMEOUT_MS,
   command,
   type Listener,
   ollamaEnvironment,
@@ -256,7 +257,7 @@ export async function applyManager(
           "The Ollama app process changed or has another owner; leaving it running."
         )
       process.kill(app.pid, "SIGTERM")
-      await waitForExit(listener)
+      await waitForExit(listener, APP_EXIT_TIMEOUT_MS)
     }
   } else if (listener) await stopListener(listener)
   const childEnv = {

--- a/packages/olc/src/ollama/process.ts
+++ b/packages/olc/src/ollama/process.ts
@@ -151,23 +151,48 @@ export async function ollamaEnvironment(
   )
 }
 
-/** Wait for a specific process to exit without escalating to SIGKILL. */
-export async function waitForExit(listener: Listener): Promise<void> {
-  for (let attempt = 0; attempt < 40; attempt++) {
+const EXIT_POLL_MS = 250
+
+/** A CLI process handles SIGTERM promptly; anything longer is a hang, not a slow stop. */
+export const EXIT_TIMEOUT_MS = 10_000
+
+/**
+ * The macOS app tears down its UI and its own serve child before the port frees,
+ * so it is given a far longer deadline than a CLI SIGTERM. Waiting costs nothing
+ * while it lasts — Ollama is still serving — whereas giving up early can abandon
+ * an app that was already asked to quit and never start its replacement.
+ */
+export const APP_EXIT_TIMEOUT_MS = 60_000
+
+/** True once the PID is gone or has been recycled into a different process. */
+async function hasExited(listener: Listener): Promise<boolean> {
+  try {
+    const current = await processIdentity(listener.pid)
+    return current.identity !== listener.identity
+  } catch {
     try {
-      const current = await processIdentity(listener.pid)
-      if (current.identity !== listener.identity) return
-    } catch {
-      try {
-        process.kill(listener.pid, 0)
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ESRCH") return
-      }
+      process.kill(listener.pid, 0)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return true
     }
-    await delay(250)
+    return false
   }
+}
+
+/** Wait for a specific process to exit without escalating to SIGKILL. */
+export async function waitForExit(
+  listener: Listener,
+  timeoutMs: number = EXIT_TIMEOUT_MS
+): Promise<void> {
+  const attempts = Math.ceil(timeoutMs / EXIT_POLL_MS)
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (await hasExited(listener)) return
+    await delay(EXIT_POLL_MS)
+  }
+  /** Poll once more: exiting during the last interval is an exit, not a timeout. */
+  if (await hasExited(listener)) return
   throw new Error(
-    "Ollama did not stop within 10 seconds. No force-kill was attempted; stop it manually and retry."
+    `Ollama did not stop within ${Math.round(timeoutMs / 1000)} seconds and is still listening on ${listener.host}. No force-kill was attempted and no replacement was started, so the running server was left as it is; stop it manually and retry.`
   )
 }
 


### PR DESCRIPTION
## Summary

Addresses both Greptile findings on #345. Targets `release/0.13.3`, so they land in that promotion.

**P1 — shutdown timeout breaks replacement** (`packages/olc/src/ollama/manager.ts:259`)

`waitForExit` was fixed at 10s. On the mac-app path it runs *after* `SIGTERM` has gone to the app, so a slower quit threw and `applyManager` returned without starting the replacement: nothing serving, nothing started.

- The app quit gets `APP_EXIT_TIMEOUT_MS` (60s). A GUI app tears down its UI and its own serve child before the port frees. Waiting costs nothing while it lasts — Ollama is still serving — and if the listener is still up at the deadline, aborting is safe because nothing has been replaced.
- A CLI `SIGTERM` keeps the 10s deadline; that path is `stopListener`, where a slow stop is a hang.
- Fixed an off-by-one: the loop delayed after its last check and threw without re-checking, so a process exiting during the final 250ms interval was reported as a timeout. It now polls once more before giving up.
- The timeout message no longer hardcodes "10 seconds" and states what was left running.

**P2 — installer executes mutable responses** (`README.md:127`)

The wrappers verify the archive's `sha256`, but the wrapper itself is fetched and executed in one step. Added `Install without piping to a shell` to the developer portal: fetch-inspect-run, or skip the wrapper and take the pinned per-tag `olc.tar.gz` + `olc.tar.gz.sha256` directly, verified before anything executes. Both shells covered. Every place showing the one-liner now links to it — README, quick start, provider setup, CORS troubleshooting.

## Type of change

- [x] Bug fix
- [x] Docs

## Quality gates

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm test:run` — 416 files / 3551 tests
- [x] `pnpm docs:build` (anchor resolves in the built page)

Two new tests in `ollama-process.test.ts`: an exit during the final poll resolves instead of throwing, and the mac-app path waits past the CLI deadline and still spawns the replacement.

## Surface area / risk

Native process lifecycle in `packages/olc` only. No extension code, no manifest, no persistence.

## Privacy / local-first

No change. Still no force-kill, no environment persistence, identity checks unchanged.

## Notes

60s is a deliberate ceiling, not a guess: past it the app has ignored the signal rather than quit slowly, and at that point the listener is still serving, so refusing is the safe answer.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends the verified macOS app shutdown window and corrects the final exit poll before starting a replacement process.
- Keeps the shorter shutdown deadline for standalone CLI listeners.
- Adds boundary and macOS replacement tests.
- Replaces the overstated immutable-tag installation guidance with explicit release-asset limitations and independently retained hash guidance.
- Links installer call sites to the safer installation instructions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/ollama/process.ts | Adds a separate macOS app exit deadline and rechecks listener identity after the final polling delay. |
| packages/olc/src/ollama/manager.ts | Applies the extended deadline only when quitting the verified macOS application. |
| packages/olc/src/__tests__/ollama-process.test.ts | Covers exit during the final polling interval and macOS shutdown beyond the CLI deadline. |
| docs/src/content/docs/developers.md | Accurately distinguishes checksum-based transfer integrity from immutable artifact identity and documents safer installation alternatives. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: correct the release-tag immutabili..."](https://github.com/shishir435/ollama-client/commit/a752331d62ca806b73bdf7ad1ee09abc74a7929a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59509508)</sub>

<!-- /greptile_comment -->