### PR TITLE
fix(release): publish the install wrappers with checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,13 @@ jobs:
           (cd release && zip -qr ../olc.zip olc)
           sha256sum olc.tar.gz > olc.tar.gz.sha256
           sha256sum olc.zip > olc.zip.sha256
+          # The install wrappers ship as release assets too, so a user can pin
+          # one to a tag and verify it before granting it their own privileges.
+          # Hashing the checked-out copy keeps them on the same verified-CI-run
+          # provenance path as the archives they install.
+          cp docs/public/olc.sh docs/public/olc.ps1 .
+          sha256sum olc.sh > olc.sh.sha256
+          sha256sum olc.ps1 > olc.ps1.sha256
           node packages/olc/dist/olc.mjs --help
 
       - name: Verify Windows launcher and installer syntax
@@ -243,6 +250,10 @@ jobs:
             olc.tar.gz.sha256
             olc.zip
             olc.zip.sha256
+            olc.sh
+            olc.sh.sha256
+            olc.ps1
+            olc.ps1.sha256
           retention-days: 14
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,12 +128,17 @@ jobs:
             verified-release-artifacts/olc.tar.gz.sha256
             verified-release-artifacts/olc.zip
             verified-release-artifacts/olc.zip.sha256
+            verified-release-artifacts/olc.sh
+            verified-release-artifacts/olc.sh.sha256
+            verified-release-artifacts/olc.ps1
+            verified-release-artifacts/olc.ps1.sha256
           )
 
