### PR TITLE
feat(agent): add preview foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.14.0]
+
+### Development
+
+- Supervised Agent Preview begins behind a disabled-by-default release gate.
+  Versioned contracts now define its commands, observations, lifecycle,
+  approvals, takeovers, and safe error vocabulary, while a new pure runtime
+  package enforces legal run transitions and strict isolation from Chat. This
+  foundation adds no browser permission, browser mutation, or visible Agent UI.
+
 ## [0.13.3]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-client",
   "displayName": "Ollama Client - Local AI Chat for Ollama, LM Studio, llama.cpp",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "Local-first browser extension for private LLM chat with Ollama, LM Studio, llama.cpp, and other local or remote providers, with local RAG, web search, and page context.",
   "author": "Shishir Chaurasiya",
   "keywords": [
@@ -90,10 +90,11 @@
     "format:fix": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "pnpm typecheck:packages && tsc6 -p tsconfig.json --noEmit",
-    "typecheck:packages": "pnpm typecheck:contracts && pnpm typecheck:runtime-core && pnpm typecheck:chat-runtime && pnpm typecheck:olc",
+    "typecheck:packages": "pnpm typecheck:contracts && pnpm typecheck:runtime-core && pnpm typecheck:chat-runtime && pnpm typecheck:agent-runtime && pnpm typecheck:olc",
     "typecheck:contracts": "tsc6 -p packages/contracts/tsconfig.json --noEmit",
     "typecheck:runtime-core": "tsc6 -p packages/runtime-core/tsconfig.json --noEmit",
     "typecheck:chat-runtime": "tsc6 -p packages/chat-runtime/tsconfig.json --noEmit",
+    "typecheck:agent-runtime": "tsc6 -p packages/agent-runtime/tsconfig.json --noEmit",
     "typecheck:olc": "tsc6 -p packages/olc/tsconfig.json",
     "check:dead": "knip --no-config-hints",
     "audit": "pnpm audit",
@@ -114,6 +115,7 @@
     "olc": "tsx packages/olc/src/cli.ts"
   },
   "dependencies": {
+    "@ollama-client/agent-runtime": "workspace:*",
     "@ollama-client/chat-runtime": "workspace:*",
     "@ollama-client/contracts": "workspace:*",
     "@ollama-client/runtime-core": "workspace:*",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ollama-client/agent-runtime",
+  "version": "0.14.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./state": "./src/state.ts"
+  },
+  "dependencies": {
+    "@ollama-client/contracts": "workspace:*"
+  }
+}

--- a/packages/agent-runtime/src/__tests__/state.test.ts
+++ b/packages/agent-runtime/src/__tests__/state.test.ts
@@ -1,0 +1,39 @@
+import { AGENT_RUN_STATUSES } from "@ollama-client/contracts"
+import { describe, expect, it } from "vitest"
+import {
+  AGENT_STATUS_PREDECESSORS,
+  isLegalAgentTransition,
+  isTerminalAgentStatus
+} from "../state"
+
+describe("AGENT_STATUS_PREDECESSORS", () => {
+  it("accepts every declared legal transition", () => {
+    for (const to of AGENT_RUN_STATUSES) {
+      for (const from of AGENT_STATUS_PREDECESSORS[to]) {
+        expect(isLegalAgentTransition(from, to)).toBe(true)
+      }
+    }
+  })
+
+  it("rejects transitions from terminal states", () => {
+    for (const from of ["completed", "failed", "cancelled"] as const) {
+      expect(isTerminalAgentStatus(from)).toBe(true)
+      for (const to of AGENT_RUN_STATUSES) {
+        expect(isLegalAgentTransition(from, to)).toBe(false)
+      }
+    }
+  })
+
+  it("does not represent uncertainty as a run status", () => {
+    expect(AGENT_RUN_STATUSES).not.toContain("uncertain")
+  })
+
+  it("requires awaiting_takeover before takeover completion", () => {
+    expect(isLegalAgentTransition("awaiting_takeover", "observing")).toBe(true)
+    expect(isLegalAgentTransition("deciding", "observing")).toBe(false)
+  })
+
+  it("does not permit executing directly from deciding", () => {
+    expect(isLegalAgentTransition("deciding", "executing")).toBe(false)
+  })
+})

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./state"

