### PR TITLE
docs: lead the install with the verified path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   recognizable red/yellow/green window controls, and the README no longer
   advertises the removed selected-text tool.
 - Every release now publishes the `olc.sh` and `olc.ps1` install wrappers with a
-  `sha256` for each, alongside the archives they install. The wrapper can be
-  pinned to a tag and verified before it runs instead of being piped straight
-  into a shell, and every place that shows the one-line installer links to that
-  path.
+  `sha256` for each, alongside the archives they install. The READMEs lead with
+  pinning a wrapper to a tag and verifying it before it runs; the one-line
+  installer is documented below it as the unverified quick path, and every guide
+  that shows it links to the verified one.
 - Embedding generation from extension pages now crosses the validated,
   background-owned `embeddings.generate` RPC. The RPC preserves model/provider
   identity, forwards cancellation, and bounds stalled provider work with a

--- a/README.md
+++ b/README.md
@@ -122,18 +122,23 @@ expose those agent runtimes through an OpenAI-compatible local API. It
 requires Node.js 22.12 or newer and the selected runtime on `PATH`.
 
 Every release publishes the install wrappers with a `sha256` for each, so the
-recommended path pins one to a tag and verifies it before it runs.
+recommended path pins one to a tag and verifies it before it runs. The steps are
+chained, so a failed checksum stops before the wrapper executes.
 
 macOS / Linux:
 
 ```bash
 tag=0.13.3
 base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
-curl -fsSL "$base/olc.sh" -o olc.sh
-curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256
-if command -v sha256sum >/dev/null; then sha256sum -c olc.sh.sha256; else shasum -a 256 -c olc.sh.sha256; fi
-less olc.sh
-OLC_VERSION="$tag" sh olc.sh
+curl -fsSL "$base/olc.sh" -o olc.sh &&
+  curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256 &&
+  { if command -v sha256sum >/dev/null
+    then sha256sum -c olc.sh.sha256
+    else shasum -a 256 -c olc.sh.sha256
+    fi
+  } &&
+  less olc.sh &&
+  OLC_VERSION="$tag" sh olc.sh
 ```
 
 Windows PowerShell:
@@ -144,11 +149,14 @@ $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
 irm "$base/olc.ps1" -OutFile olc.ps1
 irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
 $expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
-if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
-Get-Content olc.ps1
-$env:OLC_VERSION = $tag
-Unblock-File olc.ps1
-powershell -ExecutionPolicy Bypass -File ./olc.ps1
+if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) {
+  Write-Error "checksum mismatch: not running olc.ps1"
+} else {
+  Get-Content olc.ps1
+  $env:OLC_VERSION = $tag
+  Unblock-File olc.ps1
+  powershell -ExecutionPolicy Bypass -File ./olc.ps1
+}
 ```
 
 If you would rather not verify anything, the site serves the same wrappers at a

--- a/README.md
+++ b/README.md
@@ -121,36 +121,50 @@ enables trusted-network access, while `olc -b opencode` and `olc -b codex`
 expose those agent runtimes through an OpenAI-compatible local API. It
 requires Node.js 22.12 or newer and the selected runtime on `PATH`.
 
+Every release publishes the install wrappers with a `sha256` for each, so the
+recommended path pins one to a tag and verifies it before it runs.
+
 macOS / Linux:
 
 ```bash
-curl -fsSL https://ollamaclient.in/olc.sh | sh
+tag=0.13.3
+base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
+curl -fsSL "$base/olc.sh" -o olc.sh
+curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256
+if command -v sha256sum >/dev/null; then sha256sum -c olc.sh.sha256; else shasum -a 256 -c olc.sh.sha256; fi
+less olc.sh
+OLC_VERSION="$tag" sh olc.sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm https://ollamaclient.in/olc.ps1 | iex
+$tag = "0.13.3"
+$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+irm "$base/olc.ps1" -OutFile olc.ps1
+irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
+$expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
+if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+Get-Content olc.ps1
+$env:OLC_VERSION = $tag
+Unblock-File olc.ps1
+powershell -ExecutionPolicy Bypass -File ./olc.ps1
 ```
 
-To pin version `0.13.2` on macOS / Linux:
+If you would rather not verify anything, the site serves the same wrappers at a
+mutable URL and both accept `OLC_VERSION`:
 
 ```bash
-export OLC_VERSION=0.13.2
-curl -fsSL https://ollamaclient.in/olc.sh | sh
+curl -fsSL https://ollamaclient.in/olc.sh | sh          # macOS / Linux
 ```
-
-To pin version `0.13.2` in Windows PowerShell:
 
 ```powershell
