### PR TITLE
feat(agent): add perception transport

### DIFF
--- a/config/__tests__/manifest-agent-permissions.test.ts
+++ b/config/__tests__/manifest-agent-permissions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import config from "../../wxt.config"
+
+type ManifestFn = (env: {
+  browser: string
+  command: string
+  manifestVersion: number
+  mode: string
+}) => { permissions?: string[]; optional_permissions?: string[] }
+
+const manifestFor = (browser: string) =>
+  (config.manifest as unknown as ManifestFn)({
+    browser,
+    command: "build",
+    manifestVersion: browser === "firefox" ? 2 : 3,
+    mode: "production"
+  })
+
+describe("Agent perception permission placement", () => {
+  it("declares webNavigation as optional rather than standing", () => {
+    for (const browser of ["chrome", "firefox"]) {
+      const manifest = manifestFor(browser)
+      expect(manifest.optional_permissions).toContain("webNavigation")
+      expect(manifest.permissions).not.toContain("webNavigation")
+    }
+  })
+
+  it("does not add unrelated powerful permissions", () => {
+    const manifest = manifestFor("chrome")
+    for (const permission of [
+      "debugger",
+      "cookies",
+      "webRequest",
+      "nativeMessaging",
+      "power"
+    ]) {
+      expect(manifest.permissions).not.toContain(permission)
+      expect(manifest.optional_permissions).not.toContain(permission)
+    }
+  })
+})

--- a/config/__tests__/wxt-build-config.test.ts
+++ b/config/__tests__/wxt-build-config.test.ts
@@ -28,6 +28,7 @@ describe("devEntrypointsToStrip", () => {
       "spike-owner",
       "spike-owner-offscreen",
       "persistence-verify",
+      "agent-perception-harness",
       "ingestion-processor"
     ])
   })
