### PR TITLE
fix(docs): resolve the middleware import Vercel does not bundle

### DIFF
--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -10,10 +10,17 @@
  * All of the behaviour lives in `src/lib/agent-routing.ts` so it can be tested
  * without a deployment; this file is the adapter. A thrown error falls through
  * to normal static serving rather than taking the site down with it.
+ *
+ * Every relative import here carries an explicit extension. Vercel transpiles
+ * this entrypoint in place rather than bundling it, so the specifiers reach
+ * Node's ESM resolver verbatim: an extensionless `./src/lib/agent-routing`
+ * typechecks under `moduleResolution: "bundler"` and then fails the deployed
+ * site with `ERR_MODULE_NOT_FOUND` on every request, because the middleware
+ * crashing takes the response with it.
  */
 import { next, rewrite } from "@vercel/functions"
 
-import { resolveRequest } from "./src/lib/agent-routing"
+import { resolveRequest } from "./src/lib/agent-routing.js"
 import { DOC_ORDER } from "./src/seo/doc-ia.mjs"
 import { LEGACY_REDIRECTS } from "./src/seo/legacy-redirects.mjs"
 

--- a/src/lib/__tests__/agent-routing.test.ts
+++ b/src/lib/__tests__/agent-routing.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
@@ -394,5 +394,54 @@ describe("published header contract", () => {
     expect(API_LINK_HEADER).toContain('rel="service-doc"')
     expect(API_LINK_HEADER).toContain('rel="api-catalog"')
     expect(API_LINK_HEADER).toContain("rel/deprecation-policy")
+  })
+})
+
+describe("routing middleware module graph", () => {
+  /*
+   * Vercel transpiles the `proxy` entrypoint in place instead of bundling it,
+   * so every relative specifier in its graph is handed to Node's ESM resolver
+   * verbatim. An extensionless one typechecks here (`moduleResolution:
+   * "bundler"`) and then throws `ERR_MODULE_NOT_FOUND` on the deployed site,
+   * which fails the middleware and therefore every request that matches it —
+   * the whole site, since the matcher covers `/`. That shipped once.
+   */
+  const RELATIVE_IMPORT = /from\s+"(\.[^"]*)"/g
+
+  const relativeImportsOf = (path: string) =>
+    [...readRepoFile(path).matchAll(RELATIVE_IMPORT)].map(([, specifier]) => ({
+      path,
+      specifier
+    }))
+
+  it("gives every relative import in the entrypoint graph an explicit extension", () => {
+    const imports = [
+      ...relativeImportsOf("docs/proxy.ts"),
+      ...relativeImportsOf("docs/src/lib/agent-routing.ts"),
+      ...relativeImportsOf("docs/src/lib/api-response.ts")
+    ]
+
+    expect(imports.length).toBeGreaterThan(0)
+    for (const { path, specifier } of imports) {
+      expect(specifier, `${path} imports ${specifier}`).toMatch(
+        /\.(js|mjs|json)$/
+      )
+    }
+  })
+
+  it("resolves each of those specifiers to a file the deployment carries", () => {
+    for (const { specifier } of relativeImportsOf("docs/proxy.ts")) {
+      /* A `.js` specifier is answered by the `.ts` source Vercel transpiles. */
+      const candidates = specifier.endsWith(".js")
+        ? [specifier, specifier.replace(/\.js$/, ".ts")]
+        : [specifier]
+
+      expect(
+        candidates.some((candidate) =>
+          existsSync(join(REPO_ROOT, "docs", candidate))
+        ),
+        specifier
+      ).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
Production docs returned 500 on every path: Vercel transpiles `docs/proxy.ts` in place instead of bundling it, so the extensionless `./src/lib/agent-routing` specifier reached Node's ESM resolver and threw `ERR_MODULE_NOT_FOUND`, failing the middleware for the whole matcher.

- adds the `.js` extension the deployed resolver needs
- contract test: every relative import in the proxy graph carries an explicit extension and resolves to a shipped file

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the explicit `.js` extension required by the deployed middleware import and introduces regression tests for proxy-module resolution.

- Updates `docs/proxy.ts` to use an explicit Node ESM-compatible specifier.
- Adds checks for relative-import extensions and source-file existence, although the checks do not recursively cover the complete proxy graph.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking gap in the regression test’s coverage of the complete proxy dependency graph.

The production import change is consistent with the existing TypeScript-to-ESM convention, while the only accepted concern is that the new contract test can miss future relative imports in reachable modules.

**Files Needing Attention:** src/lib/__tests__/agent-routing.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/proxy.ts | Changes the middleware's agent-routing import to an explicit `.js` specifier, addressing the reported deployed ESM resolution failure. |
| src/lib/__tests__/agent-routing.test.ts | Adds useful import-resolution guards, but their hard-coded and non-recursive scope can allow future transitive regressions to pass. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shishir435%2Follama-client%20PR%20%23358%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shishir435%2Follama-client&pr=358&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Flib%2F__tests__%2Fagent-routing.test.ts%3A418-422%0A**Proxy%20graph%20check%20is%20incomplete**%0A%0AThe%20hard-coded%20scan%20omits%20the%20directly%20imported%20%60doc-ia.mjs%60%20and%20%60legacy-redirects.mjs%60%20modules%2C%20while%20the%20shipped-target%20assertion%20checks%20only%20imports%20declared%20in%20%60proxy.ts%60.%20A%20relative%20import%20added%20to%20either%20omitted%20module%20therefore%20bypasses%20this%20regression%20test%2C%20allowing%20the%20deployment%20resolution%20failure%20the%20test%20is%20intended%20to%20prevent.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=shishir435%2Follama-client&pr=358&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22shishir435%2Follama-client%22%20on%20the%20existing%20branch%20%22preview%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22preview%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Flib%2F__tests__%2Fagent-routing.test.ts%3A418-422%0A**Proxy%20graph%20check%20is%20incomplete**%0A%0AThe%20hard-coded%20scan%20omits%20the%20directly%20imported%20%60doc-ia.mjs%60%20and%20%60legacy-redirects.mjs%60%20modules%2C%20while%20the%20shipped-target%20assertion%20checks%20only%20imports%20declared%20in%20%60proxy.ts%60.%20A%20relative%20import%20added%20to%20either%20omitted%20module%20therefore%20bypasses%20this%20regression%20test%2C%20allowing%20the%20deployment%20resolution%20failure%20the%20test%20is%20intended%20to%20prevent.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=shishir435%2Follama-client&pr=358&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): resolve the middleware import..."](https://github.com/shishir435/ollama-client/commit/4d311756570148ae631517d93eaadd6cba4efc4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60052804)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Restore Markdown access to legacy documentation URLs](https://app.greptile.com/shishir435/-/custom-context/knowledge-base/shishir435/ollama-client/-/reverts/rollback_356-20260903-legacy-markdown-aliases-e8019de.md)

<!-- /greptile_comment -->