### PR TITLE
feat(agent): add read-only browser actions

### DIFF
--- a/packages/agent-runtime/src/__tests__/controller.test.ts
+++ b/packages/agent-runtime/src/__tests__/controller.test.ts
@@ -80,6 +80,8 @@ const resolvedEffect = (
     tabId: currentObservation.tabId,
     documentId: currentObservation.documentId
   },
+  sourceUrl: currentObservation.url,
+  sourceOrigin: currentObservation.origin,
   ...overrides
 })
 
@@ -124,6 +126,7 @@ interface HarnessOptions {
   decisions?: unknown[]
   observations?: AgentObservation[]
   verification?: AgentVerificationResult[]
+  controlledTabIdAfterExecution?: number
   policy?:
     | AgentPolicyDecision
     | ((input: AgentPolicyInput) => AgentPolicyDecision)
@@ -208,7 +211,10 @@ const createHarness = (options: HarnessOptions = {}) => {
       },
       async execute() {
         calls.push("execute")
-        return { executedAt: 10 }
+        return {
+          executedAt: 10,
+          controlledTabId: options.controlledTabIdAfterExecution
+        }
       },
       async verify() {
         calls.push("verify")
@@ -346,6 +352,12 @@ describe("agent controller", () => {
     await harness.controller.start("run-1")
     expect(harness.steps).toContain("verified")
     expect(harness.getState().status).toBe("completed")
+  })
+
+  it("persists a switch-tab target before verification begins", async () => {
+    const harness = createHarness({ controlledTabIdAfterExecution: 9 })
+    await harness.controller.start("run-1")
+    expect(harness.getState().controlledTabId).toBe(9)
   })
 
   it("fails from the claimed verifying phase when verification throws", async () => {

--- a/packages/agent-runtime/src/__tests__/controller.test.ts
+++ b/packages/agent-runtime/src/__tests__/controller.test.ts
@@ -364,6 +364,22 @@ describe("agent controller", () => {
     expect(harness.calls.indexOf("verify")).toBeLessThan(
       harness.calls.lastIndexOf("claim:observing")
     )
+    expect(
+      harness.calls.filter((call) => call === "claim:observing")
+    ).toHaveLength(2)
+  })
+
+  it("persists a confirmed switch-tab target before the next observation", async () => {
+    const harness = createHarness({
+      controlledTabIdAfterExecution: 9,
+      observations: [observation()]
+    })
+    await harness.controller.start("run-1")
+    expect(harness.getState()).toMatchObject({
+      controlledTabId: 9,
+      status: "failed",
+      error: { code: "observation_failed" }
+    })
   })
 
   it("keeps the controlled tab when switch-tab verification is negative", async () => {

--- a/packages/agent-runtime/src/__tests__/controller.test.ts
+++ b/packages/agent-runtime/src/__tests__/controller.test.ts
@@ -126,6 +126,7 @@ interface HarnessOptions {
   decisions?: unknown[]
   observations?: AgentObservation[]
   verification?: AgentVerificationResult[]
+  onVerify?: () => Promise<void>
   controlledTabIdAfterExecution?: number
   policy?:
     | AgentPolicyDecision
@@ -218,6 +219,7 @@ const createHarness = (options: HarnessOptions = {}) => {
       },
       async verify() {
         calls.push("verify")
+        await options.onVerify?.()
         const next = verifications.shift()
         if (!next) throw new Error("No verification")
         return next
@@ -380,6 +382,47 @@ describe("agent controller", () => {
       status: "failed",
       error: { code: "observation_failed" }
     })
+  })
+
+  it("keeps the controlled tab when a pause races verification", async () => {
+    let requestPause: () => Promise<void> = async () => {}
+    const harness = createHarness({
+      controlledTabIdAfterExecution: 9,
+      onVerify: () => requestPause()
+    })
+    requestPause = () => harness.controller.requestPause("run-1")
+    await harness.controller.start("run-1")
+    expect(harness.getState()).toMatchObject({
+      controlledTabId: 7,
+      status: "paused",
+      pauseReason: "unresolved_effect"
+    })
+  })
+
+  it("does not resume a run paused while a negative step verified", async () => {
+    let requestPause: () => Promise<void> = async () => {}
+    const harness = createHarness({
+      onVerify: () => requestPause(),
+      // A pause committed by another owner does not abort this controller, so
+      // the phase claim is the only thing that may stop the loop.
+      createCancellationController: () => ({
+        signal: { aborted: false },
+        abort() {}
+      }),
+      verification: [
+        {
+          outcome: "negative",
+          evidence: { kind: "dom", summary: "No change", observedAt: 2 }
+        }
+      ]
+    })
+    requestPause = () => harness.controller.requestPause("run-1")
+    await harness.controller.start("run-1")
+    expect(harness.getState()).toMatchObject({
+      status: "paused",
+      pauseReason: "unresolved_effect"
+    })
+    expect(harness.calls.filter((call) => call === "decide")).toHaveLength(1)
   })
 
   it("keeps the controlled tab when switch-tab verification is negative", async () => {

--- a/packages/agent-runtime/src/__tests__/controller.test.ts
+++ b/packages/agent-runtime/src/__tests__/controller.test.ts
@@ -354,10 +354,57 @@ describe("agent controller", () => {
     expect(harness.getState().status).toBe("completed")
   })
 
-  it("persists a switch-tab target before verification begins", async () => {
-    const harness = createHarness({ controlledTabIdAfterExecution: 9 })
+  it("adopts a switch-tab target only after confirmed verification", async () => {
+    const harness = createHarness({
+      controlledTabIdAfterExecution: 9,
+      observations: [observation(), observation({ tabId: 9 })]
+    })
     await harness.controller.start("run-1")
     expect(harness.getState().controlledTabId).toBe(9)
+    expect(harness.calls.indexOf("verify")).toBeLessThan(
+      harness.calls.lastIndexOf("claim:observing")
+    )
+  })
+
+  it("keeps the controlled tab when switch-tab verification is negative", async () => {
+    const harness = createHarness({
+      controlledTabIdAfterExecution: 9,
+      verification: [
+        {
+          outcome: "negative",
+          evidence: {
+            kind: "tab",
+            summary: "Requested tab is not active",
+            observedAt: 2
+          }
+        }
+      ]
+    })
+    await harness.controller.start("run-1")
+    expect(harness.getState().controlledTabId).toBe(7)
+    expect(harness.getState().status).toBe("completed")
+  })
+
+  it("keeps the controlled tab when switch-tab verification is ambiguous", async () => {
+    const harness = createHarness({
+      controlledTabIdAfterExecution: 9,
+      verification: [
+        {
+          outcome: "ambiguous",
+          evidence: {
+            kind: "tab",
+            summary: "Active tab destination changed",
+            observedAt: 2
+          }
+        }
+      ]
+    })
+    await harness.controller.start("run-1")
+    expect(harness.getState()).toMatchObject({
+      controlledTabId: 7,
+      status: "paused",
+      pauseReason: "unresolved_effect"
+    })
   })
 
   it("fails from the claimed verifying phase when verification throws", async () => {

--- a/packages/agent-runtime/src/__tests__/policy.test.ts
+++ b/packages/agent-runtime/src/__tests__/policy.test.ts
@@ -27,6 +27,8 @@ const effect = (
     tabId: 1,
     documentId: "document-1"
   },
+  sourceUrl: "https://example.com/",
+  sourceOrigin: "https://example.com",
   ...overrides
 })
 

--- a/packages/agent-runtime/src/controller.ts
+++ b/packages/agent-runtime/src/controller.ts
@@ -50,7 +50,6 @@ export const createAgentController = (
   const active = new Map<string, AgentCancellationController>()
   const lastGeneration = new Map<string, number>()
   const minimumGeneration = new Map<string, number>()
-  const pendingControlledTab = new Map<string, number>()
 
   const claim = async (
     state: AgentRunState,
@@ -411,13 +410,6 @@ export const createAgentController = (
         verification,
         at: dependencies.clock.now()
       })
-      // A tab the run does not yet own becomes the observation target only
-      // once verification confirms it; a negative or ambiguous outcome leaves
-      // the run on the tab it already controls.
-      pendingControlledTab.delete(state.id)
-      if (action.type === "advance" && receipt.controlledTabId !== undefined) {
-        pendingControlledTab.set(state.id, receipt.controlledTabId)
-      }
       if (action.type === "pause") {
         await pause(
           verifying,
@@ -425,7 +417,17 @@ export const createAgentController = (
         )
         return undefined
       }
-      return verifying
+      if (action.type === "redecide") return verifying
+      // The write closing a confirmed step also opens the next observation, so
+      // a tab the effect switched to is durably owned before this controller
+      // can lose the run. A negative or ambiguous outcome never reaches here
+      // and leaves the run on the tab it already controls.
+      return claim(verifying, "observing", {
+        ...(receipt.controlledTabId === undefined
+          ? {}
+          : { controlledTabId: receipt.controlledTabId }),
+        updatedAt: dependencies.clock.now()
+      })
     } catch {
       if (!signal.aborted) {
         await fail(
@@ -498,29 +500,41 @@ export const createAgentController = (
     return processCommand(state, decision, observation, signal)
   }
 
+  const claimObserving = async (
+    state: AgentRunState,
+    resumeDeadline: boolean
+  ): Promise<AgentRunState | undefined> =>
+    claim(state, "observing", {
+      ...(resumeDeadline && state.deadline
+        ? {
+            deadline: resumeAgentDeadlines(
+              state.deadline,
+              dependencies.clock.now()
+            )
+          }
+        : {}),
+      updatedAt: dependencies.clock.now()
+    })
+
   const runLoop = async (
     initialState: AgentRunState,
     controller: AgentCancellationController,
     afterTakeover = false
   ): Promise<void> => {
     let state = initialState
+    // A confirmed step already claimed the next observing phase, durably, in
+    // the write that closed it; re-claiming it here would lose that CAS.
+    let observingClaimed = false
     while (!controller.signal.aborted) {
-      const adopted = pendingControlledTab.get(state.id)
-      const observing = await claim(state, "observing", {
-        ...(adopted === undefined ? {} : { controlledTabId: adopted }),
-        ...((afterTakeover || state.status === "paused") && state.deadline
-          ? {
-              deadline: resumeAgentDeadlines(
-                state.deadline,
-                dependencies.clock.now()
-              )
-            }
-          : {}),
-        updatedAt: dependencies.clock.now()
-      })
-      pendingControlledTab.delete(state.id)
+      const observing = observingClaimed
+        ? state
+        : await claimObserving(
+            state,
+            afterTakeover || state.status === "paused"
+          )
       if (!observing) return
       state = observing
+      observingClaimed = false
       const observation = await observe(state, controller.signal)
       if (!observation) return
 
@@ -549,6 +563,7 @@ export const createAgentController = (
       )
       if (!next) return
       state = next
+      observingClaimed = next.status === "observing"
       // Both confirmed and a provable safe negative require a fresh
       // observation and model decision; neither repeats the command here.
     }

--- a/packages/agent-runtime/src/controller.ts
+++ b/packages/agent-runtime/src/controller.ts
@@ -392,6 +392,9 @@ export const createAgentController = (
         at: dependencies.clock.now()
       })
       const verifying = await claim(executing, "verifying", {
+        ...(receipt.controlledTabId === undefined
+          ? {}
+          : { controlledTabId: receipt.controlledTabId }),
         updatedAt: dependencies.clock.now()
       })
       if (!verifying) return undefined

--- a/packages/agent-runtime/src/controller.ts
+++ b/packages/agent-runtime/src/controller.ts
@@ -54,12 +54,13 @@ export const createAgentController = (
   const claim = async (
     state: AgentRunState,
     phase: AgentRunStatus,
-    patch?: AgentStatePatch
+    patch?: AgentStatePatch,
+    expected: readonly AgentRunStatus[] = AGENT_STATUS_PREDECESSORS[phase]
   ): Promise<AgentRunState | undefined> => {
     const result = await dependencies.persistence.claim({
       runId: state.id,
       phase,
-      expected: AGENT_STATUS_PREDECESSORS[phase],
+      expected,
       patch
     })
     return result.claimed ? result.state : undefined
@@ -420,14 +421,22 @@ export const createAgentController = (
       if (action.type === "redecide") return verifying
       // The write closing a confirmed step also opens the next observation, so
       // a tab the effect switched to is durably owned before this controller
-      // can lose the run. A negative or ambiguous outcome never reaches here
+      // can lose the run. Only the verifying run this step owns may be claimed:
+      // a pause or cancellation that raced verification has already recorded
+      // the effect as unresolved, and resurrecting it here would restart a run
+      // the user stopped. A negative or ambiguous outcome never reaches here
       // and leaves the run on the tab it already controls.
-      return claim(verifying, "observing", {
-        ...(receipt.controlledTabId === undefined
-          ? {}
-          : { controlledTabId: receipt.controlledTabId }),
-        updatedAt: dependencies.clock.now()
-      })
+      return claim(
+        verifying,
+        "observing",
+        {
+          ...(receipt.controlledTabId === undefined
+            ? {}
+            : { controlledTabId: receipt.controlledTabId }),
+          updatedAt: dependencies.clock.now()
+        },
+        ["verifying"]
+      )
     } catch {
       if (!signal.aborted) {
         await fail(
@@ -502,19 +511,25 @@ export const createAgentController = (
 
   const claimObserving = async (
     state: AgentRunState,
-    resumeDeadline: boolean
+    resumeDeadline: boolean,
+    expected?: readonly AgentRunStatus[]
   ): Promise<AgentRunState | undefined> =>
-    claim(state, "observing", {
-      ...(resumeDeadline && state.deadline
-        ? {
-            deadline: resumeAgentDeadlines(
-              state.deadline,
-              dependencies.clock.now()
-            )
-          }
-        : {}),
-      updatedAt: dependencies.clock.now()
-    })
+    claim(
+      state,
+      "observing",
+      {
+        ...(resumeDeadline && state.deadline
+          ? {
+              deadline: resumeAgentDeadlines(
+                state.deadline,
+                dependencies.clock.now()
+              )
+            }
+          : {}),
+        updatedAt: dependencies.clock.now()
+      },
+      expected
+    )
 
   const runLoop = async (
     initialState: AgentRunState,
@@ -525,16 +540,22 @@ export const createAgentController = (
     // A confirmed step already claimed the next observing phase, durably, in
     // the write that closed it; re-claiming it here would lose that CAS.
     let observingClaimed = false
+    // Only the first iteration may enter from a resumed or recovered status;
+    // later ones come from the step they just closed, so a pause that raced
+    // that step cannot be claimed back into observation.
+    let entered = false
     while (!controller.signal.aborted) {
       const observing = observingClaimed
         ? state
         : await claimObserving(
             state,
-            afterTakeover || state.status === "paused"
+            afterTakeover || state.status === "paused",
+            entered ? ["verifying"] : undefined
           )
       if (!observing) return
       state = observing
       observingClaimed = false
+      entered = true
       const observation = await observe(state, controller.signal)
       if (!observation) return
 

--- a/packages/agent-runtime/src/controller.ts
+++ b/packages/agent-runtime/src/controller.ts
@@ -50,6 +50,7 @@ export const createAgentController = (
   const active = new Map<string, AgentCancellationController>()
   const lastGeneration = new Map<string, number>()
   const minimumGeneration = new Map<string, number>()
+  const pendingControlledTab = new Map<string, number>()
 
   const claim = async (
     state: AgentRunState,
@@ -392,9 +393,6 @@ export const createAgentController = (
         at: dependencies.clock.now()
       })
       const verifying = await claim(executing, "verifying", {
-        ...(receipt.controlledTabId === undefined
-          ? {}
-          : { controlledTabId: receipt.controlledTabId }),
         updatedAt: dependencies.clock.now()
       })
       if (!verifying) return undefined
@@ -413,6 +411,13 @@ export const createAgentController = (
         verification,
         at: dependencies.clock.now()
       })
+      // A tab the run does not yet own becomes the observation target only
+      // once verification confirms it; a negative or ambiguous outcome leaves
+      // the run on the tab it already controls.
+      pendingControlledTab.delete(state.id)
+      if (action.type === "advance" && receipt.controlledTabId !== undefined) {
+        pendingControlledTab.set(state.id, receipt.controlledTabId)
+      }
       if (action.type === "pause") {
         await pause(
           verifying,
@@ -500,7 +505,9 @@ export const createAgentController = (
   ): Promise<void> => {
     let state = initialState
     while (!controller.signal.aborted) {
+      const adopted = pendingControlledTab.get(state.id)
       const observing = await claim(state, "observing", {
+        ...(adopted === undefined ? {} : { controlledTabId: adopted }),
         ...((afterTakeover || state.status === "paused") && state.deadline
           ? {
               deadline: resumeAgentDeadlines(
@@ -511,6 +518,7 @@ export const createAgentController = (
           : {}),
         updatedAt: dependencies.clock.now()
       })
+      pendingControlledTab.delete(state.id)
       if (!observing) return
       state = observing
       const observation = await observe(state, controller.signal)

--- a/packages/agent-runtime/src/ports.ts
+++ b/packages/agent-runtime/src/ports.ts
@@ -39,7 +39,7 @@ export interface ResolvedAgentTarget {
 export interface AgentDestination {
   url: string
   origin: string
-  source: "observed" | "model"
+  source: "observed" | "model" | "browser"
 }
 
 export type AgentSemanticEffect =
@@ -60,6 +60,8 @@ export interface ResolvedAgentEffect {
   destination?: AgentDestination
   semanticEffects: readonly AgentSemanticEffect[]
   snapshotIdentity: AgentSnapshotIdentity
+  sourceUrl: string
+  sourceOrigin: string
 }
 
 export interface AuthorizedAgentEffect extends ResolvedAgentEffect {
@@ -76,6 +78,7 @@ export interface AuthorizedAgentEffect extends ResolvedAgentEffect {
 export interface AgentExecutionReceipt {
   executedAt: number
   details?: string
+  controlledTabId?: number
 }
 
 export interface AgentVerificationEvidence {
@@ -143,6 +146,7 @@ export type AgentStatePatch = Partial<
   Pick<
     AgentRunState,
     | "deadline"
+    | "controlledTabId"
     | "error"
     | "observationCount"
     | "pauseReason"

--- a/packages/contracts/src/__tests__/agent.test.ts
+++ b/packages/contracts/src/__tests__/agent.test.ts
@@ -13,6 +13,7 @@ const ground = { snapshotId: "snapshot-1", generation: 1 }
 describe("agent contract schemas", () => {
   it("accepts each supported command shape", () => {
     const commands = [
+      { type: "read", ...ground },
       { type: "click", ref: "e1", ...ground },
       { type: "type", ref: "e1", text: "hello", ...ground },
       { type: "press_key", ref: "e1", key: "Enter", ...ground },

--- a/packages/contracts/src/agent-command.ts
+++ b/packages/contracts/src/agent-command.ts
@@ -10,6 +10,7 @@ const ElementCommandSchema = GroundedCommandSchema.extend({
 })
 
 export const AgentCommandSchema = z.discriminatedUnion("type", [
+  GroundedCommandSchema.extend({ type: z.literal("read") }).strict(),
   ElementCommandSchema.extend({ type: z.literal("click") }).strict(),
   ElementCommandSchema.extend({
     type: z.literal("type"),

--- a/src/lib/browser-agent/__tests__/element-references.test.ts
+++ b/src/lib/browser-agent/__tests__/element-references.test.ts
@@ -12,6 +12,8 @@ describe("Agent element references", () => {
     const button = document.createElement("button")
     const ref = first.reference(button)
     expect(first.resolve(ref, first)).toBe(button)
+    expect(store.matches(first)).toBe(true)
+    expect(store.resolve(ref, first)).toBe(button)
     expect(
       first.resolve(ref, { ...first, documentId: "other" })
     ).toBeUndefined()
@@ -30,6 +32,7 @@ describe("Agent element references", () => {
       createSnapshotId: () => "snapshot-2"
     })
     expect(first.resolve(ref, first)).toBeUndefined()
+    expect(store.matches(first)).toBe(false)
     expect(second.generation).toBe(2)
   })
 })

--- a/src/lib/browser-agent/__tests__/read-only-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/read-only-actions.test.ts
@@ -1,0 +1,287 @@
+import type {
+  AgentCancellationSignal,
+  AgentVerificationInput,
+  AuthorizedAgentEffect
+} from "@ollama-client/agent-runtime"
+import type { AgentCommand, AgentObservation } from "@ollama-client/contracts"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type AgentCommandExecutorAdapter,
+  executeAgentScrollInDocument,
+  executeReadOnlyAgentEffect,
+  READ_ONLY_AGENT_EXECUTORS
+} from "../command-executor"
+import {
+  type AgentEffectVerifierAdapter,
+  READ_ONLY_AGENT_VERIFIERS,
+  verifyReadOnlyAgentEffect
+} from "../effect-verifier"
+import {
+  type AgentEffectResolverAdapter,
+  READ_ONLY_AGENT_ACTIONS,
+  resolveReadOnlyAgentEffect
+} from "../resolved-effect"
+
+const signal: AgentCancellationSignal = { aborted: false }
+
+const observation = (
+  overrides: Partial<AgentObservation> = {}
+): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  documentId: "document-1",
+  url: "https://example.com/start",
+  origin: "https://example.com",
+  title: "Example",
+  elements: [],
+  visibleText: "Initial content",
+  scroll: {
+    x: 0,
+    y: 20,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 500
+  },
+  dialogs: [],
+  capturedAt: 1,
+  ...overrides
+})
+
+const resolverAdapter = (
+  overrides: Partial<AgentEffectResolverAdapter> = {}
+): AgentEffectResolverAdapter => ({
+  getTab: async (tabId) => ({ id: tabId, url: "https://example.com/other" }),
+  classifyAccess: async () => "ok",
+  resolveHistoryDestination: async () => "https://example.com/previous",
+  ...overrides
+})
+
+const resolve = (
+  command: AgentCommand,
+  before = observation(),
+  adapter = resolverAdapter()
+) => resolveReadOnlyAgentEffect({ command, observation: before, adapter })
+
+const authorize = async (
+  command: AgentCommand,
+  before = observation(),
+  adapter = resolverAdapter()
+): Promise<AuthorizedAgentEffect> => ({
+  ...(await resolve(command, before, adapter)),
+  authorization: { type: "policy", risk: "low", authorizedAt: 2 }
+})
+
+const executorAdapter = (
+  overrides: Partial<AgentCommandExecutorAdapter> = {}
+): AgentCommandExecutorAdapter => ({
+  getTab: async (tabId) => ({ id: tabId, url: "https://example.com/start" }),
+  getMainFrame: async () => ({
+    documentId: "document-1",
+    url: "https://example.com/start"
+  }),
+  classifyAccess: async () => "ok",
+  scroll: vi.fn(),
+  activateTab: vi.fn(),
+  goHistory: vi.fn(),
+  resolveHistoryDestination: async () => "https://example.com/previous",
+  wait: vi.fn(),
+  now: () => 10,
+  ...overrides
+})
+
+const verifierAdapter = (
+  after: AgentObservation,
+  overrides: Partial<AgentEffectVerifierAdapter> = {}
+): AgentEffectVerifierAdapter => ({
+  observe: async () => after,
+  getActiveTabId: async () => 7,
+  getTab: async () => ({ url: after.url }),
+  classifyAccess: async () => "ok",
+  now: () => 10,
+  ...overrides
+})
+
+const verificationInput = async (
+  command: AgentCommand,
+  before = observation()
+): Promise<AgentVerificationInput> => ({
+  effect: await authorize(command, before),
+  receipt: { executedAt: 2 },
+  before
+})
+
+describe("read-only Agent effects", () => {
+  it("rejects stale observations during resolution", async () => {
+    await expect(
+      resolve({ type: "read", snapshotId: "stale", generation: 1 })
+    ).rejects.toThrow("stale observation")
+  })
+
+  it("resolves browser-owned destinations for switch and safe history", async () => {
+    await expect(
+      resolve({
+        type: "switch_tab",
+        tabId: 9,
+        snapshotId: "snapshot-1",
+        generation: 1
+      })
+    ).resolves.toMatchObject({
+      destination: { url: "https://example.com/other", source: "browser" },
+      semanticEffects: ["navigation"]
+    })
+    await expect(
+      resolve({ type: "back", snapshotId: "snapshot-1", generation: 1 })
+    ).resolves.toMatchObject({
+      destination: { url: "https://example.com/previous" }
+    })
+  })
+
+  it("refuses history when its destination cannot be known before execution", async () => {
+    await expect(
+      resolve(
+        { type: "back", snapshotId: "snapshot-1", generation: 1 },
+        observation(),
+        resolverAdapter({ resolveHistoryDestination: async () => undefined })
+      )
+    ).rejects.toThrow("not known safely")
+  })
+
+  it("rejects excluded destinations during semantic resolution", async () => {
+    await expect(
+      resolve(
+        { type: "forward", snapshotId: "snapshot-1", generation: 1 },
+        observation(),
+        resolverAdapter({
+          classifyAccess: async (url) =>
+            url?.endsWith("/previous") ? "excluded" : "ok"
+        })
+      )
+    ).rejects.toThrow("destination is not readable")
+  })
+
+  it("re-runs source, destination, origin access, and history policy", async () => {
+    const effect = await authorize({
+      type: "back",
+      snapshotId: "snapshot-1",
+      generation: 1
+    })
+    const goHistory = vi.fn()
+    const classifyAccess = vi.fn(async () => "excluded" as const)
+    await expect(
+      executeReadOnlyAgentEffect({
+        effect,
+        adapter: executorAdapter({ classifyAccess, goHistory }),
+        signal
+      })
+    ).rejects.toThrow("access changed")
+    expect(goHistory).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["confirmed", 20, 120, 500],
+    ["negative", 400, 400, 500],
+    ["ambiguous", 20, 20, 500]
+  ] as const)("classifies scroll verification as %s", async (expected, beforeY, afterY, documentHeight) => {
+    const before = observation({
+      scroll: { ...observation().scroll, y: beforeY, documentHeight }
+    })
+    const after = observation({
+      snapshotId: "snapshot-2",
+      generation: 2,
+      scroll: { ...before.scroll, y: afterY }
+    })
+    const input = await verificationInput(
+      {
+        type: "scroll",
+        direction: "down",
+        snapshotId: "snapshot-1",
+        generation: 1
+      },
+      before
+    )
+    await expect(
+      verifyReadOnlyAgentEffect({
+        verification: input,
+        adapter: verifierAdapter(after),
+        signal
+      })
+    ).resolves.toMatchObject({ outcome: expected })
+  })
+
+  it("rejects a document scroll after its snapshot was invalidated", () => {
+    const references = {
+      beginSnapshot: vi.fn(),
+      invalidate: vi.fn(),
+      currentGeneration: () => 2,
+      matches: () => false,
+      resolve: vi.fn()
+    }
+    expect(() =>
+      executeAgentScrollInDocument({
+        command: {
+          type: "scroll",
+          direction: "down",
+          snapshotId: "snapshot-1",
+          generation: 1
+        },
+        identity: {
+          snapshotId: "snapshot-1",
+          generation: 1,
+          tabId: 7,
+          documentId: "document-1"
+        },
+        document,
+        references
+      })
+    ).toThrow("snapshot is stale")
+  })
+
+  it("confirms or negatively verifies a named wait condition", async () => {
+    const command = {
+      type: "wait",
+      condition: "results ready",
+      timeoutMs: 1,
+      snapshotId: "snapshot-1",
+      generation: 1
+    } as const
+    const input = await verificationInput(command)
+    await expect(
+      verifyReadOnlyAgentEffect({
+        verification: input,
+        adapter: verifierAdapter(
+          observation({
+            snapshotId: "snapshot-2",
+            generation: 2,
+            visibleText: "Results ready"
+          })
+        ),
+        signal
+      })
+    ).resolves.toMatchObject({ outcome: "confirmed" })
+    await expect(
+      verifyReadOnlyAgentEffect({
+        verification: input,
+        adapter: verifierAdapter(
+          observation({
+            snapshotId: "snapshot-2",
+            generation: 2,
+            visibleText: "Still loading"
+          })
+        ),
+        signal
+      })
+    ).resolves.toMatchObject({ outcome: "negative" })
+  })
+
+  it("registers a verifier for every shipped executor", () => {
+    expect(Object.keys(READ_ONLY_AGENT_EXECUTORS).sort()).toEqual(
+      [...READ_ONLY_AGENT_ACTIONS].sort()
+    )
+    expect(Object.keys(READ_ONLY_AGENT_VERIFIERS).sort()).toEqual(
+      [...READ_ONLY_AGENT_ACTIONS].sort()
+    )
+  })
+})

--- a/src/lib/browser-agent/command-executor.ts
+++ b/src/lib/browser-agent/command-executor.ts
@@ -1,0 +1,213 @@
+import type {
+  AgentCancellationSignal,
+  AgentExecutionReceipt,
+  AuthorizedAgentEffect
+} from "@ollama-client/agent-runtime"
+import type { AgentSnapshotIdentity } from "@ollama-client/contracts"
+
+import type { TabAccess } from "@/lib/browser-tab-access"
+import type { AgentElementReferenceStore } from "./element-references"
+import type { ReadOnlyAgentAction } from "./resolved-effect"
+
+export const executeAgentScrollInDocument = (input: {
+  command: Extract<AuthorizedAgentEffect["command"], { type: "scroll" }>
+  identity: AgentSnapshotIdentity
+  document: Document
+  references: AgentElementReferenceStore
+}): void => {
+  const identity = { ...input.identity, frameId: 0 as const }
+  if (!input.references.matches(identity)) {
+    throw new Error("Agent scroll snapshot is stale")
+  }
+  if (input.command.ref) {
+    const target = input.references.resolve(input.command.ref, identity)
+    if (!target) throw new Error("Agent scroll target is stale")
+    target.scrollIntoView({ block: "center", inline: "center" })
+    return
+  }
+  const view = input.document.defaultView
+  if (!view) throw new Error("Agent scroll window is unavailable")
+  const amount =
+    input.command.amount ??
+    (input.command.direction === "up" || input.command.direction === "down"
+      ? view.innerHeight * 0.8
+      : view.innerWidth * 0.8)
+  view.scrollBy({
+    behavior: "instant",
+    left:
+      input.command.direction === "left"
+        ? -amount
+        : input.command.direction === "right"
+          ? amount
+          : 0,
+    top:
+      input.command.direction === "up"
+        ? -amount
+        : input.command.direction === "down"
+          ? amount
+          : 0
+  })
+}
+
+export interface AgentCommandExecutorAdapter {
+  getTab(tabId: number): Promise<{ id?: number; url?: string } | undefined>
+  getMainFrame(
+    tabId: number
+  ): Promise<{ documentId?: string; url: string } | null>
+  classifyAccess(url?: string): Promise<TabAccess>
+  scroll(
+    command: Extract<AuthorizedAgentEffect["command"], { type: "scroll" }>,
+    identity: AgentSnapshotIdentity,
+    signal: AgentCancellationSignal
+  ): Promise<void>
+  activateTab(tabId: number): Promise<void>
+  goHistory(tabId: number, direction: "back" | "forward"): Promise<void>
+  resolveHistoryDestination(
+    tabId: number,
+    direction: "back" | "forward"
+  ): Promise<string | undefined>
+  wait(ms: number, signal: AgentCancellationSignal): Promise<void>
+  now(): number
+}
+
+const exactUrl = (value: string | undefined, expected: string): boolean => {
+  if (!value) return false
+  try {
+    return new URL(value).href === new URL(expected).href
+  } catch {
+    return false
+  }
+}
+
+const exactOrigin = (value: string | undefined, expected: string): boolean => {
+  if (!value) return false
+  try {
+    return new URL(value).origin === expected
+  } catch {
+    return false
+  }
+}
+
+const assertReadable = async (
+  adapter: AgentCommandExecutorAdapter,
+  url: string | undefined
+): Promise<void> => {
+  if ((await adapter.classifyAccess(url)) !== "ok") {
+    throw new Error("Agent tab access changed before execution")
+  }
+}
+
+const assertSource = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  requireDocument: boolean
+): Promise<void> => {
+  const tab = await adapter.getTab(effect.snapshotIdentity.tabId)
+  if (
+    !tab ||
+    !exactUrl(tab.url, effect.sourceUrl) ||
+    !exactOrigin(tab.url, effect.sourceOrigin)
+  ) {
+    throw new Error("Agent source tab changed before execution")
+  }
+  await assertReadable(adapter, tab.url)
+  if (!requireDocument) return
+  const frame = await adapter.getMainFrame(effect.snapshotIdentity.tabId)
+  if (
+    !frame ||
+    frame.documentId !== effect.snapshotIdentity.documentId ||
+    !exactUrl(frame.url, effect.sourceUrl)
+  ) {
+    throw new Error("Agent source document changed before execution")
+  }
+}
+
+type Executor = (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  signal: AgentCancellationSignal
+) => Promise<AgentExecutionReceipt>
+
+const receipt = (
+  adapter: AgentCommandExecutorAdapter,
+  details: string,
+  controlledTabId?: number
+): AgentExecutionReceipt => ({
+  executedAt: adapter.now(),
+  details,
+  ...(controlledTabId === undefined ? {} : { controlledTabId })
+})
+
+export const READ_ONLY_AGENT_EXECUTORS = {
+  async read(effect, adapter) {
+    await assertSource(effect, adapter, true)
+    return receipt(adapter, "read")
+  },
+  async wait(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    if (effect.command.type !== "wait") throw new Error("Invalid wait effect")
+    await adapter.wait(effect.command.timeoutMs, signal)
+    return receipt(adapter, "wait")
+  },
+  async scroll(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    if (effect.command.type !== "scroll") {
+      throw new Error("Invalid scroll effect")
+    }
+    await adapter.scroll(effect.command, effect.snapshotIdentity, signal)
+    return receipt(adapter, "scroll")
+  },
+  async switch_tab(effect, adapter) {
+    if (effect.command.type !== "switch_tab" || !effect.destination) {
+      throw new Error("Invalid switch-tab effect")
+    }
+    await assertSource(effect, adapter, false)
+    const target = await adapter.getTab(effect.command.tabId)
+    if (!target || !exactUrl(target.url, effect.destination.url)) {
+      throw new Error("Agent switch-tab destination changed")
+    }
+    await assertReadable(adapter, target.url)
+    await adapter.activateTab(effect.command.tabId)
+    return receipt(adapter, "switch_tab", effect.command.tabId)
+  },
+  async back(effect, adapter) {
+    await assertSource(effect, adapter, false)
+    if (!effect.destination) throw new Error("Unknown back destination")
+    const destination = await adapter.resolveHistoryDestination(
+      effect.snapshotIdentity.tabId,
+      "back"
+    )
+    if (!exactUrl(destination, effect.destination.url)) {
+      throw new Error("Agent back destination changed")
+    }
+    await assertReadable(adapter, destination)
+    await adapter.goHistory(effect.snapshotIdentity.tabId, "back")
+    return receipt(adapter, "back")
+  },
+  async forward(effect, adapter) {
+    await assertSource(effect, adapter, false)
+    if (!effect.destination) throw new Error("Unknown forward destination")
+    const destination = await adapter.resolveHistoryDestination(
+      effect.snapshotIdentity.tabId,
+      "forward"
+    )
+    if (!exactUrl(destination, effect.destination.url)) {
+      throw new Error("Agent forward destination changed")
+    }
+    await assertReadable(adapter, destination)
+    await adapter.goHistory(effect.snapshotIdentity.tabId, "forward")
+    return receipt(adapter, "forward")
+  }
+} satisfies Record<ReadOnlyAgentAction, Executor>
+
+export const executeReadOnlyAgentEffect = async (input: {
+  effect: AuthorizedAgentEffect
+  adapter: AgentCommandExecutorAdapter
+  signal: AgentCancellationSignal
+}): Promise<AgentExecutionReceipt> => {
+  const executor = READ_ONLY_AGENT_EXECUTORS[
+    input.effect.command.type as ReadOnlyAgentAction
+  ] as Executor | undefined
+  if (!executor) throw new Error("Agent action has no read-only executor")
+  return executor(input.effect, input.adapter, input.signal)
+}

--- a/src/lib/browser-agent/effect-verifier.ts
+++ b/src/lib/browser-agent/effect-verifier.ts
@@ -1,0 +1,275 @@
+import type {
+  AgentCancellationSignal,
+  AgentVerificationInput,
+  AgentVerificationResult
+} from "@ollama-client/agent-runtime"
+import type { AgentObservation } from "@ollama-client/contracts"
+
+import type { TabAccess } from "@/lib/browser-tab-access"
+import type { ReadOnlyAgentAction } from "./resolved-effect"
+
+export interface AgentEffectVerifierAdapter {
+  observe(
+    tabId: number,
+    minimumGeneration: number,
+    signal: AgentCancellationSignal
+  ): Promise<AgentObservation>
+  getActiveTabId(): Promise<number | undefined>
+  getTab(tabId: number): Promise<{ url?: string } | undefined>
+  classifyAccess(url?: string): Promise<TabAccess>
+  now(): number
+}
+
+const result = (
+  outcome: AgentVerificationResult["outcome"],
+  kind: string,
+  summary: string,
+  now: number
+): AgentVerificationResult => ({
+  outcome,
+  evidence: { kind, summary, observedAt: now }
+})
+
+const observeAfter = (
+  input: AgentVerificationInput,
+  adapter: AgentEffectVerifierAdapter,
+  signal: AgentCancellationSignal,
+  tabId = input.effect.snapshotIdentity.tabId
+): Promise<AgentObservation> =>
+  adapter.observe(tabId, input.effect.snapshotIdentity.generation + 1, signal)
+
+const sameUrl = (first: string | undefined, second: string): boolean => {
+  if (!first) return false
+  try {
+    return new URL(first).href === new URL(second).href
+  } catch {
+    return false
+  }
+}
+
+const conditionAppears = (
+  condition: string,
+  observation: AgentObservation
+): boolean => {
+  const needle = condition.replaceAll(/\s+/g, " ").trim().toLocaleLowerCase()
+  if (!needle) return false
+  const haystack = [
+    observation.title,
+    observation.visibleText,
+    ...observation.elements.flatMap((element) =>
+      [element.name, element.value].filter(
+        (value): value is string => value !== undefined
+      )
+    )
+  ]
+    .join(" ")
+    .replaceAll(/\s+/g, " ")
+    .toLocaleLowerCase()
+  return haystack.includes(needle)
+}
+
+const resolvedTargetBecameVisible = (
+  input: AgentVerificationInput,
+  after: AgentObservation
+): boolean => {
+  if (!input.effect.target.ref) return false
+  const before = input.before.elements.find(
+    (element) => element.ref === input.effect.target.ref
+  )
+  if (!before || before.visible) return false
+  const candidates = after.elements.filter(
+    (element) =>
+      element.visible &&
+      element.tag === input.effect.target.tag &&
+      element.role === input.effect.target.role &&
+      element.name === input.effect.target.accessibleName &&
+      element.type === input.effect.target.inputType
+  )
+  return candidates.length === 1
+}
+
+type Verifier = (
+  input: AgentVerificationInput,
+  adapter: AgentEffectVerifierAdapter,
+  signal: AgentCancellationSignal
+) => Promise<AgentVerificationResult>
+
+const verifyHistory: Verifier = async (input, adapter) => {
+  const destination = input.effect.destination
+  if (!destination) {
+    return result(
+      "ambiguous",
+      "navigation",
+      "Destination unavailable",
+      adapter.now()
+    )
+  }
+  const tab = await adapter.getTab(input.effect.snapshotIdentity.tabId)
+  if (!tab?.url) {
+    return result("ambiguous", "navigation", "Tab unavailable", adapter.now())
+  }
+  if (sameUrl(tab.url, destination.url)) {
+    return (await adapter.classifyAccess(tab.url)) === "ok"
+      ? result(
+          "confirmed",
+          "navigation",
+          "Expected history destination committed",
+          adapter.now()
+        )
+      : result(
+          "ambiguous",
+          "navigation",
+          "Destination is no longer readable",
+          adapter.now()
+        )
+  }
+  return sameUrl(tab.url, input.effect.sourceUrl)
+    ? result(
+        "negative",
+        "navigation",
+        "History position did not change",
+        adapter.now()
+      )
+    : result(
+        "ambiguous",
+        "navigation",
+        "A different destination committed",
+        adapter.now()
+      )
+}
+
+export const READ_ONLY_AGENT_VERIFIERS = {
+  async read(input, adapter, signal) {
+    const after = await observeAfter(input, adapter, signal)
+    return after.documentId === input.before.documentId &&
+      sameUrl(after.url, input.before.url)
+      ? result(
+          "confirmed",
+          "observation",
+          "Fresh page observation received",
+          adapter.now()
+        )
+      : result(
+          "ambiguous",
+          "observation",
+          "Page changed while it was read",
+          adapter.now()
+        )
+  },
+  async wait(input, adapter, signal) {
+    if (input.effect.command.type !== "wait")
+      throw new Error("Invalid wait effect")
+    const after = await observeAfter(input, adapter, signal)
+    return conditionAppears(input.effect.command.condition, after)
+      ? result(
+          "confirmed",
+          "condition",
+          "Named wait condition is present",
+          adapter.now()
+        )
+      : result(
+          "negative",
+          "condition",
+          "Named wait condition is absent after timeout",
+          adapter.now()
+        )
+  },
+  async scroll(input, adapter, signal) {
+    if (input.effect.command.type !== "scroll")
+      throw new Error("Invalid scroll effect")
+    const after = await observeAfter(input, adapter, signal)
+    const before = input.before.scroll
+    const delta = {
+      x: after.scroll.x - before.x,
+      y: after.scroll.y - before.y
+    }
+    const moved =
+      (input.effect.command.direction === "down" && delta.y > 0) ||
+      (input.effect.command.direction === "up" && delta.y < 0) ||
+      (input.effect.command.direction === "right" && delta.x > 0) ||
+      (input.effect.command.direction === "left" && delta.x < 0)
+    if (moved) {
+      return result(
+        "confirmed",
+        "scroll",
+        "Scroll position changed as requested",
+        adapter.now()
+      )
+    }
+    if (resolvedTargetBecameVisible(input, after)) {
+      return result(
+        "confirmed",
+        "scroll",
+        "Resolved scroll target became visible",
+        adapter.now()
+      )
+    }
+    const atBoundary =
+      (input.effect.command.direction === "up" && before.y <= 0) ||
+      (input.effect.command.direction === "left" && before.x <= 0) ||
+      (input.effect.command.direction === "down" &&
+        before.y + before.viewportHeight >= before.documentHeight) ||
+      (input.effect.command.direction === "right" &&
+        before.x + before.viewportWidth >= before.documentWidth)
+    return atBoundary
+      ? result(
+          "negative",
+          "scroll",
+          "Page was already at the requested boundary",
+          adapter.now()
+        )
+      : result(
+          "ambiguous",
+          "scroll",
+          "Scroll movement could not be established",
+          adapter.now()
+        )
+  },
+  async switch_tab(input, adapter) {
+    if (
+      input.effect.command.type !== "switch_tab" ||
+      !input.effect.destination
+    ) {
+      throw new Error("Invalid switch-tab effect")
+    }
+    const active = await adapter.getActiveTabId()
+    if (active !== input.effect.command.tabId) {
+      return result(
+        "negative",
+        "tab",
+        "Requested tab is not active",
+        adapter.now()
+      )
+    }
+    const tab = await adapter.getTab(active)
+    return tab?.url &&
+      sameUrl(tab.url, input.effect.destination.url) &&
+      (await adapter.classifyAccess(tab.url)) === "ok"
+      ? result(
+          "confirmed",
+          "tab",
+          "Requested readable tab is active",
+          adapter.now()
+        )
+      : result(
+          "ambiguous",
+          "tab",
+          "Active tab destination changed",
+          adapter.now()
+        )
+  },
+  back: verifyHistory,
+  forward: verifyHistory
+} satisfies Record<ReadOnlyAgentAction, Verifier>
+
+export const verifyReadOnlyAgentEffect = async (input: {
+  verification: AgentVerificationInput
+  adapter: AgentEffectVerifierAdapter
+  signal: AgentCancellationSignal
+}): Promise<AgentVerificationResult> => {
+  const verifier = READ_ONLY_AGENT_VERIFIERS[
+    input.verification.effect.command.type as ReadOnlyAgentAction
+  ] as Verifier | undefined
+  if (!verifier) throw new Error("Agent action has no read-only verifier")
+  return verifier(input.verification, input.adapter, input.signal)
+}

--- a/src/lib/browser-agent/element-references.ts
+++ b/src/lib/browser-agent/element-references.ts
@@ -17,6 +17,8 @@ export interface AgentElementReferenceStore {
   }): AgentElementReferenceSnapshot
   invalidate(): void
   currentGeneration(): number
+  matches(identity: AgentReferenceIdentity): boolean
+  resolve(ref: string, identity: AgentReferenceIdentity): Element | undefined
 }
 
 export const createAgentElementReferenceStore = (input: {
@@ -68,6 +70,18 @@ export const createAgentElementReferenceStore = (input: {
       generation += 1
       active = undefined
     },
-    currentGeneration: () => generation
+    currentGeneration: () => generation,
+    matches(identity) {
+      return Boolean(
+        active &&
+          active.snapshotId === identity.snapshotId &&
+          active.generation === identity.generation &&
+          active.documentId === identity.documentId &&
+          identity.frameId === 0
+      )
+    },
+    resolve(ref, identity) {
+      return active?.resolve(ref, identity)
+    }
   }
 }

--- a/src/lib/browser-agent/resolved-effect.ts
+++ b/src/lib/browser-agent/resolved-effect.ts
@@ -1,0 +1,129 @@
+import type {
+  AgentDestination,
+  ResolvedAgentEffect,
+  ResolvedAgentTarget
+} from "@ollama-client/agent-runtime"
+import type { AgentCommand, AgentObservation } from "@ollama-client/contracts"
+
+import type { TabAccess } from "@/lib/browser-tab-access"
+
+export const READ_ONLY_AGENT_ACTIONS = [
+  "read",
+  "wait",
+  "scroll",
+  "switch_tab",
+  "back",
+  "forward"
+] as const
+
+export type ReadOnlyAgentAction = (typeof READ_ONLY_AGENT_ACTIONS)[number]
+
+export interface AgentEffectResolverAdapter {
+  getTab(tabId: number): Promise<{ id?: number; url?: string } | undefined>
+  classifyAccess(url?: string): Promise<TabAccess>
+  resolveHistoryDestination(
+    tabId: number,
+    direction: "back" | "forward"
+  ): Promise<string | undefined>
+}
+
+const isReadOnlyAction = (type: string): type is ReadOnlyAgentAction =>
+  (READ_ONLY_AGENT_ACTIONS as readonly string[]).includes(type)
+
+const destination = (url: string): AgentDestination => {
+  const parsed = new URL(url)
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Agent destination is not HTTP(S)")
+  }
+  return { url: parsed.href, origin: parsed.origin, source: "browser" }
+}
+
+const targetFromObservation = (
+  command: AgentCommand,
+  observation: AgentObservation
+): ResolvedAgentTarget => {
+  if (command.type !== "scroll" || !command.ref) {
+    return { sensitive: false, maySubmit: false }
+  }
+  const element = observation.elements.find(
+    (candidate) => candidate.ref === command.ref && candidate.frameId === 0
+  )
+  if (!element) throw new Error("Agent scroll target is stale")
+  return {
+    ref: element.ref,
+    tag: element.tag,
+    role: element.role,
+    accessibleName: element.name,
+    inputType: element.type,
+    sensitive: element.sensitive,
+    maySubmit: false
+  }
+}
+
+export const resolveReadOnlyAgentEffect = async (input: {
+  command: AgentCommand
+  observation: AgentObservation
+  adapter: AgentEffectResolverAdapter
+}): Promise<ResolvedAgentEffect> => {
+  const { command, observation } = input
+  if (!isReadOnlyAction(command.type)) {
+    throw new Error(`Unsupported Agent action: ${command.type}`)
+  }
+  if (
+    command.snapshotId !== observation.snapshotId ||
+    command.generation !== observation.generation
+  ) {
+    throw new Error("Agent command references a stale observation")
+  }
+  const source = destination(observation.url)
+  if (
+    source.origin !== observation.origin ||
+    (await input.adapter.classifyAccess(source.url)) !== "ok"
+  ) {
+    throw new Error("Agent observation is no longer readable")
+  }
+
+  let resolvedDestination: AgentDestination | undefined
+  if (command.type === "switch_tab") {
+    const tab = await input.adapter.getTab(command.tabId)
+    if (!tab?.url || tab.id !== command.tabId) {
+      throw new Error("Agent switch-tab target is unavailable")
+    }
+    resolvedDestination = destination(tab.url)
+  } else if (command.type === "back" || command.type === "forward") {
+    const url = await input.adapter.resolveHistoryDestination(
+      observation.tabId,
+      command.type
+    )
+    if (!url) throw new Error("Agent history destination is not known safely")
+    resolvedDestination = destination(url)
+  }
+  if (
+    resolvedDestination &&
+    (await input.adapter.classifyAccess(resolvedDestination.url)) !== "ok"
+  ) {
+    throw new Error("Agent destination is not readable")
+  }
+
+  return {
+    command,
+    target: targetFromObservation(command, observation),
+    ...(resolvedDestination ? { destination: resolvedDestination } : {}),
+    semanticEffects:
+      command.type === "scroll"
+        ? ["scroll"]
+        : command.type === "switch_tab" ||
+            command.type === "back" ||
+            command.type === "forward"
+          ? ["navigation"]
+          : ["read"],
+    snapshotIdentity: {
+      snapshotId: observation.snapshotId,
+      generation: observation.generation,
+      tabId: observation.tabId,
+      documentId: observation.documentId
+    },
+    sourceUrl: source.url,
+    sourceOrigin: source.origin
+  }
+}


### PR DESCRIPTION
## Summary

- add grounded read, wait, scroll, switch-tab, and safe back/forward actions
- require fresh tab, origin, document, and snapshot evidence immediately before execution
- pair every shipped executor with confirmed, negative, and ambiguous verification outcomes
- persist controlled-tab ownership across verified switch-tab execution
- refuse history traversal when its destination cannot be established and revalidated safely

## Safety invariant

Every browser effect remains behind the durable SQL executing claim introduced in PR 5. Recovery never retries an uncertain effect. Arbitrary navigation and DOM mutation remain deferred.

## Validation

- pnpm typecheck
- pnpm lint:check
- pnpm test:run (430 files, 3,689 tests)
- pnpm build







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds grounded read-only browser actions and strengthens switch-tab ownership handling across verification and durable state transitions.
- Adds read, wait, scroll, switch-tab, back, and forward resolution, execution, and verification.
- Revalidates source documents, origins, destinations, and browser access immediately before execution.
- Atomically persists a confirmed switched-tab ID while advancing the run into observation.
- Adds coverage for confirmed, negative, ambiguous, pause-race, and stale-snapshot outcomes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/agent-runtime/src/controller.ts | Atomically advances confirmed effects into observation while persisting verified tab ownership and preventing raced pauses from being reclaimed. |
| packages/agent-runtime/src/ports.ts | Extends effect and receipt contracts with source identity, browser-owned destinations, and controlled-tab persistence. |
| packages/contracts/src/agent-command.ts | Adds a strict grounded read command to the agent command union. |
| src/lib/browser-agent/resolved-effect.ts | Resolves read-only actions against fresh snapshot, source, destination, and access evidence. |
| src/lib/browser-agent/command-executor.ts | Implements read-only action execution with immediate source, document, destination, and access revalidation. |
| src/lib/browser-agent/effect-verifier.ts | Classifies read-only action outcomes using fresh observation and browser state evidence. |
| src/lib/browser-agent/element-references.ts | Adds snapshot identity matching and reference resolution needed for safe document scrolling. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Fresh browser observation] --> B[Resolve grounded effect]
  B --> C[Authorize effect]
  C --> D[Revalidate source and destination]
  D --> E[Execute read-only action]
  E --> F[Verify outcome]
  F -->|Confirmed| G[Atomically persist controlled tab and claim observing]
  F -->|Safe negative| H[Re-observe and redecide]
  F -->|Ambiguous or critical| I[Pause as unresolved]
  G --> A
  H --> A
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(agent): scope the post-step observin..."](https://github.com/shishir435/ollama-client/commit/f5d4e77afb34f2684f6a6b31b444378e31e15df8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60067150)</sub>

<!-- /greptile_comment -->