--- a/packages/agent-runtime/src/state.ts
+++ b/packages/agent-runtime/src/state.ts
@@ -1,0 +1,70 @@
+import type { AgentRunStatus } from "@ollama-client/contracts"
+
+export const TERMINAL_AGENT_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled"
+] as const satisfies readonly AgentRunStatus[]
+
+/**
+ * Legal lifecycle predecessors, stored in the same direction used by a SQL
+ * compare-and-set. A transition not named here must fail closed.
+ */
+export const AGENT_STATUS_PREDECESSORS = {
+  submitted: [],
+  observing: ["submitted", "verifying", "paused", "awaiting_takeover"],
+  deciding: ["observing"],
+  awaiting_approval: ["deciding"],
+  awaiting_takeover: ["deciding", "awaiting_approval"],
+  executing: ["awaiting_approval"],
+  verifying: ["executing"],
+  pause_requested: [
+    "submitted",
+    "observing",
+    "deciding",
+    "awaiting_approval",
+    "awaiting_takeover",
+    "executing",
+    "verifying"
+  ],
+  paused: [
+    "pause_requested",
+    "awaiting_approval",
+    "awaiting_takeover",
+    "verifying"
+  ],
+  cancelling: [
+    "submitted",
+    "observing",
+    "deciding",
+    "awaiting_approval",
+    "awaiting_takeover",
+    "executing",
+    "verifying",
+    "pause_requested",
+    "paused"
+  ],
+  completed: ["deciding", "cancelling"],
+  failed: [
+    "submitted",
+    "observing",
+    "deciding",
+    "awaiting_approval",
+    "awaiting_takeover",
+    "executing",
+    "verifying",
+    "pause_requested",
+    "paused",
+    "cancelling"
+  ],
+  cancelled: ["cancelling"]
+} as const satisfies Readonly<Record<AgentRunStatus, readonly AgentRunStatus[]>>
+
+export const isLegalAgentTransition = (
+  from: AgentRunStatus,
+  to: AgentRunStatus
+): boolean =>
+  (AGENT_STATUS_PREDECESSORS[to] as readonly AgentRunStatus[]).includes(from)
+
+export const isTerminalAgentStatus = (status: AgentRunStatus): boolean =>
+  (TERMINAL_AGENT_STATUSES as readonly AgentRunStatus[]).includes(status)

--- a/packages/agent-runtime/tsconfig.json
+++ b/packages/agent-runtime/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/chat-runtime/package.json
+++ b/packages/chat-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollama-client/chat-runtime",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@ollama-client/contracts",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./agent": "./src/agent.ts",
+    "./agent-command": "./src/agent-command.ts",
+    "./agent-events": "./src/agent-events.ts",
+    "./agent-observation": "./src/agent-observation.ts",
     "./app-failure": "./src/app-failure.ts",
     "./chat": "./src/chat.ts",
     "./context": "./src/context.ts",