-$env:OLC_VERSION = "0.13.2"
-irm https://ollamaclient.in/olc.ps1 | iex
+irm https://ollamaclient.in/olc.ps1 | iex               # Windows PowerShell
 ```
 
-These commands pipe a remote script into your shell. Each release also publishes
-the wrappers with their own checksums, so they can be pinned and verified first —
-see
-[installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell).
+That form executes a remote script unread, with your own privileges. The
+[developer guide](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell)
+covers both paths, plus installing the release archive without a wrapper at all.
 
 Then run `olc` for native Ollama, or `olc --help` for all short/long options.
 All modes detach by default; `--debug` or `--foreground` stays attached.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ expose those agent runtimes through an OpenAI-compatible local API. It
 requires Node.js 22.12 or newer and the selected runtime on `PATH`.
 
 Every release publishes the install wrappers with a `sha256` for each, so the
-recommended path pins one to a tag and verifies it before it runs. The steps are
-chained, so a failed checksum stops before the wrapper executes.
+recommended path pins one to a tag and verifies it before it runs. Each block is
+one guarded unit, so a failed download or checksum ends it instead of falling
+through to whatever is already on disk.
 
 macOS / Linux:
 
@@ -145,17 +146,19 @@ Windows PowerShell:
 
 ```powershell
 $tag = "0.13.3"
-$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
-irm "$base/olc.ps1" -OutFile olc.ps1
-irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
-$expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
-if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) {
-  Write-Error "checksum mismatch: not running olc.ps1"
-} else {
-  Get-Content olc.ps1
+try {
+  $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+  $dir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "olc-$tag-$(Get-Random)")).FullName
+  irm "$base/olc.ps1" -OutFile "$dir\olc.ps1" -ErrorAction Stop
+  irm "$base/olc.ps1.sha256" -OutFile "$dir\olc.ps1.sha256" -ErrorAction Stop
+  $expected = (Get-Content "$dir\olc.ps1.sha256").Split(" ")[0]
+  if ((Get-FileHash "$dir\olc.ps1" -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+  Get-Content "$dir\olc.ps1"
   $env:OLC_VERSION = $tag
-  Unblock-File olc.ps1
-  powershell -ExecutionPolicy Bypass -File ./olc.ps1
+  Unblock-File "$dir\olc.ps1"
+  powershell -ExecutionPolicy Bypass -File "$dir\olc.ps1"
+} catch {
+  Write-Error "olc install stopped: $_"
 }
 ```
 

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -51,11 +51,15 @@ Every release publishes both wrappers alongside the archives, each with its own
 ```bash
 tag=0.13.3
 base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
-curl -fsSL "$base/olc.sh" -o olc.sh
-curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256
-if command -v sha256sum >/dev/null; then sha256sum -c olc.sh.sha256; else shasum -a 256 -c olc.sh.sha256; fi
-less olc.sh
-OLC_VERSION="$tag" sh olc.sh
+curl -fsSL "$base/olc.sh" -o olc.sh &&
+  curl -fsSL "$base/olc.sh.sha256" -o olc.sh.sha256 &&
+  { if command -v sha256sum >/dev/null
+    then sha256sum -c olc.sh.sha256
+    else shasum -a 256 -c olc.sh.sha256
+    fi
+  } &&
+  less olc.sh &&
+  OLC_VERSION="$tag" sh olc.sh
 ```
 
 ```powershell
@@ -64,12 +68,19 @@ $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
 irm "$base/olc.ps1" -OutFile olc.ps1
 irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
 $expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
-if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
-Get-Content olc.ps1
-$env:OLC_VERSION = $tag
-Unblock-File olc.ps1
-powershell -ExecutionPolicy Bypass -File ./olc.ps1
+if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) {
+  Write-Error "checksum mismatch: not running olc.ps1"
+} else {
+  Get-Content olc.ps1
+  $env:OLC_VERSION = $tag
+  Unblock-File olc.ps1
+  powershell -ExecutionPolicy Bypass -File ./olc.ps1
+}
 ```
+
+Every step is chained to the one before it, so a failed checksum stops the block
+instead of letting the wrapper run anyway — the point of verifying is lost if the
+next pasted line executes regardless.
 
 A file downloaded rather than piped carries the mark of the web, so PowerShell
 blocks it until `Unblock-File` clears the mark; the explicit policy on that one
@@ -81,11 +92,15 @@ is the same artifact the wrapper would install, and nothing but `tar` runs:
 ```bash
 tag=0.13.3
 base="https://github.com/Shishir435/ollama-client/releases/download/$tag"
