### PR TITLE
fix(docs): answer legacy inbound URLs for Markdown clients

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -13,6 +13,7 @@ import {
   SITE_URL
 } from "./src/seo/constants.mjs"
 import { withReferenceGroup } from "./src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"
 import { lastModifiedForUrl } from "./src/seo/last-modified.mjs"
 
 /**
@@ -45,12 +46,13 @@ export default defineConfig({
    * Chrome Web Store listing, GitHub README, and existing index
    * results. Keep entries here as long as the old URLs are still
    * referenced anywhere we don't control.
+   *
+   * The map itself lives in src/seo/legacy-redirects.mjs because the Routing
+   * Middleware needs the same list: it answers a Markdown request before the
+   * filesystem, so a path it does not recognize is a 404 no redirect file ever
+   * gets to serve.
    */
-  redirects: {
-    "/architecture": "/concepts/architecture/",
-    "/ollama-setup-guide": "/guides/provider-setup/",
-    "/privacy-policy": "/legal/privacy-policy/"
-  },
+  redirects: LEGACY_REDIRECTS,
   markdown: {
     /*
      * Convert fenced ```mermaid blocks from a code-language block

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -15,6 +15,7 @@ import { next, rewrite } from "@vercel/functions"
 
 import { resolveRequest } from "./src/lib/agent-routing"
 import { DOC_ORDER } from "./src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"
 
 export const config = {
   runtime: "nodejs",
@@ -44,11 +45,23 @@ export default function proxy(request: Request): Response {
       pathname,
       method: request.method.toUpperCase(),
       accept: request.headers.get("accept"),
-      markdownSlugs: DOC_ORDER
+      markdownSlugs: DOC_ORDER,
+      legacyRedirects: LEGACY_REDIRECTS
     })
 
     if (decision.kind === "rewrite") {
       return rewrite(new URL(decision.destination, request.url))
+    }
+
+    if (decision.kind === "redirect") {
+      return new Response(null, {
+        status: decision.status,
+        headers: {
+          Location: decision.location,
+          Vary: "Accept, Accept-Encoding",
+          "Cache-Control": "public, max-age=3600"
+        }
+      })
     }
 
     if (decision.kind === "respond") {

--- a/docs/src/lib/agent-routing.ts
+++ b/docs/src/lib/agent-routing.ts
@@ -26,6 +26,8 @@ export type RouteDecision =
   | { kind: "pass" }
   /** Serve a different path's bytes under the requested URL. */
   | { kind: "rewrite"; destination: string }
+  /** Send the client to the canonical URL for this path. */
+  | { kind: "redirect"; status: number; location: string }
   /** Answer here; static serving never runs. */
   | {
       kind: "respond"
@@ -40,6 +42,8 @@ export type ResolveInput = {
   accept: string | null
   /** Slugs with a published `.md` twin, i.e. `DOC_ORDER`. */
   markdownSlugs: readonly string[]
+  /** Old inbound paths and their canonical destinations, i.e. `LEGACY_REDIRECTS`. */
+  legacyRedirects: Readonly<Record<string, string>>
 }
 
 /**
@@ -135,6 +139,10 @@ export type Preference = "markdown" | "html" | "unacceptable"
  * `text/html,…,<full wildcard>;q=0.8`, which keeps HTML; `Accept: text/markdown` alone
  * flips it. No `Accept` header at all is not a preference — it means "anything"
  * (RFC 9110), so it keeps the default HTML representation.
+ *
+ * The order of the two zero-quality checks below is load-bearing: nothing
+ * acceptable has to be decided before the HTML default, or a sole
+ * `text/html;q=0` falls through to the representation it excluded.
  */
 export function preferredRepresentation(accept: string | null): Preference {
   const ranges = parseAccept(accept)
@@ -143,8 +151,6 @@ export function preferredRepresentation(accept: string | null): Preference {
   const markdown = scoreFor(ranges, "text", "markdown")
   const html = scoreFor(ranges, "text", "html")
 
-  // Order matters: nothing acceptable is decided before the HTML default, or a
-  // sole `text/html;q=0` would fall through to the representation it excluded.
   if (markdown.q === 0 && html.q === 0) return "unacceptable"
   if (markdown.q === 0) return "html"
   if (markdown.q > html.q) return "markdown"
@@ -246,7 +252,8 @@ export function resolveRequest({
   pathname,
   method,
   accept,
-  markdownSlugs
+  markdownSlugs,
+  legacyRedirects
 }: ResolveInput): RouteDecision {
   const normalized = pathname.replace(/\/{2,}/g, "/")
 
@@ -266,6 +273,18 @@ export function resolveRequest({
   }
 
   if (preference === "html") return { kind: "pass" }
+
+  /*
+   * A legacy alias exists — Astro emits a meta-refresh page at each one — but
+   * only as HTML, and this runs before the filesystem, so without the map the
+   * path reads as unknown and a Markdown client is told 404 for a URL that
+   * plainly resolves in a browser. Redirecting rather than rewriting hands the
+   * agent the canonical address, which is the thing it should remember.
+   */
+  const alias =
+    legacyRedirects[normalized] ??
+    legacyRedirects[normalized.replace(/\/$/, "")]
+  if (alias) return { kind: "redirect", status: 308, location: alias }
 
   const slug = slugOf(normalized)
   if (slug === "") return { kind: "rewrite", destination: "/index.md" }

--- a/docs/src/seo/legacy-redirects.d.mts
+++ b/docs/src/seo/legacy-redirects.d.mts
@@ -1,0 +1,3 @@
+// Type declarations for the plain-JS legacy redirect map consumed by the
+// Routing Middleware and its tests under the strict root tsconfig.
+export const LEGACY_REDIRECTS: Record<string, string>

--- a/docs/src/seo/legacy-redirects.d.mts
+++ b/docs/src/seo/legacy-redirects.d.mts
@@ -1,3 +1,5 @@
-// Type declarations for the plain-JS legacy redirect map consumed by the
-// Routing Middleware and its tests under the strict root tsconfig.
+/**
+ * Type declarations for the plain-JS legacy redirect map consumed by the
+ * Routing Middleware and its tests under the strict root tsconfig.
+ */
 export const LEGACY_REDIRECTS: Record<string, string>

--- a/docs/src/seo/legacy-redirects.mjs
+++ b/docs/src/seo/legacy-redirects.mjs
@@ -1,0 +1,21 @@
+/**
+ * Inbound URLs from the pre-Starlight IA, mapped to where they live now.
+ *
+ * Single source of truth for two consumers that must not disagree:
+ *
+ *   - `docs/astro.config.mjs`, which emits a meta-refresh page at each old path
+ *     for browsers and crawlers,
+ *   - `docs/src/lib/agent-routing.ts`, which answers a Markdown client before
+ *     the filesystem is consulted and would otherwise call these paths unknown.
+ *
+ * They had already disagreed once: the Routing Middleware landed knowing only
+ * `DOC_ORDER`, so `/architecture` with `Accept: text/markdown` returned a 404
+ * for a path that plainly resolves in a browser. An alias only stops being an
+ * alias when nothing links to it, so entries stay as long as the Chrome Web
+ * Store listing, the README, or an existing search result can still point here.
+ */
+export const LEGACY_REDIRECTS = {
+  "/architecture": "/concepts/architecture/",
+  "/ollama-setup-guide": "/guides/provider-setup/",
+  "/privacy-policy": "/legal/privacy-policy/"
+}

--- a/src/lib/__tests__/agent-routing.test.ts
+++ b/src/lib/__tests__/agent-routing.test.ts
@@ -16,6 +16,7 @@ import {
   RATE_LIMIT,
   SITE_ORIGIN
 } from "../../../docs/src/lib/api-response"
+import { LEGACY_REDIRECTS } from "../../../docs/src/seo/legacy-redirects.mjs"
 
 const REPO_ROOT = join(__dirname, "../../..")
 const readRepoFile = (path: string) =>
@@ -27,6 +28,8 @@ const MARKDOWN_SLUGS = [
   "guides/troubleshooting/error-reports"
 ]
 
+const LEGACY_ALIASES = { "/architecture": "/concepts/architecture/" }
+
 const resolve = (
   pathname: string,
   accept: string | null = null,
@@ -36,7 +39,8 @@ const resolve = (
     pathname,
     method,
     accept,
-    markdownSlugs: MARKDOWN_SLUGS
+    markdownSlugs: MARKDOWN_SLUGS,
+    legacyRedirects: LEGACY_ALIASES
   })
 
 describe("Accept parsing", () => {
@@ -178,6 +182,56 @@ describe("Markdown negotiation", () => {
       "application/json; charset=utf-8"
     )
     expect(JSON.parse(decision.body).error.code).toBe("not_acceptable")
+  })
+})
+
+describe("legacy inbound URLs", () => {
+  /*
+   * These paths exist as Astro meta-refresh pages, but this runs before the
+   * filesystem, so an unrecognized path is a 404 no redirect file ever gets to
+   * serve. A Markdown client following a link from the store listing or an old
+   * search result was told the page was gone.
+   */
+  it("sends a Markdown client to the canonical URL, not to a 404", () => {
+    expect(resolve("/architecture", "text/markdown")).toEqual({
+      kind: "redirect",
+      status: 308,
+      location: "/concepts/architecture/"
+    })
+    expect(resolve("/architecture/", "text/markdown")).toEqual({
+      kind: "redirect",
+      status: 308,
+      location: "/concepts/architecture/"
+    })
+  })
+
+  it("leaves the HTML redirect page to serve browsers unchanged", () => {
+    expect(resolve("/architecture", "text/html")).toEqual({ kind: "pass" })
+    expect(resolve("/architecture", null)).toEqual({ kind: "pass" })
+  })
+
+  it("still refuses a path that is neither published nor an alias", () => {
+    expect(resolve("/architecture-notes", "text/markdown")).toMatchObject({
+      kind: "respond",
+      status: 404
+    })
+  })
+
+  it("shares one alias map with the Astro redirect config", () => {
+    const config = readRepoFile("docs/astro.config.mjs")
+
+    expect(config).toContain(
+      'import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"'
+    )
+    expect(config).toContain("redirects: LEGACY_REDIRECTS")
+    expect(readRepoFile("docs/proxy.ts")).toContain(
+      "legacyRedirects: LEGACY_REDIRECTS"
+    )
+    expect(Object.keys(LEGACY_REDIRECTS).length).toBeGreaterThan(0)
+    for (const [from, to] of Object.entries(LEGACY_REDIRECTS)) {
+      expect(from, from).toMatch(/^\//)
+      expect(to, to).toMatch(/^\/.*\/$/)
+    }
   })
 })
 

--- a/tools/verify/verify-agent-endpoints.ts
+++ b/tools/verify/verify-agent-endpoints.ts
@@ -13,6 +13,7 @@
 import { pathToFileURL } from "node:url"
 
 import { DOC_ORDER } from "../../docs/src/seo/doc-ia.mjs"
+import { LEGACY_REDIRECTS } from "../../docs/src/seo/legacy-redirects.mjs"
 
 const DEFAULT_BASE = "https://www.ollamaclient.in"
 
@@ -131,6 +132,20 @@ const checkStatus = async (
   )
 }
 
+const checkLegacyAlias = async (base: string, path: string, target: string) => {
+  const { response } = await fetchPath(base, path, {
+    headers: { Accept: "text/markdown" }
+  })
+  const location = response.headers.get("location") ?? ""
+  const ok = response.status === 308 && location === target
+
+  record(
+    `legacy alias ${path}`,
+    ok,
+    `${response.status} -> ${location || "none"} (expected 308 -> ${target})`
+  )
+}
+
 const checkMachineFile = async (
   base: string,
   path: string,
@@ -163,6 +178,14 @@ export async function verifyAgentEndpoints(base: string) {
    * carrying a Markdown body, not an HTML shell and not a 200.
    */
   await checkMarkdownVariant(base, "/some-path-that-does-not-exist", 404)
+  /*
+   * Old inbound URLs resolve in a browser through a meta-refresh page the
+   * middleware never reaches. A Markdown client has to be sent somewhere real.
+   */
+  for (const [from, to] of Object.entries(LEGACY_REDIRECTS)) {
+    await checkLegacyAlias(base, from, to)
+  }
+
   await checkStatus(base, "/some-path-that-does-not-exist", 404)
   await checkStatus(base, "/developers", 406, {
     headers: { Accept: "application/xml" }


### PR DESCRIPTION
Follow-up to #353, found by review on #355.

`/architecture`, `/ollama-setup-guide` and `/privacy-policy` exist as Astro meta-refresh pages, but the Routing Middleware runs before the filesystem and knew only `DOC_ORDER` — so `Accept: text/markdown` on any of them returned a 404 for a URL that plainly resolves in a browser. All three are still linked from the Chrome Web Store listing, the README, and existing search results.

The map moves to `docs/src/seo/legacy-redirects.mjs` and feeds both consumers, so they cannot drift again: `astro.config.mjs` for the meta-refresh pages, and the middleware for request-time routing. A Markdown client now gets `308` to the canonical path; browsers are untouched.

Verified against the built site: an agent following `/architecture` with `Accept: text/markdown` lands on `/concepts/architecture/` as `text/markdown` in one hop, while an HTML client still gets the meta-refresh page. `verify:agent-endpoints` now probes every entry in the map — 44/44.

Also folds the `preferredRepresentation` ordering note into that function's JSDoc, which is where the repo keeps declaration prose.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes legacy documentation redirects and teaches Markdown request routing to redirect legacy URLs to their canonical pages while preserving browser behavior.
- Shares one legacy redirect map between Astro configuration and routing middleware.
- Adds request-time `308` redirects for Markdown clients.
- Expands unit and endpoint verification across every configured alias.
- Converts the previously flagged declaration prose to JSDoc.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/src/seo/legacy-redirects.d.mts | Replaces the previously flagged declaration prose with a correctly placed JSDoc block. |
| docs/src/seo/legacy-redirects.mjs | Introduces the shared source of truth for legacy documentation redirects. |
| docs/src/lib/agent-routing.ts | Adds redirect decisions for Markdown requests targeting configured legacy paths. |
| docs/proxy.ts | Supplies the shared redirect map and emits the resulting request-time redirect response. |
| docs/astro.config.mjs | Reuses the shared redirect map for Astro-generated browser redirect pages. |
| src/lib/__tests__/agent-routing.test.ts | Covers Markdown redirects, trailing slashes, unchanged HTML behavior, and map sharing. |
| tools/verify/verify-agent-endpoints.ts | Verifies every configured legacy alias returns the expected Markdown redirect. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Legacy documentation request] --> Preference{Preferred representation}
  Preference -->|HTML or unspecified| Astro[Serve Astro meta-refresh page]
  Preference -->|Markdown| Middleware[Routing middleware]
  Middleware --> Redirects[Look up shared LEGACY_REDIRECTS map]
  Redirects --> Canonical[Return 308 to canonical documentation URL]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style(docs): use JSDoc for the legacy-re..."](https://github.com/shishir435/ollama-client/commit/4b30286fcf81bf5ae2cb51e7f63343987a22d419) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59652054)</sub>

<!-- /greptile_comment -->