--- a/packages/contracts/src/__tests__/agent.test.ts
+++ b/packages/contracts/src/__tests__/agent.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest"
+import {
+  AGENT_RUN_STATUSES,
+  AgentCommandSchema,
+  AgentDecisionSchema,
+  AgentObservationSchema,
+  AgentRunStatusSchema,
+  AgentStepStatusSchema
+} from ".."
+
+const ground = { snapshotId: "snapshot-1", generation: 1 }
+
+describe("agent contract schemas", () => {
+  it("accepts each supported command shape", () => {
+    const commands = [
+      { type: "click", ref: "e1", ...ground },
+      { type: "type", ref: "e1", text: "hello", ...ground },
+      { type: "press_key", ref: "e1", key: "Enter", ...ground },
+      { type: "select", ref: "e1", value: "one", ...ground },
+      { type: "check", ref: "e1", checked: true, ...ground },
+      { type: "scroll", direction: "down", ...ground },
+      { type: "navigate", url: "https://example.com/path", ...ground },
+      { type: "back", ...ground },
+      { type: "forward", ...ground },
+      { type: "open_tab", url: "https://example.com", ...ground },
+      { type: "switch_tab", tabId: 7, ...ground },
+      { type: "wait", condition: "Results appear", timeoutMs: 5_000, ...ground }
+    ]
+
+    for (const command of commands) {
+      expect(AgentCommandSchema.safeParse(command).success).toBe(true)
+    }
+  })
+
+  it("rejects arbitrary JavaScript commands", () => {
+    expect(
+      AgentCommandSchema.safeParse({
+        type: "javascript",
+        script: "document.body.remove()",
+        ...ground
+      }).success
+    ).toBe(false)
+  })
+
+  it("rejects batch decisions containing multiple commands", () => {
+    expect(
+      AgentDecisionSchema.safeParse({
+        type: "command",
+        commands: [
+          { type: "back", ...ground },
+          { type: "forward", ...ground }
+        ]
+      }).success
+    ).toBe(false)
+  })
+
+  it("rejects observations without snapshot identity", () => {
+    expect(
+      AgentObservationSchema.safeParse({
+        url: "https://example.com",
+        origin: "https://example.com",
+        title: "Example",
+        elements: [],
+        visibleText: "Example",
+        scroll: {
+          x: 0,
+          y: 0,
+          viewportWidth: 100,
+          viewportHeight: 100,
+          documentWidth: 100,
+          documentHeight: 100
+        },
+        dialogs: [],
+        capturedAt: 1
+      }).success
+    ).toBe(false)
+  })
+
+  it("rejects sensitive element values", () => {
+    const observation = {
+      snapshotId: "snapshot-1",
+      generation: 1,
+      tabId: 7,
+      documentId: "document-1",
+      url: "https://example.com",
+      origin: "https://example.com",
+      title: "Example",
+      elements: [
+        {
+          ref: "password",
+          frameId: 0,
+          tag: "input",
+          type: "password",
+          value: "secret",
+          visible: true,
+          enabled: true,
+          editable: true,
+          sensitive: true
+        }
+      ],
+      visibleText: "",
+      scroll: {
+        x: 0,
+        y: 0,
+        viewportWidth: 100,
+        viewportHeight: 100,
+        documentWidth: 100,
+        documentHeight: 100
+      },
+      dialogs: [],
+      capturedAt: 1
+    }
+
+    expect(AgentObservationSchema.safeParse(observation).success).toBe(false)
+  })
+
+  it("rejects unknown run and step statuses", () => {
+    expect(AgentRunStatusSchema.safeParse("uncertain").success).toBe(false)
+    expect(AgentStepStatusSchema.safeParse("running").success).toBe(false)
+    expect(AGENT_RUN_STATUSES).not.toContain("uncertain")
+  })
+})

--- a/packages/contracts/src/agent-command.ts
+++ b/packages/contracts/src/agent-command.ts
@@ -1,0 +1,56 @@
+import { z } from "zod"
+
+const GroundedCommandSchema = z.object({
+  snapshotId: z.string().min(1),
+  generation: z.number().int().nonnegative()
+})
+
+const ElementCommandSchema = GroundedCommandSchema.extend({
+  ref: z.string().min(1)
+})
+
+export const AgentCommandSchema = z.discriminatedUnion("type", [
+  ElementCommandSchema.extend({ type: z.literal("click") }).strict(),
+  ElementCommandSchema.extend({
+    type: z.literal("type"),
+    text: z.string().max(20_000)
+  }).strict(),
+  ElementCommandSchema.extend({
+    type: z.literal("press_key"),
+    key: z.enum(["Enter", "Escape", "Tab", "ArrowUp", "ArrowDown"])
+  }).strict(),
+  ElementCommandSchema.extend({
+    type: z.literal("select"),
+    value: z.string().max(2_000)
+  }).strict(),
+  ElementCommandSchema.extend({
+    type: z.literal("check"),
+    checked: z.boolean()
+  }).strict(),
+  GroundedCommandSchema.extend({
+    type: z.literal("scroll"),
+    direction: z.enum(["up", "down", "left", "right"]),
+    amount: z.number().finite().positive().max(10_000).optional(),
+    ref: z.string().min(1).optional()
+  }).strict(),
+  GroundedCommandSchema.extend({
+    type: z.literal("navigate"),
+    url: z.url()
+  }).strict(),
+  GroundedCommandSchema.extend({ type: z.literal("back") }).strict(),
+  GroundedCommandSchema.extend({ type: z.literal("forward") }).strict(),
+  GroundedCommandSchema.extend({
+    type: z.literal("open_tab"),
+    url: z.url()
+  }).strict(),
+  GroundedCommandSchema.extend({
+    type: z.literal("switch_tab"),
+    tabId: z.number().int().nonnegative()
+  }).strict(),
+  GroundedCommandSchema.extend({
+    type: z.literal("wait"),
+    condition: z.string().min(1).max(500),
+    timeoutMs: z.number().int().positive().max(30_000)
+  }).strict()
+])
+export type AgentCommand = z.infer<typeof AgentCommandSchema>