-curl -fsSL "$base/olc.tar.gz" -o olc.tar.gz
-curl -fsSL "$base/olc.tar.gz.sha256" -o olc.tar.gz.sha256
-if command -v sha256sum >/dev/null; then sha256sum -c olc.tar.gz.sha256; else shasum -a 256 -c olc.tar.gz.sha256; fi
-tar -xzf olc.tar.gz
-node olc/dist/olc.mjs --help
+curl -fsSL "$base/olc.tar.gz" -o olc.tar.gz &&
+  curl -fsSL "$base/olc.tar.gz.sha256" -o olc.tar.gz.sha256 &&
+  { if command -v sha256sum >/dev/null
+    then sha256sum -c olc.tar.gz.sha256
+    else shasum -a 256 -c olc.tar.gz.sha256
+    fi
+  } &&
+  tar -xzf olc.tar.gz &&
+  node olc/dist/olc.mjs --help
 ```
 
 ```powershell
@@ -94,9 +109,12 @@ $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
 irm "$base/olc.tar.gz" -OutFile olc.tar.gz
 irm "$base/olc.tar.gz.sha256" -OutFile olc.tar.gz.sha256
 $expected = (Get-Content olc.tar.gz.sha256).Split(" ")[0]
-if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
-tar -xzf olc.tar.gz
-node olc/dist/olc.mjs --help
+if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) {
+  Write-Error "checksum mismatch: not running olc.tar.gz"
+} else {
+  tar -xzf olc.tar.gz
+  node olc/dist/olc.mjs --help
+}
 ```
 
 Each checksum is published beside the file it covers on the same release, so it

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -64,23 +64,28 @@ curl -fsSL "$base/olc.sh" -o olc.sh &&
 
 ```powershell
 $tag = "0.13.3"