@@ -200,6 +201,8 @@ describe("env wiring", () => {
       { name: "spike-owner" },
       { name: "spike-owner-offscreen" },
       { name: "persistence-verify" },
+      { name: "agent-perception-harness" },
+      { name: "agent-control" },
       { name: "persistence-host" },
       { name: "ingestion-processor" },
       { name: "background" }
@@ -246,6 +249,9 @@ describe("env wiring", () => {
     delete process.env.WXT_SPIKE_OWNER
 
     expect(strippedFor("chrome")).toContain("persistence-verify")
+    expect(strippedFor("chrome")).toContain("agent-perception-harness")
+    expect(strippedFor("chrome")).not.toContain("agent-control")
+    expect(strippedFor("firefox")).toContain("agent-control")
     expect(definesFor("chrome").__SPIKE_OPFS_OWNER__).toBe("false")
     expect(definesFor("firefox").__SPIKE_OPFS_OWNER_MV2__).toBe("false")
   })

--- a/config/wxt-hooks.ts
+++ b/config/wxt-hooks.ts
@@ -8,15 +8,17 @@ type WxtHooks = NonNullable<Parameters<typeof defineConfig>[0]["hooks"]>
  *
  * Never in a store package. `benchmark` and `spike-opfs` are the measurement
  * pages, `spike-owner`/`spike-owner-offscreen` are the owner-topology spike,
- * and `persistence-verify` drives the production OPFS path for
- * verify-opfs-migration.
+ * `persistence-verify` drives the production OPFS path for
+ * verify-opfs-migration, and `agent-perception-harness` exercises the
+ * read-only Agent protocol without creating a store-visible surface.
  */
 const DEV_ENTRYPOINTS = [
   "benchmark",
   "spike-opfs",
   "spike-owner",
   "spike-owner-offscreen",
-  "persistence-verify"
+  "persistence-verify",
+  "agent-perception-harness"
 ] as const
 
 export interface BuildTarget {
@@ -63,7 +65,7 @@ export const devEntrypointsToStrip = (target: BuildTarget): string[] => {
   // Firefox needs a separate hidden page because loading file processors into
   // its persistent background page would add several megabytes.
   return target.browser === "firefox"
-    ? [...devOnly, "persistence-host"]
+    ? [...devOnly, "persistence-host", "agent-control"]
     : [...devOnly, "ingestion-processor"]
 }
 

--- a/src/background/__tests__/runtime-sender-authorization.test.ts
+++ b/src/background/__tests__/runtime-sender-authorization.test.ts
@@ -128,6 +128,7 @@ describe("runtime sender authorization", () => {
       portMessageAllowed(portName, MESSAGE_KEYS.PROVIDER.CHAT_WITH_MODEL)
     ).toBe(false)
     expect(portAllowed(MESSAGE_KEYS.BROWSER.SELECTION_BRIDGE_PORT)).toBe(false)
+    expect(portAllowed(MESSAGE_KEYS.AGENT.CONTROL_PORT)).toBe(false)
   })
 
   it("rejects every message and port from foreign senders", () => {

--- a/src/contents/agent-control.ts
+++ b/src/contents/agent-control.ts
@@ -1,0 +1,39 @@
+import type { Runtime } from "webextension-polyfill"
+import {
+  type AgentControlPort,
+  attachAgentControlContentPort
+} from "@/lib/browser-agent/control-port"
+import { createAgentElementReferenceStore } from "@/lib/browser-agent/element-references"
+import { buildAgentObservation } from "@/lib/browser-agent/observation-builder"
+import { browser } from "@/lib/browser-api"
+
+const INSTALL_MARKER = "__ollamaClientAgentControlInstalled__"
+
+export const installAgentControlContentScript = (): void => {
+  const scope = globalThis as typeof globalThis & Record<string, unknown>
+  if (scope[INSTALL_MARKER]) return
+  scope[INSTALL_MARKER] = true
+
+  browser.runtime.onConnect.addListener(((rawPort: Runtime.Port) => {
+    let references:
+      | ReturnType<typeof createAgentElementReferenceStore>
+      | undefined
+    attachAgentControlContentPort(
+      rawPort as unknown as AgentControlPort,
+      (request) => {
+        references ??= createAgentElementReferenceStore({
+          documentId: request.documentId
+        })
+        return buildAgentObservation({
+          document,
+          tabId: request.tabId,
+          documentId: request.documentId,
+          minimumGeneration: request.minimumGeneration,
+          references
+        })
+      }
+    )
+  }) as Parameters<typeof browser.runtime.onConnect.addListener>[0])
+}
+
+installAgentControlContentScript()

--- a/src/entrypoints/agent-control.content.ts
+++ b/src/entrypoints/agent-control.content.ts
@@ -1,0 +1,9 @@
+import { defineContentScript } from "wxt/utils/define-content-script"
+
+export default defineContentScript({
+  matches: ["http://*/*", "https://*/*"],
+  registration: "runtime",
+  main() {
+    return import("@/contents/agent-control")
+  }
+})

--- a/src/entrypoints/agent-perception-harness/index.html
+++ b/src/entrypoints/agent-perception-harness/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agent Perception Harness</title>
+  </head>
+  <body>
+    <main>
+      <h1>Agent Perception Harness</h1>
+      <textarea id="envelope" rows="18" cols="100"></textarea>
+      <button id="validate" type="button">Validate request</button>
+      <pre id="result"></pre>
+    </main>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/entrypoints/agent-perception-harness/main.ts
+++ b/src/entrypoints/agent-perception-harness/main.ts
@@ -1,0 +1,15 @@
+import { AgentObserveRequestSchema } from "@/lib/browser-agent/control-port"
+
+const envelope = document.querySelector<HTMLTextAreaElement>("#envelope")
+const validate = document.querySelector<HTMLButtonElement>("#validate")
+const result = document.querySelector<HTMLElement>("#result")
+
+validate?.addEventListener("click", () => {
+  if (!envelope || !result) return
+  try {
+    const parsed = AgentObserveRequestSchema.parse(JSON.parse(envelope.value))
+    result.textContent = JSON.stringify(parsed, null, 2)
+  } catch {
+    result.textContent = "Rejected invalid Agent control request"
+  }
+})

--- a/src/lib/__tests__/architecture-boundaries.test.ts
+++ b/src/lib/__tests__/architecture-boundaries.test.ts
@@ -200,13 +200,17 @@ describe("architecture import boundaries", () => {
   })
 
   it("prevents agent application and features from importing chat", () => {
-    const agentRoots = ["application/agent/", "features/agent/"]
+    const agentRoots = [
+      "application/agent/",
+      "features/agent/",
+      "lib/browser-agent/"
+    ]
     const offenders = productionSources.filter((file) => {
       if (!agentRoots.some((root) => file.startsWith(root))) return false
       const source = readFileSync(join(sourceRoot, file), "utf8")
       return importsModule(
         source,
-        /@\/(?:application\/turns|features\/chat)\/[^"']+/
+        /(?:@\/(?:application\/turns|background\/turns|features\/chat)\/[^"']+|@ollama-client\/chat-runtime(?:\/[^"']+)?)/
       )
     })
 
@@ -218,7 +222,10 @@ describe("architecture import boundaries", () => {
     const offenders = productionSources.filter((file) => {
       if (!chatRoots.some((root) => file.startsWith(root))) return false
       const source = readFileSync(join(sourceRoot, file), "utf8")
-      return importsModule(source, /@\/(?:application|features)\/agent\/[^"']+/)
+      return importsModule(
+        source,
+        /(?:@\/(?:application|features)\/agent\/[^"']+|@\/lib\/browser-agent\/[^"']+|@ollama-client\/agent-runtime(?:\/[^"']+)?)/
+      )
     })
 
     expect(offenders).toEqual([])

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
+  hasAgentPerceptionPermission,
   hasPermission,
   removePermission,
+  requestAgentPerceptionPermission,
   requestPermission,
   requestPermissions
 } from "@/lib/permissions"
@@ -45,6 +47,15 @@ describe("permissions helper", () => {
     expect(request).toHaveBeenCalledWith({
       permissions: ["alarms", "notifications"]
     })
+  })
+
+  it("requests webNavigation only through the Agent user-gesture helper", async () => {
+    contains.mockResolvedValue(true)
+    request.mockResolvedValue(true)
+    await expect(hasAgentPerceptionPermission()).resolves.toBe(true)
+    await expect(requestAgentPerceptionPermission()).resolves.toBe(true)
+    expect(contains).toHaveBeenCalledWith({ permissions: ["webNavigation"] })
+    expect(request).toHaveBeenCalledWith({ permissions: ["webNavigation"] })
   })
 
   it("removePermission returns the removal result", async () => {

--- a/src/lib/browser-agent/__tests__/control-port.test.ts
+++ b/src/lib/browser-agent/__tests__/control-port.test.ts
@@ -1,0 +1,289 @@
+import type { AgentObservation } from "@ollama-client/contracts"
+import { describe, expect, it, vi } from "vitest"
+
+import { MESSAGE_KEYS } from "@/lib/constants"
+import {
+  AGENT_CONTROL_VERSION,
+  type AgentControlBrowserAdapter,
+  type AgentControlEvent,
+  type AgentControlPort,
+  AgentObserveRequestSchema,
+  attachAgentControlContentPort,
+  createAgentControlSession,
+  openAgentControlSession,
+  validateAgentObservationResponse
+} from "../control-port"
+
+class FakeEvent<T extends (...args: never[]) => unknown>
+  implements AgentControlEvent<T>
+{
+  listeners = new Set<T>()
+  addListener = (listener: T) => this.listeners.add(listener)
+  removeListener = (listener: T) => this.listeners.delete(listener)
+  emit(...args: Parameters<T>) {
+    for (const listener of this.listeners) listener(...args)
+  }
+}
+
+const observation = (overrides: Partial<AgentObservation> = {}) =>
+  ({
+    snapshotId: "snapshot-1",
+    generation: 1,
+    tabId: 7,
+    documentId: "document-1",
+    url: "https://example.com/",
+    origin: "https://example.com",
+    title: "Example",
+    elements: [],
+    visibleText: "Example",
+    scroll: {
+      x: 0,
+      y: 0,
+      viewportWidth: 100,
+      viewportHeight: 100,
+      documentWidth: 100,
+      documentHeight: 100
+    },
+    dialogs: [],
+    capturedAt: 1,
+    ...overrides
+  }) satisfies AgentObservation
+
+const binding = {
+  runId: "run-1",
+  tabId: 7,
+  frameId: 0 as const,
+  nonce: "0123456789abcdef",
+  documentId: "document-1"
+}
+
+const response = (overrides: Record<string, unknown> = {}) => ({
+  version: AGENT_CONTROL_VERSION,
+  type: "agent_observation",
+  ...binding,
+  sequence: 1,
+  observation: observation(),
+  ...overrides
+})
+
+const createPort = () => {
+  const onMessage = new FakeEvent<(message: unknown) => void>()
+  const onDisconnect = new FakeEvent<() => void>()
+  const port: AgentControlPort = {
+    name: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage,
+    onDisconnect
+  }
+  return { port, onMessage, onDisconnect }
+}
+
+describe("Agent control port", () => {
+  it("rejects malformed and unversioned envelopes with Zod", () => {
+    expect(
+      AgentObserveRequestSchema.safeParse({ type: "agent_observe" }).success
+    ).toBe(false)
+    expect(
+      AgentObserveRequestSchema.safeParse({
+        version: 99,
+        type: "agent_observe",
+        ...binding,
+        sequence: 1,
+        minimumGeneration: 0
+      }).success
+    ).toBe(false)
+  })
+
+  it.each([
+    ["runId", "other-run"],
+    ["tabId", 8],
+    ["nonce", "fedcba9876543210"],
+    ["sequence", 2],
+    ["documentId", "other-document"]
+  ])("rejects a mismatched %s", (field, value) => {
+    expect(() =>
+      validateAgentObservationResponse(response({ [field]: value }), binding, 1)
+    ).toThrow("binding mismatch")
+  })
+
+  it("rejects mismatched observation identity", () => {
+    expect(() =>
+      validateAgentObservationResponse(
+        response({ observation: observation({ documentId: "other" }) }),
+        binding,
+        1
+      )
+    ).toThrow("binding mismatch")
+  })
+
+  it("rejects subframe elements and inconsistent origins", () => {
+    expect(() =>
+      validateAgentObservationResponse(
+        response({
+          observation: observation({
+            elements: [
+              {
+                ref: "e1",
+                frameId: 2,
+                tag: "button",
+                visible: true,
+                enabled: true,
+                editable: false,
+                sensitive: false
+              }
+            ]
+          })
+        }),
+        binding,
+        1
+      )
+    ).toThrow("binding mismatch")
+    expect(() =>
+      validateAgentObservationResponse(
+        response({
+          observation: observation({ origin: "https://other.example" })
+        }),
+        binding,
+        1
+      )
+    ).toThrow("invalid origin")
+  })
+
+  it("requires browser evidence for the exact main-frame document", () => {
+    const { port } = createPort()
+    expect(() =>
+      createAgentControlSession({
+        port,
+        binding,
+        sender: { tabId: 7, frameId: 2, documentId: "document-1" }
+      })
+    ).toThrow("sender binding mismatch")
+  })
+
+  it("uses a monotonic sequence and validates each response", async () => {
+    const { port, onMessage } = createPort()
+    vi.mocked(port.postMessage).mockImplementation((raw) => {
+      const request = AgentObserveRequestSchema.parse(raw)
+      queueMicrotask(() =>
+        onMessage.emit(
+          response({
+            sequence: request.sequence,
+            observation: observation({
+              generation: Math.max(1, request.minimumGeneration)
+            })
+          })
+        )
+      )
+    })
+    const session = createAgentControlSession({
+      port,
+      binding,
+      sender: { tabId: 7, frameId: 0, documentId: "document-1" }
+    })
+
+    await expect(session.observe(0)).resolves.toMatchObject({ generation: 1 })
+    await expect(session.observe(2)).resolves.toMatchObject({ generation: 2 })
+    expect(
+      vi
+        .mocked(port.postMessage)
+        .mock.calls.map(([raw]) => (raw as { sequence: number }).sequence)
+    ).toEqual([1, 2])
+  })
+
+  it("rejects a generation older than the requested minimum", async () => {
+    const { port, onMessage } = createPort()
+    vi.mocked(port.postMessage).mockImplementation(() => {
+      queueMicrotask(() => onMessage.emit(response()))
+    })
+    const session = createAgentControlSession({
+      port,
+      binding,
+      sender: { tabId: 7, frameId: 0, documentId: "document-1" }
+    })
+    await expect(session.observe(2)).rejects.toThrow("generation is stale")
+    expect(port.disconnect).toHaveBeenCalledOnce()
+  })
+
+  it("locks content responses to the first run, nonce, sequence, and document", () => {
+    const { port, onMessage } = createPort()
+    expect(attachAgentControlContentPort(port, () => observation())).toBe(true)
+    onMessage.emit({
+      version: 1,
+      type: "agent_observe",
+      ...binding,
+      sequence: 1,
+      minimumGeneration: 0
+    })
+    expect(port.postMessage).toHaveBeenCalledOnce()
+    onMessage.emit({
+      version: 1,
+      type: "agent_observe",
+      ...binding,
+      nonce: "fedcba9876543210",
+      sequence: 2,
+      minimumGeneration: 0
+    })
+    expect(port.disconnect).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    "file:///tmp/page.html",
+    "chrome://settings",
+    "ftp://example.com"
+  ])("refuses non-http(s) tab access for %s", async (url) => {
+    const { port } = createPort()
+    const adapter: AgentControlBrowserAdapter = {
+      getTab: async () => ({ url }),
+      getMainFrame: vi.fn(),
+      inject: vi.fn(),
+      connect: vi.fn(() => port),
+      classifyAccess: async (candidate) =>
+        candidate?.startsWith("http") ? "ok" : "restricted",
+      createNonce: () => binding.nonce
+    }
+    await expect(
+      openAgentControlSession({ runId: "run-1", tabId: 7, adapter })
+    ).rejects.toThrow("restricted")
+    expect(adapter.inject).not.toHaveBeenCalled()
+  })
+
+  it("reuses excluded-site classification before injection", async () => {
+    const { port } = createPort()
+    const adapter: AgentControlBrowserAdapter = {
+      getTab: async () => ({ url: "https://private.example" }),
+      getMainFrame: vi.fn(),
+      inject: vi.fn(),
+      connect: vi.fn(() => port),
+      classifyAccess: async () => "excluded",
+      createNonce: () => binding.nonce
+    }
+    await expect(
+      openAgentControlSession({ runId: "run-1", tabId: 7, adapter })
+    ).rejects.toThrow("excluded")
+    expect(adapter.getMainFrame).not.toHaveBeenCalled()
+  })
+
+  it("connects only to the observed main-frame document", async () => {
+    const { port } = createPort()
+    const connect = vi.fn(() => port)
+    const adapter: AgentControlBrowserAdapter = {
+      getTab: async () => ({ url: "https://example.com" }),
+      getMainFrame: async () => ({
+        frameId: 0,
+        documentId: "document-1",
+        url: "https://example.com/"
+      }),
+      inject: vi.fn(),
+      connect,
+      classifyAccess: async () => "ok",
+      createNonce: () => binding.nonce
+    }
+    await openAgentControlSession({ runId: "run-1", tabId: 7, adapter })
+    expect(connect).toHaveBeenCalledWith(7, {
+      name: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+      frameId: 0,
+      documentId: "document-1"
+    })
+  })
+})

--- a/src/lib/browser-agent/__tests__/element-references.test.ts
+++ b/src/lib/browser-agent/__tests__/element-references.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { createAgentElementReferenceStore } from "../element-references"
+
+describe("Agent element references", () => {
+  it("binds references to one document, frame, snapshot, and generation", () => {
+    const store = createAgentElementReferenceStore({ documentId: "document-1" })
+    const first = store.beginSnapshot({
+      minimumGeneration: 0,
+      createSnapshotId: () => "snapshot-1"
+    })
+    const button = document.createElement("button")
+    const ref = first.reference(button)
+    expect(first.resolve(ref, first)).toBe(button)
+    expect(
+      first.resolve(ref, { ...first, documentId: "other" })
+    ).toBeUndefined()
+    expect(first.resolve(ref, { ...first, generation: 2 })).toBeUndefined()
+  })
+
+  it("invalidates every reference when a new snapshot starts", () => {
+    const store = createAgentElementReferenceStore({ documentId: "document-1" })
+    const first = store.beginSnapshot({
+      minimumGeneration: 0,
+      createSnapshotId: () => "snapshot-1"
+    })
+    const ref = first.reference(document.createElement("button"))
+    const second = store.beginSnapshot({
+      minimumGeneration: 2,
+      createSnapshotId: () => "snapshot-2"
+    })
+    expect(first.resolve(ref, first)).toBeUndefined()
+    expect(second.generation).toBe(2)
+  })
+})

--- a/src/lib/browser-agent/__tests__/navigation-observer.test.ts
+++ b/src/lib/browser-agent/__tests__/navigation-observer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  AgentNavigationDetails,
+  AgentNavigationEvent
+} from "../navigation-observer"
+import { createAgentNavigationObserver } from "../navigation-observer"
+
+const event = () => {
+  const listeners = new Set<(details: AgentNavigationDetails) => void>()
+  const value: AgentNavigationEvent = {
+    addListener: (listener) => listeners.add(listener),
+    removeListener: (listener) => listeners.delete(listener)
+  }
+  return {
+    value,
+    emit: (details: AgentNavigationDetails) => {
+      for (const listener of listeners) listener(details)
+    }
+  }
+}
+
+describe("Agent navigation observer", () => {
+  it("ignores subframe commits", () => {
+    const committed = event()
+    const historyUpdated = event()
+    const observer = createAgentNavigationObserver({
+      committed: committed.value,
+      historyUpdated: historyUpdated.value
+    })
+    committed.emit({
+      tabId: 7,
+      frameId: 4,
+      documentId: "subframe",
+      url: "https://example.com/frame"
+    })
+    expect(observer.current(7)).toBeUndefined()
+  })
+
+  it("invalidates snapshots for main-frame commits and SPA navigation", () => {
+    const committed = event()
+    const historyUpdated = event()
+    const invalidate = vi.fn()
+    const observer = createAgentNavigationObserver({
+      committed: committed.value,
+      historyUpdated: historyUpdated.value,
+      onInvalidate: invalidate
+    })
+    committed.emit({
+      tabId: 7,
+      frameId: 0,
+      documentId: "document-1",
+      url: "https://example.com/"
+    })
+    historyUpdated.emit({
+      tabId: 7,
+      frameId: 0,
+      documentId: "document-1",
+      url: "https://example.com/results"
+    })
+    expect(observer.current(7)).toMatchObject({ generation: 2 })
+    expect(invalidate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -1,0 +1,100 @@
+import { Window } from "happy-dom"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { createAgentElementReferenceStore } from "../element-references"
+import {
+  AGENT_OBSERVATION_LIMITS,
+  buildAgentObservation
+} from "../observation-builder"
+
+beforeEach(() => {
+  document.title = "Example"
+  document.body.replaceChildren()
+  history.replaceState({}, "", "/path")
+})
+
+const build = (minimumGeneration = 0) =>
+  buildAgentObservation({
+    document,
+    tabId: 7,
+    documentId: "document-1",
+    minimumGeneration,
+    references: createAgentElementReferenceStore({
+      documentId: "document-1"
+    }),
+    createSnapshotId: () => "snapshot-1",
+    capturedAt: 1
+  })
+
+describe("Agent observation builder", () => {
+  it("caps visible text and interactive elements", () => {
+    document.body.textContent = "x".repeat(
+      AGENT_OBSERVATION_LIMITS.visibleTextChars + 100
+    )
+    for (
+      let index = 0;
+      index < AGENT_OBSERVATION_LIMITS.elements + 5;
+      index += 1
+    ) {
+      document.body.append(document.createElement("button"))
+    }
+    const result = build()
+    expect(result.visibleText).toHaveLength(
+      AGENT_OBSERVATION_LIMITS.visibleTextChars
+    )
+    expect(result.elements).toHaveLength(AGENT_OBSERVATION_LIMITS.elements)
+  })
+
+  it.each([
+    ["password", { type: "password", value: "secret" }],
+    ["one-time code", { autocomplete: "one-time-code", value: "123456" }],
+    ["card", { name: "card-number", value: "4111111111111111" }],
+    ["file", { type: "file", value: "" }]
+  ])("redacts the existing %s value", (_label, attributes) => {
+    const input = document.createElement("input")
+    for (const [name, value] of Object.entries(attributes)) {
+      if (name === "value") input.value = value
+      else input.setAttribute(name, value)
+    }
+    document.body.append(input)
+    expect(build().elements[0]).toMatchObject({ sensitive: true })
+    expect(build().elements[0]).not.toHaveProperty("value")
+  })
+
+  it("keeps bounded non-sensitive values", () => {
+    const input = document.createElement("input")
+    input.value = "safe value"
+    document.body.append(input)
+    expect(build().elements[0]).toMatchObject({
+      sensitive: false,
+      value: "safe value"
+    })
+  })
+
+  it("rejects subframe and unsupported-scheme observations", () => {
+    const references = createAgentElementReferenceStore({
+      documentId: "document-1"
+    })
+    expect(() =>
+      buildAgentObservation({
+        document,
+        tabId: 7,
+        frameId: 2,
+        documentId: "document-1",
+        minimumGeneration: 0,
+        references
+      })
+    ).toThrow("main-frame only")
+
+    const unsupported = new Window({ url: "file:///tmp/page.html" }).document
+    expect(() =>
+      buildAgentObservation({
+        document: unsupported as unknown as Document,
+        tabId: 7,
+        documentId: "document-1",
+        minimumGeneration: 0,
+        references
+      })
+    ).toThrow("HTTP(S)")
+  })
+})

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -148,6 +148,52 @@ describe("Agent observation builder", () => {
     expect(build().elements[0]).not.toHaveProperty("value")
   })
 
+  it.each([
+    ["hidden", (element: HTMLElement) => element.setAttribute("hidden", "")],
+    [
+      "hidden ancestor",
+      (element: HTMLElement) =>
+        element.parentElement?.setAttribute("aria-hidden", "true")
+    ],
+    [
+      "transparent",
+      (element: HTMLElement) => element.style.setProperty("opacity", "0")
+    ],
+    [
+      "content-hidden",
+      (element: HTMLElement) =>
+        element.style.setProperty("content-visibility", "hidden")
+    ],
+    [
+      "offscreen",
+      (element: HTMLElement) => {
+        element.getClientRects = () =>
+          [
+            {
+              bottom: 20,
+              height: 20,
+              left: window.innerWidth + 100,
+              right: window.innerWidth + 200,
+              top: 0,
+              width: 100
+            } as DOMRect
+          ] as unknown as DOMRectList
+      }
+    ]
+  ])("omits %s DOM text and element names", (_label, hide) => {
+    const wrapper = document.createElement("div")
+    const element = document.createElement("button")
+    element.textContent = "hidden-page-secret"
+    wrapper.append(element)
+    document.body.append("visible page text", wrapper)
+    hide(element)
+
+    const observation = build()
+    expect(observation.visibleText).toBe("visible page text")
+    expect(observation.visibleText).not.toContain("hidden-page-secret")
+    expect(observation.elements[0]).not.toHaveProperty("name")
+  })
+
   it("rejects subframe and unsupported-scheme observations", () => {
     const references = createAgentElementReferenceStore({
       documentId: "document-1"

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -1,5 +1,5 @@
 import { Window } from "happy-dom"
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createAgentElementReferenceStore } from "../element-references"
 import {
@@ -11,7 +11,19 @@ beforeEach(() => {
   document.title = "Example"
   document.body.replaceChildren()
   history.replaceState({}, "", "/path")
+  vi.spyOn(Element.prototype, "getClientRects").mockReturnValue([
+    {
+      bottom: 20,
+      height: 20,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100
+    } as DOMRect
+  ] as unknown as DOMRectList)
 })
+
+afterEach(() => vi.restoreAllMocks())
 
 const build = (minimumGeneration = 0) =>
   buildAgentObservation({
@@ -69,6 +81,71 @@ describe("Agent observation builder", () => {
       sensitive: false,
       value: "safe value"
     })
+  })
+
+  it.each([
+    [
+      "hidden input",
+      (input: HTMLInputElement) => input.setAttribute("type", "hidden")
+    ],
+    [
+      "hidden attribute",
+      (input: HTMLInputElement) => input.setAttribute("hidden", "")
+    ],
+    [
+      "hidden ancestor",
+      (input: HTMLInputElement) =>
+        input.parentElement?.setAttribute("hidden", "")
+    ],
+    [
+      "display none",
+      (input: HTMLInputElement) => input.style.setProperty("display", "none")
+    ],
+    [
+      "visibility hidden",
+      (input: HTMLInputElement) =>
+        input.style.setProperty("visibility", "hidden")
+    ],
+    [
+      "transparent",
+      (input: HTMLInputElement) => input.style.setProperty("opacity", "0")
+    ]
+  ])("redacts values from a %s", (_label, hide) => {
+    const wrapper = document.createElement("div")
+    const input = document.createElement("input")
+    input.value = "page-secret"
+    wrapper.append(input)
+    document.body.append(wrapper)
+    hide(input)
+
+    expect(build().elements[0]).toMatchObject({
+      sensitive: true,
+      visible: false
+    })
+    expect(build().elements[0]).not.toHaveProperty("value")
+  })
+
+  it("redacts values outside the viewport", () => {
+    const input = document.createElement("input")
+    input.value = "offscreen-secret"
+    input.getClientRects = () =>
+      [
+        {
+          bottom: 20,
+          height: 20,
+          left: window.innerWidth + 100,
+          right: window.innerWidth + 200,
+          top: 0,
+          width: 100
+        } as DOMRect
+      ] as unknown as DOMRectList
+    document.body.append(input)
+
+    expect(build().elements[0]).toMatchObject({
+      sensitive: true,
+      visible: false
+    })
+    expect(build().elements[0]).not.toHaveProperty("value")
   })
 
   it("rejects subframe and unsupported-scheme observations", () => {

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -148,6 +148,59 @@ describe("Agent observation builder", () => {
     expect(build().elements[0]).not.toHaveProperty("value")
   })
 
+  it("redacts values clipped by an overflow ancestor", () => {
+    const wrapper = document.createElement("div")
+    wrapper.style.overflow = "hidden"
+    wrapper.getClientRects = () =>
+      [
+        {
+          bottom: 50,
+          height: 50,
+          left: 0,
+          right: 50,
+          top: 0,
+          width: 50
+        } as DOMRect
+      ] as unknown as DOMRectList
+    const input = document.createElement("input")
+    input.value = "clipped-secret"
+    input.getClientRects = () =>
+      [
+        {
+          bottom: 30,
+          height: 20,
+          left: 60,
+          right: 100,
+          top: 10,
+          width: 40
+        } as DOMRect
+      ] as unknown as DOMRectList
+    wrapper.append(input)
+    document.body.append(wrapper)
+
+    expect(build().elements[0]).toMatchObject({
+      sensitive: true,
+      visible: false
+    })
+    expect(build().elements[0]).not.toHaveProperty("value")
+  })
+
+  it.each([
+    ["clip-path", "inset(100%)"],
+    ["mask-image", "linear-gradient(transparent, transparent)"]
+  ])("redacts values behind %s", (property, value) => {
+    const input = document.createElement("input")
+    input.value = "clipped-secret"
+    input.style.setProperty(property, value)
+    document.body.append(input)
+
+    expect(build().elements[0]).toMatchObject({
+      sensitive: true,
+      visible: false
+    })
+    expect(build().elements[0]).not.toHaveProperty("value")
+  })
+
   it.each([
     ["hidden", (element: HTMLElement) => element.setAttribute("hidden", "")],
     [
@@ -192,6 +245,21 @@ describe("Agent observation builder", () => {
     expect(observation.visibleText).toBe("visible page text")
     expect(observation.visibleText).not.toContain("hidden-page-secret")
     expect(observation.elements[0]).not.toHaveProperty("name")
+  })
+
+  it("excludes hidden descendants from visible element names", () => {
+    const button = document.createElement("button")
+    button.append("Visible label")
+    const hidden = document.createElement("span")
+    hidden.hidden = true
+    hidden.textContent = " hidden-name-secret"
+    button.append(hidden)
+    document.body.append(button)
+
+    const observation = build()
+    expect(observation.visibleText).toBe("Visible label")
+    expect(observation.elements[0]?.name).toBe("Visible label")
+    expect(observation.elements[0]?.name).not.toContain("hidden-name-secret")
   })
 
   it("rejects subframe and unsupported-scheme observations", () => {

--- a/src/lib/browser-agent/__tests__/tab-access.test.ts
+++ b/src/lib/browser-agent/__tests__/tab-access.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  patterns: vi.fn(),
+  matches: vi.fn(),
+  neverRead: vi.fn()
+}))
+
+vi.mock("@/contents/url-filter", () => ({
+  resolveExcludedUrlPatterns: (...args: unknown[]) => mocks.patterns(...args),
+  urlMatchesAny: (...args: unknown[]) => mocks.matches(...args)
+}))
+
+vi.mock("@/lib/browser-api", () => ({
+  browser: { tabs: { query: vi.fn() } }
+}))
+
+vi.mock("@/lib/per-site-profiles", () => ({
+  isNeverReadUrl: (...args: unknown[]) => mocks.neverRead(...args)
+}))
+
+import { classifyAgentTabAccess } from "@/lib/browser-tab-access"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.patterns.mockResolvedValue(["private.example"])
+  mocks.matches.mockReturnValue(false)
+  mocks.neverRead.mockResolvedValue(false)
+})
+
+describe("Agent tab access", () => {
+  it.each([
+    "file:///tmp/page",
+    "ftp://example.com",
+    "chrome://settings"
+  ])("restricts %s before consulting site settings", async (url) => {
+    await expect(classifyAgentTabAccess(url)).resolves.toBe("restricted")
+    expect(mocks.patterns).not.toHaveBeenCalled()
+  })
+
+  it("reuses the content-extraction exclusion list", async () => {
+    mocks.matches.mockReturnValue(true)
+    await expect(
+      classifyAgentTabAccess("https://private.example/account")
+    ).resolves.toBe("excluded")
+    expect(mocks.matches).toHaveBeenCalledWith(
+      "https://private.example/account",
+      ["private.example"]
+    )
+  })
+
+  it("reuses never-read per-site profiles", async () => {
+    mocks.neverRead.mockResolvedValue(true)
+    await expect(
+      classifyAgentTabAccess("https://example.com/private")
+    ).resolves.toBe("excluded")
+  })
+})

--- a/src/lib/browser-agent/control-port.ts
+++ b/src/lib/browser-agent/control-port.ts
@@ -1,0 +1,341 @@
+import {
+  type AgentObservation,
+  AgentObservationSchema
+} from "@ollama-client/contracts"
+import { z } from "zod"
+
+import { browser } from "@/lib/browser-api"
+import {
+  classifyAgentTabAccess,
+  type TabAccess
+} from "@/lib/browser-tab-access"
+import { MESSAGE_KEYS } from "@/lib/constants"
+
+export const AGENT_CONTROL_VERSION = 1 as const
+
+export const AgentObserveRequestSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.literal("agent_observe"),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.literal(0),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1),
+    minimumGeneration: z.number().int().nonnegative()
+  })
+  .strict()
+export type AgentObserveRequest = z.infer<typeof AgentObserveRequestSchema>
+
+export const AgentObserveResponseSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.literal("agent_observation"),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.literal(0),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1),
+    observation: AgentObservationSchema
+  })
+  .strict()
+export type AgentObserveResponse = z.infer<typeof AgentObserveResponseSchema>
+
+export interface AgentControlEvent<T extends (...args: never[]) => unknown> {
+  addListener(listener: T): void
+  removeListener(listener: T): void
+}
+
+export interface AgentControlPort {
+  readonly name: string
+  postMessage(message: unknown): void
+  disconnect(): void
+  onMessage: AgentControlEvent<(message: unknown) => void>
+  onDisconnect: AgentControlEvent<() => void>
+}
+
+export interface AgentControlBinding {
+  runId: string
+  tabId: number
+  frameId: 0
+  nonce: string
+  documentId: string
+}
+
+export interface AgentControlSenderEvidence {
+  tabId: number
+  frameId: number
+  documentId: string
+}
+
+export interface AgentControlSession {
+  observe(
+    minimumGeneration: number,
+    signal?: AbortSignal
+  ): Promise<AgentObservation>
+  disconnect(): void
+}
+
+export interface AgentControlBrowserAdapter {
+  getTab(tabId: number): Promise<{ url?: string }>
+  getMainFrame(tabId: number): Promise<{
+    frameId: number
+    documentId?: string
+    url: string
+  } | null>
+  inject(tabId: number): Promise<void>
+  connect(
+    tabId: number,
+    options: { name: string; frameId: 0; documentId: string }
+  ): AgentControlPort
+  classifyAccess(url?: string): Promise<TabAccess>
+  createNonce(): string
+}
+
+const defaultBrowserAdapter = (): AgentControlBrowserAdapter => ({
+  getTab: (tabId) => browser.tabs.get(tabId),
+  async getMainFrame(tabId) {
+    const frame = await browser.webNavigation.getFrame({ tabId, frameId: 0 })
+    return frame ? { ...frame, frameId: 0 } : null
+  },
+  async inject(tabId) {
+    await browser.scripting.executeScript({
+      target: { tabId, frameIds: [0] },
+      files: ["content-scripts/agent-control.js"]
+    })
+  },
+  connect(tabId, options) {
+    return browser.tabs.connect(tabId, options) as unknown as AgentControlPort
+  },
+  classifyAccess: classifyAgentTabAccess,
+  createNonce: () =>
+    `${globalThis.crypto.randomUUID()}${globalThis.crypto.randomUUID()}`
+})
+
+const assertBinding = (
+  binding: AgentControlBinding,
+  sender: AgentControlSenderEvidence
+): void => {
+  if (
+    binding.frameId !== 0 ||
+    sender.frameId !== 0 ||
+    sender.tabId !== binding.tabId ||
+    sender.documentId !== binding.documentId
+  ) {
+    throw new Error("Agent control port sender binding mismatch")
+  }
+}
+
+export const validateAgentObservationResponse = (
+  raw: unknown,
+  binding: AgentControlBinding,
+  sequence: number
+): AgentObservation => {
+  const response = AgentObserveResponseSchema.parse(raw)
+  if (
+    response.runId !== binding.runId ||
+    response.tabId !== binding.tabId ||
+    response.frameId !== binding.frameId ||
+    response.nonce !== binding.nonce ||
+    response.sequence !== sequence ||
+    response.documentId !== binding.documentId ||
+    response.observation.tabId !== binding.tabId ||
+    response.observation.documentId !== binding.documentId ||
+    response.observation.elements.some((element) => element.frameId !== 0)
+  ) {
+    throw new Error("Agent observation response binding mismatch")
+  }
+  const observedUrl = new URL(response.observation.url)
+  if (
+    !["http:", "https:"].includes(observedUrl.protocol) ||
+    observedUrl.origin !== response.observation.origin
+  ) {
+    throw new Error("Agent observation response has an invalid origin")
+  }
+  return response.observation
+}
+
+export const createAgentControlSession = (input: {
+  port: AgentControlPort
+  binding: AgentControlBinding
+  sender: AgentControlSenderEvidence
+}): AgentControlSession => {
+  if (input.port.name !== MESSAGE_KEYS.AGENT.CONTROL_PORT) {
+    throw new Error("Unexpected Agent control port")
+  }
+  assertBinding(input.binding, input.sender)
+  let sequence = 0
+  let inFlight = false
+
+  return {
+    observe(minimumGeneration, signal) {
+      if (inFlight) {
+        return Promise.reject(new Error("Agent observation already in flight"))
+      }
+      inFlight = true
+      sequence += 1
+      const expectedSequence = sequence
+      const request: AgentObserveRequest = {
+        version: AGENT_CONTROL_VERSION,
+        type: "agent_observe",
+        ...input.binding,
+        sequence: expectedSequence,
+        minimumGeneration
+      }
+
+      return new Promise<AgentObservation>((resolve, reject) => {
+        const cleanup = () => {
+          inFlight = false
+          input.port.onMessage.removeListener(onMessage)
+          input.port.onDisconnect.removeListener(onDisconnect)
+          signal?.removeEventListener("abort", onAbort)
+        }
+        const fail = (error: Error) => {
+          cleanup()
+          reject(error)
+        }
+        const onMessage = (raw: unknown) => {
+          try {
+            const observation = validateAgentObservationResponse(
+              raw,
+              input.binding,
+              expectedSequence
+            )
+            if (observation.generation < minimumGeneration) {
+              throw new Error("Agent observation generation is stale")
+            }
+            cleanup()
+            resolve(observation)
+          } catch (error) {
+            input.port.disconnect()
+            fail(
+              error instanceof Error
+                ? error
+                : new Error("Invalid Agent observation")
+            )
+          }
+        }
+        const onDisconnect = () => fail(new Error("Agent control port closed"))
+        const onAbort = () => {
+          input.port.disconnect()
+          fail(new Error("Agent observation cancelled"))
+        }
+
+        input.port.onMessage.addListener(onMessage)
+        input.port.onDisconnect.addListener(onDisconnect)
+        signal?.addEventListener("abort", onAbort, { once: true })
+        if (signal?.aborted) {
+          onAbort()
+          return
+        }
+        input.port.postMessage(request)
+      })
+    },
+    disconnect() {
+      input.port.disconnect()
+    }
+  }
+}
+
+export const openAgentControlSession = async (input: {
+  runId: string
+  tabId: number
+  adapter?: AgentControlBrowserAdapter
+}): Promise<AgentControlSession> => {
+  const adapter = input.adapter ?? defaultBrowserAdapter()
+  const tab = await adapter.getTab(input.tabId)
+  const access = await adapter.classifyAccess(tab.url)
+  if (access !== "ok") {
+    throw new Error(`Agent tab access denied: ${access}`)
+  }
+  const frame = await adapter.getMainFrame(input.tabId)
+  if (!frame || frame.frameId !== 0 || !frame.documentId) {
+    throw new Error("Agent main-frame document is unavailable")
+  }
+  if ((await adapter.classifyAccess(frame.url)) !== "ok") {
+    throw new Error("Agent main-frame document is not readable")
+  }
+  await adapter.inject(input.tabId)
+  const binding: AgentControlBinding = {
+    runId: input.runId,
+    tabId: input.tabId,
+    frameId: 0,
+    nonce: adapter.createNonce(),
+    documentId: frame.documentId
+  }
+  const port = adapter.connect(input.tabId, {
+    name: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+    frameId: 0,
+    documentId: frame.documentId
+  })
+  return createAgentControlSession({
+    port,
+    binding,
+    sender: {
+      tabId: input.tabId,
+      frameId: frame.frameId,
+      documentId: frame.documentId
+    }
+  })
+}
+
+export const attachAgentControlContentPort = (
+  port: AgentControlPort,
+  buildObservation: (request: AgentObserveRequest) => AgentObservation
+): boolean => {
+  if (port.name !== MESSAGE_KEYS.AGENT.CONTROL_PORT) return false
+  let binding: AgentControlBinding | undefined
+  let lastSequence = 0
+
+  port.onMessage.addListener((raw) => {
+    const parsed = AgentObserveRequestSchema.safeParse(raw)
+    if (!parsed.success) {
+      port.disconnect()
+      return
+    }
+    const request = parsed.data
+    const nextBinding: AgentControlBinding = {
+      runId: request.runId,
+      tabId: request.tabId,
+      frameId: request.frameId,
+      nonce: request.nonce,
+      documentId: request.documentId
+    }
+    if (binding) {
+      const matches =
+        binding.runId === nextBinding.runId &&
+        binding.tabId === nextBinding.tabId &&
+        binding.frameId === nextBinding.frameId &&
+        binding.nonce === nextBinding.nonce &&
+        binding.documentId === nextBinding.documentId
+      if (!matches || request.sequence !== lastSequence + 1) {
+        port.disconnect()
+        return
+      }
+    } else if (request.sequence !== 1) {
+      port.disconnect()
+      return
+    }
+
+    try {
+      const observation = AgentObservationSchema.parse(
+        buildObservation(request)
+      )
+      binding = nextBinding
+      lastSequence = request.sequence
+      const response: AgentObserveResponse = {
+        version: AGENT_CONTROL_VERSION,
+        type: "agent_observation",
+        ...nextBinding,
+        sequence: request.sequence,
+        observation
+      }
+      port.postMessage(response)
+    } catch {
+      port.disconnect()
+    }
+  })
+  return true
+}

--- a/src/lib/browser-agent/element-references.ts
+++ b/src/lib/browser-agent/element-references.ts
@@ -1,0 +1,73 @@
+export interface AgentReferenceIdentity {
+  snapshotId: string
+  generation: number
+  documentId: string
+  frameId: 0
+}
+
+export interface AgentElementReferenceSnapshot extends AgentReferenceIdentity {
+  reference(element: Element): string
+  resolve(ref: string, identity: AgentReferenceIdentity): Element | undefined
+}
+
+export interface AgentElementReferenceStore {
+  beginSnapshot(input: {
+    minimumGeneration: number
+    createSnapshotId: () => string
+  }): AgentElementReferenceSnapshot
+  invalidate(): void
+  currentGeneration(): number
+}
+
+export const createAgentElementReferenceStore = (input: {
+  documentId: string
+}): AgentElementReferenceStore => {
+  let generation = 0
+  let active: AgentElementReferenceSnapshot | undefined
+
+  return {
+    beginSnapshot({ minimumGeneration, createSnapshotId }) {
+      generation = Math.max(generation + 1, minimumGeneration)
+      const snapshotId = createSnapshotId()
+      const byElement = new WeakMap<Element, string>()
+      const byRef = new Map<string, Element>()
+      let nextRef = 0
+      const identity: AgentReferenceIdentity = {
+        snapshotId,
+        generation,
+        documentId: input.documentId,
+        frameId: 0
+      }
+      const snapshot: AgentElementReferenceSnapshot = {
+        ...identity,
+        reference(element) {
+          const existing = byElement.get(element)
+          if (existing) return existing
+          const ref = `e${++nextRef}`
+          byElement.set(element, ref)
+          byRef.set(ref, element)
+          return ref
+        },
+        resolve(ref, candidate) {
+          if (active !== snapshot) return undefined
+          if (
+            candidate.snapshotId !== snapshotId ||
+            candidate.generation !== generation ||
+            candidate.documentId !== input.documentId ||
+            candidate.frameId !== 0
+          ) {
+            return undefined
+          }
+          return byRef.get(ref)
+        }
+      }
+      active = snapshot
+      return snapshot
+    },
+    invalidate() {
+      generation += 1
+      active = undefined
+    },
+    currentGeneration: () => generation
+  }
+}

--- a/src/lib/browser-agent/navigation-observer.ts
+++ b/src/lib/browser-agent/navigation-observer.ts
@@ -1,0 +1,67 @@
+export interface AgentNavigationDetails {
+  tabId: number
+  frameId: number
+  url: string
+  documentId?: string
+}
+
+export interface AgentNavigationEvent {
+  addListener(listener: (details: AgentNavigationDetails) => void): void
+  removeListener(listener: (details: AgentNavigationDetails) => void): void
+}
+
+export interface AgentNavigationSnapshot {
+  tabId: number
+  documentId: string
+  url: string
+  generation: number
+}
+
+export interface AgentNavigationObserver {
+  current(tabId: number): AgentNavigationSnapshot | undefined
+  stop(): void
+}
+
+export const createAgentNavigationObserver = (input: {
+  committed: AgentNavigationEvent
+  historyUpdated: AgentNavigationEvent
+  onInvalidate?: (snapshot: AgentNavigationSnapshot) => void
+}): AgentNavigationObserver => {
+  const snapshots = new Map<number, AgentNavigationSnapshot>()
+
+  const update = (details: AgentNavigationDetails) => {
+    if (details.frameId !== 0 || !details.documentId) return
+    const previous = snapshots.get(details.tabId)
+    const snapshot = {
+      tabId: details.tabId,
+      documentId: details.documentId,
+      url: details.url,
+      generation: (previous?.generation ?? 0) + 1
+    }
+    snapshots.set(details.tabId, snapshot)
+    input.onInvalidate?.(snapshot)
+  }
+
+  input.committed.addListener(update)
+  input.historyUpdated.addListener(update)
+  return {
+    current: (tabId) => snapshots.get(tabId),
+    stop() {
+      input.committed.removeListener(update)
+      input.historyUpdated.removeListener(update)
+      snapshots.clear()
+    }
+  }
+}
+
+/** Bind the pure observer to Chromium after `webNavigation` is granted. */
+export const startBrowserAgentNavigationObserver = (
+  onInvalidate?: (snapshot: AgentNavigationSnapshot) => void
+): AgentNavigationObserver =>
+  createAgentNavigationObserver({
+    committed: chrome.webNavigation
+      .onCommitted as unknown as AgentNavigationEvent,
+    historyUpdated: chrome.webNavigation
+      .onHistoryStateUpdated as unknown as AgentNavigationEvent,
+    onInvalidate
+  })

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -112,19 +112,43 @@ const elementValue = (element: Element): string | undefined => {
   return value || undefined
 }
 
+const collectVisibleText = (document: Document): string => {
+  const body = document.body
+  if (!body) return ""
+
+  const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT)
+  let result = ""
+  for (
+    let node = walker.nextNode();
+    node && result.length < AGENT_OBSERVATION_LIMITS.visibleTextChars;
+    node = walker.nextNode()
+  ) {
+    const parent = node.parentElement
+    if (!parent || !isVisible(parent)) continue
+    const text = normalizedText(node.textContent ?? "")
+    if (!text) continue
+    const addition = `${result ? " " : ""}${text}`
+    result += truncate(
+      addition,
+      AGENT_OBSERVATION_LIMITS.visibleTextChars - result.length
+    )
+  }
+  return result
+}
+
 const toAgentElement = (element: Element, ref: string): AgentElement => {
   const visible = isVisible(element)
   const sensitive = !visible || isSensitiveAgentElement(element)
-  const name = accessibleName(element)
+  const name = visible ? accessibleName(element) : undefined
   const value = sensitive ? undefined : elementValue(element)
   const control = element as HTMLInputElement
   return {
     ref,
     frameId: 0,
     role: element.getAttribute("role") || undefined,
-    name: name
-      ? truncate(name, AGENT_OBSERVATION_LIMITS.elementNameChars)
-      : undefined,
+    ...(name
+      ? { name: truncate(name, AGENT_OBSERVATION_LIMITS.elementNameChars) }
+      : {}),
     tag: element.tagName.toLowerCase(),
     type: control.type || undefined,
     ...(value
@@ -171,10 +195,7 @@ export const buildAgentObservation = (input: {
   const elements = candidates.map((element) =>
     toAgentElement(element, snapshot.reference(element))
   )
-  const body = input.document.body
-  const visibleText = normalizedText(
-    body ? (body.innerText ?? body.textContent ?? "") : ""
-  )
+  const visibleText = collectVisibleText(input.document)
   const view = input.document.defaultView
   const root = input.document.documentElement
 
@@ -187,10 +208,7 @@ export const buildAgentObservation = (input: {
     origin: url.origin,
     title: truncate(input.document.title, AGENT_OBSERVATION_LIMITS.titleChars),
     elements,
-    visibleText: truncate(
-      visibleText,
-      AGENT_OBSERVATION_LIMITS.visibleTextChars
-    ),
+    visibleText,
     scroll: {
       x: view?.scrollX ?? 0,
       y: view?.scrollY ?? 0,

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -30,6 +30,121 @@ const truncate = (value: string, limit: number): string =>
 const normalizedText = (value: string): string =>
   value.replaceAll(/\s+/g, " ").trim()
 
+interface VisibleBounds {
+  bottom: number
+  left: number
+  right: number
+  top: number
+}
+
+const intersectBounds = (
+  first: VisibleBounds,
+  second: VisibleBounds
+): VisibleBounds | undefined => {
+  const intersection = {
+    bottom: Math.min(first.bottom, second.bottom),
+    left: Math.max(first.left, second.left),
+    right: Math.min(first.right, second.right),
+    top: Math.max(first.top, second.top)
+  }
+  return intersection.right > intersection.left &&
+    intersection.bottom > intersection.top
+    ? intersection
+    : undefined
+}
+
+const clipsOverflow = (value: string): boolean =>
+  ["auto", "clip", "hidden", "overlay", "scroll"].includes(value)
+
+const isSemanticallyHidden = (element: Element): boolean =>
+  element.hasAttribute("hidden") ||
+  element.hasAttribute("inert") ||
+  element.getAttribute("aria-hidden") === "true"
+
+const isHiddenByStyle = (style: CSSStyleDeclaration): boolean =>
+  style.display === "none" ||
+  style.visibility === "hidden" ||
+  style.visibility === "collapse" ||
+  style.contentVisibility === "hidden" ||
+  style.opacity === "0"
+
+const isActiveClipValue = (
+  value: string | null | undefined,
+  defaults: readonly string[]
+): boolean => Boolean(value && !defaults.includes(value))
+
+const hasConservativeClip = (
+  element: Element,
+  style: CSSStyleDeclaration
+): boolean => {
+  const declared = (element as HTMLElement).style
+  return (
+    [style.clip, declared.clip].some((value) =>
+      isActiveClipValue(value, ["auto", "none"])
+    ) ||
+    [style.clipPath, declared.clipPath].some((value) =>
+      isActiveClipValue(value, ["none"])
+    ) ||
+    [
+      style.maskImage,
+      style.getPropertyValue("mask-image"),
+      declared.maskImage,
+      declared.getPropertyValue("mask-image")
+    ].some((value) => isActiveClipValue(value, ["none"]))
+  )
+}
+
+const clipBoundsByAncestor = (
+  bounds: VisibleBounds[],
+  ancestor: Element,
+  style: CSSStyleDeclaration
+): VisibleBounds[] => {
+  const containPaint = style.contain
+    .split(/\s+/)
+    .some((value) => value === "paint" || value === "strict")
+  const declared = (ancestor as HTMLElement).style
+  const clipX =
+    containPaint ||
+    [
+      style.overflow,
+      style.overflowX,
+      declared.overflow,
+      declared.overflowX
+    ].some(clipsOverflow)
+  const clipY =
+    containPaint ||
+    [
+      style.overflow,
+      style.overflowY,
+      declared.overflow,
+      declared.overflowY
+    ].some(clipsOverflow)
+  if (!clipX && !clipY) return bounds
+
+  const clippingRects = Array.from(ancestor.getClientRects()).filter(
+    (rect) => rect.width > 0 && rect.height > 0
+  )
+  return bounds.flatMap((visible) =>
+    clippingRects
+      .map((rect) =>
+        intersectBounds(visible, {
+          bottom: clipY ? rect.bottom : visible.bottom,
+          left: clipX ? rect.left : visible.left,
+          right: clipX ? rect.right : visible.right,
+          top: clipY ? rect.top : visible.top
+        })
+      )
+      .filter((rect): rect is VisibleBounds => Boolean(rect))
+  )
+}
+
+const composedParent = (element: Element): Element | null => {
+  const root = element.getRootNode()
+  return (
+    element.parentElement ?? (root instanceof ShadowRoot ? root.host : null)
+  )
+}
+
 const isVisible = (element: Element): boolean => {
   if (
     element instanceof HTMLInputElement &&
@@ -39,43 +154,35 @@ const isVisible = (element: Element): boolean => {
   }
 
   const view = element.ownerDocument.defaultView
-  for (let current: Element | null = element; current; ) {
-    if (
-      current.hasAttribute("hidden") ||
-      current.hasAttribute("inert") ||
-      current.getAttribute("aria-hidden") === "true"
-    ) {
-      return false
-    }
-    const style = view?.getComputedStyle(current)
-    if (
-      style?.display === "none" ||
-      style?.visibility === "hidden" ||
-      style?.visibility === "collapse" ||
-      style?.contentVisibility === "hidden" ||
-      style?.opacity === "0"
-    ) {
-      return false
-    }
-    const root = current.getRootNode()
-    current =
-      current.parentElement ?? (root instanceof ShadowRoot ? root.host : null)
+  const viewport = {
+    bottom: view?.innerHeight ?? 0,
+    left: 0,
+    right: view?.innerWidth ?? 0,
+    top: 0
   }
+  let visibleBounds = Array.from(element.getClientRects())
+    .filter((rect) => rect.width > 0 && rect.height > 0)
+    .map((rect) => intersectBounds(rect, viewport))
+    .filter((rect): rect is VisibleBounds => Boolean(rect))
+  if (visibleBounds.length === 0) return false
 
-  const renderedRects = Array.from(element.getClientRects()).filter(
-    (rect) => rect.width > 0 && rect.height > 0
-  )
-  if (renderedRects.length === 0) return false
-
-  const viewportWidth = view?.innerWidth ?? 0
-  const viewportHeight = view?.innerHeight ?? 0
-  return renderedRects.some(
-    (rect) =>
-      rect.bottom > 0 &&
-      rect.right > 0 &&
-      rect.top < viewportHeight &&
-      rect.left < viewportWidth
-  )
+  for (
+    let current: Element | null = element;
+    current;
+    current = composedParent(current)
+  ) {
+    if (isSemanticallyHidden(current)) return false
+    const style = view?.getComputedStyle(current)
+    if (!style) return false
+    if (isHiddenByStyle(style) || hasConservativeClip(current, style)) {
+      return false
+    }
+    if (current !== element && style) {
+      visibleBounds = clipBoundsByAncestor(visibleBounds, current, style)
+      if (visibleBounds.length === 0) return false
+    }
+  }
+  return true
 }
 
 export const isSensitiveAgentElement = (element: Element): boolean => {
@@ -96,31 +203,18 @@ export const isSensitiveAgentElement = (element: Element): boolean => {
   )
 }
 
-const accessibleName = (element: Element): string | undefined => {
-  const labelled = element.getAttribute("aria-label")
-  if (labelled) return labelled
-  const text = normalizedText(element.textContent ?? "")
-  if (text) return text
-  const placeholder = element.getAttribute("placeholder")
-  if (placeholder) return placeholder
-  return undefined
-}
-
 const elementValue = (element: Element): string | undefined => {
   if (!("value" in element)) return undefined
   const value = String((element as HTMLInputElement).value ?? "")
   return value || undefined
 }
 
-const collectVisibleText = (document: Document): string => {
-  const body = document.body
-  if (!body) return ""
-
-  const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT)
+const collectVisibleText = (root: Element, limit: number): string => {
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
   let result = ""
   for (
     let node = walker.nextNode();
-    node && result.length < AGENT_OBSERVATION_LIMITS.visibleTextChars;
+    node && result.length < limit;
     node = walker.nextNode()
   ) {
     const parent = node.parentElement
@@ -128,12 +222,22 @@ const collectVisibleText = (document: Document): string => {
     const text = normalizedText(node.textContent ?? "")
     if (!text) continue
     const addition = `${result ? " " : ""}${text}`
-    result += truncate(
-      addition,
-      AGENT_OBSERVATION_LIMITS.visibleTextChars - result.length
-    )
+    result += truncate(addition, limit - result.length)
   }
   return result
+}
+
+const accessibleName = (element: Element): string | undefined => {
+  const labelled = element.getAttribute("aria-label")
+  if (labelled) return labelled
+  const text = collectVisibleText(
+    element,
+    AGENT_OBSERVATION_LIMITS.elementNameChars
+  )
+  if (text) return text
+  const placeholder = element.getAttribute("placeholder")
+  if (placeholder) return placeholder
+  return undefined
 }
 
 const toAgentElement = (element: Element, ref: string): AgentElement => {
@@ -195,7 +299,12 @@ export const buildAgentObservation = (input: {
   const elements = candidates.map((element) =>
     toAgentElement(element, snapshot.reference(element))
   )
-  const visibleText = collectVisibleText(input.document)
+  const visibleText = input.document.body
+    ? collectVisibleText(
+        input.document.body,
+        AGENT_OBSERVATION_LIMITS.visibleTextChars
+      )
+    : ""
   const view = input.document.defaultView
   const root = input.document.documentElement
 

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -1,0 +1,163 @@
+import {
+  type AgentElement,
+  type AgentObservation,
+  AgentObservationSchema
+} from "@ollama-client/contracts"
+
+import type { AgentElementReferenceStore } from "./element-references"
+
+export const AGENT_OBSERVATION_LIMITS = {
+  elements: 2_000,
+  visibleTextChars: 100_000,
+  titleChars: 500,
+  elementNameChars: 500,
+  elementValueChars: 500
+} as const
+
+const INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "[role]",
+  "[contenteditable='true']"
+].join(",")
+
+const truncate = (value: string, limit: number): string =>
+  value.length <= limit ? value : value.slice(0, limit)
+
+const normalizedText = (value: string): string =>
+  value.replaceAll(/\s+/g, " ").trim()
+
+const isVisible = (element: Element): boolean => {
+  if (element.hasAttribute("hidden")) return false
+  if (element.getAttribute("aria-hidden") === "true") return false
+  const style = (element as HTMLElement).style
+  return style?.display !== "none" && style?.visibility !== "hidden"
+}
+
+export const isSensitiveAgentElement = (element: Element): boolean => {
+  const input = element as HTMLInputElement
+  const type = input.type?.toLowerCase()
+  if (["password", "file"].includes(type)) return true
+  const evidence = [
+    element.getAttribute("autocomplete"),
+    element.getAttribute("name"),
+    element.getAttribute("id"),
+    element.getAttribute("aria-label")
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+  return /(?:one-time|otp|verification|passcode|password|card|cc-|cvv|cvc|captcha)/.test(
+    evidence
+  )
+}
+
+const accessibleName = (element: Element): string | undefined => {
+  const labelled = element.getAttribute("aria-label")
+  if (labelled) return labelled
+  const text = normalizedText(element.textContent ?? "")
+  if (text) return text
+  const placeholder = element.getAttribute("placeholder")
+  if (placeholder) return placeholder
+  return undefined
+}
+
+const elementValue = (element: Element): string | undefined => {
+  if (!("value" in element)) return undefined
+  const value = String((element as HTMLInputElement).value ?? "")
+  return value || undefined
+}
+
+const toAgentElement = (element: Element, ref: string): AgentElement => {
+  const sensitive = isSensitiveAgentElement(element)
+  const name = accessibleName(element)
+  const value = sensitive ? undefined : elementValue(element)
+  const control = element as HTMLInputElement
+  return {
+    ref,
+    frameId: 0,
+    role: element.getAttribute("role") || undefined,
+    name: name
+      ? truncate(name, AGENT_OBSERVATION_LIMITS.elementNameChars)
+      : undefined,
+    tag: element.tagName.toLowerCase(),
+    type: control.type || undefined,
+    ...(value
+      ? {
+          value: truncate(value, AGENT_OBSERVATION_LIMITS.elementValueChars)
+        }
+      : {}),
+    visible: isVisible(element),
+    enabled: !(control.disabled ?? false),
+    editable:
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement ||
+      element instanceof HTMLSelectElement ||
+      (element as HTMLElement).isContentEditable,
+    sensitive
+  }
+}
+
+export const buildAgentObservation = (input: {
+  document: Document
+  tabId: number
+  documentId: string
+  frameId?: number
+  minimumGeneration: number
+  references: AgentElementReferenceStore
+  capturedAt?: number
+  createSnapshotId?: () => string
+}): AgentObservation => {
+  if ((input.frameId ?? 0) !== 0 || input.document.defaultView?.frameElement) {
+    throw new Error("Agent observations are main-frame only")
+  }
+  const url = new URL(input.document.location.href)
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Agent observations require an HTTP(S) document")
+  }
+  const snapshot = input.references.beginSnapshot({
+    minimumGeneration: input.minimumGeneration,
+    createSnapshotId:
+      input.createSnapshotId ?? (() => globalThis.crypto.randomUUID())
+  })
+  const candidates = Array.from(
+    input.document.querySelectorAll(INTERACTIVE_SELECTOR)
+  ).slice(0, AGENT_OBSERVATION_LIMITS.elements)
+  const elements = candidates.map((element) =>
+    toAgentElement(element, snapshot.reference(element))
+  )
+  const body = input.document.body
+  const visibleText = normalizedText(
+    body ? (body.innerText ?? body.textContent ?? "") : ""
+  )
+  const view = input.document.defaultView
+  const root = input.document.documentElement
+
+  return AgentObservationSchema.parse({
+    snapshotId: snapshot.snapshotId,
+    generation: snapshot.generation,
+    tabId: input.tabId,
+    documentId: input.documentId,
+    url: url.href,
+    origin: url.origin,
+    title: truncate(input.document.title, AGENT_OBSERVATION_LIMITS.titleChars),
+    elements,
+    visibleText: truncate(
+      visibleText,
+      AGENT_OBSERVATION_LIMITS.visibleTextChars
+    ),
+    scroll: {
+      x: view?.scrollX ?? 0,
+      y: view?.scrollY ?? 0,
+      viewportWidth: view?.innerWidth ?? root.clientWidth,
+      viewportHeight: view?.innerHeight ?? root.clientHeight,
+      documentWidth: Math.max(root.scrollWidth, root.clientWidth),
+      documentHeight: Math.max(root.scrollHeight, root.clientHeight)
+    },
+    dialogs: [],
+    capturedAt: input.capturedAt ?? Date.now()
+  })
+}

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -31,10 +31,51 @@ const normalizedText = (value: string): string =>
   value.replaceAll(/\s+/g, " ").trim()
 
 const isVisible = (element: Element): boolean => {
-  if (element.hasAttribute("hidden")) return false
-  if (element.getAttribute("aria-hidden") === "true") return false
-  const style = (element as HTMLElement).style
-  return style?.display !== "none" && style?.visibility !== "hidden"
+  if (
+    element instanceof HTMLInputElement &&
+    element.type.toLowerCase() === "hidden"
+  ) {
+    return false
+  }
+
+  const view = element.ownerDocument.defaultView
+  for (let current: Element | null = element; current; ) {
+    if (
+      current.hasAttribute("hidden") ||
+      current.hasAttribute("inert") ||
+      current.getAttribute("aria-hidden") === "true"
+    ) {
+      return false
+    }
+    const style = view?.getComputedStyle(current)
+    if (
+      style?.display === "none" ||
+      style?.visibility === "hidden" ||
+      style?.visibility === "collapse" ||
+      style?.contentVisibility === "hidden" ||
+      style?.opacity === "0"
+    ) {
+      return false
+    }
+    const root = current.getRootNode()
+    current =
+      current.parentElement ?? (root instanceof ShadowRoot ? root.host : null)
+  }
+
+  const renderedRects = Array.from(element.getClientRects()).filter(
+    (rect) => rect.width > 0 && rect.height > 0
+  )
+  if (renderedRects.length === 0) return false
+
+  const viewportWidth = view?.innerWidth ?? 0
+  const viewportHeight = view?.innerHeight ?? 0
+  return renderedRects.some(
+    (rect) =>
+      rect.bottom > 0 &&
+      rect.right > 0 &&
+      rect.top < viewportHeight &&
+      rect.left < viewportWidth
+  )
 }
 
 export const isSensitiveAgentElement = (element: Element): boolean => {
@@ -72,7 +113,8 @@ const elementValue = (element: Element): string | undefined => {
 }
 
 const toAgentElement = (element: Element, ref: string): AgentElement => {
-  const sensitive = isSensitiveAgentElement(element)
+  const visible = isVisible(element)
+  const sensitive = !visible || isSensitiveAgentElement(element)
   const name = accessibleName(element)
   const value = sensitive ? undefined : elementValue(element)
   const control = element as HTMLInputElement
@@ -90,7 +132,7 @@ const toAgentElement = (element: Element, ref: string): AgentElement => {
           value: truncate(value, AGENT_OBSERVATION_LIMITS.elementValueChars)
         }
       : {}),
-    visible: isVisible(element),
+    visible,
     enabled: !(control.disabled ?? false),
     editable:
       element instanceof HTMLInputElement ||

--- a/src/lib/browser-tab-access.ts
+++ b/src/lib/browser-tab-access.ts
@@ -1,3 +1,10 @@
+import {
+  resolveExcludedUrlPatterns,
+  urlMatchesAny
+} from "@/contents/url-filter"
+import { browser } from "@/lib/browser-api"
+import { isNeverReadUrl } from "@/lib/per-site-profiles"
+
 /** URL schemes where a content script can run at all. */
 export const isReadableTabScheme = (url?: string): boolean =>
   !!url && /^(https?|file|ftp):/i.test(url)
@@ -23,3 +30,71 @@ export const isContentScriptReadableUrl = (url?: string): boolean =>
 
 export const blockedTabAccessMessage = (label: string): string =>
   `Can't read ${label} — the browser blocks extensions on internal pages and extension galleries (chrome://, Chrome Web Store, etc.). Do not retry this same tab; answer from visible tab metadata or ask the user to switch/share details.`
+
+export interface OpenTab {
+  id: number
+  title: string
+  url: string
+  active: boolean
+}
+
+export type TabAccess = "ok" | "restricted" | "excluded"
+
+export const classifyTabAccess = async (url?: string): Promise<TabAccess> => {
+  if (!isContentScriptReadableUrl(url)) return "restricted"
+  const patterns = await resolveExcludedUrlPatterns()
+  return urlMatchesAny(url as string, patterns) ||
+    (await isNeverReadUrl(url as string))
+    ? "excluded"
+    : "ok"
+}
+
+/** Agent is stricter than general tab tools: it never reads file or FTP pages. */
+export const classifyAgentTabAccess = async (
+  url?: string
+): Promise<TabAccess> => {
+  if (!url || !/^https?:/i.test(url)) return "restricted"
+  return classifyTabAccess(url)
+}
+
+export const accessDeniedMessage = (
+  access: "restricted" | "excluded",
+  label: string
+): string =>
+  access === "restricted"
+    ? blockedTabAccessMessage(label)
+    : `Can't read ${label} — this site is excluded in your content-extraction settings.`
+
+const toOpenTab = (tab: {
+  id?: number
+  title?: string
+  url?: string
+  active?: boolean
+}): OpenTab => ({
+  id: tab.id as number,
+  title: tab.title || "Untitled",
+  url: tab.url || "",
+  active: Boolean(tab.active)
+})
+
+export const queryActiveTab = async () =>
+  (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0] ??
+  (await browser.tabs.query({ active: true, currentWindow: true }))[0]
+
+export const getAllTabs = async (): Promise<OpenTab[]> => {
+  const tabs = await browser.tabs.query({})
+  return tabs.filter((tab) => tab.id !== undefined).map(toOpenTab)
+}
+
+export const listReadableTabs = async (): Promise<OpenTab[]> => {
+  const tabs = await getAllTabs()
+  const patterns = await resolveExcludedUrlPatterns()
+  const readable: OpenTab[] = []
+  for (const tab of tabs) {
+    if (!isContentScriptReadableUrl(tab.url)) continue
+    if (urlMatchesAny(tab.url, patterns)) continue
+    if (await isNeverReadUrl(tab.url)) continue
+    readable.push(tab)
+  }
+  return readable
+}

--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -34,6 +34,9 @@ export const LEGACY_OLLAMA_MESSAGE_KEYS = {
 } as const
 
 export const MESSAGE_KEYS = {
+  AGENT: {
+    CONTROL_PORT: "agent-control-port"
+  },
   PROVIDER: PROVIDER_MESSAGE_KEYS,
   OLLAMA: LEGACY_OLLAMA_MESSAGE_KEYS,
   BROWSER: {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -24,27 +24,43 @@ export type OptionalApiPermission =
   | "alarms"
   | "sessions"
 
+type RequestableApiPermission = OptionalApiPermission | "webNavigation"
+
 /**
  * `alarms` is genuinely requestable at runtime in Chrome MV3, but
  * `@types/webextension-polyfill` classifies it as a standing (non-optional)
  * permission, so the permission-API arg types reject it. This wraps the cast in
  * one place — the underlying runtime call is valid.
  */
-const permissionArg = (permissions: OptionalApiPermission[]) =>
+const permissionArg = (permissions: RequestableApiPermission[]) =>
   ({ permissions }) as unknown as Parameters<
     typeof browser.permissions.request
   >[0]
 
-/** Is the optional permission currently granted? Never throws. */
-export const hasPermission = async (
-  perm: OptionalApiPermission
+const hasApiPermission = async (
+  permission: RequestableApiPermission
 ): Promise<boolean> => {
   try {
-    return await browser.permissions.contains(permissionArg([perm]))
+    return await browser.permissions.contains(permissionArg([permission]))
   } catch {
     return false
   }
 }
+
+const requestApiPermissions = async (
+  permissions: RequestableApiPermission[]
+): Promise<boolean> => {
+  try {
+    return await browser.permissions.request(permissionArg(permissions))
+  } catch {
+    return false
+  }
+}
+
+/** Is the optional permission currently granted? Never throws. */
+export const hasPermission = async (
+  perm: OptionalApiPermission
+): Promise<boolean> => hasApiPermission(perm)
 
 /**
  * Request an optional permission. Returns whether it is granted afterward.
@@ -54,16 +70,17 @@ export const requestPermission = async (
   perm: OptionalApiPermission
 ): Promise<boolean> => requestPermissions([perm])
 
+/** User-gesture entrypoint for enabling the Chromium Agent perception path. */
+export const hasAgentPerceptionPermission = (): Promise<boolean> =>
+  hasApiPermission("webNavigation")
+
+export const requestAgentPerceptionPermission = (): Promise<boolean> =>
+  requestApiPermissions(["webNavigation"])
+
 /** Request several related optional permissions from one user gesture. */
 export const requestPermissions = async (
   permissions: OptionalApiPermission[]
-): Promise<boolean> => {
-  try {
-    return await browser.permissions.request(permissionArg(permissions))
-  } catch {
-    return false
-  }
-}
+): Promise<boolean> => requestApiPermissions(permissions)
 
 /** Revoke an optional permission. Returns whether removal succeeded. Never throws. */
 export const removePermission = async (

--- a/src/lib/tools/internal/tab-utils.ts
+++ b/src/lib/tools/internal/tab-utils.ts
@@ -1,16 +1,25 @@
-import {
-  resolveExcludedUrlPatterns,
-  urlMatchesAny
-} from "@/contents/url-filter"
 import { browser } from "@/lib/browser-api"
 import {
-  blockedTabAccessMessage,
-  isContentScriptReadableUrl
+  accessDeniedMessage,
+  classifyTabAccess,
+  getAllTabs,
+  listReadableTabs,
+  type OpenTab,
+  queryActiveTab,
+  type TabAccess
 } from "@/lib/browser-tab-access"
 import { MESSAGE_KEYS } from "@/lib/constants"
 import { logger } from "@/lib/logger"
-import { isNeverReadUrl } from "@/lib/per-site-profiles"
 import type { ChromeResponse } from "@/types"
+
+export type { OpenTab, TabAccess }
+export {
+  accessDeniedMessage,
+  classifyTabAccess,
+  getAllTabs,
+  listReadableTabs,
+  queryActiveTab
+}
 
 /** Runtime-only extractor injected when a readable tab is requested. */
 const CONTENT_SCRIPT_FILE = "content-scripts/content.js"
@@ -183,79 +192,4 @@ export const readTabContent = async (
     logger.debug("readTabContent: recovery failed", "tabUtils", { error })
     throw error
   }
-}
-
-export interface OpenTab {
-  id: number
-  title: string
-  url: string
-  active: boolean
-}
-
-export type TabAccess =
-  /** Readable by the extension. */
-  | "ok"
-  /** Browser-internal/unsupported scheme (chrome://, web store, etc.). */
-  | "restricted"
-  /** Readable scheme, but the user excluded it via settings. */
-  | "excluded"
-
-/** Classify whether a tab's URL can be read, honoring the user's exclude list. */
-export const classifyTabAccess = async (url?: string): Promise<TabAccess> => {
-  if (!isContentScriptReadableUrl(url)) return "restricted"
-  const patterns = await resolveExcludedUrlPatterns()
-  return urlMatchesAny(url as string, patterns) ||
-    (await isNeverReadUrl(url as string))
-    ? "excluded"
-    : "ok"
-}
-
-/** Human-facing explanation the model can relay when a tab can't be read. */
-export const accessDeniedMessage = (
-  access: "restricted" | "excluded",
-  label: string
-): string =>
-  access === "restricted"
-    ? blockedTabAccessMessage(label)
-    : `Can't read ${label} — this site is excluded in your content-extraction settings.`
-
-const toOpenTab = (tab: {
-  id?: number
-  title?: string
-  url?: string
-  active?: boolean
-}): OpenTab => ({
-  id: tab.id as number,
-  title: tab.title || "Untitled",
-  url: tab.url || "",
-  active: Boolean(tab.active)
-})
-
-/**
- * The active tab of the user's focused window (falling back to the current
- * window). A bare `{ active: true }` could return an active tab from a
- * NON-focused window, which is never what "the visible tab" means.
- */
-export const queryActiveTab = async () =>
-  (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0] ??
-  (await browser.tabs.query({ active: true, currentWindow: true }))[0]
-
-/** Every tab that has an id, across all normal windows (any scheme). */
-export const getAllTabs = async (): Promise<OpenTab[]> => {
-  const tabs = await browser.tabs.query({})
-  return tabs.filter((tab) => tab.id !== undefined).map(toOpenTab)
-}
-
-/** Tabs the extension can actually read: readable scheme and not excluded. */
-export const listReadableTabs = async (): Promise<OpenTab[]> => {
-  const tabs = await getAllTabs()
-  const patterns = await resolveExcludedUrlPatterns()
-  const readable: OpenTab[] = []
-  for (const tab of tabs) {
-    if (!isContentScriptReadableUrl(tab.url)) continue
-    if (urlMatchesAny(tab.url, patterns)) continue
-    if (await isNeverReadUrl(tab.url)) continue
-    readable.push(tab)
-  }
-  return readable
 }

--- a/src/protocol/__tests__/runtime-transport-registry.test.ts
+++ b/src/protocol/__tests__/runtime-transport-registry.test.ts
@@ -54,6 +54,19 @@ describe("runtime transport registry", () => {
     ])
   })
 
+  it("classifies Agent control as background-initiated rather than RPC", () => {
+    expect(
+      RUNTIME_TRANSPORT_DEFINITIONS.find(
+        (definition) => definition.type === MESSAGE_KEYS.AGENT.CONTROL_PORT
+      )
+    ).toEqual({
+      type: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+      transport: "port",
+      operation: "control",
+      allowedSources: ["background"]
+    })
+  })
+
   it("denies unregistered content-script traffic", () => {
     expect(
       isRuntimeTransportAllowed(

--- a/src/protocol/runtime-transport-registry.ts
+++ b/src/protocol/runtime-transport-registry.ts
@@ -24,6 +24,12 @@ const extensionOrContent = ["extension-page", "content-script"] as const
  */
 export const RUNTIME_TRANSPORT_DEFINITIONS = [
   {
+    type: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+    transport: "port",
+    operation: "query",
+    allowedSources: extensionPage
+  },
+  {
     type: MESSAGE_KEYS.PROVIDER.GET_MODELS,
     transport: "message",
     operation: "query",

--- a/src/protocol/runtime-transport-registry.ts
+++ b/src/protocol/runtime-transport-registry.ts
@@ -1,8 +1,13 @@
 import { MESSAGE_KEYS } from "@/lib/constants"
 
 export type RuntimeTransport = "message" | "port" | "port-message"
-export type RuntimeOperation = "query" | "command" | "event" | "stream"
-export type RuntimeSource = "extension-page" | "content-script"
+export type RuntimeOperation =
+  | "query"
+  | "command"
+  | "event"
+  | "stream"
+  | "control"
+export type RuntimeSource = "background" | "extension-page" | "content-script"
 
 export interface RuntimeTransportDefinition {
   type: string
@@ -13,6 +18,7 @@ export interface RuntimeTransportDefinition {
 
 const extensionPage = ["extension-page"] as const
 const extensionOrContent = ["extension-page", "content-script"] as const
+const background = ["background"] as const
 
 /**
  * Policy ledger for runtime traffic that intentionally remains outside the
@@ -20,14 +26,15 @@ const extensionOrContent = ["extension-page", "content-script"] as const
  *
  * New request/response operations belong in RpcMethod. Entries here cover
  * streaming ports, lifecycle commands, one-way events, content-script reads,
- * and messages delivered to extension/content-page listeners.
+ * background-initiated control channels, and messages delivered to
+ * extension/content-page listeners.
  */
 export const RUNTIME_TRANSPORT_DEFINITIONS = [
   {
     type: MESSAGE_KEYS.AGENT.CONTROL_PORT,
     transport: "port",
-    operation: "query",
-    allowedSources: extensionPage
+    operation: "control",
+    allowedSources: background
   },
   {
     type: MESSAGE_KEYS.PROVIDER.GET_MODELS,

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -80,7 +80,8 @@ export default defineConfig({
       "downloads",
       "tabGroups",
       "alarms",
-      "sessions"
+      "sessions",
+      "webNavigation"
     ],
     // Browser-level keyboard command. Uses the reserved
     // `_execute_action` so the hotkey mirrors a toolbar-icon click: with


### PR DESCRIPTION
## Summary
- add a background-initiated, run-bound Agent observation channel
- validate tab, main frame, document, nonce, sequence, origin, and snapshot generation
- add capped observations, sensitive-value redaction, navigation invalidation, and element references
- keep webNavigation optional and strip the perception harness from store builds
- preserve Agent/Chat architecture boundaries

## Verification
- `pnpm typecheck`
- `pnpm test:run` (428 files, 3651 tests)
- targeted Biome check across config, src, packages, tools, e2e, and root configs
- Chrome and Firefox production builds







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a run-bound Agent perception channel that captures validated, bounded observations from an authorized tab while protecting hidden and sensitive page content.

- Adds a background-initiated control port bound to the run, tab, main-frame document, nonce, and monotonic sequence.
- Adds visibility-aware observation generation, sensitive-value redaction, clipping checks, navigation invalidation, and document-scoped element references.
- Adds optional `webNavigation` permission handling and excludes the perception harness from store builds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains from the previously reported issues.

The current code filters hidden and clipped observation content and correctly models the perception transport as a background-initiated, run-bound control channel, so no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/browser-agent/observation-builder.ts | Builds bounded observations while filtering hidden, clipped, offscreen, and sensitive element content; the previously reported disclosure paths are addressed. |
| src/lib/browser-agent/control-port.ts | Implements a background-initiated control channel with strict run, tab, frame, document, nonce, sequence, origin, and generation validation. |
| src/protocol/runtime-transport-registry.ts | Reclassifies Agent perception as a background-originated control port rather than an extension-page query, resolving the prior transport-boundary concern. |
| config/wxt-hooks.ts | Removes the development perception harness from store builds and excludes the redundant runtime content-script entrypoint from Firefox output. |
| src/contents/agent-control.ts | Installs the document-local control listener and creates references scoped to the requested document. |
| src/lib/browser-agent/navigation-observer.ts | Tracks main-frame commits and history changes so observations and references can be invalidated across navigation. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Agent as Agent runtime
  participant BG as Background control
  participant CS as Main-frame content script
  participant DOM as Page document
  Agent->>BG: Request observation for run and tab
  BG->>BG: Validate tab access and main-frame document
  BG->>CS: Connect to exact document
  BG->>CS: agent_observe(run, nonce, sequence, generation)
  CS->>DOM: Build bounded visibility-filtered snapshot
  CS-->>BG: Bound agent_observation
  BG->>BG: Validate identity, origin, sequence, and generation
  BG-->>Agent: Validated observation
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(agent): close clipped content leaks"](https://github.com/shishir435/ollama-client/commit/ca95fd6e63fdd59c9bb03f6de24943099b0229f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59636056)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Extension runtime and lifecycle](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/extension-runtime.md)
- Knowledge Base — [Runtime messaging and RPC](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/runtime-messaging.md)
- Knowledge Base — [Browser context integration](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/docs/browser-context-integration.md)
</details>


<!-- /greptile_comment -->