--- a/packages/contracts/src/agent-events.ts
+++ b/packages/contracts/src/agent-events.ts
@@ -1,0 +1,43 @@
+import { z } from "zod"
+import {
+  AgentApprovalRequestSchema,
+  AgentDecisionSchema,
+  AgentErrorSchema,
+  AgentPauseReasonSchema,
+  AgentRunStatusSchema,
+  AgentTakeoverRequestSchema
+} from "./agent"
+
+const EventBaseSchema = z.object({
+  runId: z.string().min(1),
+  at: z.number().int().nonnegative()
+})
+
+export const AgentEventSchema = z.discriminatedUnion("type", [
+  EventBaseSchema.extend({
+    type: z.literal("status_changed"),
+    from: AgentRunStatusSchema,
+    to: AgentRunStatusSchema
+  }).strict(),
+  EventBaseSchema.extend({
+    type: z.literal("decision_received"),
+    decision: AgentDecisionSchema
+  }).strict(),
+  EventBaseSchema.extend({
+    type: z.literal("approval_requested"),
+    request: AgentApprovalRequestSchema
+  }).strict(),
+  EventBaseSchema.extend({
+    type: z.literal("takeover_requested"),
+    request: AgentTakeoverRequestSchema
+  }).strict(),
+  EventBaseSchema.extend({
+    type: z.literal("pause_requested"),
+    reason: AgentPauseReasonSchema
+  }).strict(),
+  EventBaseSchema.extend({
+    type: z.literal("failed"),
+    error: AgentErrorSchema
+  }).strict()
+])
+export type AgentEvent = z.infer<typeof AgentEventSchema>