-          # CI publishes three extension packages plus two olc archives and their
-          # checksums. Refuse an incomplete or ambiguous set before touching a release.
-          if [ ${#ASSETS[@]} -ne 7 ]; then
-            echo "Expected exactly seven verified release assets; found ${#ASSETS[@]}."
+          # CI publishes three extension packages, two olc archives, the two
+          # install wrappers, and a checksum for each of those four. Refuse an
+          # incomplete or ambiguous set before touching a release.
+          if [ ${#ASSETS[@]} -ne 11 ]; then
+            echo "Expected exactly eleven verified release assets; found ${#ASSETS[@]}."
             exit 1
           fi
           for asset in "${ASSETS[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Documentation articles remain centered on wide screens, terminal snippets use
   recognizable red/yellow/green window controls, and the README no longer
   advertises the removed selected-text tool.
-- The olc installation docs now document a pinned, checksum-verified path that
-  does not pipe a remote script into a shell, and every place that shows the
-  one-line installer links to it.
+- Every release now publishes the `olc.sh` and `olc.ps1` install wrappers with a
+  `sha256` for each, alongside the archives they install. The wrapper can be
+  pinned to a tag and verified before it runs instead of being piped straight
+  into a shell, and every place that shows the one-line installer links to that
+  path.
 - Embedding generation from extension pages now crosses the validated,
   background-owned `embeddings.generate` RPC. The RPC preserves model/provider
   identity, forwards cancellation, and bounds stalled provider work with a

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ $env:OLC_VERSION = "0.13.2"
 irm https://ollamaclient.in/olc.ps1 | iex
 ```
 
-These commands pipe a remote script into your shell. To pin the release and
-verify it before running anything, see
+These commands pipe a remote script into your shell. Each release also publishes
+the wrappers with their own checksums, so they can be pinned and verified first —
+see
 [installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell).
 
 Then run `olc` for native Ollama, or `olc --help` for all short/long options.

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -53,7 +53,7 @@ tag=0.13.3
 base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
 curl -fsSL "$base/olc.sh" -o olc.sh
 curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256
-shasum -a 256 -c olc.sh.sha256
+if command -v sha256sum >/dev/null; then sha256sum -c olc.sh.sha256; else shasum -a 256 -c olc.sh.sha256; fi
 less olc.sh
 OLC_VERSION="$tag" sh olc.sh
 ```
@@ -83,7 +83,7 @@ tag=0.13.3
 base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
 curl -fsSL "$base/olc.tar.gz" -o olc.tar.gz
 curl -fsSL "$base/olc.tar.gz.sha256" -o olc.tar.gz.sha256
-shasum -a 256 -c olc.tar.gz.sha256
+if command -v sha256sum >/dev/null; then sha256sum -c olc.tar.gz.sha256; else shasum -a 256 -c olc.tar.gz.sha256; fi
 tar -xzf olc.tar.gz
 node olc/dist/olc.mjs --help
 ```

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -40,28 +40,43 @@ irm https://ollamaclient.in/olc.ps1 | iex
 
 ### Install without piping to a shell
 
-`ollamaclient.in/olc.sh` and `olc.ps1` are mutable convenience wrappers. Both
-verify the archive they download against its published `sha256`, but the wrapper
-itself is fetched and executed in one step, so there is nothing to inspect or
-authenticate first. Two alternatives avoid that.
+`ollamaclient.in/olc.sh` and `olc.ps1` are convenience wrappers served from a
+mutable URL. Both verify the archive they download against its published
+`sha256`, but the one-line commands fetch and execute the wrapper in a single
+step, so there is nothing to check or read before it runs with your privileges.
 
-Fetch the wrapper, read it, then run it:
+Every release publishes both wrappers alongside the archives, each with its own
+`sha256`. Pin one to a tag, verify it, read it, and only then run it:
 
 ```bash
-curl -fsSL https://ollamaclient.in/olc.sh -o olc-install.sh
-less olc-install.sh
-sh olc-install.sh
+tag=0.13.3
+base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
+curl -fsSL "$base/olc.sh" -o olc.sh
+curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256
+shasum -a 256 -c olc.sh.sha256
+less olc.sh
+OLC_VERSION="$tag" sh olc.sh
 ```
 
 ```powershell
-irm https://ollamaclient.in/olc.ps1 -OutFile olc-install.ps1
-Get-Content olc-install.ps1
-./olc-install.ps1
+$tag = "0.13.3"
+$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+irm "$base/olc.ps1" -OutFile olc.ps1
+irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
+$expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
+if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+Get-Content olc.ps1
+$env:OLC_VERSION = $tag
+Unblock-File olc.ps1
+powershell -ExecutionPolicy Bypass -File ./olc.ps1
 ```
 
+A file downloaded rather than piped carries the mark of the web, so PowerShell
+blocks it until `Unblock-File` clears the mark; the explicit policy on that one
+invocation avoids changing the machine's default.
+
 Or skip the wrapper and take the release archive for a chosen tag directly. This
-is the same artifact the wrapper would install, checked against its published
-`sha256` before anything runs:
+is the same artifact the wrapper would install, and nothing but `tar` runs:
 
 ```bash
 tag=0.13.3
@@ -84,12 +99,13 @@ tar -xzf olc.tar.gz
 node olc/dist/olc.mjs --help
 ```
 
-The checksum is published beside the archive on the same release, so it shows
-the download arrived intact — not that the file behind a tag is still the one you
-reviewed. The release workflow never overwrites a published asset (a re-run on a
-moved tag uploads only what is missing), but release assets can still be changed
-by hand. For a pin that does not depend on that, record the hash of a release you
-have checked and compare against it on later installs.
+Each checksum is published beside the file it covers on the same release, so it
+shows the download arrived intact — not that the file behind a tag is still the
+one you reviewed. The release workflow never overwrites a published asset (a
+re-run on a moved tag uploads only what is missing), but release assets can still
+be changed by hand, and a checksum served from the same place as its file is not
+an independent signature. For a pin that does not depend on any of that, record
+the hash of a release you have checked and compare against it on later installs.
 
 Move the extracted `olc` directory wherever you keep tools and put `olc.mjs`
 on `PATH` under whatever name you prefer; the wrapper's only extra job is

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -133,6 +133,11 @@ release. Set `OLC_VERSION` to install a specific tag, or `OLC_INSTALL_DIR` to
 change the destination. Node remains an explicit prerequisite; olc itself and
 its runtime dependency are bundled, so npm is not involved.
 
+Those two commands execute a script fetched from a mutable URL. Each release
+also publishes `olc.sh`, `olc.ps1`, and a `sha256` for each, so the wrapper can
+be pinned to a tag and verified before it runs — see
+[installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell).
+
 To run from a clone instead:
 
 ```bash


### PR DESCRIPTION
## Summary

Closes the remaining half of Greptile's P2 on #345. The archive already had a checksum; the *wrapper* had none, so the one-liner had nothing to verify against and no way to read it first.

- **CI** (`.github/workflows/ci.yml`) — the job that packages the archives now also copies `docs/public/olc.sh` and `olc.ps1` and writes a `sha256` for each. Hashing them in that job keeps the wrappers on the same verified-CI-run provenance path as the archives; generating them in the release job would bypass it.
- **Release** (`.github/workflows/release.yml`) — the four new files join `ASSETS`, and the completeness guard goes 7 → 11. Still additive-only, so a re-run on a moved tag never overwrites a published asset.
- **Docs** — `Install without piping to a shell` now leads with the verifiable path: pin the wrapper to a tag, check its `sha256`, read it, then run it with `OLC_VERSION` set to the same tag. Both shells, including `Unblock-File` and a scoped `-ExecutionPolicy Bypass` for the PowerShell case, since a downloaded file carries the mark of the web that a piped one does not.

## Type of change

- [x] Bug fix
- [x] Docs
- [x] Build / tooling / CI

## Quality gates

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm test:run` — 416 files / 3551 tests
- [x] `pnpm docs:build`

Both workflows re-parsed after editing; the `release-package-olc` artifact list resolves to the eight expected files.

## Surface area / risk

Release pipeline and docs only. No extension code. First release after this carries four more assets; the guard fails loudly rather than publishing a partial set.

## Privacy / local-first

No change.

## Notes

This gives integrity, not authentication: a checksum served from the same release as its file proves the download arrived intact, not that it came from us. The docs now say that explicitly and suggest recording a hash you have checked. Real authentication means a signature — minisign, or keyless cosign via the workflow's OIDC identity. That adds a verification dependency for users, so it is worth deciding on separately rather than slipping into a release-gate PR.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR publishes versioned install wrappers and their checksums through the verified release-artifact pipeline, then documents how to verify and inspect them before execution.
- Adds both install wrappers and checksum files to CI packaging and release publication.
- Updates shell and PowerShell instructions for pinned, verified installation.
- Fixes checksum-tool portability by selecting `sha256sum` when available and otherwise using `shasum`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Packages the shell and PowerShell wrappers with SHA-256 checksum files in the existing verified CI artifact. |
| .github/workflows/release.yml | Adds all four wrapper assets to release publication and updates the completeness guard accordingly. |
| docs/src/content/docs/developers.md | Documents pinned wrapper verification for both shells and resolves the previously reported Linux checksum-command portability issue. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: verify checksums with whichever to..."](https://github.com/shishir435/ollama-client/commit/0d8788d983e450d8654b135e8a877287d5a01bd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59522232)</sub>

<!-- /greptile_comment -->