### PR TITLE
feat(docs): make the site answer agent requests correctly (#353)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ docs/public/llms-full.txt
 docs/public/ai.txt
 docs/public/**/*.md
 docs/public/openapi.json
+docs/public/.well-known/api-catalog
 
 # astro / starlight build caches
 docs/.astro/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,44 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
 - **A browser origin is refused unless it is allowed.** The proxy listens on loopback and runs an agent, so a wildcard `Access-Control-Allow-Origin` would let any page spend a turn — a missing response header does not stop a simple request. `ALLOWED_ORIGINS` defaults to the extension schemes; a request with no `Origin` is not a page and is left alone.
 - `packages/olc/README.md` has the options, endpoints, build outputs and known limits.
 
+### Docs site and its agent surface
+
+`docs/` is an Astro static build deployed by Vercel from `vercel.json`. Two
+rules decide where a change goes.
+
+- **Vercel evaluates `rewrites` after the filesystem.** Every documentation page
+  is a built file, so nothing in `rewrites` can reshape its response. An
+  `Accept`-conditioned rewrite there is dead config; an `Accept`-conditioned
+  *header* there is worse, because it relabels a body it never replaced. That is
+  what stamped `Content-Type: text/markdown` on the HTML homepage.
+- **Request-time behaviour lives in `docs/proxy.ts`**, the Routing Middleware
+  named by `vercel.json`'s `proxy` entry, which runs before the filesystem. It is
+  an adapter only: every decision is in `docs/src/lib/agent-routing.ts` so it can
+  be tested without a deployment (`src/lib/__tests__/agent-routing.test.ts`). Its
+  `config.matcher` excludes assets, `og/`, `.well-known/`, `reference/`, and any
+  path with a file extension — which is also what stops a `.md` rewrite from
+  re-entering it.
+
+The published contract, and where each piece is owned:
+
+| Surface | Owner |
+|---|---|
+| Markdown twin of every page, negotiated at the same URL | `agent-routing.ts` + the `.md` files `generate-llms-docs.ts` writes |
+| `llms.txt`, `llms-full.txt`, `ai.txt`, `index.md`, `404.md`, `.well-known/api-catalog` | `tools/generate/generate-llms-docs.ts`, gitignored under `docs/public/` |
+| `openapi.json` | `tools/generate/generate-openapi.ts` over `tools/generate/openapi/olc-openapi.template.json`, versioned from `packages/olc` |
+| JSON body of `/api` and `/api/health` | `docs/src/pages/`, prerendered |
+| Headers of those two paths | `vercel.json`, because a static build discards the headers an endpoint module sets. `agent-routing.test.ts` asserts they match `apiHeaders()` exactly |
+| JSON errors for `/api/*` (404, 405, 406) | `agent-routing.ts`; a static file cannot answer them |
+
+- A page's Markdown twin exists because its slug is in `DOC_ORDER`
+  (`docs/src/seo/doc-ia.mjs`), which is also the sidebar and the `llms.txt`
+  order. A route that is published but has no twin goes in
+  `NON_NEGOTIABLE_ROUTES`, or a Markdown client gets a 404 for a page it can
+  plainly load.
+- `pnpm verify:agent-endpoints [baseUrl]` proves the contract against a real
+  deployment. Routing order, middleware execution and CDN variant caching are
+  the parts no unit test can reach.
+
 ### Browser sessions and capture
 
 - Read-only helpers: `src/lib/browser-sessions.ts`. Model tools: `src/lib/tools/internal/browser-session-tools.ts`.
@@ -436,6 +474,8 @@ Contract tests worth knowing about, because they enforce conventions no reviewer
 | `config/__tests__/documentation-comments.test.ts` | module/declaration prose uses JSDoc instead of `//` blocks |
 | `config/__tests__/wxt-build-config.test.ts` | which dev pages and WASM assets a store build carries |
 | `config/__tests__/package-versions.test.ts` | workspace packages carry the extension version |
+| `lib/__tests__/agent-routing.test.ts` | Accept negotiation, agent 404s, JSON API errors, and that `vercel.json` restates `apiHeaders()` exactly |
+| `lib/__tests__/agent-docs.test.ts` | OpenAPI operations carry typed inputs and a rate-limit contract; negotiation stays out of post-filesystem rewrites |
 
 ### Lint and formatting
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -13,6 +13,7 @@ import {
   SITE_URL
 } from "./src/seo/constants.mjs"
 import { withReferenceGroup } from "./src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"
 import { lastModifiedForUrl } from "./src/seo/last-modified.mjs"
 
 /**
@@ -45,12 +46,13 @@ export default defineConfig({
    * Chrome Web Store listing, GitHub README, and existing index
    * results. Keep entries here as long as the old URLs are still
    * referenced anywhere we don't control.
+   *
+   * The map itself lives in src/seo/legacy-redirects.mjs because the Routing
+   * Middleware needs the same list: it answers a Markdown request before the
+   * filesystem, so a path it does not recognize is a 404 no redirect file ever
+   * gets to serve.
    */
-  redirects: {
-    "/architecture": "/concepts/architecture/",
-    "/ollama-setup-guide": "/guides/provider-setup/",
-    "/privacy-policy": "/legal/privacy-policy/"
-  },
+  redirects: LEGACY_REDIRECTS,
   markdown: {
     /*
      * Convert fenced ```mermaid blocks from a code-language block

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "@astrojs/starlight": "^0.41.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
+    "@vercel/functions": "^3.9.5",
     "astro-og-canvas": "^0.12.0",
     "canvaskit-wasm": "^0.41.1",
     "rehype-mermaid": "^3.0.0",

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -15,6 +15,7 @@ import { next, rewrite } from "@vercel/functions"
 
 import { resolveRequest } from "./src/lib/agent-routing"
 import { DOC_ORDER } from "./src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"
 
 export const config = {
   runtime: "nodejs",
@@ -44,11 +45,23 @@ export default function proxy(request: Request): Response {
       pathname,
       method: request.method.toUpperCase(),
       accept: request.headers.get("accept"),
-      markdownSlugs: DOC_ORDER
+      markdownSlugs: DOC_ORDER,
+      legacyRedirects: LEGACY_REDIRECTS
     })
 
     if (decision.kind === "rewrite") {
       return rewrite(new URL(decision.destination, request.url))
+    }
+
+    if (decision.kind === "redirect") {
+      return new Response(null, {
+        status: decision.status,
+        headers: {
+          Location: decision.location,
+          Vary: "Accept, Accept-Encoding",
+          "Cache-Control": "public, max-age=3600"
+        }
+      })
     }
 
     if (decision.kind === "respond") {

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -1,0 +1,66 @@
+/**
+ * Vercel Routing Middleware for the documentation site.
+ *
+ * It exists for one structural reason: Vercel evaluates `vercel.json` rewrites
+ * after the filesystem, so nothing declared there can change the response for a
+ * path that is a built file. Every documentation page is a built file, which is
+ * why `Accept`-based content negotiation, a machine-readable 404 and JSON API
+ * errors have to be decided here, before static serving.
+ *
+ * All of the behaviour lives in `src/lib/agent-routing.ts` so it can be tested
+ * without a deployment; this file is the adapter. A thrown error falls through
+ * to normal static serving rather than taking the site down with it.
+ */
+import { next, rewrite } from "@vercel/functions"
+
+import { resolveRequest } from "./src/lib/agent-routing"
+import { DOC_ORDER } from "./src/seo/doc-ia.mjs"
+
+export const config = {
+  runtime: "nodejs",
+  /*
+   * Skip anything that cannot be negotiated: build assets, generated OG
+   * images, the well-known and reference trees, and any path carrying a file
+   * extension (which includes the `.md` twins this middleware rewrites to, so
+   * a rewrite can never re-enter it).
+   *
+   * `/api` is listed separately and unconditionally, because that exclusion
+   * would otherwise hand `/api/models.json` to static serving and answer a
+   * machine with an HTML 404 — the one thing the JSON error contract promises
+   * never happens under `/api`.
+   */
+  matcher: [
+    "/",
+    "/api",
+    "/api/:path*",
+    "/((?!_astro/|assets/|og/|\\.well-known/|reference/|[^/]*\\.[^/]+$).*)"
+  ]
+}
+
+export default function proxy(request: Request): Response {
+  try {
+    const { pathname } = new URL(request.url)
+    const decision = resolveRequest({
+      pathname,
+      method: request.method.toUpperCase(),
+      accept: request.headers.get("accept"),
+      markdownSlugs: DOC_ORDER
+    })
+
+    if (decision.kind === "rewrite") {
+      return rewrite(new URL(decision.destination, request.url))
+    }
+
+    if (decision.kind === "respond") {
+      return new Response(decision.status === 204 ? null : decision.body, {
+        status: decision.status,
+        headers: decision.headers
+      })
+    }
+
+    return next()
+  } catch (error) {
+    console.error("routing middleware failed", error)
+    return next()
+  }
+}

--- a/docs/src/content/docs/about.md
+++ b/docs/src/content/docs/about.md
@@ -7,6 +7,17 @@ Ollama Client is an open-source browser extension for chatting with local and us
 
 The project is maintained by [Shishir Chaurasiya](https://www.shishirchaurasiya.in/) and developed publicly in the [Ollama Client GitHub repository](https://github.com/Shishir435/ollama-client). Source code is available under the MIT license. Releases are distributed through browser extension stores, while this site publishes setup, architecture, privacy, troubleshooting, and developer documentation.
 
+## Where Ollama Client is published
+
+These are the only official listings. Anything else carrying the name is not
+maintained by this project.
+
+- Chrome, Edge, and Brave: [Ollama Client on the Chrome Web Store](https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl)
+- Firefox: [Ollama Client on Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/ollama-client/)
+- Source and releases: [github.com/Shishir435/ollama-client](https://github.com/Shishir435/ollama-client)
+- Documentation and machine-readable resources: [www.ollamaclient.in](https://www.ollamaclient.in/)
+- Command-line tool: [olc](https://github.com/Shishir435/ollama-client/tree/main/packages/olc), installed from the GitHub releases
+
 ## What local-first means here
 
 Chat history, sessions, attachments, and most application state are stored by the extension in the user's browser profile. Model prompts go to the provider endpoint the user configures. A local provider can keep inference traffic on the device; a remote provider receives the data sent to it under that provider's terms. Optional web-search services likewise receive their search requests. “Local-first” describes the default ownership and architecture, not a claim that every possible configuration is offline.

--- a/docs/src/content/docs/developers.md
+++ b/docs/src/content/docs/developers.md
@@ -9,6 +9,12 @@ The project includes **olc**, a local CLI. Bare `olc` starts or reuses native Ol
 
 ## Quickstart
 
+**olc** is the project's official command-line tool. It is distributed as a
+checksum-verified archive attached to each [GitHub release](https://github.com/Shishir435/ollama-client/releases),
+fetched by the two installer wrappers below. There is no npm, PyPI, or Homebrew
+package yet; do not install a similarly named package from a public registry
+expecting this one.
+
 olc requires Node.js 22.12 or newer plus the selected runtime on `PATH`:
 Ollama for native mode, OpenCode, or Codex CLI with an existing `codex login`.
 macOS/Linux native mode also requires `lsof` for process inspection.
@@ -263,20 +269,118 @@ Common statuses are `400` for malformed requests or stale tool results, `401` fo
 
 ## Versioning, rate limits, and deprecation
 
-The local proxy's public API is versioned in its URL under `/v1`. Clients should
-use the documented versioned routes and inspect `X-API-Version` in responses.
-The proxy publishes the RFC RateLimit fields (`RateLimit-Policy`, `RateLimit`,
-`RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset`) on API
-responses. When a client exceeds the configured window it receives `429` with
+Both API surfaces are versioned in the URL path: the local proxy under `/v1`,
+and the website's read-only discovery surface at [`/api`](/api) as version
+`v1`. Every response carries `X-API-Version` with the major version of the
+contract that produced it. Use the documented versioned routes; do not depend
+on an undocumented path continuing to answer.
+
+### Rate-limit headers
+
+The proxy publishes the RFC RateLimit fields on every API response:
+
+| Header | Meaning |
+| --- | --- |
+| `RateLimit-Policy` | The published budget, `"default";q=<limit>;w=<window seconds>`. The proxy default is 60 requests per 60 seconds. |
+| `RateLimit` | The live window, `"default";r=<remaining>;t=<seconds to reset>`. |
+| `RateLimit-Limit` | Requests allowed in one window. |
+| `RateLimit-Remaining` | Requests left in the current window. |
+| `RateLimit-Reset` | Seconds until the window resets. |
+| `Retry-After` | On `429` only: seconds to wait. |
+
+The bucket is the bearer token when one is configured, and the remote address
+otherwise. When a client exceeds the window it receives `429` with
 `Retry-After`; retry with exponential backoff and do not blindly replay a
 non-idempotent generation.
 
-No `/v1` route is removed without advance notice. A future deprecated route
-will return the standard `Deprecation` response header and a `Sunset` HTTP date
-at least 30 days before removal. The migration and replacement route will be
-documented here and in the OpenAPI specification. The website's read-only
-discovery surface is available at [`/api`](/api) and uses the same header
-conventions.
+The website endpoints publish the same fields with the same names. They serve
+cached static JSON from a CDN and do not meter callers, so `RateLimit-Remaining`
+there always reports a full window — an honest answer to "have I been
+throttled", and a documented budget to pace against rather than guess at.
+
+### Deprecation and sunset policy
+
+No route on either surface is removed without advance notice. When a route is
+deprecated:
+
+1. Its responses carry the `Deprecation` header ([RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html))
+   with the HTTP date the deprecation took effect.
+2. They carry a `Sunset` HTTP date ([RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html))
+   at least **30 days** in the future. The route keeps working until that date.
+3. They carry a `Link` header pointing at the replacement route and at this
+   policy, using the extension relation
+   `https://www.ollamaclient.in/rel/deprecation-policy`.
+4. The migration and the replacement route are documented here and in the
+   OpenAPI specification *before* the headers appear, and the OpenAPI operation
+   is marked `deprecated: true`.
+
+No current route is deprecated, so neither header appears on any response
+today. The machine-readable form of this policy lives in `info.x-api-lifecycle`
+of the [OpenAPI document](/openapi.json) and in the `versioning` object of
+[`/api`](/api).
+
+## Website discovery API
+
+The website publishes two read-only JSON endpoints so an agent can find the rest
+of the surface without scraping HTML:
+
+| Method and path | Purpose |
+| --- | --- |
+| `GET /api` | Service metadata, error format, content-negotiation rules, rate-limit and versioning policy, CLI install commands. |
+| `GET /api/health` | Liveness response. |
+
+Errors from these endpoints are JSON, never an HTML page:
+
+```json
+{
+  "error": {
+    "status": 404,
+    "code": "route_not_found",
+    "message": "No API route for GET /api/models.",
+    "resolution": "This site publishes GET /api and GET /api/health. Inference endpoints live on the local olc proxy described by the OpenAPI document.",
+    "documentation": "https://www.ollamaclient.in/developers/",
+    "openapi": "https://www.ollamaclient.in/openapi.json",
+    "agentMap": "https://www.ollamaclient.in/llms.txt"
+  }
+}
+```
+
+`404` is an unknown route, `405` is a method other than `GET`, `HEAD`, or
+`OPTIONS` (the response names the allowed set in `Allow`), and `406` means no
+representation matched the `Accept` header. Read `error.resolution` before
+retrying.
+
+Both endpoints advertise the rest of the surface through `Link` relations:
+`service-desc` for the OpenAPI document, `service-doc` for this page, and
+`api-catalog` for the [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727.html)
+linkset at [`/.well-known/api-catalog`](/.well-known/api-catalog).
+
+## Markdown content negotiation
+
+Every documentation page has a Markdown twin at the same URL. Send
+`Accept: text/markdown` and the response body is Markdown with
+`Content-Type: text/markdown; charset=utf-8`; send a browser's `Accept` and it
+is the rendered HTML page. Responses `Vary: Accept, Accept-Encoding`, so a CDN
+cannot hand one variant to a client that asked for the other.
+
+```bash
+curl -H 'Accept: text/markdown' https://www.ollamaclient.in/developers
+```
+
+Quality factors are honoured, and the most specific matching range decides a
+type's quality, so `Accept: text/markdown;q=0.5, text/html` returns HTML and
+`Accept: text/html;q=0, */*` returns Markdown. An `Accept` header that matches
+no available representation returns `406` with a JSON explanation. The twins are
+also addressable directly by appending `.md`, and `/index.md` is the twin of the
+landing page.
+
+Negotiation applies to documentation pages. `/api` and `/api/health` are JSON
+only and ignore `Accept`, so a machine probing them always gets something it can
+parse.
+
+An unknown path returns a real `404`, with a short Markdown recovery map when
+Markdown was requested and the [HTML 404 page](/404.md) otherwise. It never
+returns `200` with an application shell, so an agent can trust the status.
 
 ## Agent integration guidance
 
@@ -286,7 +390,10 @@ Do not use this interface as a substitute for the extension's internal RPC contr
 
 ## Resources
 
-- [OpenAPI 3.1 JSON](/openapi.json)
+- [OpenAPI 3.1 JSON](/openapi.json) — machine-readable schema for the local olc API
+- [API catalog](/.well-known/api-catalog) — RFC 9727 linkset for both API surfaces
+- [Website JSON API](/api) and [health](/api/health)
+- [Agent map (llms.txt)](/llms.txt) and [full Markdown docs](/llms-full.txt)
 - [olc source and full operator guide](https://github.com/Shishir435/ollama-client/tree/main/packages/olc)
 - [Provider setup](/guides/provider-setup/)
 - [Error reports](/guides/troubleshooting/error-reports/)

--- a/docs/src/lib/agent-routing.ts
+++ b/docs/src/lib/agent-routing.ts
@@ -26,6 +26,8 @@ export type RouteDecision =
   | { kind: "pass" }
   /** Serve a different path's bytes under the requested URL. */
   | { kind: "rewrite"; destination: string }
+  /** Send the client to the canonical URL for this path. */
+  | { kind: "redirect"; status: number; location: string }
   /** Answer here; static serving never runs. */
   | {
       kind: "respond"
@@ -40,6 +42,8 @@ export type ResolveInput = {
   accept: string | null
   /** Slugs with a published `.md` twin, i.e. `DOC_ORDER`. */
   markdownSlugs: readonly string[]
+  /** Old inbound paths and their canonical destinations, i.e. `LEGACY_REDIRECTS`. */
+  legacyRedirects: Readonly<Record<string, string>>
 }
 
 /**
@@ -135,6 +139,10 @@ export type Preference = "markdown" | "html" | "unacceptable"
  * `text/html,…,<full wildcard>;q=0.8`, which keeps HTML; `Accept: text/markdown` alone
  * flips it. No `Accept` header at all is not a preference — it means "anything"
  * (RFC 9110), so it keeps the default HTML representation.
+ *
+ * The order of the two zero-quality checks below is load-bearing: nothing
+ * acceptable has to be decided before the HTML default, or a sole
+ * `text/html;q=0` falls through to the representation it excluded.
  */
 export function preferredRepresentation(accept: string | null): Preference {
   const ranges = parseAccept(accept)
@@ -143,8 +151,6 @@ export function preferredRepresentation(accept: string | null): Preference {
   const markdown = scoreFor(ranges, "text", "markdown")
   const html = scoreFor(ranges, "text", "html")
 
-  // Order matters: nothing acceptable is decided before the HTML default, or a
-  // sole `text/html;q=0` would fall through to the representation it excluded.
   if (markdown.q === 0 && html.q === 0) return "unacceptable"
   if (markdown.q === 0) return "html"
   if (markdown.q > html.q) return "markdown"
@@ -246,7 +252,8 @@ export function resolveRequest({
   pathname,
   method,
   accept,
-  markdownSlugs
+  markdownSlugs,
+  legacyRedirects
 }: ResolveInput): RouteDecision {
   const normalized = pathname.replace(/\/{2,}/g, "/")
 
@@ -266,6 +273,18 @@ export function resolveRequest({
   }
 
   if (preference === "html") return { kind: "pass" }
+
+  /*
+   * A legacy alias exists — Astro emits a meta-refresh page at each one — but
+   * only as HTML, and this runs before the filesystem, so without the map the
+   * path reads as unknown and a Markdown client is told 404 for a URL that
+   * plainly resolves in a browser. Redirecting rather than rewriting hands the
+   * agent the canonical address, which is the thing it should remember.
+   */
+  const alias =
+    legacyRedirects[normalized] ??
+    legacyRedirects[normalized.replace(/\/$/, "")]
+  if (alias) return { kind: "redirect", status: 308, location: alias }
 
   const slug = slugOf(normalized)
   if (slug === "") return { kind: "rewrite", destination: "/index.md" }

--- a/docs/src/lib/agent-routing.ts
+++ b/docs/src/lib/agent-routing.ts
@@ -1,0 +1,291 @@
+/**
+ * Request-time routing decisions for agent clients.
+ *
+ * The site is statically built, and Vercel evaluates `vercel.json` rewrites
+ * *after* the filesystem: a rewrite can never reshape a response for a path
+ * that exists as a file, which is every documentation page. Content
+ * negotiation, a machine-readable 404 and JSON API errors therefore have to be
+ * decided before the filesystem, in Routing Middleware.
+ *
+ * This module is the whole decision; `proxy.ts` only turns a decision into a
+ * `Response`. Keeping the two apart is what makes the behaviour testable
+ * without a deployment.
+ */
+import {
+  API_LINK_HEADER,
+  apiErrorBody,
+  apiHeaders,
+  SITE_ORIGIN
+} from "./api-response.js"
+
+/** Media type of the Markdown variant, per RFC 7763. */
+export const MARKDOWN_TYPE = "text/markdown; charset=utf-8"
+
+export type RouteDecision =
+  /** Hand the request to normal static serving. */
+  | { kind: "pass" }
+  /** Serve a different path's bytes under the requested URL. */
+  | { kind: "rewrite"; destination: string }
+  /** Answer here; static serving never runs. */
+  | {
+      kind: "respond"
+      status: number
+      headers: Record<string, string>
+      body: string
+    }
+
+export type ResolveInput = {
+  pathname: string
+  method: string
+  accept: string | null
+  /** Slugs with a published `.md` twin, i.e. `DOC_ORDER`. */
+  markdownSlugs: readonly string[]
+}
+
+/**
+ * Extension-less routes that exist but have no Markdown twin.
+ *
+ * Negotiation has to tell "this page has no Markdown form" apart from "this
+ * path does not exist": answering 404 for a page a client can plainly load as
+ * HTML would be a lie, and the recovery links would send it somewhere it had
+ * already been. The generated TypeDoc reference is published but not part of
+ * the Markdown IA (it carries no descriptions and is `noindex`), and
+ * `/goodbye` is the post-uninstall destination.
+ */
+export const NON_NEGOTIABLE_ROUTES = ["reference", "goodbye"] as const
+
+type MediaRange = {
+  type: string
+  subtype: string
+  q: number
+  /** 2 for an exact type, 1 for a subtype wildcard, 0 for a full wildcard. */
+  specificity: number
+}
+
+/**
+ * Parse an `Accept` header into ranges with their quality factors.
+ *
+ * A malformed parameter is dropped rather than failing the whole header: a
+ * client that sends one still deserves its readable ranges honoured. A `q`
+ * outside `[0, 1]` is not a preference, so it is ignored too.
+ */
+export function parseAccept(header: string | null): MediaRange[] {
+  if (!header) return []
+
+  const ranges: MediaRange[] = []
+
+  for (const entry of header.split(",")) {
+    const [rawRange, ...params] = entry.split(";")
+    const range = rawRange.trim().toLowerCase()
+    if (!range) continue
+
+    const [type, subtype] = range.split("/")
+    if (!type || !subtype) continue
+
+    let q = 1
+    for (const param of params) {
+      const match = param.trim().match(/^q=([0-9]*\.?[0-9]+)$/i)
+      if (!match) continue
+      const parsed = Number.parseFloat(match[1])
+      if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) q = parsed
+    }
+
+    ranges.push({
+      type,
+      subtype,
+      q,
+      specificity: type === "*" ? 0 : subtype === "*" ? 1 : 2
+    })
+  }
+
+  return ranges
+}
+
+/**
+ * Score one media type against the client's ranges.
+ *
+ * RFC 9110 settles a type's quality with the *most specific* range that matches
+ * it, not the most generous one. Taking the highest `q` instead would let
+ * `text/html;q=0, <full wildcard>` serve HTML: the wildcard's q=1 would outrank
+ * the exact exclusion the client wrote to rule it out.
+ */
+const scoreFor = (ranges: MediaRange[], type: string, subtype: string) =>
+  ranges
+    .filter(
+      (range) =>
+        (range.type === "*" || range.type === type) &&
+        (range.subtype === "*" || range.subtype === subtype)
+    )
+    .reduce(
+      (best, range) =>
+        range.specificity > best.specificity ||
+        (range.specificity === best.specificity && range.q > best.q)
+          ? { q: range.q, specificity: range.specificity }
+          : best,
+      { q: 0, specificity: -1 }
+    )
+
+export type Preference = "markdown" | "html" | "unacceptable"
+
+/**
+ * Pick the representation to serve.
+ *
+ * Markdown wins only when the client asked for it more strongly than HTML, or
+ * asked for it by name while reaching HTML through a wildcard. A browser sends
+ * `text/html,…,<full wildcard>;q=0.8`, which keeps HTML; `Accept: text/markdown` alone
+ * flips it. No `Accept` header at all is not a preference — it means "anything"
+ * (RFC 9110), so it keeps the default HTML representation.
+ */
+export function preferredRepresentation(accept: string | null): Preference {
+  const ranges = parseAccept(accept)
+  if (ranges.length === 0) return "html"
+
+  const markdown = scoreFor(ranges, "text", "markdown")
+  const html = scoreFor(ranges, "text", "html")
+
+  // Order matters: nothing acceptable is decided before the HTML default, or a
+  // sole `text/html;q=0` would fall through to the representation it excluded.
+  if (markdown.q === 0 && html.q === 0) return "unacceptable"
+  if (markdown.q === 0) return "html"
+  if (markdown.q > html.q) return "markdown"
+  if (markdown.q < html.q) return "html"
+  return markdown.specificity > html.specificity ? "markdown" : "html"
+}
+
+/** Strip the trailing slash so `/developers` and `/developers/` are one page. */
+const slugOf = (pathname: string) =>
+  pathname.replace(/^\/+/, "").replace(/\/+$/, "")
+
+const NOT_FOUND_MARKDOWN = `# 404 — Ollama Client page not found
+
+The requested path does not exist on this site. It is a documentation host, so
+nothing is generated on demand — every published page is listed in the maps
+below.
+
+- Home: ${SITE_ORIGIN}/
+- Agent map: ${SITE_ORIGIN}/llms.txt
+- Full Markdown docs: ${SITE_ORIGIN}/llms-full.txt
+- Sitemap: ${SITE_ORIGIN}/sitemap-index.xml
+- Developer portal: ${SITE_ORIGIN}/developers/
+- OpenAPI: ${SITE_ORIGIN}/openapi.json
+- API catalog: ${SITE_ORIGIN}/.well-known/api-catalog
+`
+
+const markdownHeaders = (): Record<string, string> => ({
+  "Content-Type": MARKDOWN_TYPE,
+  "Vary": "Accept, Accept-Encoding",
+  "Cache-Control": "public, max-age=0, must-revalidate",
+  "Link": API_LINK_HEADER
+})
+
+/** Paths whose JSON is prerendered; everything else under /api is unknown. */
+const API_PATHS = new Set(["/api", "/api/health"])
+
+const READ_METHODS = new Set(["GET", "HEAD"])
+
+const jsonDecision = (
+  status: number,
+  code: string,
+  message: string,
+  resolution: string,
+  extraHeaders: Record<string, string> = {}
+): RouteDecision => ({
+  kind: "respond",
+  status,
+  headers: { ...apiHeaders(), ...extraHeaders },
+  body: `${JSON.stringify(apiErrorBody(status, code, message, resolution), null, 2)}\n`
+})
+
+const resolveApi = (pathname: string, method: string): RouteDecision => {
+  if (method === "OPTIONS") {
+    /*
+     * A 204 carries no representation, so it carries no `Content-Type` either.
+     * The rate-limit and versioning headers stay: a client probing what a route
+     * accepts is exactly the one that should learn its budget before spending
+     * it.
+     */
+    const { "Content-Type": _contentType, ...headers } = apiHeaders()
+    return {
+      kind: "respond",
+      status: 204,
+      headers: { ...headers, Allow: "GET, HEAD, OPTIONS" },
+      body: ""
+    }
+  }
+
+  if (!API_PATHS.has(pathname)) {
+    return jsonDecision(
+      404,
+      "route_not_found",
+      `No API route for ${method} ${pathname}.`,
+      "This site publishes GET /api and GET /api/health. Inference endpoints live on the local olc proxy described by the OpenAPI document."
+    )
+  }
+
+  if (!READ_METHODS.has(method)) {
+    return jsonDecision(
+      405,
+      "method_not_allowed",
+      `${method} is not supported by this read-only endpoint.`,
+      "Use GET. The website publishes discovery metadata only; send generation requests to your local olc proxy.",
+      { Allow: "GET, HEAD, OPTIONS" }
+    )
+  }
+
+  return { kind: "pass" }
+}
+
+/**
+ * Decide how one request is answered.
+ *
+ * Order matters. `/api` is settled first so an agent probing it always gets
+ * JSON, whatever it put in `Accept`; a 406 there would be an HTML-shaped answer
+ * to a machine question.
+ */
+export function resolveRequest({
+  pathname,
+  method,
+  accept,
+  markdownSlugs
+}: ResolveInput): RouteDecision {
+  const normalized = pathname.replace(/\/{2,}/g, "/")
+
+  if (normalized === "/api" || normalized.startsWith("/api/")) {
+    return resolveApi(normalized.replace(/\/$/, "") || "/api", method)
+  }
+
+  const preference = preferredRepresentation(accept)
+
+  if (preference === "unacceptable") {
+    return jsonDecision(
+      406,
+      "not_acceptable",
+      "No representation matches the Accept header.",
+      "Request text/html for the rendered page, text/markdown for the Markdown twin, or */* to accept the default."
+    )
+  }
+
+  if (preference === "html") return { kind: "pass" }
+
+  const slug = slugOf(normalized)
+  if (slug === "") return { kind: "rewrite", destination: "/index.md" }
+  if (markdownSlugs.includes(slug)) {
+    return { kind: "rewrite", destination: `/${slug}.md` }
+  }
+  if (
+    NON_NEGOTIABLE_ROUTES.some(
+      (route) => slug === route || slug.startsWith(`${route}/`)
+    )
+  ) {
+    return { kind: "pass" }
+  }
+
+  return {
+    kind: "respond",
+    status: 404,
+    headers: markdownHeaders(),
+    body: NOT_FOUND_MARKDOWN
+  }
+}
+
+export const notFoundMarkdown = () => NOT_FOUND_MARKDOWN

--- a/docs/src/lib/api-response.ts
+++ b/docs/src/lib/api-response.ts
@@ -1,12 +1,94 @@
-const API_VERSION = "1"
-const RATE_LIMIT = 60
-const RATE_WINDOW_SECONDS = 60
+/**
+ * Response shaping for the website's read-only JSON API.
+ *
+ * Two callers share this module, and they must not drift:
+ *
+ *   - `src/pages/api.ts` / `src/pages/api-health.ts`, which Astro prerenders to
+ *     static files. A static build keeps the body and throws the headers away,
+ *     so `vercel.json` restates the header set for those two paths.
+ *   - `proxy.ts`, the Routing Middleware, which answers the error cases a
+ *     static file cannot answer at all: an unknown `/api/*` path, and any
+ *     method other than GET/HEAD/OPTIONS.
+ *
+ * Everything an agent needs to self-throttle or recover is a header or a field
+ * here, never prose in an HTML page.
+ */
+export const SITE_ORIGIN = "https://www.ollamaclient.in"
 
-export function apiHeaders(remaining = RATE_LIMIT, reset = RATE_WINDOW_SECONDS) {
+export const API_VERSION = "1"
+export const API_VERSION_PATH = "v1"
+
+/**
+ * Published request budget for the website's discovery endpoints.
+ *
+ * The website serves static JSON from a CDN and does not meter callers, so
+ * `RateLimit-Remaining` always reports a full window: it is the honest answer
+ * to "have I been throttled", not a counter pretending to exist. The policy is
+ * published so an agent can pace itself against a documented number instead of
+ * guessing, and so the same conventions the local olc proxy enforces are
+ * discoverable here.
+ */
+export const RATE_LIMIT = 60
+export const RATE_WINDOW_SECONDS = 60
+
+const DOCS_URL = `${SITE_ORIGIN}/developers/`
+const OPENAPI_URL = `${SITE_ORIGIN}/openapi.json`
+const CATALOG_URL = `${SITE_ORIGIN}/.well-known/api-catalog`
+const AGENT_MAP_URL = `${SITE_ORIGIN}/llms.txt`
+
+/**
+ * Deprecation signalling contract, restated in every discovery payload.
+ *
+ * `Deprecation` (RFC 9745) and `Sunset` (RFC 8594) are the headers a retiring
+ * route will carry. `deprecation-policy` is not a registered relation type, so
+ * it is expressed as an extension relation URI, which is what RFC 8288 requires
+ * of anything outside the IANA registry.
+ */
+export const DEPRECATION_POLICY_URL = `${SITE_ORIGIN}/developers/#versioning-rate-limits-and-deprecation`
+export const DEPRECATION_POLICY_REL = `${SITE_ORIGIN}/rel/deprecation-policy`
+
+export const API_LINK_HEADER = [
+  `<${OPENAPI_URL}>; rel="service-desc"; type="application/json"`,
+  `<${DOCS_URL}>; rel="service-doc"; type="text/html"`,
+  `<${CATALOG_URL}>; rel="api-catalog"`,
+  `<${DEPRECATION_POLICY_URL}>; rel="${DEPRECATION_POLICY_REL}"`
+].join(", ")
+
+export const VERSIONING = {
+  current: API_VERSION_PATH,
+  scheme: "URL path versioning (/api for this site, /v1 for the local olc API)",
+  versionHeader: "X-API-Version",
+  deprecationHeaders: ["Deprecation", "Sunset"],
+  minimumNoticeDays: 30,
+  policy:
+    "A route is never removed without notice. A deprecated route responds with the Deprecation header, a Sunset HTTP date at least 30 days ahead, and a Link to its replacement.",
+  policyUrl: DEPRECATION_POLICY_URL
+}
+
+export const RATE_LIMIT_DOC = {
+  policy: `${RATE_LIMIT} requests per ${RATE_WINDOW_SECONDS} seconds`,
+  headers: [
+    "RateLimit-Policy",
+    "RateLimit",
+    "RateLimit-Limit",
+    "RateLimit-Remaining",
+    "RateLimit-Reset"
+  ],
+  retry: "A 429 response carries Retry-After with the seconds to wait.",
+  enforcement:
+    "The website serves cached static JSON and does not meter callers; the published policy is the budget the local olc proxy enforces."
+}
+
+export function apiHeaders(
+  remaining = RATE_LIMIT,
+  reset = RATE_WINDOW_SECONDS
+): Record<string, string> {
   return {
     "Cache-Control": "public, max-age=60",
     "Content-Type": "application/json; charset=utf-8",
+    "Vary": "Accept, Accept-Encoding",
     "X-API-Version": API_VERSION,
+    "Link": API_LINK_HEADER,
     "RateLimit-Policy": `"default";q=${RATE_LIMIT};w=${RATE_WINDOW_SECONDS}`,
     "RateLimit": `"default";r=${Math.max(0, remaining)};t=${reset}`,
     "RateLimit-Limit": String(RATE_LIMIT),
@@ -15,12 +97,31 @@ export function apiHeaders(remaining = RATE_LIMIT, reset = RATE_WINDOW_SECONDS) 
   }
 }
 
+export function apiErrorBody(
+  status: number,
+  code: string,
+  message: string,
+  resolution: string
+) {
+  return {
+    error: {
+      status,
+      code,
+      message,
+      resolution,
+      documentation: DOCS_URL,
+      openapi: OPENAPI_URL,
+      agentMap: AGENT_MAP_URL
+    }
+  }
+}
+
 export function apiJson(
   body: unknown,
   status = 200,
   extraHeaders: Record<string, string> = {}
 ) {
-  return new Response(JSON.stringify(body, null, 2), {
+  return new Response(`${JSON.stringify(body, null, 2)}\n`, {
     status,
     headers: { ...apiHeaders(), ...extraHeaders }
   })
@@ -30,11 +131,13 @@ export function apiError(
   status: number,
   code: string,
   message: string,
-  resolution: string
+  resolution: string,
+  extraHeaders: Record<string, string> = {}
 ) {
-  return apiJson(
-    { error: { code, message, resolution } },
-    status,
-    status === 429 ? { "Retry-After": String(RATE_WINDOW_SECONDS) } : {}
-  )
+  return apiJson(apiErrorBody(status, code, message, resolution), status, {
+    ...(status === 429
+      ? { "Retry-After": String(RATE_WINDOW_SECONDS) }
+      : {}),
+    ...extraHeaders
+  })
 }

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro"
+import { notFoundMarkdown } from "@/lib/agent-routing"
 
 const title = "404 — Page not found | Ollama Client"
 const description =
@@ -23,12 +24,8 @@ const description =
       <li><a class="underline underline-offset-4" href="/llms.txt">llms.txt — concise Markdown docs map</a></li>
       <li><a class="underline underline-offset-4" href="/sitemap-index.xml">XML sitemap</a></li>
       <li><a class="underline underline-offset-4" href="/developers/">Developer portal and OpenAPI resources</a></li>
+      <li><a class="underline underline-offset-4" href="/404.md">Markdown recovery map</a></li>
     </ul>
-    <pre class="mt-10 max-w-2xl overflow-x-auto rounded-sm border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed"><code># 404 — Ollama Client page not found
-
-- Docs: https://www.ollamaclient.in/
-- Agent map: https://www.ollamaclient.in/llms.txt
-- Sitemap: https://www.ollamaclient.in/sitemap-index.xml
-- Developers: https://www.ollamaclient.in/developers/</code></pre>
+    <pre class="mt-10 max-w-2xl overflow-x-auto rounded-sm border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed"><code>{notFoundMarkdown()}</code></pre>
   </section>
 </BaseLayout>

--- a/docs/src/pages/api-health.ts
+++ b/docs/src/pages/api-health.ts
@@ -1,7 +1,21 @@
-import { apiError, apiJson } from "@/lib/api-response"
+import {
+  API_VERSION_PATH,
+  apiError,
+  apiJson,
+  SITE_ORIGIN
+} from "@/lib/api-response"
 
 export function GET() {
-  return apiJson({ status: "ok", service: "ollama-client-website", version: "v1" })
+  return apiJson({
+    status: "ok",
+    service: "ollama-client-website",
+    version: API_VERSION_PATH,
+    checks: {
+      docs: "static",
+      inference: "not-hosted"
+    },
+    self: `${SITE_ORIGIN}/api/health`
+  })
 }
 
 export function ALL() {
@@ -9,6 +23,7 @@ export function ALL() {
     405,
     "method_not_allowed",
     "Only GET is supported by this read-only endpoint.",
-    "Use GET /api/health."
+    "Use GET /api/health.",
+    { Allow: "GET, HEAD, OPTIONS" }
   )
 }

--- a/docs/src/pages/api.ts
+++ b/docs/src/pages/api.ts
@@ -1,32 +1,63 @@
-import { apiError, apiJson } from "@/lib/api-response"
+import {
+  API_LINK_HEADER,
+  API_VERSION_PATH,
+  apiError,
+  apiJson,
+  RATE_LIMIT_DOC,
+  SITE_ORIGIN,
+  VERSIONING
+} from "@/lib/api-response"
 
 const service = {
   service: "Ollama Client website API",
-  version: "v1",
+  version: API_VERSION_PATH,
   description:
     "Read-only discovery metadata for Ollama Client. Inference runs locally through the olc CLI; this website does not host model requests.",
-  docs: "https://www.ollamaclient.in/developers/",
-  openapi: "https://www.ollamaclient.in/openapi.json",
-  agentMap: "https://www.ollamaclient.in/llms.txt",
-  endpoints: {
-    self: "https://www.ollamaclient.in/api",
-    health: "https://www.ollamaclient.in/api/health"
+  docs: `${SITE_ORIGIN}/developers/`,
+  openapi: `${SITE_ORIGIN}/openapi.json`,
+  apiCatalog: `${SITE_ORIGIN}/.well-known/api-catalog`,
+  agentMap: `${SITE_ORIGIN}/llms.txt`,
+  cli: {
+    name: "olc",
+    description:
+      "Local CLI that starts native Ollama, or exposes a local agent runtime over an OpenAI-compatible API.",
+    source: "https://github.com/Shishir435/ollama-client/tree/main/packages/olc",
+    install: {
+      shell: `curl -fsSL ${SITE_ORIGIN}/olc.sh | sh`,
+      powershell: `irm ${SITE_ORIGIN}/olc.ps1 | iex`
+    },
+    docs: `${SITE_ORIGIN}/developers/#quickstart`
   },
-  rateLimit: {
-    policy: "60 requests per 60 seconds",
-    headers: [
-      "RateLimit-Policy",
-      "RateLimit",
-      "RateLimit-Limit",
-      "RateLimit-Remaining",
-      "RateLimit-Reset"
-    ],
-    retry: "429 responses include Retry-After"
-  }
+  endpoints: {
+    self: `${SITE_ORIGIN}/api`,
+    health: `${SITE_ORIGIN}/api/health`
+  },
+  errorFormat: {
+    mediaType: "application/json",
+    shape: "{ error: { status, code, message, resolution, documentation } }",
+    statuses: {
+      "404": "Unknown API route.",
+      "405": "Method other than GET, HEAD, or OPTIONS.",
+      "406": "No representation matches the Accept header.",
+      "429": "Rate limit exceeded; retry after the Retry-After delay."
+    }
+  },
+  contentNegotiation: {
+    appliesTo:
+      "Documentation pages. The endpoints under /api are JSON only and ignore Accept, so a machine probe always gets a parseable answer.",
+    default: "text/html",
+    markdown:
+      "Send Accept: text/markdown to receive the Markdown twin of any documentation page at the same URL. Quality factors are honoured, and the most specific matching range wins.",
+    vary: "Accept, Accept-Encoding",
+    unsupported:
+      "A documentation page whose Accept header matches no available representation returns 406 with a JSON explanation."
+  },
+  rateLimit: RATE_LIMIT_DOC,
+  versioning: VERSIONING
 }
 
 export function GET() {
-  return apiJson(service)
+  return apiJson(service, 200, { Link: API_LINK_HEADER })
 }
 
 export function ALL() {
@@ -34,6 +65,7 @@ export function ALL() {
     405,
     "method_not_allowed",
     "Only GET is supported by this read-only endpoint.",
-    "Use GET /api for discovery metadata or the local olc API for inference."
+    "Use GET /api for discovery metadata, or the local olc API for inference.",
+    { Allow: "GET, HEAD, OPTIONS" }
   )
 }

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -6,7 +6,10 @@ import {
   AUTHOR_URL,
   LANDING_TITLE,
   LANDING_DESCRIPTION,
-  SITE_TITLE
+  REPO_URL,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL
 } from "@/seo/constants.mjs"
 
 const title = LANDING_TITLE
@@ -30,11 +33,61 @@ const homepageFaq = [
   }
 ]
 
+/*
+ * Distribution URLs, listed once.
+ *
+ * These are the identities a brand-name search has to be able to tie back to
+ * this domain: two store listings, the repository, and the author. They are
+ * repeated as `sameAs` on both the application and the organization node
+ * because a search engine reconciles an entity from whichever node it reaches
+ * first, and a listing that appears on only one of them is a link it may never
+ * follow back here.
+ */
+const CHROME_LISTING =
+  "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl"
+const FIREFOX_LISTING =
+  "https://addons.mozilla.org/en-US/firefox/addon/ollama-client/"
+
+const brandProfiles = [REPO_URL, CHROME_LISTING, FIREFOX_LISTING]
+
+const publisher = {
+  "@type": "Organization",
+  "@id": `${SITE_URL}/#organization`,
+  name: SITE_TITLE,
+  alternateName: ["Ollama Client extension", "ollamaclient.in"],
+  url: `${SITE_URL}/`,
+  description: SITE_DESCRIPTION,
+  logo: {
+    "@type": "ImageObject",
+    url: `${SITE_URL}/assets/favicon-32x32.png`,
+    width: 32,
+    height: 32
+  },
+  founder: {
+    "@type": "Person",
+    name: AUTHOR_NAME,
+    url: AUTHOR_URL
+  },
+  sameAs: brandProfiles
+}
+
 const jsonLd = {
   "@context": "https://schema.org",
   "@graph": [
+    publisher,
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      name: SITE_TITLE,
+      alternateName: "Ollama Client docs",
+      url: `${SITE_URL}/`,
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": `${SITE_URL}/#organization` }
+    },
     {
       "@type": "SoftwareApplication",
+      "@id": `${SITE_URL}/#software`,
       name: SITE_TITLE,
       alternateName: "Ollama Client local AI browser extension",
       description,
@@ -51,15 +104,17 @@ const jsonLd = {
         name: AUTHOR_NAME,
         url: AUTHOR_URL
       },
-      url: "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
-      downloadUrl:
-        "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl",
-      codeRepository: "https://github.com/Shishir435/ollama-client",
-      sameAs: [
-        "https://github.com/Shishir435/ollama-client",
-        "https://chromewebstore.google.com/detail/ollama-client-chat-with-l/bfaoaaogfcgomkjfbmfepbiijmciinjl"
-      ],
-      softwareVersion: APP_VERSION
+      publisher: { "@id": `${SITE_URL}/#organization` },
+      url: CHROME_LISTING,
+      downloadUrl: CHROME_LISTING,
+      installUrl: CHROME_LISTING,
+      codeRepository: REPO_URL,
+      sameAs: brandProfiles,
+      softwareVersion: APP_VERSION,
+      softwareHelp: {
+        "@type": "CreativeWork",
+        url: `${SITE_URL}/guides/quick-start/`
+      }
     },
     {
       "@type": "FAQPage",

--- a/docs/src/seo/legacy-redirects.d.mts
+++ b/docs/src/seo/legacy-redirects.d.mts
@@ -1,0 +1,5 @@
+/**
+ * Type declarations for the plain-JS legacy redirect map consumed by the
+ * Routing Middleware and its tests under the strict root tsconfig.
+ */
+export const LEGACY_REDIRECTS: Record<string, string>

--- a/docs/src/seo/legacy-redirects.mjs
+++ b/docs/src/seo/legacy-redirects.mjs
@@ -1,0 +1,21 @@
+/**
+ * Inbound URLs from the pre-Starlight IA, mapped to where they live now.
+ *
+ * Single source of truth for two consumers that must not disagree:
+ *
+ *   - `docs/astro.config.mjs`, which emits a meta-refresh page at each old path
+ *     for browsers and crawlers,
+ *   - `docs/src/lib/agent-routing.ts`, which answers a Markdown client before
+ *     the filesystem is consulted and would otherwise call these paths unknown.
+ *
+ * They had already disagreed once: the Routing Middleware landed knowing only
+ * `DOC_ORDER`, so `/architecture` with `Accept: text/markdown` returned a 404
+ * for a path that plainly resolves in a browser. An alias only stops being an
+ * alias when nothing links to it, so entries stay as long as the Chrome Web
+ * Store listing, the README, or an existing search result can still point here.
+ */
+export const LEGACY_REDIRECTS = {
+  "/architecture": "/concepts/architecture/",
+  "/ollama-setup-guide": "/guides/provider-setup/",
+  "/privacy-policy": "/legal/privacy-policy/"
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "verify:ci-parity": "tsx tools/verify/verify-ci-parity.ts",
     "verify:ci": "pnpm check:static && pnpm test:coverage",
     "verify:opfs-migration": "tsx tools/verify/verify-opfs-migration.ts",
+    "verify:agent-endpoints": "tsx tools/verify/verify-agent-endpoints.ts",
     "verify:firefox-opfs-migration": "tsx tools/verify/verify-firefox-opfs-migration.ts",
     "verify:sw-turn-recovery": "tsx tools/verify/verify-sw-turn-recovery.ts",
     "e2e": "pnpm e2e:build && pnpm e2e:chromium:critical",

--- a/packages/olc/package.json
+++ b/packages/olc/package.json
@@ -2,6 +2,32 @@
   "name": "@ollama-client/olc",
   "version": "0.13.3",
   "description": "OpenAI-compatible proxy for a local agent runtime, with a tool bridge that lets OpenAI-compatible clients run their own tools",
+  "keywords": [
+    "ollama",
+    "ollama-client",
+    "olc",
+    "openai-compatible",
+    "proxy",
+    "cli",
+    "agent",
+    "opencode",
+    "codex",
+    "local-llm"
+  ],
+  "homepage": "https://www.ollamaclient.in/developers/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shishir435/ollama-client.git",
+    "directory": "packages/olc"
+  },
+  "bugs": {
+    "url": "https://github.com/Shishir435/ollama-client/issues"
+  },
+  "license": "MIT",
+  "author": "Shishir Chaurasiya (https://www.shishirchaurasiya.in/)",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,22 +296,25 @@ importers:
         version: 7.2.1(supports-color@7.2.0)
       '@astrojs/mdx':
         specifier: ^7.0.0
-        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
+        version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
       '@astrojs/sitemap':
         specifier: ^3.7.3
         version: 3.7.3
       '@astrojs/starlight':
         specifier: ^0.41.1
-        version: 0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
+        version: 0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
       '@fontsource-variable/geist-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@vercel/functions':
+        specifier: ^3.9.5
+        version: 3.9.5(ws@8.21.0)
       astro-og-canvas:
         specifier: ^0.12.0
-        version: 0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -320,7 +323,7 @@ importers:
         version: 3.0.0(playwright@1.60.0)
       starlight-typedoc:
         specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.2)))(typedoc@0.28.19(@typescript/typescript6@6.0.2))
+        version: 0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.2)))(typedoc@0.28.19(@typescript/typescript6@6.0.2))
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(@typescript/typescript6@6.0.2)
@@ -333,7 +336,7 @@ importers:
         version: 4.3.0
       astro:
         specifier: 7.1.3
-        version: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       postcss:
         specifier: 8.5.18
         version: 8.5.18
@@ -2925,6 +2928,29 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/cli-config@0.2.4':
+    resolution: {integrity: sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
+  '@vercel/functions@3.9.5':
+    resolution: {integrity: sha512-EUfqlb7AzoEh7URlMNAO4jbJiLWz9grDBHvfjKTDvEP9c8y3DqX3SWPvfaQkUjtkm3b83flhaUUMuewdHa+qmw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
+
+  '@vercel/oidc@3.8.5':
+    resolution: {integrity: sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3004,6 +3030,7 @@ packages:
   '@xmldom/xmldom@0.9.11':
     resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zip.js/zip.js@2.8.31':
     resolution: {integrity: sha512-2NLmow9ax/5IdBbJKxNQp3Ur9mNxmgLfN2Yp/FKNh1ZIGs3OYkiC3AIUfIZouTPSgeW5+F1bzTAZAyD2Y4ZfFA==}
@@ -4717,6 +4744,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -5489,6 +5519,10 @@ packages:
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   os-shim@0.1.3:
     resolution: {integrity: sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==}
@@ -7008,9 +7042,17 @@ packages:
       eslint:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -7084,6 +7126,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -7277,13 +7322,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.4
 
-  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)':
+  '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0(supports-color@7.2.0)
       '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
       acorn: 8.16.0
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -7309,17 +7354,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)':
+  '@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.2
-      '@astrojs/mdx': 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
+      '@astrojs/mdx': 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
-      astro-expressive-code: 0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro-expressive-code: 0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -9366,6 +9411,27 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/cli-config@0.2.4':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/functions@3.9.5(ws@8.21.0)':
+    dependencies:
+      '@vercel/oidc': 3.8.5
+    optionalDependencies:
+      ws: 8.21.0
+
+  '@vercel/oidc@3.8.5':
+    dependencies:
+      '@vercel/cli-config': 0.2.4
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.10.0
+
   '@vitejs/plugin-react@5.2.0(supports-color@7.2.0)(vite@8.1.2(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0(supports-color@7.2.0)
@@ -9588,20 +9654,20 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
+  astro-expressive-code@0.44.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro-og-canvas@0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
+  astro-og-canvas@0.12.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0):
+  astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.1
@@ -9650,7 +9716,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
-      unstorage: 1.17.5
+      unstorage: 1.17.5(@vercel/functions@3.9.5(ws@8.21.0))
       vite: 8.1.2(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.2(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -11385,6 +11451,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
@@ -12501,6 +12569,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  os-paths@4.4.0: {}
+
   os-shim@0.1.3: {}
 
   outvariant@1.4.3:
@@ -13530,9 +13600,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.2)))(typedoc@0.28.19(@typescript/typescript6@6.0.2)):
+  starlight-typedoc@0.23.0(@astrojs/starlight@0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.2)))(typedoc@0.28.19(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@astrojs/starlight': 0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
+      '@astrojs/starlight': 0.41.1(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(astro@7.1.3(@astrojs/markdown-remark@7.2.1(supports-color@7.2.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.20.1)(@vercel/functions@3.9.5(ws@8.21.0))(jiti@2.7.0)(rollup@4.60.4)(sass@1.89.0)(tsx@4.23.1)(yaml@2.9.0))(supports-color@7.2.0)
       github-slugger: 2.0.0
       typedoc: 0.28.19(@typescript/typescript6@6.0.2)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.2))
@@ -13913,7 +13983,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.5:
+  unstorage@1.17.5(@vercel/functions@3.9.5(ws@8.21.0)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -13923,6 +13993,8 @@ snapshots:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.4
+    optionalDependencies:
+      '@vercel/functions': 3.9.5(ws@8.21.0)
 
   until-async@3.0.2:
     optional: true
@@ -14308,7 +14380,16 @@ snapshots:
       - tsx
       - yaml
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
   xdg-basedir@5.1.0: {}
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   xml-name-validator@5.0.0: {}
 
@@ -14374,6 +14455,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}
 
   zod@4.4.3: {}
 

--- a/src/lib/__tests__/agent-docs.test.ts
+++ b/src/lib/__tests__/agent-docs.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 
 import { OLC_PUBLIC_ROUTES } from "../../../packages/olc/src/core/public-api-contract"
+import {
+  apiCatalogDocument,
+  llmsTxtContent
+} from "../../../tools/generate/generate-llms-docs"
 import { buildOlcOpenApi } from "../../../tools/generate/generate-openapi"
 
 const REPO_ROOT = join(__dirname, "../../..")
@@ -12,6 +16,7 @@ const readRepoFile = (path: string) =>
 
 const openApi = buildOlcOpenApi() as {
   openapi: string
+  components: unknown
   info: { title: string; version: string; description: string }
   servers: Array<{ url: string }>
   paths: Record<
@@ -21,11 +26,35 @@ const openApi = buildOlcOpenApi() as {
       {
         operationId?: string
         description?: string
-        parameters?: Array<{ schema?: unknown }>
+        parameters?: Array<{ schema?: unknown; $ref?: string }>
+        requestBody?: { schema?: unknown; $ref?: string }
         responses?: Record<string, unknown>
       }
     >
   >
+}
+
+/**
+ * Resolve one local `$ref` so an assertion reads the shape a client would.
+ *
+ * Only the single hop the document actually uses is followed: components here
+ * never point at further refs, and a general resolver would hide a chain that
+ * does not exist.
+ */
+type OpenApiNode = {
+  $ref?: string
+  schema?: unknown
+  headers?: Record<string, unknown>
+  content?: Record<string, { schema?: unknown }>
+}
+
+const deref = (node: OpenApiNode): OpenApiNode => {
+  if (!node.$ref) return node
+  const path = node.$ref.replace(/^#\//, "").split("/")
+  return path.reduce<Record<string, unknown>>(
+    (current, key) => current[key] as Record<string, unknown>,
+    openApi as unknown as Record<string, unknown>
+  ) as OpenApiNode
 }
 
 describe("agent-facing documentation", () => {
@@ -67,8 +96,52 @@ describe("agent-facing documentation", () => {
     expect(
       operations
         .flatMap((operation) => operation.parameters ?? [])
-        .every((parameter) => Boolean(parameter.schema))
+        .every((parameter) => Boolean(deref(parameter).schema))
     ).toBe(true)
+  })
+
+  it("gives every operation a typed input and a documented rate limit", () => {
+    /*
+     * A function-calling client builds its tool schema from an operation's
+     * inputs. Three of the six had none at all — no path parameter and no
+     * request body — which reads as an untyped tool rather than one that takes
+     * nothing. Every operation now documents the `Origin` header the proxy
+     * actually inspects, which is a real input and the reason each can answer
+     * 403.
+     */
+    const operations = Object.values(openApi.paths).flatMap((path) =>
+      Object.values(path)
+    )
+
+    for (const operation of operations) {
+      const parameterSchemas = (operation.parameters ?? []).map(
+        (parameter) => deref(parameter).schema
+      )
+      const bodySchemas = Object.values(
+        deref(operation.requestBody ?? {}).content ?? {}
+      ).map((media) => media.schema)
+      const inputs = [...parameterSchemas, ...bodySchemas]
+
+      expect(inputs.length, operation.operationId).toBeGreaterThan(0)
+      expect(inputs.every(Boolean), operation.operationId).toBe(true)
+      expect(operation.responses?.["429"], operation.operationId).toBeDefined()
+    }
+
+    const rateLimited = deref({
+      $ref: "#/components/responses/RateLimitExceeded"
+    })
+
+    expect(Object.keys(rateLimited.headers ?? {})).toEqual(
+      expect.arrayContaining([
+        "Retry-After",
+        "RateLimit-Policy",
+        "RateLimit-Limit",
+        "RateLimit-Remaining",
+        "RateLimit-Reset",
+        "Deprecation",
+        "Sunset"
+      ])
+    )
   })
 
   it("keeps trust pages substantive and product-specific", () => {
@@ -85,8 +158,16 @@ describe("agent-facing documentation", () => {
     }
   })
 
-  it("configures Markdown negotiation without hiding response variants", () => {
+  it("routes Accept negotiation through middleware, not a post-filesystem rewrite", () => {
+    /*
+     * Vercel evaluates `rewrites` after the filesystem, so the rule this
+     * replaced could never fire for a documentation page: every one of them is
+     * a built file. What shipped instead was a header rule that stamped
+     * `Content-Type: text/markdown` on the HTML body it failed to replace.
+     * Negotiation belongs in Routing Middleware, which runs first.
+     */
     const config = JSON.parse(readRepoFile("vercel.json")) as {
+      proxy?: { entrypoint: string }
       rewrites: Array<{
         source: string
         destination: string
@@ -94,33 +175,126 @@ describe("agent-facing documentation", () => {
       }>
       headers: Array<{
         source: string
+        has?: Array<{ type: string; key: string; value?: string }>
         headers: Array<{ key: string; value: string }>
       }>
     }
-    const markdownRewrite = config.rewrites.find(
-      ({ source, destination }) =>
-        source === "/:path((?!reference(?:/|$))(?!.*\\.).*)" &&
-        destination === "/:path*.md"
-    )
-    const vary = config.headers
-      .flatMap(({ headers }) => headers)
-      .find(({ key }) => key.toLowerCase() === "vary")
 
-    expect(markdownRewrite?.has).toContainEqual({
-      type: "header",
-      key: "Accept",
-      value: ".*text/markdown.*"
-    })
-    const routePattern = markdownRewrite?.source.match(/^\/:path\((.*)\)$/)?.[1]
-    expect(routePattern).toBeDefined()
-    const negotiatedPath = new RegExp(`^${routePattern}$`)
-    expect(negotiatedPath.test("developers")).toBe(true)
-    expect(negotiatedPath.test("guides/provider-setup")).toBe(true)
-    expect(negotiatedPath.test("reference")).toBe(false)
-    expect(negotiatedPath.test("reference/lib/providers")).toBe(false)
-    expect(negotiatedPath.test("openapi.json")).toBe(false)
+    expect(config.proxy?.entrypoint).toBe("docs/proxy.ts")
+    expect(
+      config.rewrites.some((rule) =>
+        rule.has?.some(({ key }) => key.toLowerCase() === "accept")
+      )
+    ).toBe(false)
+    expect(
+      config.headers.some((rule) =>
+        rule.has?.some(({ key }) => key.toLowerCase() === "accept")
+      )
+    ).toBe(false)
+
+    const vary = config.headers
+      .find(({ source }) => source === "/:path*")
+      ?.headers.find(({ key }) => key.toLowerCase() === "vary")
     expect(vary?.value).toContain("Accept")
     expect(vary?.value).toContain("Accept-Encoding")
+
+    const markdownType = config.headers
+      .find(({ source }) => source === "/:path*.md")
+      ?.headers.find(({ key }) => key.toLowerCase() === "content-type")
+    expect(markdownType?.value).toBe("text/markdown; charset=utf-8")
+  })
+
+  it("keeps the middleware off paths it cannot negotiate, but never off /api", () => {
+    const proxy = readRepoFile("docs/proxy.ts")
+
+    expect(proxy).toContain('runtime: "nodejs"')
+    for (const excluded of [
+      "_astro/",
+      "assets/",
+      "og/",
+      "\\.well-known/",
+      "reference/"
+    ]) {
+      expect(proxy, excluded).toContain(excluded)
+    }
+
+    /*
+     * The exclusion above drops any path with a file extension, which is what
+     * stops a `.md` rewrite re-entering the middleware. `/api` is matched
+     * unconditionally beside it so `/api/models.json` still reaches the JSON
+     * error contract instead of the static HTML 404.
+     */
+    expect(proxy).toContain('"/api"')
+    expect(proxy).toContain('"/api/:path*"')
+  })
+
+  it("publishes an RFC 9727 API catalog naming both surfaces", () => {
+    /*
+     * Built rather than read: `docs/public` is generated and gitignored, so the
+     * published artifact exists only after `docs:generate`. A test that read it
+     * passed locally and failed on a clean checkout.
+     */
+    const catalog = apiCatalogDocument()
+
+    expect(catalog.linkset).toHaveLength(2)
+    for (const entry of catalog.linkset) {
+      expect(entry.anchor).toMatch(/^https?:\/\//)
+      expect(entry["service-desc"][0].href).toMatch(/^https:\/\//)
+      expect(entry["service-doc"][0].href).toContain("/developers/")
+      expect(entry.status[0].href).toBeTruthy()
+    }
+
+    const anchors = catalog.linkset.map((entry) => entry.anchor)
+    expect(anchors).toContain("https://www.ollamaclient.in/api")
+    expect(
+      anchors.some((anchor) => anchor.startsWith("http://127.0.0.1"))
+    ).toBe(true)
+  })
+
+  it("declares a deprecation policy an agent can read without prose", () => {
+    const lifecycle = (
+      openApi.info as unknown as {
+        "x-api-lifecycle"?: {
+          deprecationHeaders: string[]
+          minimumNoticeDays: number
+          policyUrl: string
+        }
+      }
+    )["x-api-lifecycle"]
+
+    expect(lifecycle?.deprecationHeaders).toEqual(["Deprecation", "Sunset"])
+    expect(lifecycle?.minimumNoticeDays).toBeGreaterThanOrEqual(30)
+    expect(lifecycle?.policyUrl).toContain(
+      "/developers/#versioning-rate-limits-and-deprecation"
+    )
+
+    const portal = readRepoFile("docs/src/content/docs/developers.md")
+    expect(portal).toContain("## Versioning, rate limits, and deprecation")
+    expect(portal).toContain("### Deprecation and sunset policy")
+    expect(portal).toContain("RFC 9745")
+    expect(portal).toContain("RFC 8594")
+  })
+
+  it("lists developer resources by name in the agent map", () => {
+    /*
+     * The page list is empty because every assertion below is about the fixed
+     * preamble, which is the part an agent navigates by. See the catalog test
+     * for why this is built rather than read.
+     */
+    const llms = llmsTxtContent([])
+
+    for (const entry of [
+      "Ollama Client Developer Portal",
+      "Ollama Client OpenAPI 3.1 Specification",
+      "Ollama Client API Catalog",
+      "Ollama Client Website JSON API",
+      "olc CLI"
+    ]) {
+      expect(llms, entry).toContain(entry)
+    }
+    expect(llms).toContain("/.well-known/api-catalog")
+    expect(llms).toContain("RateLimit-Remaining")
+    expect(llms).toContain("Deprecation")
   })
 
   it("provides a custom 404 with stable recovery links", () => {

--- a/src/lib/__tests__/agent-routing.test.ts
+++ b/src/lib/__tests__/agent-routing.test.ts
@@ -1,0 +1,344 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  NON_NEGOTIABLE_ROUTES,
+  notFoundMarkdown,
+  parseAccept,
+  preferredRepresentation,
+  resolveRequest
+} from "../../../docs/src/lib/agent-routing"
+import {
+  API_LINK_HEADER,
+  apiHeaders,
+  RATE_LIMIT,
+  SITE_ORIGIN
+} from "../../../docs/src/lib/api-response"
+
+const REPO_ROOT = join(__dirname, "../../..")
+const readRepoFile = (path: string) =>
+  readFileSync(join(REPO_ROOT, path), "utf-8")
+
+const MARKDOWN_SLUGS = [
+  "developers",
+  "guides/quick-start",
+  "guides/troubleshooting/error-reports"
+]
+
+const resolve = (
+  pathname: string,
+  accept: string | null = null,
+  method = "GET"
+) =>
+  resolveRequest({
+    pathname,
+    method,
+    accept,
+    markdownSlugs: MARKDOWN_SLUGS
+  })
+
+describe("Accept parsing", () => {
+  it("reads quality factors and specificity", () => {
+    expect(parseAccept("text/markdown")).toEqual([
+      { type: "text", subtype: "markdown", q: 1, specificity: 2 }
+    ])
+    expect(parseAccept("text/*;q=0.4")).toEqual([
+      { type: "text", subtype: "*", q: 0.4, specificity: 1 }
+    ])
+    expect(parseAccept("*/*")).toEqual([
+      { type: "*", subtype: "*", q: 1, specificity: 0 }
+    ])
+  })
+
+  it("drops entries it cannot read instead of failing the header", () => {
+    expect(parseAccept("garbage, text/markdown;q=nope, text/html")).toEqual([
+      { type: "text", subtype: "markdown", q: 1, specificity: 2 },
+      { type: "text", subtype: "html", q: 1, specificity: 2 }
+    ])
+  })
+
+  it("ignores a q outside the legal range", () => {
+    expect(parseAccept("text/markdown;q=5")[0].q).toBe(1)
+  })
+})
+
+describe("representation preference", () => {
+  it("keeps HTML for a browser and for a caller with no preference", () => {
+    expect(
+      preferredRepresentation(
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+      )
+    ).toBe("html")
+    expect(preferredRepresentation(null)).toBe("html")
+    expect(preferredRepresentation("*/*")).toBe("html")
+  })
+
+  it("serves Markdown when it is asked for by name", () => {
+    expect(preferredRepresentation("text/markdown")).toBe("markdown")
+    expect(preferredRepresentation("text/markdown, text/html;q=0.5")).toBe(
+      "markdown"
+    )
+  })
+
+  it("honours a quality factor that ranks HTML higher", () => {
+    expect(
+      preferredRepresentation("text/markdown;q=0.5, text/html;q=0.9")
+    ).toBe("html")
+  })
+
+  it("breaks a tie towards the range named explicitly", () => {
+    expect(preferredRepresentation("text/markdown, text/*")).toBe("markdown")
+    expect(preferredRepresentation("text/html, text/*")).toBe("html")
+  })
+
+  it("lets an explicit exclusion outrank a permissive wildcard", () => {
+    /*
+     * RFC 9110 resolves a type's quality with the most specific matching range.
+     * Ranking by quality alone would serve the exact thing the client just
+     * excluded, because the wildcard beside it carries a higher q.
+     */
+    expect(preferredRepresentation("text/html;q=0, */*;q=1")).toBe("markdown")
+    expect(preferredRepresentation("text/markdown;q=0, */*;q=1")).toBe("html")
+    expect(preferredRepresentation("text/html;q=0, text/*;q=1")).toBe(
+      "markdown"
+    )
+  })
+
+  it("reports an Accept header nothing satisfies", () => {
+    expect(preferredRepresentation("application/xml")).toBe("unacceptable")
+    expect(preferredRepresentation("text/html;q=0, text/markdown;q=0")).toBe(
+      "unacceptable"
+    )
+  })
+
+  it("refuses a sole exclusion rather than falling back to the default", () => {
+    /*
+     * `text/html;q=0` names one representation and rejects it, leaving nothing
+     * acceptable — the Markdown twin is not reachable through a range the
+     * client never wrote. The "no Markdown preference means HTML" shortcut must
+     * stay behind the check for that, or a client that ruled HTML out is
+     * answered with 200 HTML.
+     */
+    for (const accept of [
+      "text/html;q=0",
+      "text/html; q=0.0",
+      "text/*;q=0",
+      "text/markdown;q=0"
+    ]) {
+      expect(preferredRepresentation(accept), accept).toBe("unacceptable")
+      expect(resolve("/developers", accept), accept).toMatchObject({
+        kind: "respond",
+        status: 406
+      })
+    }
+  })
+})
+
+describe("Markdown negotiation", () => {
+  it("serves the Markdown twin of a documentation page at the same URL", () => {
+    expect(resolve("/developers", "text/markdown")).toEqual({
+      kind: "rewrite",
+      destination: "/developers.md"
+    })
+    expect(resolve("/guides/quick-start/", "text/markdown")).toEqual({
+      kind: "rewrite",
+      destination: "/guides/quick-start.md"
+    })
+  })
+
+  it("serves the landing page's twin for the site root", () => {
+    expect(resolve("/", "text/markdown")).toEqual({
+      kind: "rewrite",
+      destination: "/index.md"
+    })
+  })
+
+  it("leaves the HTML representation alone for every other caller", () => {
+    expect(resolve("/developers", "text/html")).toEqual({ kind: "pass" })
+    expect(resolve("/developers", null)).toEqual({ kind: "pass" })
+  })
+
+  it("passes through a page that exists without a Markdown twin", () => {
+    for (const route of NON_NEGOTIABLE_ROUTES) {
+      expect(resolve(`/${route}`, "text/markdown")).toEqual({ kind: "pass" })
+      expect(resolve(`/${route}/lib/providers`, "text/markdown")).toEqual({
+        kind: "pass"
+      })
+    }
+  })
+
+  it("answers 406 when no available representation matches", () => {
+    const decision = resolve("/developers", "application/xml")
+
+    expect(decision).toMatchObject({ kind: "respond", status: 406 })
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(decision.headers["Content-Type"]).toBe(
+      "application/json; charset=utf-8"
+    )
+    expect(JSON.parse(decision.body).error.code).toBe("not_acceptable")
+  })
+})
+
+describe("404 handling", () => {
+  it("returns a Markdown recovery map to a Markdown client", () => {
+    const decision = resolve("/does-not-exist", "text/markdown")
+
+    expect(decision).toMatchObject({ kind: "respond", status: 404 })
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(decision.headers["Content-Type"]).toBe(
+      "text/markdown; charset=utf-8"
+    )
+    expect(decision.headers.Vary).toContain("Accept")
+    expect(decision.body).toContain("# 404")
+    for (const link of [
+      `${SITE_ORIGIN}/llms.txt`,
+      `${SITE_ORIGIN}/sitemap-index.xml`,
+      `${SITE_ORIGIN}/developers/`,
+      `${SITE_ORIGIN}/.well-known/api-catalog`
+    ]) {
+      expect(decision.body).toContain(link)
+    }
+  })
+
+  it("leaves an HTML client on the rendered 404 page", () => {
+    expect(resolve("/does-not-exist", "text/html")).toEqual({ kind: "pass" })
+  })
+
+  it("publishes the same recovery map as the static /404.md", () => {
+    /*
+     * `docs/public` is generated and gitignored, so the artifact itself cannot
+     * be read here. What matters is that one string feeds both surfaces: the
+     * generator writes `notFoundMarkdown()` verbatim, and the rendered 404 page
+     * prints the same call.
+     */
+    expect(readRepoFile("tools/generate/generate-llms-docs.ts")).toContain(
+      'writeFileSync(join(PUBLIC_DIR, "404.md"), notFoundMarkdown(), "utf-8")'
+    )
+    expect(readRepoFile("docs/src/pages/404.astro")).toContain(
+      "{notFoundMarkdown()}"
+    )
+  })
+})
+
+describe("JSON API errors", () => {
+  it("passes a read of a published endpoint through to its static JSON", () => {
+    expect(resolve("/api")).toEqual({ kind: "pass" })
+    expect(resolve("/api/health")).toEqual({ kind: "pass" })
+    expect(resolve("/api/health/", null, "HEAD")).toEqual({ kind: "pass" })
+  })
+
+  it("answers an unknown API path with JSON, whatever the Accept header", () => {
+    for (const accept of [
+      null,
+      "text/html",
+      "text/markdown",
+      "application/xml"
+    ]) {
+      const decision = resolve("/api/models", accept)
+
+      expect(decision).toMatchObject({ kind: "respond", status: 404 })
+      if (decision.kind !== "respond") throw new Error("expected a response")
+      const body = JSON.parse(decision.body)
+      expect(body.error.code).toBe("route_not_found")
+      expect(body.error.resolution).toBeTruthy()
+      expect(body.error.documentation).toBe(`${SITE_ORIGIN}/developers/`)
+      expect(decision.headers["Content-Type"]).toBe(
+        "application/json; charset=utf-8"
+      )
+    }
+  })
+
+  it("answers an unknown API path that carries a file extension", () => {
+    /*
+     * `/api/models.json` looks like a static asset to a path matcher and like
+     * an API call to everyone else. It has to reach the JSON contract, or the
+     * one shape a machine is promised under /api is the one it does not get.
+     */
+    const decision = resolve("/api/models.json")
+
+    expect(decision).toMatchObject({ kind: "respond", status: 404 })
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(JSON.parse(decision.body).error.code).toBe("route_not_found")
+  })
+
+  it("answers a write with 405 and names the methods it accepts", () => {
+    const decision = resolve("/api", "application/json", "POST")
+
+    expect(decision).toMatchObject({ kind: "respond", status: 405 })
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(decision.headers.Allow).toBe("GET, HEAD, OPTIONS")
+    expect(JSON.parse(decision.body).error.code).toBe("method_not_allowed")
+  })
+
+  it("answers a preflight without a body or a content type", () => {
+    const decision = resolve("/api", null, "OPTIONS")
+
+    expect(decision).toMatchObject({ kind: "respond", status: 204, body: "" })
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(decision.headers["Content-Type"]).toBeUndefined()
+    expect(decision.headers.Allow).toBe("GET, HEAD, OPTIONS")
+    expect(decision.headers["RateLimit-Limit"]).toBe(String(RATE_LIMIT))
+  })
+
+  it("carries the rate-limit contract on every JSON answer", () => {
+    const decision = resolve("/api/models")
+
+    if (decision.kind !== "respond") throw new Error("expected a response")
+    expect(decision.headers["RateLimit-Limit"]).toBe(String(RATE_LIMIT))
+    expect(decision.headers["RateLimit-Policy"]).toBe(
+      `"default";q=${RATE_LIMIT};w=60`
+    )
+    expect(decision.headers["RateLimit-Remaining"]).toBe(String(RATE_LIMIT))
+    expect(decision.headers["RateLimit-Reset"]).toBe("60")
+    expect(decision.headers["X-API-Version"]).toBe("1")
+    expect(decision.headers.Link).toBe(API_LINK_HEADER)
+  })
+})
+
+describe("published header contract", () => {
+  /*
+   * A static Astro build keeps an endpoint's body and discards the headers its
+   * module set, so `vercel.json` restates them for the two prerendered API
+   * paths. Two copies of a header set drift; this is the check that they have
+   * not.
+   */
+  it("restates the API headers in vercel.json exactly as the module builds them", () => {
+    const config = JSON.parse(readRepoFile("vercel.json")) as {
+      headers: Array<{
+        source: string
+        headers: Array<{ key: string; value: string }>
+      }>
+    }
+    const expected = apiHeaders()
+
+    for (const source of ["/api", "/api/health"]) {
+      const rule = config.headers.find((entry) => entry.source === source)
+      expect(rule, source).toBeDefined()
+      const declared = Object.fromEntries(
+        (rule?.headers ?? []).map(({ key, value }) => [key, value])
+      )
+
+      for (const key of [
+        "Content-Type",
+        "X-API-Version",
+        "Link",
+        "RateLimit-Policy",
+        "RateLimit",
+        "RateLimit-Limit",
+        "RateLimit-Remaining",
+        "RateLimit-Reset"
+      ]) {
+        expect(declared[key], `${source} ${key}`).toBe(expected[key])
+      }
+    }
+  })
+
+  it("names both API surfaces and the deprecation policy in the Link header", () => {
+    expect(API_LINK_HEADER).toContain('rel="service-desc"')
+    expect(API_LINK_HEADER).toContain('rel="service-doc"')
+    expect(API_LINK_HEADER).toContain('rel="api-catalog"')
+    expect(API_LINK_HEADER).toContain("rel/deprecation-policy")
+  })
+})

--- a/src/lib/__tests__/agent-routing.test.ts
+++ b/src/lib/__tests__/agent-routing.test.ts
@@ -16,6 +16,7 @@ import {
   RATE_LIMIT,
   SITE_ORIGIN
 } from "../../../docs/src/lib/api-response"
+import { LEGACY_REDIRECTS } from "../../../docs/src/seo/legacy-redirects.mjs"
 
 const REPO_ROOT = join(__dirname, "../../..")
 const readRepoFile = (path: string) =>
@@ -27,6 +28,8 @@ const MARKDOWN_SLUGS = [
   "guides/troubleshooting/error-reports"
 ]
 
+const LEGACY_ALIASES = { "/architecture": "/concepts/architecture/" }
+
 const resolve = (
   pathname: string,
   accept: string | null = null,
@@ -36,7 +39,8 @@ const resolve = (
     pathname,
     method,
     accept,
-    markdownSlugs: MARKDOWN_SLUGS
+    markdownSlugs: MARKDOWN_SLUGS,
+    legacyRedirects: LEGACY_ALIASES
   })
 
 describe("Accept parsing", () => {
@@ -178,6 +182,56 @@ describe("Markdown negotiation", () => {
       "application/json; charset=utf-8"
     )
     expect(JSON.parse(decision.body).error.code).toBe("not_acceptable")
+  })
+})
+
+describe("legacy inbound URLs", () => {
+  /*
+   * These paths exist as Astro meta-refresh pages, but this runs before the
+   * filesystem, so an unrecognized path is a 404 no redirect file ever gets to
+   * serve. A Markdown client following a link from the store listing or an old
+   * search result was told the page was gone.
+   */
+  it("sends a Markdown client to the canonical URL, not to a 404", () => {
+    expect(resolve("/architecture", "text/markdown")).toEqual({
+      kind: "redirect",
+      status: 308,
+      location: "/concepts/architecture/"
+    })
+    expect(resolve("/architecture/", "text/markdown")).toEqual({
+      kind: "redirect",
+      status: 308,
+      location: "/concepts/architecture/"
+    })
+  })
+
+  it("leaves the HTML redirect page to serve browsers unchanged", () => {
+    expect(resolve("/architecture", "text/html")).toEqual({ kind: "pass" })
+    expect(resolve("/architecture", null)).toEqual({ kind: "pass" })
+  })
+
+  it("still refuses a path that is neither published nor an alias", () => {
+    expect(resolve("/architecture-notes", "text/markdown")).toMatchObject({
+      kind: "respond",
+      status: 404
+    })
+  })
+
+  it("shares one alias map with the Astro redirect config", () => {
+    const config = readRepoFile("docs/astro.config.mjs")
+
+    expect(config).toContain(
+      'import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"'
+    )
+    expect(config).toContain("redirects: LEGACY_REDIRECTS")
+    expect(readRepoFile("docs/proxy.ts")).toContain(
+      "legacyRedirects: LEGACY_REDIRECTS"
+    )
+    expect(Object.keys(LEGACY_REDIRECTS).length).toBeGreaterThan(0)
+    for (const [from, to] of Object.entries(LEGACY_REDIRECTS)) {
+      expect(from, from).toMatch(/^\//)
+      expect(to, to).toMatch(/^\/.*\/$/)
+    }
   })
 })
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -68,6 +68,7 @@ only after merging the reports.
 | `pnpm e2e:release:run` | Consume those four builds; run critical Chromium, worker recovery, and Chrome/Firefox migration gates |
 | `pnpm e2e:release` | Build all four targets and run the release browser gates |
 | `pnpm verify:release` | Static checks + coverage, all four builds, manifest/bundle checks, docs build, and release browser gates; each browser target builds once |
+| `pnpm verify:agent-endpoints [baseUrl]` | Probe a deployed docs site for the agent contract: Markdown negotiation, 404 status and body, JSON API errors, rate-limit headers, and every machine-readable file. Defaults to production; pass a preview URL to check a deploy before promoting it. Needs network, no build |
 
 Browser gates need the corresponding installed browsers. Chromium automation
 uses Playwright; the Firefox migration gate uses Firefox and geckodriver.

--- a/tools/generate/generate-llms-docs.ts
+++ b/tools/generate/generate-llms-docs.ts
@@ -19,6 +19,7 @@ import {
 import { dirname, join, relative } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
+import { notFoundMarkdown } from "../../docs/src/lib/agent-routing.js"
 import {
   SITE_DESCRIPTION,
   SITE_TITLE,
@@ -270,12 +271,19 @@ function writePageMarkdown(pages: DocPage[]) {
   }
 }
 
-function writeLlmsTxt(pages: DocPage[]) {
+/**
+ * Build `llms.txt`.
+ *
+ * Split from the writer so a test can assert the published contract without a
+ * generated tree on disk: `docs/public` is gitignored, so a test that read the
+ * artifact passed locally and failed on a clean CI checkout.
+ */
+export function llmsTxtContent(pages: DocPage[]) {
   const lines = pages.map(
     (page) => `- [${page.title}](${page.markdownUrl}): ${page.description}`
   )
 
-  const content = `# ${SITE_TITLE}
+  return `# ${SITE_TITLE}
 
 > ${SITE_DESCRIPTION}
 
@@ -298,18 +306,37 @@ Ollama Client is a local-first browser extension for private LLM chat, provider 
 
 ${lines.join("\n")}
 
-## Reference
+## Developer resources
 
-- [Developer Portal](${SITE_URL}/developers/): Local proxy quickstart, authentication, endpoints, errors, and integration guidance.
-- [OpenAPI 3.1 Specification](${SITE_URL}/openapi.json): Machine-readable schema for the local olc proxy; its servers are loopback addresses, not this website.
-- [Website JSON API](${SITE_URL}/api): Read-only service metadata, versioning, and rate-limit conventions for agents.
-- [Website API health](${SITE_URL}/api/health): Machine-readable liveness response.
-- [API Reference](${SITE_URL}/reference/): Generated TypeScript API reference.
+- [Ollama Client Developer Portal](${SITE_URL}/developers.md): Local proxy quickstart, authentication, endpoints, errors, and integration guidance.
+- [Ollama Client OpenAPI 3.1 Specification](${SITE_URL}/openapi.json): Machine-readable schema for the local olc proxy; its servers are loopback addresses, not this website.
+- [Ollama Client API Catalog](${SITE_URL}/.well-known/api-catalog): RFC 9727 linkset naming both API surfaces and their descriptions, docs, and status endpoints.
+- [Ollama Client Website JSON API](${SITE_URL}/api): Read-only service metadata, error format, versioning, and rate-limit conventions for agents.
+- [Ollama Client Website API health](${SITE_URL}/api/health): Machine-readable liveness response.
+- [olc CLI](https://github.com/Shishir435/ollama-client/tree/main/packages/olc): Official command-line tool. Install with \`curl -fsSL ${SITE_URL}/olc.sh | sh\` on macOS/Linux or \`irm ${SITE_URL}/olc.ps1 | iex\` on Windows; both verify a checksummed archive from the GitHub release.
+- [Ollama Client TypeScript API Reference](${SITE_URL}/reference/): Generated reference for the extension's public modules.
+
+## API conventions
+
+- Versioning: the website API is \`/api\` (version \`v1\`); the local olc API is versioned in its path under \`/v1\`. Every response carries \`X-API-Version\`.
+- Deprecation: no route is removed without notice. A deprecated route responds with \`Deprecation\` (RFC 9745) and a \`Sunset\` date (RFC 8594) at least 30 days ahead, plus a \`Link\` to its replacement. Policy: ${SITE_URL}/developers/#versioning-rate-limits-and-deprecation
+- Rate limits: responses carry \`RateLimit-Policy\`, \`RateLimit\`, \`RateLimit-Limit\`, \`RateLimit-Remaining\`, and \`RateLimit-Reset\`. A \`429\` adds \`Retry-After\`.
+- Errors: JSON, shaped \`{ "error": { "status", "code", "message", "resolution" } }\`. Agents should read \`resolution\` before retrying.
+- Content negotiation: send \`Accept: text/markdown\` to any documentation URL for its Markdown twin; responses \`Vary\` on \`Accept\`. An unsupported \`Accept\` returns \`406\` with JSON.
+
+## Entrypoints
+
+- [Markdown home](${SITE_URL}/index.md): Markdown twin of the landing page.
 - [Full Markdown Docs](${SITE_URL}/llms-full.txt): All public docs in one Markdown file.
+- [AI crawler guidance](${SITE_URL}/ai.txt): Fetch order and usage boundaries.
+- [Sitemap](${SITE_URL}/sitemap-index.xml): Canonical HTML URLs.
+- [Recovery map](${SITE_URL}/404.md): What a 404 returns, so a lost agent can re-orient.
 - [GitHub Repository](https://github.com/Shishir435/ollama-client): Source code and issue tracker.
 `
+}
 
-  writeFileSync(join(PUBLIC_DIR, "llms.txt"), content, "utf-8")
+function writeLlmsTxt(pages: DocPage[]) {
+  writeFileSync(join(PUBLIC_DIR, "llms.txt"), llmsTxtContent(pages), "utf-8")
 }
 
 function writeLlmsFullTxt(pages: DocPage[]) {
@@ -335,12 +362,16 @@ Purpose: Help AI agents fetch clean, canonical documentation without parsing HTM
 
 Canonical site: ${SITE_URL}
 Primary AI docs index: ${SITE_URL}/llms.txt
+Markdown home: ${SITE_URL}/index.md
 Full Markdown docs: ${SITE_URL}/llms-full.txt
 Sitemap: ${SITE_URL}/sitemap-index.xml
 Repository: https://github.com/Shishir435/ollama-client
 Developer portal: ${SITE_URL}/developers/
 OpenAPI specification: ${SITE_URL}/openapi.json
+API catalog (RFC 9727): ${SITE_URL}/.well-known/api-catalog
 Website JSON API: ${SITE_URL}/api
+Recovery map for a 404: ${SITE_URL}/404.md
+Official CLI: olc — https://github.com/Shishir435/ollama-client/tree/main/packages/olc
 
 When to use Ollama Client:
 - A user wants a local-first Chrome or Firefox interface for their configured LLM provider.
@@ -349,7 +380,9 @@ When to use Ollama Client:
 
 Do not treat this documentation host as a model API. The olc OpenAPI servers are loopback URLs, and the extension sends requests only to provider endpoints the user configures.
 
-API compatibility: website discovery endpoints use /api and version v1. Responses include RateLimit-Policy, RateLimit, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, and X-API-Version. A 429 response includes Retry-After. The local olc API uses /v1 paths; deprecated versions will be announced in the developer portal and signaled with Deprecation and Sunset headers before removal.
+API compatibility: website discovery endpoints use /api and version v1. Responses include RateLimit-Policy, RateLimit, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, and X-API-Version. A 429 response includes Retry-After. Errors are JSON, shaped { "error": { "status", "code", "message", "resolution" } }; read resolution before retrying. The local olc API uses /v1 paths. No route is removed without notice: a deprecated route carries Deprecation (RFC 9745) and a Sunset date (RFC 8594) at least 30 days ahead, documented at ${SITE_URL}/developers/#versioning-rate-limits-and-deprecation.
+
+Content negotiation: send Accept: text/markdown to any documentation URL to receive its Markdown twin at the same address. Responses Vary on Accept. An Accept header matching no available representation returns 406 with a JSON explanation.
 
 Preferred fetch order:
 1. Fetch /llms.txt for the docs map.
@@ -364,19 +397,137 @@ ${lines.join("\n")}
   writeFileSync(join(PUBLIC_DIR, "ai.txt"), content, "utf-8")
 }
 
+/**
+ * Write the Markdown 404 body.
+ *
+ * The same string is what the Routing Middleware returns for an unknown path
+ * negotiated as Markdown, imported from the module that owns it. Two hand-kept
+ * copies of a recovery map is how one of them ends up pointing at a path that
+ * moved.
+ */
 function writeNotFoundMarkdown() {
+  writeFileSync(join(PUBLIC_DIR, "404.md"), notFoundMarkdown(), "utf-8")
+}
+
+/**
+ * Write the Markdown twin of the landing page.
+ *
+ * `/` is the one URL with no page markdown of its own, and it is the first
+ * thing an agent asks for. Pointing negotiation at `llms.txt` instead would
+ * serve a docs index under a URL whose HTML is a product page, so the twin says
+ * what the landing page says and then hands over the maps.
+ */
+function writeIndexMarkdown(pages: DocPage[]) {
+  const lines = pages.map(
+    (page) => `- [${page.title}](${page.markdownUrl}): ${page.description}`
+  )
+
   writeFileSync(
-    join(PUBLIC_DIR, "404.md"),
-    `# 404 — ${SITE_TITLE} page not found
+    join(PUBLIC_DIR, "index.md"),
+    `# ${SITE_TITLE}
 
-The requested path does not exist.
+Source: ${SITE_URL}/
+Markdown: ${SITE_URL}/index.md
+Description: ${SITE_DESCRIPTION}
 
-- [${SITE_TITLE} home](${SITE_URL}/)
-- [Agent map](${SITE_URL}/llms.txt)
-- [Full Markdown docs](${SITE_URL}/llms-full.txt)
+${SITE_TITLE} is a local-first browser extension for private LLM chat, provider
+management, and local RAG workflows. It runs in Chrome and Firefox and talks to
+Ollama, LM Studio, llama.cpp, Anthropic, or any OpenAI-compatible server the
+user configures. This website publishes documentation only; it hosts no models
+and accepts no prompts.
+
+## Start here
+
+- [Quick start](${SITE_URL}/guides/quick-start.md): install the extension and connect a provider.
+- [Provider setup](${SITE_URL}/guides/provider-setup.md): configure Ollama, LM Studio, llama.cpp, or a custom endpoint.
+- [Developer portal](${SITE_URL}/developers.md): the local olc OpenAI-compatible proxy, its CLI, and its OpenAPI document.
+
+## Machine-readable entrypoints
+
+- [Agent map](${SITE_URL}/llms.txt): every page with a one-line description.
+- [Full Markdown docs](${SITE_URL}/llms-full.txt): all public docs in one file.
+- [AI crawler guidance](${SITE_URL}/ai.txt): fetch order and usage boundaries.
+- [OpenAPI 3.1](${SITE_URL}/openapi.json): the local olc API; its servers are loopback addresses.
+- [API catalog](${SITE_URL}/.well-known/api-catalog): RFC 9727 linkset for both API surfaces.
+- [Website JSON API](${SITE_URL}/api): versioning, rate-limit, and error conventions.
 - [Sitemap](${SITE_URL}/sitemap-index.xml)
-- [Developer portal and OpenAPI](${SITE_URL}/developers/)
+
+## All documentation
+
+${lines.join("\n")}
 `,
+    "utf-8"
+  )
+}
+
+/**
+ * Write the RFC 9727 API catalog.
+ *
+ * Two API surfaces exist and they are easy to confuse, which is the whole
+ * reason for publishing the catalog: the website answers discovery questions
+ * over HTTPS, and the olc proxy answers inference questions over loopback on
+ * the user's own machine. The linkset states which is which, in the shape
+ * RFC 9264 defines, so an agent does not have to infer it from prose.
+ */
+export function apiCatalogDocument() {
+  return {
+    linkset: [
+      {
+        anchor: `${SITE_URL}/api`,
+        "service-desc": [
+          {
+            href: `${SITE_URL}/api`,
+            type: "application/json",
+            title: `${SITE_TITLE} website discovery API`
+          }
+        ],
+        "service-doc": [
+          {
+            href: `${SITE_URL}/developers/`,
+            type: "text/html",
+            title: `${SITE_TITLE} developer portal`
+          }
+        ],
+        status: [
+          {
+            href: `${SITE_URL}/api/health`,
+            type: "application/json"
+          }
+        ]
+      },
+      {
+        anchor: "http://127.0.0.1:8083/v1",
+        "service-desc": [
+          {
+            href: `${SITE_URL}/openapi.json`,
+            type: "application/json",
+            title: "olc local OpenAI-compatible proxy (OpenAPI 3.1)"
+          }
+        ],
+        "service-doc": [
+          {
+            href: `${SITE_URL}/developers/`,
+            type: "text/html",
+            title: "olc integration guide"
+          }
+        ],
+        status: [
+          {
+            href: "http://127.0.0.1:8083/health",
+            type: "application/json"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+function writeApiCatalog() {
+  const target = join(PUBLIC_DIR, ".well-known/api-catalog")
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(
+    target,
+    `${JSON.stringify(apiCatalogDocument(), null, 2)}\n`,
     "utf-8"
   )
 }
@@ -402,10 +553,12 @@ function main() {
   writeLlmsTxt(pages)
   writeLlmsFullTxt(pages)
   writeAiTxt(pages)
+  writeIndexMarkdown(pages)
   writeNotFoundMarkdown()
+  writeApiCatalog()
 
   console.log(
-    `Generated llms.txt, llms-full.txt, ai.txt, and ${pages.length} page markdown files`
+    `Generated llms.txt, llms-full.txt, ai.txt, index.md, .well-known/api-catalog, and ${pages.length} page markdown files`
   )
 }
 

--- a/tools/generate/openapi/olc-openapi.template.json
+++ b/tools/generate/openapi/olc-openapi.template.json
@@ -7,6 +7,30 @@
     "license": {
       "name": "MIT",
       "identifier": "MIT"
+    },
+    "contact": {
+      "name": "Ollama Client",
+      "url": "https://www.ollamaclient.in/contact/"
+    },
+    "x-api-lifecycle": {
+      "versioning": "URL path versioning under /v1",
+      "versionHeader": "X-API-Version",
+      "deprecationHeaders": ["Deprecation", "Sunset"],
+      "minimumNoticeDays": 30,
+      "policy": "No /v1 route is removed without notice. A deprecated route responds with the Deprecation header (RFC 9745), a Sunset date (RFC 8594) at least 30 days ahead, and a Link to its replacement. The migration is documented in the developer portal and in this specification before the header appears.",
+      "policyUrl": "https://www.ollamaclient.in/developers/#versioning-rate-limits-and-deprecation"
+    },
+    "x-rate-limit": {
+      "scope": "per client bucket (bearer token when configured, otherwise remote address)",
+      "headers": [
+        "RateLimit-Policy",
+        "RateLimit",
+        "RateLimit-Limit",
+        "RateLimit-Remaining",
+        "RateLimit-Reset"
+      ],
+      "exceeded": "429 with Retry-After",
+      "policy": "60 requests per 60 seconds"
     }
   },
   "x-api-version": "v1",
@@ -77,12 +101,46 @@
                   "$ref": "#/components/schemas/ServiceInfo"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          }
+        ]
       }
     },
     "/health": {
@@ -101,12 +159,46 @@
                   "$ref": "#/components/schemas/Health"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          }
+        ]
       }
     },
     "/v1/models": {
@@ -130,6 +222,32 @@
                   "$ref": "#/components/schemas/ModelList"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "401": {
@@ -138,10 +256,18 @@
           "403": {
             "$ref": "#/components/responses/ForbiddenOrigin"
           },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
           "502": {
             "$ref": "#/components/responses/BackendFailure"
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          }
+        ]
       }
     },
     "/v1/models/{modelId}": {
@@ -157,6 +283,9 @@
           {}
         ],
         "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          },
           {
             "name": "modelId",
             "in": "path",
@@ -177,6 +306,32 @@
                 "schema": {
                   "$ref": "#/components/schemas/Model"
                 }
+              }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
               }
             }
           },
@@ -199,7 +354,36 @@
                   }
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
           },
           "502": {
             "$ref": "#/components/responses/BackendFailure"
@@ -260,6 +444,32 @@
                   "description": "OpenAI-compatible data events followed by data: [DONE]."
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "400": {
@@ -270,6 +480,32 @@
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "401": {
@@ -277,6 +513,9 @@
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
           },
           "500": {
             "$ref": "#/components/responses/ProxyFailure"
@@ -292,6 +531,32 @@
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "504": {
@@ -302,9 +567,40 @@
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          }
+        ]
       }
     },
     "/v1/images/generations": {
@@ -338,6 +634,32 @@
                   "$ref": "#/components/schemas/ImageGenerationResponse"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "400": {
@@ -348,6 +670,32 @@
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "401": {
@@ -355,6 +703,9 @@
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenOrigin"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
           },
           "501": {
             "description": "The selected runtime has no image-generation operation.",
@@ -364,12 +715,43 @@
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
+            },
+            "headers": {
+              "RateLimit-Policy": {
+                "$ref": "#/components/headers/RateLimitPolicy"
+              },
+              "RateLimit": {
+                "$ref": "#/components/headers/RateLimit"
+              },
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              },
+              "Deprecation": {
+                "$ref": "#/components/headers/Deprecation"
+              },
+              "Sunset": {
+                "$ref": "#/components/headers/Sunset"
+              }
             }
           },
           "502": {
             "$ref": "#/components/responses/BackendFailure"
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OriginHeader"
+          }
+        ]
       }
     }
   },
@@ -395,6 +777,32 @@
               }
             }
           }
+        },
+        "headers": {
+          "RateLimit-Policy": {
+            "$ref": "#/components/headers/RateLimitPolicy"
+          },
+          "RateLimit": {
+            "$ref": "#/components/headers/RateLimit"
+          },
+          "RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "X-API-Version": {
+            "$ref": "#/components/headers/ApiVersion"
+          },
+          "Deprecation": {
+            "$ref": "#/components/headers/Deprecation"
+          },
+          "Sunset": {
+            "$ref": "#/components/headers/Sunset"
+          }
         }
       },
       "ForbiddenOrigin": {
@@ -404,6 +812,32 @@
             "schema": {
               "$ref": "#/components/schemas/ErrorEnvelope"
             }
+          }
+        },
+        "headers": {
+          "RateLimit-Policy": {
+            "$ref": "#/components/headers/RateLimitPolicy"
+          },
+          "RateLimit": {
+            "$ref": "#/components/headers/RateLimit"
+          },
+          "RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "X-API-Version": {
+            "$ref": "#/components/headers/ApiVersion"
+          },
+          "Deprecation": {
+            "$ref": "#/components/headers/Deprecation"
+          },
+          "Sunset": {
+            "$ref": "#/components/headers/Sunset"
           }
         }
       },
@@ -415,6 +849,32 @@
               "$ref": "#/components/schemas/ErrorEnvelope"
             }
           }
+        },
+        "headers": {
+          "RateLimit-Policy": {
+            "$ref": "#/components/headers/RateLimitPolicy"
+          },
+          "RateLimit": {
+            "$ref": "#/components/headers/RateLimit"
+          },
+          "RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "X-API-Version": {
+            "$ref": "#/components/headers/ApiVersion"
+          },
+          "Deprecation": {
+            "$ref": "#/components/headers/Deprecation"
+          },
+          "Sunset": {
+            "$ref": "#/components/headers/Sunset"
+          }
         }
       },
       "ProxyFailure": {
@@ -423,6 +883,79 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        },
+        "headers": {
+          "RateLimit-Policy": {
+            "$ref": "#/components/headers/RateLimitPolicy"
+          },
+          "RateLimit": {
+            "$ref": "#/components/headers/RateLimit"
+          },
+          "RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "X-API-Version": {
+            "$ref": "#/components/headers/ApiVersion"
+          },
+          "Deprecation": {
+            "$ref": "#/components/headers/Deprecation"
+          },
+          "Sunset": {
+            "$ref": "#/components/headers/Sunset"
+          }
+        }
+      },
+      "RateLimitExceeded": {
+        "description": "The caller exceeded the configured window. Wait for Retry-After, then retry with exponential backoff. Do not blindly replay a non-idempotent generation.",
+        "headers": {
+          "Retry-After": {
+            "$ref": "#/components/headers/RetryAfter"
+          },
+          "RateLimit-Policy": {
+            "$ref": "#/components/headers/RateLimitPolicy"
+          },
+          "RateLimit": {
+            "$ref": "#/components/headers/RateLimit"
+          },
+          "RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "X-API-Version": {
+            "$ref": "#/components/headers/ApiVersion"
+          },
+          "Deprecation": {
+            "$ref": "#/components/headers/Deprecation"
+          },
+          "Sunset": {
+            "$ref": "#/components/headers/Sunset"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "error": {
+                "type": "RateLimitExceeded",
+                "code": "rate_limit_exceeded",
+                "message": "Request rate limit exceeded.",
+                "resolution": "Wait 58 seconds, then retry with backoff."
+              }
             }
           }
         }
@@ -812,6 +1345,95 @@
         },
         "additionalProperties": false
       }
+    },
+    "parameters": {
+      "OriginHeader": {
+        "name": "Origin",
+        "in": "header",
+        "required": false,
+        "description": "Browser origin of the caller. olc refuses any origin outside --allowed-origins with 403 and echoes an allowed one back in Access-Control-Allow-Origin. Non-browser clients omit it and are not origin-checked.",
+        "schema": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://"
+        },
+        "example": "chrome-extension://bfaoaaogfcgomkjfbmfepbiijmciinjl"
+      }
+    },
+    "headers": {
+      "RateLimitPolicy": {
+        "description": "Published request budget, as RFC RateLimit fields: \"default\";q=<limit>;w=<window seconds>. The proxy budget is 60 requests per 60 seconds.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "\"default\";q=60;w=60"
+      },
+      "RateLimit": {
+        "description": "Remaining budget for the current window: \"default\";r=<remaining>;t=<seconds until reset>.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "\"default\";r=59;t=58"
+      },
+      "RateLimitLimit": {
+        "description": "Requests allowed in one window.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "example": 60
+      },
+      "RateLimitRemaining": {
+        "description": "Requests left in the current window.",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "example": 59
+      },
+      "RateLimitReset": {
+        "description": "Seconds until the current window resets.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "example": 58
+      },
+      "ApiVersion": {
+        "description": "Major version of the olc HTTP contract. A breaking change increments it and is announced through Deprecation and Sunset first.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "1"
+      },
+      "RetryAfter": {
+        "description": "Seconds to wait before retrying, with backoff.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "example": 58
+      },
+      "Deprecation": {
+        "description": "Present only on a deprecated route (RFC 9745). An HTTP date, or the value true, marking when the route became deprecated. Absent on every current route.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "Wed, 01 Jul 2026 00:00:00 GMT"
+      },
+      "Sunset": {
+        "description": "Present only on a deprecated route (RFC 8594). The HTTP date after which the route stops responding, at least 30 days ahead of removal.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "Sat, 01 Aug 2026 00:00:00 GMT"
+      }
     }
-  }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    },
+    {}
+  ]
 }

--- a/tools/verify/verify-agent-endpoints.ts
+++ b/tools/verify/verify-agent-endpoints.ts
@@ -13,6 +13,7 @@
 import { pathToFileURL } from "node:url"
 
 import { DOC_ORDER } from "../../docs/src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "../../docs/src/seo/legacy-redirects.mjs"
 
 const DEFAULT_BASE = "https://www.ollamaclient.in"
 
@@ -131,6 +132,20 @@ const checkStatus = async (
   )
 }
 
+const checkLegacyAlias = async (base: string, path: string, target: string) => {
+  const { response } = await fetchPath(base, path, {
+    headers: { Accept: "text/markdown" }
+  })
+  const location = response.headers.get("location") ?? ""
+  const ok = response.status === 308 && location === target
+
+  record(
+    `legacy alias ${path}`,
+    ok,
+    `${response.status} -> ${location || "none"} (expected 308 -> ${target})`
+  )
+}
+
 const checkMachineFile = async (
   base: string,
   path: string,
@@ -163,6 +178,14 @@ export async function verifyAgentEndpoints(base: string) {
    * carrying a Markdown body, not an HTML shell and not a 200.
    */
   await checkMarkdownVariant(base, "/some-path-that-does-not-exist", 404)
+  /*
+   * Old inbound URLs resolve in a browser through a meta-refresh page the
+   * middleware never reaches. A Markdown client has to be sent somewhere real.
+   */
+  for (const [from, to] of Object.entries(LEGACY_REDIRECTS)) {
+    await checkLegacyAlias(base, from, to)
+  }
+
   await checkStatus(base, "/some-path-that-does-not-exist", 404)
   await checkStatus(base, "/developers", 406, {
     headers: { Accept: "application/xml" }

--- a/tools/verify/verify-agent-endpoints.ts
+++ b/tools/verify/verify-agent-endpoints.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env tsx
+/**
+ * Probe a deployed docs site for the contract agent clients depend on.
+ *
+ * Every check here is something only a real deployment can answer: Vercel's
+ * routing order, whether the Routing Middleware ran, and whether a CDN handed
+ * back the wrong cached variant. The unit tests cover the decisions; this
+ * covers the deployment that carries them out.
+ *
+ *   pnpm verify:agent-endpoints                       # production
+ *   pnpm verify:agent-endpoints https://preview.host  # a preview deploy
+ */
+import { pathToFileURL } from "node:url"
+
+import { DOC_ORDER } from "../../docs/src/seo/doc-ia.mjs"
+
+const DEFAULT_BASE = "https://www.ollamaclient.in"
+
+type Check = {
+  name: string
+  ok: boolean
+  detail: string
+}
+
+const results: Check[] = []
+
+const record = (name: string, ok: boolean, detail: string) => {
+  results.push({ name, ok, detail })
+}
+
+const fetchPath = async (
+  base: string,
+  path: string,
+  init: RequestInit = {}
+) => {
+  const response = await fetch(`${base}${path}`, {
+    redirect: "manual",
+    ...init
+  })
+  const body = await response.text()
+  return { response, body }
+}
+
+const contentType = (response: Response) =>
+  response.headers.get("content-type") ?? ""
+
+const looksLikeHtml = (body: string) => /^\s*<(!doctype|html)/i.test(body)
+
+const checkMarkdownVariant = async (
+  base: string,
+  path: string,
+  expectedStatus = 200
+) => {
+  const { response, body } = await fetchPath(base, path, {
+    headers: { Accept: "text/markdown" }
+  })
+  const vary = response.headers.get("vary") ?? ""
+  const ok =
+    response.status === expectedStatus &&
+    contentType(response).includes("text/markdown") &&
+    !looksLikeHtml(body) &&
+    /accept/i.test(vary)
+
+  record(
+    `markdown negotiation ${path}`,
+    ok,
+    `${response.status} ${contentType(response)} vary=${vary || "none"} html=${looksLikeHtml(body)}`
+  )
+}
+
+const checkHtmlVariant = async (base: string, path: string) => {
+  const { response, body } = await fetchPath(base, path, {
+    headers: {
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    }
+  })
+  const ok =
+    response.status === 200 &&
+    contentType(response).includes("text/html") &&
+    looksLikeHtml(body)
+
+  record(
+    `html variant ${path}`,
+    ok,
+    `${response.status} ${contentType(response)} html=${looksLikeHtml(body)}`
+  )
+}
+
+const checkJson = async (
+  base: string,
+  path: string,
+  expectedStatus: number,
+  init: RequestInit = {}
+) => {
+  const { response, body } = await fetchPath(base, path, init)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    parsed = undefined
+  }
+
+  const rateLimited = ["RateLimit-Limit", "RateLimit-Remaining"].every((key) =>
+    response.headers.has(key)
+  )
+  const ok =
+    response.status === expectedStatus &&
+    contentType(response).includes("application/json") &&
+    parsed !== undefined &&
+    rateLimited
+
+  record(
+    `json ${init.method ?? "GET"} ${path}`,
+    ok,
+    `${response.status} ${contentType(response)} rateLimitHeaders=${rateLimited} parsed=${parsed !== undefined}`
+  )
+  return parsed
+}
+
+const checkStatus = async (
+  base: string,
+  path: string,
+  expectedStatus: number,
+  init: RequestInit = {}
+) => {
+  const { response } = await fetchPath(base, path, init)
+  record(
+    `status ${init.method ?? "GET"} ${path}`,
+    response.status === expectedStatus,
+    `${response.status} (expected ${expectedStatus})`
+  )
+}
+
+const checkMachineFile = async (
+  base: string,
+  path: string,
+  expectedType: string,
+  mustContain: string
+) => {
+  const { response, body } = await fetchPath(base, path)
+  const ok =
+    response.status === 200 &&
+    contentType(response).includes(expectedType) &&
+    body.includes(mustContain)
+
+  record(
+    `machine-readable ${path}`,
+    ok,
+    `${response.status} ${contentType(response)} contains=${body.includes(mustContain)}`
+  )
+}
+
+export async function verifyAgentEndpoints(base: string) {
+  await checkHtmlVariant(base, "/")
+  await checkHtmlVariant(base, "/developers")
+  await checkMarkdownVariant(base, "/")
+  for (const slug of DOC_ORDER) {
+    await checkMarkdownVariant(base, `/${slug}`)
+  }
+
+  /*
+   * A 404 negotiated as Markdown is the recovery path: a real 404 status
+   * carrying a Markdown body, not an HTML shell and not a 200.
+   */
+  await checkMarkdownVariant(base, "/some-path-that-does-not-exist", 404)
+  await checkStatus(base, "/some-path-that-does-not-exist", 404)
+  await checkStatus(base, "/developers", 406, {
+    headers: { Accept: "application/xml" }
+  })
+
+  await checkJson(base, "/api", 200)
+  await checkJson(base, "/api/health", 200)
+  await checkJson(base, "/api/does-not-exist", 404)
+  /*
+   * An extension on an unknown API path is what a path matcher mistakes for a
+   * static asset. If this one comes back as HTML, the middleware is not seeing
+   * the request.
+   */
+  await checkJson(base, "/api/models.json", 404)
+  await checkJson(base, "/api", 405, { method: "POST" })
+
+  await checkMachineFile(base, "/llms.txt", "text/markdown", "## Docs")
+  await checkMachineFile(base, "/llms-full.txt", "text/markdown", "# Ollama")
+  await checkMachineFile(base, "/ai.txt", "text/plain", "llms.txt")
+  await checkMachineFile(base, "/index.md", "text/markdown", "# Ollama Client")
+  await checkMachineFile(base, "/404.md", "text/markdown", "# 404")
+  await checkMachineFile(base, "/openapi.json", "application/json", "openapi")
+  await checkMachineFile(
+    base,
+    "/.well-known/api-catalog",
+    "application/linkset+json",
+    "linkset"
+  )
+  await checkMachineFile(base, "/robots.txt", "text/plain", "Sitemap:")
+  await checkMachineFile(base, "/sitemap-index.xml", "xml", "sitemap")
+
+  return results
+}
+
+async function main() {
+  const base = (process.argv[2] ?? DEFAULT_BASE).replace(/\/+$/, "")
+  console.log(`Verifying agent endpoints on ${base}\n`)
+
+  const checks = await verifyAgentEndpoints(base)
+  for (const check of checks) {
+    console.log(
+      `${check.ok ? "PASS" : "FAIL"}  ${check.name} — ${check.detail}`
+    )
+  }
+
+  const failed = checks.filter((check) => !check.ok)
+  console.log(`\n${checks.length - failed.length}/${checks.length} passed`)
+  if (failed.length > 0) process.exitCode = 1
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main()
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "e2e/**/*.ts",
     "tools/**/*.ts",
     "config/**/*.ts",
+    "docs/proxy.ts",
     "playwright.config.ts",
     "wxt.config.ts"
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -3,55 +3,16 @@
   "buildCommand": "pnpm docs:build",
   "outputDirectory": "docs/dist",
   "installCommand": "pnpm install --frozen-lockfile",
+  "proxy": {
+    "entrypoint": "docs/proxy.ts"
+  },
   "rewrites": [
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "header",
-          "key": "Accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/llms.txt"
-    },
-    {
-      "source": "/:path((?!reference(?:/|$))(?!.*\\.).*)",
-      "has": [
-        {
-          "type": "header",
-          "key": "Accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/:path*.md"
-    },
     {
       "source": "/api/health",
       "destination": "/api-health"
     }
   ],
   "headers": [
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "header",
-          "key": "Accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "headers": [
-        {
-          "key": "Content-Type",
-          "value": "text/markdown; charset=utf-8"
-        },
-        {
-          "key": "Vary",
-          "value": "Accept, Accept-Encoding"
-        }
-      ]
-    },
     {
       "source": "/:path*",
       "headers": [
@@ -75,11 +36,74 @@
       ]
     },
     {
+      "source": "/llms.txt",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/llms-full.txt",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/api-catalog",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/linkset+json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300"
+        }
+      ]
+    },
+    {
       "source": "/api",
       "headers": [
         {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=60"
+        },
+        {
+          "key": "X-API-Version",
+          "value": "1"
+        },
+        {
+          "key": "Link",
+          "value": "<https://www.ollamaclient.in/openapi.json>; rel=\"service-desc\"; type=\"application/json\", <https://www.ollamaclient.in/developers/>; rel=\"service-doc\"; type=\"text/html\", <https://www.ollamaclient.in/.well-known/api-catalog>; rel=\"api-catalog\", <https://www.ollamaclient.in/developers/#versioning-rate-limits-and-deprecation>; rel=\"https://www.ollamaclient.in/rel/deprecation-policy\""
+        },
+        {
+          "key": "RateLimit-Policy",
+          "value": "\"default\";q=60;w=60"
+        },
+        {
+          "key": "RateLimit",
+          "value": "\"default\";r=60;t=60"
+        },
+        {
+          "key": "RateLimit-Limit",
+          "value": "60"
+        },
+        {
+          "key": "RateLimit-Remaining",
+          "value": "60"
+        },
+        {
+          "key": "RateLimit-Reset",
+          "value": "60"
         }
       ]
     },
@@ -87,8 +111,53 @@
       "source": "/api/health",
       "headers": [
         {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=60"
+        },
+        {
+          "key": "X-API-Version",
+          "value": "1"
+        },
+        {
+          "key": "Link",
+          "value": "<https://www.ollamaclient.in/openapi.json>; rel=\"service-desc\"; type=\"application/json\", <https://www.ollamaclient.in/developers/>; rel=\"service-doc\"; type=\"text/html\", <https://www.ollamaclient.in/.well-known/api-catalog>; rel=\"api-catalog\", <https://www.ollamaclient.in/developers/#versioning-rate-limits-and-deprecation>; rel=\"https://www.ollamaclient.in/rel/deprecation-policy\""
+        },
+        {
+          "key": "RateLimit-Policy",
+          "value": "\"default\";q=60;w=60"
+        },
+        {
+          "key": "RateLimit",
+          "value": "\"default\";r=60;t=60"
+        },
+        {
+          "key": "RateLimit-Limit",
+          "value": "60"
+        },
+        {
+          "key": "RateLimit-Remaining",
+          "value": "60"
+        },
+        {
+          "key": "RateLimit-Reset",
+          "value": "60"
+        }
+      ]
+    },
+    {
+      "source": "/openapi.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300"
+        },
+        {
+          "key": "Link",
+          "value": "<https://www.ollamaclient.in/developers/>; rel=\"service-doc\"; type=\"text/html\", <https://www.ollamaclient.in/.well-known/api-catalog>; rel=\"api-catalog\""
         }
       ]
     }


### PR DESCRIPTION
* feat(docs): make the site answer agent requests correctly

Vercel evaluates rewrites after the filesystem, so the Accept-conditioned rewrite could never fire for a documentation page while its sibling header rule relabelled the HTML body as text/markdown. A static build also drops the headers an endpoint module sets, which is why /api served application/octet-stream with no rate-limit fields and no way to answer an unknown path with JSON.

Negotiation, agent 404s and API errors now run in Routing Middleware (docs/proxy.ts) ahead of the filesystem, with every decision in a pure module so it is testable without a deployment. Adds an RFC 9727 API catalog, a Markdown twin for the landing page, typed inputs and a rate-limit contract on every OpenAPI operation, an explicit Deprecation/Sunset policy, and brand and publisher JSON-LD.

pnpm verify:agent-endpoints probes a real deployment for the whole contract.

* fix(docs): resolve Accept quality by range precedence, not by highest q

RFC 9110 settles a media type's quality with the most specific matching range. Scoring by the highest q let a permissive wildcard override an exact exclusion, so `text/html;q=0, */*` served the HTML the client had just ruled out.

Also stops the new contract tests reading generated artifacts under docs/public, which is gitignored: they passed locally and failed on a clean CI checkout. They assert on the generator's builders instead, which is the thing the artifact is written from.

Scopes the negotiation contract in /api and the portal to documentation pages; /api is JSON only and ignores Accept.

* fix(docs): match /api unconditionally in the routing middleware

The matcher drops any path with a file extension, which is what stops a .md rewrite re-entering the middleware. It also dropped /api/models.json, handing a machine the static HTML 404 under the one prefix that promises JSON. /api is now matched beside that rule rather than through it.

* test(docs): pin the sole-exclusion Accept case at 406

A review read the HTML default as reachable for `Accept: text/html;q=0`. It is not — the unacceptable check precedes it — but nothing said so, and swapping the two lines would silently answer 200 HTML to a client that excluded HTML. Now a test holds the order.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The follow-up centralizes legacy documentation aliases so Astro and the routing middleware use the same redirect definitions, and it corrects the Accept-negotiation documentation.
- Markdown requests for legacy URLs now receive canonical redirects before filesystem routing.
- Shared redirect tests and deployment verification cover the alias contract.
- The previously flagged standalone prose was moved into JSDoc.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/src/lib/agent-routing.ts | Uses the shared legacy redirect map before Markdown page lookup and replaces the previously flagged standalone prose with JSDoc. |
| docs/src/seo/legacy-redirects.mjs | Defines the three existing legacy aliases once for both Astro and routing middleware. |
| docs/astro.config.mjs | Replaces the inline redirect object with the shared legacy alias map. |
| docs/proxy.ts | Supplies the shared alias map to the pure routing decision module. |
| src/lib/__tests__/agent-routing.test.ts | Verifies canonical Markdown redirects, trailing-slash handling, shared-map wiring, and Accept exclusion behavior. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[Incoming documentation request] --> M[Routing Middleware]
  M --> A{Markdown preferred?}
  A -- No --> F[Static filesystem serving]
  A -- Yes --> L{Legacy alias?}
  L -- Yes --> C[308 canonical redirect]
  L -- No --> D{Published Markdown twin?}
  D -- Yes --> W[Rewrite to generated .md file]
  D -- No --> N[Markdown 404 response]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): answer legacy inbound URLs fo..."](https://github.com/shishir435/ollama-client/commit/e8019de6160522ebf4dd7b54b81d8f73d8df076c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59647625)</sub>

<!-- /greptile_comment -->