--- a/packages/contracts/src/agent-observation.ts
+++ b/packages/contracts/src/agent-observation.ts
@@ -1,0 +1,63 @@
+import { z } from "zod"
+
+export const AgentSnapshotIdentitySchema = z.object({
+  snapshotId: z.string().min(1),
+  generation: z.number().int().nonnegative(),
+  tabId: z.number().int().nonnegative(),
+  documentId: z.string().min(1)
+})
+export type AgentSnapshotIdentity = z.infer<typeof AgentSnapshotIdentitySchema>
+
+export const AgentElementSchema = z
+  .object({
+    ref: z.string().min(1),
+    frameId: z.number().int().nonnegative(),
+    role: z.string().min(1).optional(),
+    name: z.string().optional(),
+    tag: z.string().min(1),
+    type: z.string().min(1).optional(),
+    value: z.string().optional(),
+    visible: z.boolean(),
+    enabled: z.boolean(),
+    editable: z.boolean(),
+    sensitive: z.boolean()
+  })
+  .strict()
+  .superRefine((element, context) => {
+    if (element.sensitive && element.value !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Sensitive element values must be omitted"
+      })
+    }
+  })
+export type AgentElement = z.infer<typeof AgentElementSchema>
+
+export const AgentScrollStateSchema = z.object({
+  x: z.number().finite(),
+  y: z.number().finite(),
+  viewportWidth: z.number().finite().nonnegative(),
+  viewportHeight: z.number().finite().nonnegative(),
+  documentWidth: z.number().finite().nonnegative(),
+  documentHeight: z.number().finite().nonnegative()
+})
+export type AgentScrollState = z.infer<typeof AgentScrollStateSchema>
+
+export const AgentDialogStateSchema = z.object({
+  type: z.enum(["alert", "confirm", "prompt", "beforeunload"]),
+  message: z.string().max(500)
+})
+export type AgentDialogState = z.infer<typeof AgentDialogStateSchema>
+
+export const AgentObservationSchema = AgentSnapshotIdentitySchema.extend({
+  url: z.url(),
+  origin: z.url(),
+  title: z.string().max(500),
+  elements: z.array(AgentElementSchema).max(2_000),
+  visibleText: z.string().max(100_000),
+  scroll: AgentScrollStateSchema,
+  dialogs: z.array(AgentDialogStateSchema).max(10),
+  capturedAt: z.number().int().nonnegative()
+}).strict()
+export type AgentObservation = z.infer<typeof AgentObservationSchema>

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1,0 +1,136 @@
+import { z } from "zod"
+import { AgentCommandSchema } from "./agent-command"
+
+export const AGENT_RUN_STATUSES = [
+  "submitted",
+  "observing",
+  "deciding",
+  "awaiting_approval",
+  "awaiting_takeover",
+  "executing",
+  "verifying",
+  "pause_requested",
+  "paused",
+  "cancelling",
+  "completed",
+  "failed",
+  "cancelled"
+] as const
+export const AgentRunStatusSchema = z.enum(AGENT_RUN_STATUSES)
+export type AgentRunStatus = z.infer<typeof AgentRunStatusSchema>
+
+export const AGENT_PAUSE_REASONS = [
+  "user",
+  "panel_closed",
+  "unresolved_effect",
+  "takeover"
+] as const
+export const AgentPauseReasonSchema = z.enum(AGENT_PAUSE_REASONS)
+export type AgentPauseReason = z.infer<typeof AgentPauseReasonSchema>
+
+export const AGENT_STEP_STATUSES = [
+  "planned",
+  "approved",
+  "executing",
+  "executed",
+  "verified",
+  "rejected",
+  "failed",
+  "uncertain"
+] as const
+export const AgentStepStatusSchema = z.enum(AGENT_STEP_STATUSES)
+export type AgentStepStatus = z.infer<typeof AgentStepStatusSchema>
+
+export const AgentDecisionSchema = z.discriminatedUnion("type", [
+  z
+    .object({ type: z.literal("command"), command: AgentCommandSchema })
+    .strict(),
+  z
+    .object({
+      type: z.literal("ask_user"),
+      question: z.string().min(1).max(2_000)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("complete"),
+      summary: z.string().min(1).max(20_000)
+    })
+    .strict(),
+  z
+    .object({ type: z.literal("fail"), reason: z.string().min(1).max(2_000) })
+    .strict()
+])
+export type AgentDecision = z.infer<typeof AgentDecisionSchema>
+
+export const AgentApprovalRequestSchema = z
+  .object({
+    id: z.string().min(1),
+    runId: z.string().min(1),
+    stepId: z.string().min(1),
+    risk: z.enum(["medium", "high", "critical"]),
+    action: z.string().min(1).max(500),
+    consequence: z.string().min(1).max(1_000),
+    pageEvidence: z.string().max(1_000).optional(),
+    createdAt: z.number().int().nonnegative()
+  })
+  .strict()
+export type AgentApprovalRequest = z.infer<typeof AgentApprovalRequestSchema>
+
+export const AgentTakeoverRequestSchema = z
+  .object({
+    id: z.string().min(1),
+    runId: z.string().min(1),
+    stepId: z.string().min(1),
+    reason: z.enum([
+      "authentication",
+      "captcha",
+      "file_upload",
+      "payment",
+      "permission_prompt",
+      "sensitive_input",
+      "unsupported_control"
+    ]),
+    instruction: z.string().min(1).max(1_000),
+    createdAt: z.number().int().nonnegative()
+  })
+  .strict()
+export type AgentTakeoverRequest = z.infer<typeof AgentTakeoverRequestSchema>
+
+export const AgentErrorSchema = z
+  .object({
+    code: z.enum([
+      "budget_exhausted",
+      "invalid_decision",
+      "model_unavailable",
+      "observation_failed",
+      "policy_blocked",
+      "stale_snapshot",
+      "unsupported_page",
+      "verification_failed"
+    ]),
+    message: z.string().min(1).max(1_000),
+    retryable: z.boolean()
+  })
+  .strict()
+export type AgentError = z.infer<typeof AgentErrorSchema>
+
+export const AgentRunStateSchema = z
+  .object({
+    version: z.literal(1),
+    id: z.string().min(1),
+    goal: z.string().min(1).max(20_000),
+    status: AgentRunStatusSchema,
+    pauseReason: AgentPauseReasonSchema.optional(),
+    stepCount: z.number().int().nonnegative().max(25),
+    observationCount: z.number().int().nonnegative(),
+    controlledTabId: z.number().int().nonnegative(),
+    providerId: z.string().min(1),
+    modelId: z.string().min(1),
+    allowedOrigins: z.array(z.string().min(1)).max(25),
+    error: AgentErrorSchema.optional(),
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative()
+  })
+  .strict()
+export type AgentRunState = z.infer<typeof AgentRunStateSchema>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,7 @@
+export * from "./agent"
+export * from "./agent-command"
+export * from "./agent-events"
+export * from "./agent-observation"
 export * from "./app-failure"
 export * from "./chat"
 export * from "./context"