-$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
-irm "$base/olc.ps1" -OutFile olc.ps1
-irm "$base/olc.ps1.sha256" -OutFile olc.ps1.sha256
-$expected = (Get-Content olc.ps1.sha256).Split(" ")[0]
-if ((Get-FileHash olc.ps1 -Algorithm SHA256).Hash -ne $expected) {
-  Write-Error "checksum mismatch: not running olc.ps1"
-} else {
-  Get-Content olc.ps1
+try {
+  $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+  $dir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "olc-$tag-$(Get-Random)")).FullName
+  irm "$base/olc.ps1" -OutFile "$dir\olc.ps1" -ErrorAction Stop
+  irm "$base/olc.ps1.sha256" -OutFile "$dir\olc.ps1.sha256" -ErrorAction Stop
+  $expected = (Get-Content "$dir\olc.ps1.sha256").Split(" ")[0]
+  if ((Get-FileHash "$dir\olc.ps1" -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+  Get-Content "$dir\olc.ps1"
   $env:OLC_VERSION = $tag
-  Unblock-File olc.ps1
-  powershell -ExecutionPolicy Bypass -File ./olc.ps1
+  Unblock-File "$dir\olc.ps1"
+  powershell -ExecutionPolicy Bypass -File "$dir\olc.ps1"
+} catch {
+  Write-Error "olc install stopped: $_"
 }
 ```
 
-Every step is chained to the one before it, so a failed checksum stops the block
-instead of letting the wrapper run anyway — the point of verifying is lost if the
-next pasted line executes regardless.
+Each block is a single guarded unit rather than a list of independent commands:
+the Unix steps are chained with `&&`, and the PowerShell steps sit inside one
+`try`/`catch` that downloads into a fresh directory. A failed download or a
+mismatched checksum ends the block. Without that, the next pasted line runs
+regardless — on Windows it would hash and execute whatever `olc.ps1` happened to
+be sitting in the working directory.
 
 A file downloaded rather than piped carries the mark of the web, so PowerShell
 blocks it until `Unblock-File` clears the mark; the explicit policy on that one
@@ -105,15 +110,16 @@ curl -fsSL "$base/olc.tar.gz" -o olc.tar.gz &&
 
 ```powershell
 $tag = "0.13.3"
-$base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
-irm "$base/olc.tar.gz" -OutFile olc.tar.gz
-irm "$base/olc.tar.gz.sha256" -OutFile olc.tar.gz.sha256
-$expected = (Get-Content olc.tar.gz.sha256).Split(" ")[0]
-if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) {
-  Write-Error "checksum mismatch: not running olc.tar.gz"
-} else {
+try {
+  $base = "https://github.com/Shishir435/ollama-client/releases/download/$tag"
+  irm "$base/olc.tar.gz" -OutFile olc.tar.gz -ErrorAction Stop
+  irm "$base/olc.tar.gz.sha256" -OutFile olc.tar.gz.sha256 -ErrorAction Stop
+  $expected = (Get-Content olc.tar.gz.sha256).Split(" ")[0]
+  if ((Get-FileHash olc.tar.gz -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
   tar -xzf olc.tar.gz
   node olc/dist/olc.mjs --help
+} catch {
+  Write-Error "olc download stopped: $_"
 }
 ```
 

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -116,7 +116,15 @@ Requires Node ≥ 22.12 and an existing [Ollama installation](https://ollama.com
 (or `--codex`) and an existing `codex login`; olc never reads, stores, or proxies
 the user's OpenAI credentials.
 
-Nothing is published to a registry. Release bundles can be installed directly:
+Nothing is published to a registry. Release bundles can be installed directly.
+
+Each release publishes `olc.sh`, `olc.ps1`, and a `sha256` for each, so the
+recommended path pins a wrapper to a tag and verifies it before it runs — see
+[installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell),
+which also covers installing the archive with no wrapper at all.
+
+The site serves the same wrappers at a mutable URL for a quicker, unverified
+install:
 
 ```powershell
 # Windows PowerShell
@@ -132,11 +140,6 @@ Both installers download a checksum-verified archive from the project's GitHub
 release. Set `OLC_VERSION` to install a specific tag, or `OLC_INSTALL_DIR` to
 change the destination. Node remains an explicit prerequisite; olc itself and
 its runtime dependency are bundled, so npm is not involved.
-
-Those two commands execute a script fetched from a mutable URL. Each release
-also publishes `olc.sh`, `olc.ps1`, and a `sha256` for each, so the wrapper can
-be pinned to a tag and verified before it runs — see
-[installing without piping to a shell](https://www.ollamaclient.in/developers/#install-without-piping-to-a-shell).
 
 To run from a clone instead:
 


### PR DESCRIPTION
## Summary

Last piece of Greptile's P2 on #345. #348 made the wrapper verifiable; this makes verifying it the path a reader reaches first.

- `README.md` — the olc section now opens with pinning a wrapper to a tag and checking its `sha256` before running it, both shells. The one-liner follows, labelled as what it is: a remote script executed unread with the reader's own privileges.
- `packages/olc/README.md` — same order, without duplicating the commands; it names the verified path and links to the developer guide, then offers the pipe as the quicker unverified install.
- Dropped the two `OLC_VERSION=0.13.2` blocks from README. The recommended path already pins, so they were a third way to say it.

## Type of change

- [x] Docs

## Quality gates

- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm test:run`
- [x] `pnpm docs:build`

## Privacy / local-first

No change.

## Notes

The one-liner stays reachable on purpose. It is what rustup, Homebrew, deno, and bun all ship as their headline command; removing it entirely costs a working copy-paste install for no gain once the verified path is the recommended one.

The task guides — quick start, provider setup, CORS troubleshooting — still lead with the one-liner and link onward. A ten-line verify block belongs in a reference page, not in step three of onboarding.

Still integrity rather than authentication: a checksum from the same release as its file proves the download arrived intact, not its origin. Signing (minisign, or keyless cosign over the workflow's OIDC identity) is the real answer and is worth its own decision.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the pinned, checksum-verified wrapper installation the primary documented path and labels mutable-URL shell pipes as unverified alternatives.
- Chains Unix download, checksum, inspection, and execution steps so failures stop the install.
- Uses a fresh temporary directory and terminating download errors for the PowerShell flow.
- Aligns the root README, developer guide, package README, and changelog with the verified-first guidance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Reorders installation guidance and safely guards both Unix and PowerShell verified-wrapper flows. |
| docs/src/content/docs/developers.md | Converts wrapper and archive instructions into guarded units that stop after download or checksum failures. |
| packages/olc/README.md | Leads with the verified installation path and clearly labels the mutable one-line installers as unverified. |
| CHANGELOG.md | Updates the release note to reflect the verified-first documentation ordering. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: guard the PowerShell install again..."](https://github.com/shishir435/ollama-client/commit/32f43bfbcf49652216a31239f8a415966428dcac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59531401)</sub>

<!-- /greptile_comment -->