--- a/packages/olc/package.json
+++ b/packages/olc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollama-client/olc",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "OpenAI-compatible proxy for a local agent runtime, with a tool bridge that lets OpenAI-compatible clients run their own tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollama-client/runtime-core",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      '@ollama-client/agent-runtime':
+        specifier: workspace:*
+        version: link:packages/agent-runtime
       '@ollama-client/chat-runtime':
         specifier: workspace:*
         version: link:packages/chat-runtime
@@ -343,6 +346,12 @@ importers:
       typescript:
         specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
+
+  packages/agent-runtime:
+    dependencies:
+      '@ollama-client/contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/chat-runtime:
     dependencies:
@@ -3004,6 +3013,7 @@ packages:
   '@xmldom/xmldom@0.9.11':
     resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zip.js/zip.js@2.8.31':
     resolution: {integrity: sha512-2NLmow9ax/5IdBbJKxNQp3Ur9mNxmgLfN2Yp/FKNh1ZIGs3OYkiC3AIUfIZouTPSgeW5+F1bzTAZAyD2Y4ZfFA==}

--- a/src/background/agent/agent-composition.ts
+++ b/src/background/agent/agent-composition.ts
@@ -1,0 +1,17 @@
+import { isLegalAgentTransition } from "@ollama-client/agent-runtime"
+import { FEATURE_FLAGS } from "@/lib/feature-flags"
+
+export interface AgentComposition {
+  canTransition: typeof isLegalAgentTransition
+}
+
+/**
+ * The disabled release gate intentionally registers no listeners, ports,
+ * permissions, or UI. Later PRs can assemble ports here without coupling the
+ * agent domain to Chat's composition.
+ */
+export const createAgentComposition = (): AgentComposition | undefined => {
+  if (!FEATURE_FLAGS.agentPreview) return undefined
+
+  return { canTransition: isLegalAgentTransition }
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,6 @@
 import "webextension-polyfill"
 
+import { createAgentComposition } from "@/background/agent/agent-composition"
 import { registerMessageRouter } from "@/background/message-router"
 import { startPersistenceTopology } from "@/background/persistence-readiness"
 import { registerPortRouter } from "@/background/port-router"
@@ -15,6 +16,7 @@ import { registerTabLifecycle } from "@/background/tab-lifecycle"
  */
 const persistenceReady = startPersistenceTopology()
 
+createAgentComposition()
 initializeBackgroundStartup(persistenceReady)
 registerPortRouter()
 registerMessageRouter()

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -224,16 +224,19 @@ describe("architecture import boundaries", () => {
     expect(offenders).toEqual([])
   })
 
-  it("prevents background agent composition from importing chat", () => {
-    const source = readFileSync(
-      join(sourceRoot, "background/agent/agent-composition.ts"),
-      "utf8"
-    )
-    const offenders = referencedModules(source).filter((module) =>
-      /^@\/(?:application\/turns|features\/chat|background\/turns)\//.test(
-        module
-      )
-    )
+  it("prevents background agent modules from importing chat", () => {
+    const offenders = productionSources
+      .filter((file) => file.startsWith("background/agent/"))
+      .flatMap((file) => {
+        const source = readFileSync(join(sourceRoot, file), "utf8")
+        return referencedModules(source)
+          .filter((module) =>
+            /^@\/(?:application\/turns|features\/chat|background\/turns)\//.test(
+              module
+            )
+          )
+          .map((module) => ({ file, module }))
+      })
 
     expect(offenders).toEqual([])
   })

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest"
 
 const sourceRoot = join(process.cwd(), "src")
 const chatRuntimeRoot = join(process.cwd(), "packages/chat-runtime/src")
+const agentRuntimeRoot = join(process.cwd(), "packages/agent-runtime/src")
 const contractsRoot = join(process.cwd(), "packages/contracts/src")
 const runtimeCoreRoot = join(process.cwd(), "packages/runtime-core/src")
 
@@ -198,27 +199,57 @@ describe("architecture import boundaries", () => {
     expect(offenders).toEqual([])
   })
 
-  it("keeps chat and future agent domains mutually independent", () => {
-    const chatRoots = ["application/turns/", "features/chat/"]
+  it("prevents agent application and features from importing chat", () => {
     const agentRoots = ["application/agent/", "features/agent/"]
     const offenders = productionSources.filter((file) => {
+      if (!agentRoots.some((root) => file.startsWith(root))) return false
       const source = readFileSync(join(sourceRoot, file), "utf8")
-      if (chatRoots.some((root) => file.startsWith(root))) {
-        return importsModule(
-          source,
-          /@\/(?:application|features)\/agent\/[^"']+/
-        )
-      }
-      if (agentRoots.some((root) => file.startsWith(root))) {
-        return importsModule(
-          source,
-          /@\/(?:application\/turns|features\/chat)\/[^"']+/
-        )
-      }
-      return false
+      return importsModule(
+        source,
+        /@\/(?:application\/turns|features\/chat)\/[^"']+/
+      )
     })
 
     expect(offenders).toEqual([])
+  })
+
+  it("prevents chat application and features from importing agent", () => {
+    const chatRoots = ["application/turns/", "features/chat/"]
+    const offenders = productionSources.filter((file) => {
+      if (!chatRoots.some((root) => file.startsWith(root))) return false
+      const source = readFileSync(join(sourceRoot, file), "utf8")
+      return importsModule(source, /@\/(?:application|features)\/agent\/[^"']+/)
+    })
+
+    expect(offenders).toEqual([])
+  })
+
+  it("prevents background agent composition from importing chat", () => {
+    const source = readFileSync(
+      join(sourceRoot, "background/agent/agent-composition.ts"),
+      "utf8"
+    )
+    const offenders = referencedModules(source).filter((module) =>
+      /^@\/(?:application\/turns|features\/chat|background\/turns)\//.test(
+        module
+      )
+    )
+
+    expect(offenders).toEqual([])
+  })
+
+  it("allows chat and agent domains to depend on shared infrastructure", () => {
+    const references = [
+      'import type { AgentRunState } from "@ollama-client/contracts"',
+      'import { FEATURE_FLAGS } from "@/lib/feature-flags"',
+      'import type { AppFailure } from "@/lib/errors"'
+    ]
+    const forbidden =
+      /@\/(?:application\/turns|features\/(?:agent|chat))\/[^"']+/
+
+    expect(references.some((source) => importsModule(source, forbidden))).toBe(
+      false
+    )
   })
 
   it("keeps package candidates free of environment and UI adapters", () => {
@@ -292,6 +323,27 @@ describe("architecture import boundaries", () => {
         )
         .map((module) => ({
           file: relative(chatRuntimeRoot, file).replaceAll("\\", "/"),
+          module
+        }))
+    })
+
+    expect(offenders).toEqual([])
+  })
+
+  it("keeps agent-runtime behind contracts and relative ports", () => {
+    const runtimeSources = walk(agentRuntimeRoot)
+      .filter((file) => /\.ts$/.test(file))
+      .filter((file) => !file.endsWith(".test.ts"))
+    const offenders = runtimeSources.flatMap((file) => {
+      const source = readFileSync(file, "utf8")
+      return referencedModules(source)
+        .filter(
+          (module) =>
+            !module.startsWith(".") &&
+            !module.startsWith("@ollama-client/contracts")
+        )
+        .map((module) => ({
+          file: relative(agentRuntimeRoot, file).replaceAll("\\", "/"),
           module
         }))
     })

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,7 @@
+/**
+ * Compile-time product gates. Agent Preview remains inert until its contracts,
+ * runtime, perception transport, dry-run loop, and durable owner have landed.
+ */
+export const FEATURE_FLAGS = Object.freeze({
+  agentPreview: false
+})


### PR DESCRIPTION
## Summary

- bump the extension and every workspace package to 0.14.0
- add versioned Agent command, observation, event, lifecycle, approval, takeover, and error contracts
- add the pure `@ollama-client/agent-runtime` lifecycle package and legal-transition tests
- enforce Chat/Agent dependency boundaries
- add a disabled-by-default Agent Preview composition gate

## Safety boundary

- no browser permission changes
- no browser observation or mutation
- no user-visible Agent UI
- no changes to Chat behavior

## Verification

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm check:dead`
- `pnpm test:run` — 418 files, 3,566 tests passed



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes the disabled-by-default Agent Preview foundation without adding browser behavior or changing Chat.

- Adds versioned Agent commands, observations, events, approvals, takeovers, errors, and run-state contracts.
- Adds a pure Agent runtime with explicit lifecycle-transition validation and tests.
- Adds a background composition gate that remains disabled and registers no listeners, ports, permissions, or UI.
- Extends architecture tests to scan every module under `src/background/agent/`, resolving the prior boundary-coverage finding.
- Updates extension and workspace package versions to 0.14.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/contracts/src/agent.ts | Defines the versioned Agent lifecycle, decision, approval, takeover, error, and persisted run-state contracts. |
| packages/contracts/src/agent-command.ts | Defines strict, grounded, single-action browser command schemas with bounded inputs. |
| packages/contracts/src/agent-observation.ts | Defines bounded observation schemas and rejects values attached to sensitive elements. |
| packages/agent-runtime/src/state.ts | Implements the pure, fail-closed Agent lifecycle transition table and terminal-state predicate. |
| src/background/agent/agent-composition.ts | Adds an inert Agent composition seam guarded by a disabled compile-time feature flag. |
| src/lib/__tests__/architecture-boundaries.test.ts | Expands Agent/Chat isolation checks to all production modules under the background Agent directory and package runtime. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Submitted[submitted] --> Observing[observing]
  Observing --> Deciding[deciding]
  Deciding --> Approval[awaiting_approval]
  Deciding --> Takeover[awaiting_takeover]
  Approval --> Executing[executing]
  Approval --> Takeover
  Takeover --> Observing
  Executing --> Verifying[verifying]
  Verifying --> Observing
  Deciding --> Completed[completed]
  AnyActive[active states] --> PauseRequested[pause_requested]
  PauseRequested --> Paused[paused]
  Paused --> Observing
  AnyActive --> Cancelling[cancelling]
  Cancelling --> Cancelled[cancelled]
  AnyActive --> Failed[failed]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(agent): scan all background modules"](https://github.com/shishir435/ollama-client/commit/4b0e3db505cba51862c664363867894b462b38c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59564293)</sub>

<!-- /greptile_comment -->