### PR TITLE
fix(olc): release a request slot when its caller leaves

### DIFF
--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -327,6 +327,7 @@ readiness reporting. Ollama itself is installed separately.
 | `SYSTEM_PROMPT` | `--system-prompt` | `OLC_SYSTEM_PROMPT` | the client's |
 | `BRIDGE_ENABLED` | `--no-bridge` to disable | `OLC_BRIDGE_ENABLED` | `true` |
 | `DEBUG` | `--debug` | `OLC_DEBUG` | `false` |
+| `REQUEST_TIMEOUT_MS` | — | `OLC_REQUEST_TIMEOUT_MS` | `300000` |
 
 `REQUEST_TIMEOUT_MS`, `BRIDGE_CALL_TIMEOUT_MS`, `BRIDGE_BATCH_MS` and
 `SUSPENDED_TURN_TTL_MS` follow the same precedence with `OLC_`-prefixed
@@ -486,6 +487,11 @@ new adapter's expectations.
   cancelled, not merely failed, and the next request waits for it to unwind. A
   cancelled turn that does not stop is never overtaken: after ten seconds the
   queue refuses requests with `503` and names it, until it stops.
+- **A departed client releases its slot.** A request whose connection closes
+  while it is still queued is dropped and never starts; one that has already
+  started is cancelled the same way a deadline cancels it, and the slot is held
+  until it unwinds. Backend startup is not cancelled — the next request reuses
+  it — but a request whose caller left does not spend a turn behind it.
 - **A turn per user message.** Conversation history is replayed from the client's
   messages; only a tool exchange reuses its turn. Trailing tool results whose turn
   the proxy no longer holds — expired, cancelled, or from an earlier run — are

--- a/packages/olc/src/config.ts
+++ b/packages/olc/src/config.ts
@@ -30,7 +30,13 @@ export const DEFAULTS = {
     "moz-extension://*",
     "safari-web-extension://*"
   ],
-  REQUEST_TIMEOUT_MS: 1_800_000,
+  /*
+   * A caller's own deadline is shorter than this: the extension abandons an
+   * agent decision after two minutes. Thirty minutes therefore only bought a
+   * slot that outlived every client that could hold it. Five aligns with the
+   * bridge and parked-call deadlines while still covering a long reasoning turn.
+   */
+  REQUEST_TIMEOUT_MS: 300_000,
   BRIDGE_PATH: "/bridge/call",
   BRIDGE_CALL_TIMEOUT_MS: 300_000,
   BRIDGE_BATCH_MS: 150,

--- a/packages/olc/src/config.ts
+++ b/packages/olc/src/config.ts
@@ -30,7 +30,7 @@ export const DEFAULTS = {
     "moz-extension://*",
     "safari-web-extension://*"
   ],
-  /*
+  /**
    * A caller's own deadline is shorter than this: the extension abandons an
    * agent decision after two minutes. Thirty minutes therefore only bought a
    * slot that outlived every client that could hold it. Five aligns with the

--- a/packages/olc/src/core/__tests__/chat-route.test.ts
+++ b/packages/olc/src/core/__tests__/chat-route.test.ts
@@ -32,6 +32,8 @@ import { createRequestQueue } from "../queue.js"
 interface FakeBackendOptions {
   mode: "answer" | "tool" | "fail" | "image"
   answer?: string
+  /** Holds `ensureReady` so a caller can leave while the backend is starting. */
+  readyDelayMs?: number
 }
 
 /** A prompt that makes the fake backend hold the queue for a while. */
@@ -58,8 +60,15 @@ const createFakeBackend = (
     startTurn: number
     dispose: number
     abort: number
+    ensureReady: number
     reasoningEfforts: Array<ReasoningEffort | undefined>
-  } = { startTurn: 0, dispose: 0, abort: 0, reasoningEfforts: [] }
+  } = {
+    startTurn: 0,
+    dispose: 0,
+    abort: 0,
+    ensureReady: 0,
+    reasoningEfforts: []
+  }
   let nextId = 0
 
   class FakeTurn implements BackendTurn {
@@ -183,7 +192,13 @@ const createFakeBackend = (
 
   const backend: AgentBackend = {
     id: "fake",
-    ensureReady: async () => {},
+    ensureReady: async () => {
+      calls.ensureReady += 1
+      if (options.readyDelayMs)
+        await new Promise((resolve) =>
+          setTimeout(resolve, options.readyDelayMs)
+        )
+    },
     listModels: async () => [MODEL],
     resolveModel: async (requested) =>
       requested === "fake/model-a"
@@ -214,6 +229,7 @@ interface Harness {
     startTurn: number
     dispose: number
     abort: number
+    ensureReady: number
     reasoningEfforts: Array<ReasoningEffort | undefined>
   }
   pending: PendingToolCalls
@@ -276,6 +292,7 @@ interface StreamedTurn {
     function: { name: string; arguments: string }
   }[]
   images: string[]
+  error?: { message: string; type: string; status: number }
 }
 
 const streamTurn = async (
@@ -310,7 +327,12 @@ const streamTurn = async (
     if (!line.startsWith("data: ")) continue
     const payload = line.slice(6).trim()
     if (payload === "[DONE]") continue
-    const choice = JSON.parse(payload).choices?.[0]
+    const frame = JSON.parse(payload)
+    if (frame.error) {
+      result.error = frame.error
+      continue
+    }
+    const choice = frame.choices?.[0]
     if (typeof choice?.delta?.content === "string") {
       result.content += choice.delta.content
     }
@@ -485,7 +507,7 @@ describe("chat completions", () => {
     )
   })
 
-  it("reports a backend failure in the stream without leaking the turn", async () => {
+  it("reports a backend failure as an error event, not as an answer", async () => {
     harness = await startHarness({ mode: "fail" })
     const turn = await streamTurn(harness.url, {
       model: "fake/model-a",
@@ -493,9 +515,117 @@ describe("chat completions", () => {
       messages: askedForTabs
     })
 
-    expect(turn.content).toContain("[Proxy Error] FakeError: upstream exploded")
-    expect(turn.finishReason).toBe("stop")
+    // A failure finished with `stop` reads as a completed turn to every
+    // OpenAI-compatible client, which is how a provider error became a
+    // decision with no tool call.
+    expect(turn.error).toEqual({
+      message: "upstream exploded",
+      type: "FakeError",
+      status: 502
+    })
+    expect(turn.content).toBe("")
+    expect(turn.finishReason).toBeNull()
     expect(harness.calls.dispose).toBe(1)
+  })
+
+  it("reports a backend failure in the non-streaming envelope too", async () => {
+    harness = await startHarness({ mode: "fail" })
+    const response = await fetch(`${harness.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/model-a",
+        stream: false,
+        messages: askedForTabs
+      })
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({
+      error: { message: "upstream exploded", type: "FakeError" }
+    })
+    expect(harness.calls.dispose).toBe(1)
+  })
+
+  it("never starts a request whose client left while it was queued", async () => {
+    harness = await startHarness({ mode: "answer" })
+    const holding = streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [{ role: "user", content: SLOW_TURN_MARKER }]
+    })
+    const abandoned = new AbortController()
+    const queued = fetch(`${harness.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/model-a",
+        stream: true,
+        messages: askedForTabs
+      }),
+      signal: abandoned.signal
+    }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    abandoned.abort()
+    await queued
+    await holding
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(harness.calls.startTurn).toBe(1)
+  })
+
+  it("unwinds a cancelled stream before admitting the next request", async () => {
+    harness = await startHarness({ mode: "answer" })
+    const leaving = new AbortController()
+    const cancelled = fetch(`${harness.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/model-a",
+        stream: true,
+        messages: [{ role: "user", content: SLOW_TURN_MARKER }]
+      }),
+      signal: leaving.signal
+    }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    leaving.abort()
+    await cancelled
+
+    const next = await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: askedForTabs
+    })
+
+    expect(next.content).toBe("working. done")
+    expect(harness.calls.abort).toBe(1)
+    expect(harness.calls.startTurn).toBe(2)
+  })
+
+  it("does not spend a turn when the client leaves during backend startup", async () => {
+    harness = await startHarness({ mode: "answer", readyDelayMs: 150 })
+    const leaving = new AbortController()
+    const cancelled = fetch(`${harness.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/model-a",
+        stream: true,
+        messages: askedForTabs
+      }),
+      signal: leaving.signal
+    }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    leaving.abort()
+    await cancelled
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    // Startup itself is shared and is not cancelled; the turn behind it is.
+    expect(harness.calls.ensureReady).toBe(1)
+    expect(harness.calls.startTurn).toBe(0)
   })
 
   it("rejects an unknown model and an empty conversation", async () => {

--- a/packages/olc/src/core/__tests__/http.test.ts
+++ b/packages/olc/src/core/__tests__/http.test.ts
@@ -1,7 +1,8 @@
-import { createServer, type Server } from "node:http"
+import { createServer, type Server, type ServerResponse } from "node:http"
 import type { AddressInfo } from "node:net"
 import { afterEach, describe, expect, it } from "vitest"
 import {
+  bindRequestAbort,
   createRouter,
   isOriginAllowed,
   matchRoute,
@@ -201,5 +202,49 @@ describe("router origin policy", () => {
 
     expect(first.status).toBe(200)
     expect(second.status).toBe(429)
+  })
+})
+
+describe("bindRequestAbort", () => {
+  const request = () =>
+    ({ raw: { once: () => {}, destroyed: true } }) as unknown as RouteRequest
+
+  const response = (state: {
+    destroyed?: boolean
+    closed?: boolean
+    writableEnded?: boolean
+  }) =>
+    ({
+      once: () => {},
+      destroyed: false,
+      closed: false,
+      writableEnded: false,
+      ...state
+    }) as unknown as ServerResponse
+
+  it.each([
+    ["a destroyed socket", { destroyed: true }],
+    ["a response closed with nothing written", { closed: true }]
+  ])("reports a caller that left before binding: %s", (_label, state) => {
+    // A listener only hears what has not happened yet, so the state has to be
+    // read as well — a caller can leave during an earlier await.
+    expect(bindRequestAbort(request(), response(state)).signal.aborted).toBe(
+      true
+    )
+  })
+
+  it("stays live for a consumed request whose response is untouched", () => {
+    // Node destroys a fully read request stream by itself, so the request side
+    // says nothing about the connection and must not be consulted.
+    expect(bindRequestAbort(request(), response({})).signal.aborted).toBe(false)
+  })
+
+  it("ignores a response that closed after it was written", () => {
+    expect(
+      bindRequestAbort(
+        request(),
+        response({ closed: true, writableEnded: true })
+      ).signal.aborted
+    ).toBe(false)
   })
 })

--- a/packages/olc/src/core/__tests__/image-route.test.ts
+++ b/packages/olc/src/core/__tests__/image-route.test.ts
@@ -11,15 +11,17 @@ const PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nXsAAAAASUVORK5CYII="
 
 const backend = (
-  generateImage?: AgentBackend["generateImage"]
+  generateImage?: AgentBackend["generateImage"],
+  { resolveDelayMs = 0 }: { resolveDelayMs?: number } = {}
 ): AgentBackend => ({
   id: "fake",
   ensureReady: vi.fn(async () => {}),
   listModels: vi.fn(async () => []),
-  resolveModel: vi.fn(async () => ({
-    providerId: "fake",
-    modelId: "image-model"
-  })),
+  resolveModel: vi.fn(async () => {
+    if (resolveDelayMs)
+      await new Promise((resolve) => setTimeout(resolve, resolveDelayMs))
+    return { providerId: "fake", modelId: "image-model" }
+  }),
   startTurn: vi.fn(async () => {
     throw new Error("not used")
   }),
@@ -139,6 +141,33 @@ describe("image generations route", () => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 
     expect(generated).toEqual(["slow"])
+  })
+
+  it("never queues an image request whose client left during model resolution", async () => {
+    const generateImage = vi.fn(async () => [{ b64Json: PNG }])
+    const url = await start(
+      backend(generateImage as unknown as AgentBackend["generateImage"], {
+        resolveDelayMs: 150
+      })
+    )
+    const leaving = new AbortController()
+    const cancelled = fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/image-model",
+        prompt: "abandoned",
+        response_format: "b64_json"
+      }),
+      signal: leaving.signal
+    }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    leaving.abort()
+    await cancelled
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(generateImage).not.toHaveBeenCalled()
   })
 
   it("returns 501 when the selected runtime has no image operation", async () => {

--- a/packages/olc/src/core/__tests__/image-route.test.ts
+++ b/packages/olc/src/core/__tests__/image-route.test.ts
@@ -100,6 +100,47 @@ describe("image generations route", () => {
     })
   })
 
+  it("never starts an image request whose client left the queue", async () => {
+    let releaseFirst: (() => void) | undefined
+    const generated: string[] = []
+    const generateImage = vi.fn(async (input: { prompt: string }) => {
+      generated.push(input.prompt)
+      if (input.prompt === "slow")
+        await new Promise<void>((resolve) => (releaseFirst = resolve))
+      return [{ b64Json: PNG }]
+    })
+    const url = await start(
+      backend(generateImage as unknown as AgentBackend["generateImage"])
+    )
+
+    const holding = post(url, {
+      model: "fake/image-model",
+      prompt: "slow",
+      response_format: "b64_json"
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    const abandoned = new AbortController()
+    const queued = fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "fake/image-model",
+        prompt: "abandoned",
+        response_format: "b64_json"
+      }),
+      signal: abandoned.signal
+    }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    abandoned.abort()
+    await queued
+    releaseFirst?.()
+    await holding
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(generated).toEqual(["slow"])
+  })
+
   it("returns 501 when the selected runtime has no image operation", async () => {
     const url = await start(backend())
     const response = await post(url, { prompt: "draw a fox" })

--- a/packages/olc/src/core/__tests__/queue.test.ts
+++ b/packages/olc/src/core/__tests__/queue.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { createRequestQueue, QueueStalledError } from "../queue.js"
+import {
+  ClientClosedError,
+  createRequestQueue,
+  QueueStalledError
+} from "../queue.js"
 
 const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -8,14 +12,20 @@ describe("createRequestQueue", () => {
     const queue = createRequestQueue()
     const order: string[] = []
 
-    const first = queue(async () => {
-      order.push("first:start")
-      await tick(20)
-      order.push("first:end")
-    }, 1000)
-    const second = queue(async () => {
-      order.push("second:start")
-    }, 1000)
+    const first = queue(
+      async () => {
+        order.push("first:start")
+        await tick(20)
+        order.push("first:end")
+      },
+      { timeoutMs: 1000 }
+    )
+    const second = queue(
+      async () => {
+        order.push("second:start")
+      },
+      { timeoutMs: 1000 }
+    )
 
     await Promise.all([first, second])
     expect(order).toEqual(["first:start", "first:end", "second:start"])
@@ -32,8 +42,7 @@ describe("createRequestQueue", () => {
           signal.addEventListener("abort", () => resolve(), { once: true })
         )
       },
-      20,
-      "cancellable"
+      { timeoutMs: 20, label: "cancellable" }
     )
 
     await expect(settled).rejects.toThrow("Request timeout after 20ms")
@@ -47,12 +56,14 @@ describe("createRequestQueue", () => {
 
     const first = queue(
       () => new Promise<void>((resolve) => (releaseFirst = resolve)),
-      20,
-      "slow"
+      { timeoutMs: 20, label: "slow" }
     )
-    const second = queue(async () => {
-      secondStarted = true
-    }, 1000)
+    const second = queue(
+      async () => {
+        secondStarted = true
+      },
+      { timeoutMs: 1000 }
+    )
 
     await expect(first).rejects.toThrow(/timeout/)
     await tick(50)
@@ -72,14 +83,17 @@ describe("createRequestQueue", () => {
       started = true
     }
 
-    const wedged = queue(() => new Promise<void>(() => {}), 20, "wedged")
-    const waiting = queue(start, 1000)
+    const wedged = queue(() => new Promise<void>(() => {}), {
+      timeoutMs: 20,
+      label: "wedged"
+    })
+    const waiting = queue(start, { timeoutMs: 1000 })
 
     await expect(wedged).rejects.toThrow(/timeout/)
     // Both the request already queued and one arriving later are refused: either
     // would otherwise run alongside a turn that is still live.
     await expect(waiting).rejects.toThrow(QueueStalledError)
-    await expect(queue(start, 1000)).rejects.toThrow(/"wedged"/)
+    await expect(queue(start, { timeoutMs: 1000 })).rejects.toThrow(/"wedged"/)
     expect(started).toBe(false)
   })
 
@@ -89,16 +103,110 @@ describe("createRequestQueue", () => {
 
     const wedged = queue(
       () => new Promise<void>((resolve) => (stopWedged = resolve)),
-      20,
-      "wedged"
+      { timeoutMs: 20, label: "wedged" }
     )
     await expect(wedged).rejects.toThrow(/timeout/)
-    await expect(queue(async () => "refused", 1000)).rejects.toThrow(
-      QueueStalledError
-    )
+    await expect(
+      queue(async () => "refused", { timeoutMs: 1000 })
+    ).rejects.toThrow(QueueStalledError)
 
     stopWedged?.()
     await tick(150)
-    await expect(queue(async () => "ran", 1000)).resolves.toBe("ran")
+    await expect(queue(async () => "ran", { timeoutMs: 1000 })).resolves.toBe(
+      "ran"
+    )
+  })
+
+  it("never starts a request whose client left the queue", async () => {
+    const queue = createRequestQueue()
+    const controller = new AbortController()
+    let releaseFirst: (() => void) | undefined
+    let secondStarted = false
+
+    const first = queue(
+      () => new Promise<void>((resolve) => (releaseFirst = resolve)),
+      { timeoutMs: 1000, label: "holding" }
+    )
+    const second = queue(
+      async () => {
+        secondStarted = true
+      },
+      { timeoutMs: 1000, label: "abandoned", signal: controller.signal }
+    )
+
+    controller.abort()
+    await expect(second).rejects.toThrow(ClientClosedError)
+    releaseFirst?.()
+    await first
+    await tick(150)
+    expect(secondStarted).toBe(false)
+  })
+
+  it("refuses a request whose client had already left", async () => {
+    const queue = createRequestQueue()
+    const controller = new AbortController()
+    controller.abort()
+    let started = false
+
+    await expect(
+      queue(
+        async () => {
+          started = true
+        },
+        { label: "gone", signal: controller.signal }
+      )
+    ).rejects.toThrow(/"gone"/)
+    expect(started).toBe(false)
+  })
+
+  it("cancels a running request whose client left, and holds the slot", async () => {
+    const queue = createRequestQueue({ cancelGraceMs: 10_000 })
+    const controller = new AbortController()
+    let observed: AbortSignal | undefined
+    let release: (() => void) | undefined
+    let nextStarted = false
+
+    const running = queue(
+      (signal) => {
+        observed = signal
+        return new Promise<void>((resolve) => (release = resolve))
+      },
+      { timeoutMs: 1000, label: "streaming", signal: controller.signal }
+    )
+    await tick(10)
+    controller.abort()
+
+    await expect(running).rejects.toThrow(ClientClosedError)
+    expect(observed?.aborted).toBe(true)
+
+    const next = queue(
+      async () => {
+        nextStarted = true
+      },
+      { timeoutMs: 1000 }
+    )
+    await tick(50)
+    // The abandoned task is still inside the boundary until it unwinds.
+    expect(nextStarted).toBe(false)
+    release?.()
+    await next
+    expect(nextStarted).toBe(true)
+  })
+
+  it("does not cancel a request whose response merely finished", async () => {
+    const queue = createRequestQueue()
+    const controller = new AbortController()
+
+    await expect(
+      queue(async () => "done", {
+        timeoutMs: 1000,
+        signal: controller.signal
+      })
+    ).resolves.toBe("done")
+    // A signal aborted after the task settled must not reach a later request.
+    controller.abort()
+    await expect(queue(async () => "next", { timeoutMs: 1000 })).resolves.toBe(
+      "next"
+    )
   })
 })

--- a/packages/olc/src/core/chat-route.ts
+++ b/packages/olc/src/core/chat-route.ts
@@ -38,7 +38,12 @@ import {
   type ToolResultMessage
 } from "../types.js"
 import { isRecord, sleep } from "../util.js"
-import { type Router, sendJson, startEventStream } from "./http.js"
+import {
+  bindRequestAbort,
+  type Router,
+  sendJson,
+  startEventStream
+} from "./http.js"
 import {
   contentChunk,
   extractTrailingToolResults,
@@ -52,7 +57,11 @@ import {
 } from "./openai-wire.js"
 import type { PendingToolCalls } from "./pending-tool-calls.js"
 import { OLC_PUBLIC_ROUTES } from "./public-api-contract.js"
-import { QueueStalledError, type RequestQueue } from "./queue.js"
+import {
+  ClientClosedError,
+  QueueStalledError,
+  type RequestQueue
+} from "./queue.js"
 
 const createRequestId = () =>
   `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
@@ -135,6 +144,18 @@ export const unsentTail = (stored: string, streamed: string): string => {
   return streamed ? "" : stored
 }
 
+/**
+ * A failure is a terminal event of its own, not a sentence in the answer.
+ * Streaming `[Proxy Error] ...` as content and finishing with `stop` looked
+ * like a completed turn to every OpenAI-compatible client: the extension read
+ * a decision with no tool call rather than an error it could report.
+ */
+export interface TurnFailure {
+  message: string
+  type: string
+  status: number
+}
+
 interface TurnEmitter {
   readonly streamMode: boolean
   start: () => void
@@ -143,6 +164,7 @@ interface TurnEmitter {
   auxiliary: (payload: unknown) => void
   toolCalls: (calls: PendingToolCall[]) => void
   finish: (reason: string) => void
+  fail: (failure: TurnFailure) => void
   readonly content: string
   readonly reasoning: string
   readonly images: readonly GeneratedImage[]
@@ -196,6 +218,19 @@ const createStreamEmitter = (
     },
     finish(reason) {
       write(finishChunk(id, model, reason))
+      if (!response.writableEnded) {
+        response.write("data: [DONE]\n\n")
+        response.end()
+      }
+    },
+    fail(failure) {
+      if (!response.headersSent) {
+        sendJson(response, failure.status, {
+          error: { message: failure.message, type: failure.type }
+        })
+        return
+      }
+      write({ error: failure })
       if (!response.writableEnded) {
         response.write("data: [DONE]\n\n")
         response.end()
@@ -291,6 +326,15 @@ const createBufferEmitter = (
           "stop"
         )
       )
+    },
+    fail(failure) {
+      if (response.headersSent) {
+        if (!response.writableEnded) response.end()
+        return
+      }
+      sendJson(response, failure.status, {
+        error: { message: failure.message, type: failure.type }
+      })
     },
     get content() {
       return content
@@ -593,7 +637,12 @@ export const registerChatRoutes = (
 
     try {
       if (!turn) {
+        // Startup is shared infrastructure the next request will reuse, so a
+        // departed caller does not cancel it — it only stops this request from
+        // spending a turn behind it.
+        signal?.throwIfAborted()
         await backend.ensureReady()
+        signal?.throwIfAborted()
         turn = await backend.startTurn({
           requestId,
           model: target,
@@ -669,15 +718,11 @@ export const registerChatRoutes = (
         if (result.status === "suspended") return
         settled = true
         if (result.status === "failed") {
-          if (emitter.streamMode) {
-            emitter.delta(
-              `[Proxy Error] ${result.error.type}: ${result.error.message}`,
-              false
-            )
-            emitter.finish("stop")
-          } else {
-            sendJson(response, 502, { error: result.error })
-          }
+          emitter.fail({
+            message: result.error.message,
+            type: result.error.type,
+            status: 502
+          })
           await discardTurn(turn as BackendTurn)
           return
         }
@@ -715,22 +760,17 @@ export const registerChatRoutes = (
           await discardTurn(turn, { abort: true })
         }
 
-        if (emitter.streamMode && response.headersSent) {
-          emitter.delta(`[Proxy Error] ${message}`, false)
-          emitter.finish("stop")
-          return
-        }
+        // Cancellation is now an ordinary way for a request to end. Reporting it
+        // means writing to a socket whose reader is gone, so the turn is cleaned
+        // up and logged and nothing is sent.
+        if (response.destroyed || error instanceof ClientClosedError) return
+
         const inputError = error instanceof BackendInputError
-        sendJson(
-          response,
-          inputError ? 400 : /Request timeout/.test(message) ? 504 : 500,
-          {
-            error: {
-              message,
-              type: inputError ? "BadRequest" : "ProxyError"
-            }
-          }
-        )
+        emitter.fail({
+          message,
+          type: inputError ? "BadRequest" : "ProxyError",
+          status: inputError ? 400 : /Request timeout/.test(message) ? 504 : 500
+        })
       }
       await handleRequestFailure()
     }
@@ -769,6 +809,8 @@ export const registerChatRoutes = (
 
     if (resumeTurn) holdTurn(resumeTurn.id)
 
+    const clientGone = bindRequestAbort(request, response)
+
     await lock(
       (signal) => {
         // The queue may have held this request for as long as another turn was
@@ -797,9 +839,17 @@ export const registerChatRoutes = (
           signal
         })
       },
-      config.REQUEST_TIMEOUT_MS + 60_000,
-      `chat-completions:${requestId}`
+      {
+        timeoutMs: config.REQUEST_TIMEOUT_MS + 60_000,
+        label: `chat-completions:${requestId}`,
+        signal: clientGone.signal
+      }
     ).catch((error: unknown) => {
+      if (error instanceof ClientClosedError) {
+        log("The client left before this request was served", { requestId })
+        if (!response.writableEnded) response.end()
+        return
+      }
       const message = (error as Error).message
       console.error("[Proxy] Request handler error:", message)
       // A stalled queue is a temporary refusal, not a failure of this request: it

--- a/packages/olc/src/core/http.ts
+++ b/packages/olc/src/core/http.ts
@@ -74,6 +74,11 @@ export const sendJson = (
  * client is the one that closed with nothing written back. Both routes bind
  * this before the queue, since a request can wait there for as long as another
  * turn is allowed to run.
+ *
+ * The state is read before the listeners are attached, because a listener only
+ * hears what has not happened yet: a caller that left during an earlier `await`
+ * fired both events already, and a controller that trusted its listeners alone
+ * would hand back a live signal for a connection that is gone.
  */
 export const bindRequestAbort = (
   request: RouteRequest,
@@ -84,6 +89,12 @@ export const bindRequestAbort = (
   response.once("close", () => {
     if (!response.writableEnded) abortController.abort()
   })
+  // Read from the response, never from the request: a fully consumed request
+  // stream is destroyed by Node on its own, so `request.raw.destroyed` is true
+  // for every ordinary POST and says nothing about the connection.
+  if (response.destroyed || (response.closed && !response.writableEnded)) {
+    abortController.abort()
+  }
   return abortController
 }
 

--- a/packages/olc/src/core/http.ts
+++ b/packages/olc/src/core/http.ts
@@ -67,6 +67,26 @@ export const sendJson = (
   response.end(body)
 }
 
+/**
+ * A controller that fires when the caller is gone.
+ *
+ * `close` also fires on a response that completed normally, so a departed
+ * client is the one that closed with nothing written back. Both routes bind
+ * this before the queue, since a request can wait there for as long as another
+ * turn is allowed to run.
+ */
+export const bindRequestAbort = (
+  request: RouteRequest,
+  response: ServerResponse
+): AbortController => {
+  const abortController = new AbortController()
+  request.raw.once("aborted", () => abortController.abort())
+  response.once("close", () => {
+    if (!response.writableEnded) abortController.abort()
+  })
+  return abortController
+}
+
 export const startEventStream = (response: ServerResponse): void => {
   response.setHeader("Content-Type", "text/event-stream; charset=utf-8")
   response.setHeader("Cache-Control", "no-cache")

--- a/packages/olc/src/core/image-route.ts
+++ b/packages/olc/src/core/image-route.ts
@@ -162,6 +162,9 @@ export const registerImageRoutes = (
   }
 ): void => {
   router.post(OLC_PUBLIC_ROUTES.imageGenerations, async (request, response) => {
+    // Bound before the first await. Model resolution can outlive the caller,
+    // and a signal established after it would never learn the caller had left.
+    const abortController = bindRequestAbort(request, response)
     const parsed = parseImageRequest(request.body)
     if (parsed.error) {
       sendJson(response, 400, badRequest(parsed.error))
@@ -183,7 +186,6 @@ export const registerImageRoutes = (
       return
     }
 
-    const abortController = bindRequestAbort(request, response)
     const imageBackend = backend as AgentBackend & {
       generateImage: NonNullable<AgentBackend["generateImage"]>
     }

--- a/packages/olc/src/core/image-route.ts
+++ b/packages/olc/src/core/image-route.ts
@@ -1,5 +1,4 @@
 /** OpenAI-compatible image generations over a runtime-native image backend. */
-import type { ServerResponse } from "node:http"
 import {
   type AgentBackend,
   BackendInputError,
@@ -12,7 +11,7 @@ import type {
   ProxyLogger
 } from "../types.js"
 import { isRecord } from "../util.js"
-import { type RouteRequest, type Router, sendJson } from "./http.js"
+import { bindRequestAbort, type Router, sendJson } from "./http.js"
 import { OLC_PUBLIC_ROUTES } from "./public-api-contract.js"
 import { QueueStalledError, type RequestQueue } from "./queue.js"
 
@@ -74,18 +73,6 @@ const parseImageRequest = (
   return { body, prompt }
 }
 
-const bindRequestAbort = (
-  request: RouteRequest,
-  response: ServerResponse
-): AbortController => {
-  const abortController = new AbortController()
-  request.raw.once("aborted", () => abortController.abort())
-  response.once("close", () => {
-    if (!response.writableEnded) abortController.abort()
-  })
-  return abortController
-}
-
 const generateImages = async ({
   backend,
   config,
@@ -119,8 +106,11 @@ const generateImages = async ({
         queueSignal.removeEventListener("abort", abortFromQueue)
       }
     },
-    config.REQUEST_TIMEOUT_MS + 60_000,
-    `image-generation:${target.providerId}/${target.modelId}`
+    {
+      timeoutMs: config.REQUEST_TIMEOUT_MS + 60_000,
+      label: `image-generation:${target.providerId}/${target.modelId}`,
+      signal: abortController.signal
+    }
   )
 
   return images

--- a/packages/olc/src/core/queue.ts
+++ b/packages/olc/src/core/queue.ts
@@ -16,10 +16,25 @@
  * that will not stop. The alternatives are both worse — starting the next request
  * interleaves two live turns, and queueing behind a task that may never settle hangs
  * every caller with no explanation. The queue heals itself if the task ever settles.
+ *
+ * A caller can also leave. Its `signal` is honoured at both stages, because they are
+ * not the same problem: a request still queued has started nothing, so it is simply
+ * dropped and nothing runs on its behalf. A request already running is cancelled the
+ * way a deadline cancels it — the task is aborted and the slot is held until it
+ * unwinds — since a task whose caller is gone is still inside the single-flight
+ * boundary until it stops.
  */
 
 /** Time a cancelled task is given to unwind before the queue declares itself stalled. */
 const CANCEL_GRACE_MS = 10_000
+
+/** Raised when the caller withdrew before its request could be served. */
+export class ClientClosedError extends Error {
+  constructor(label: string) {
+    super(`The client closed the connection before "${label}" was served.`)
+    this.name = "ClientClosedError"
+  }
+}
 
 /** Raised when a cancelled task is still running and nothing else may start. */
 export class QueueStalledError extends Error {
@@ -36,14 +51,23 @@ interface QueueEntry {
   timeoutMs: number
   label: string
   queuedAt: number
+  signal?: AbortSignal
+  /** Drops whichever stage's abort listener is currently attached. */
+  detach?: () => void
   resolve: (value: unknown) => void
   reject: (reason: unknown) => void
 }
 
+export interface RequestQueueOptions {
+  timeoutMs?: number
+  label?: string
+  /** Aborted when the caller is gone: see the stage rules above. */
+  signal?: AbortSignal
+}
+
 export type RequestQueue = <T>(
   task: (signal: AbortSignal) => Promise<T>,
-  timeoutMs?: number,
-  label?: string
+  options?: RequestQueueOptions
 ) => Promise<T>
 
 export const createRequestQueue = ({
@@ -61,6 +85,7 @@ export const createRequestQueue = ({
   const failWaiting = (label: string) => {
     while (queue.length > 0) {
       const waiting = queue.shift() as QueueEntry
+      waiting.detach?.()
       waiting.reject(new QueueStalledError(label))
     }
   }
@@ -70,6 +95,7 @@ export const createRequestQueue = ({
     isProcessing = true
 
     const entry = queue.shift() as QueueEntry
+    entry.detach?.()
     const waitedMs = Date.now() - entry.queuedAt
     if (waitedMs > 50) {
       console.log(
@@ -82,14 +108,17 @@ export const createRequestQueue = ({
     const controller = new AbortController()
     const startedAt = Date.now()
 
-    const timeoutId = setTimeout(() => {
+    /**
+     * One cancellation path for both reasons a running task is ended. The slot
+     * is held either way: the caller has its answer, but the task has not left
+     * the boundary until it unwinds, and the grace timer is what turns "will
+     * not stop" into a refusal instead of an overlap.
+     */
+    const cancelRunning = (error: Error) => {
       if (settled) return
       settled = true
-      console.error(
-        `[Proxy][Queue] "${entry.label}" timed out after ${entry.timeoutMs}ms`
-      )
-      controller.abort(new Error(`Request timeout after ${entry.timeoutMs}ms`))
-      entry.reject(new Error(`Request timeout after ${entry.timeoutMs}ms`))
+      controller.abort(error)
+      entry.reject(error)
       graceId = setTimeout(() => {
         console.error(
           `[Proxy][Queue] "${entry.label}" is still running ${cancelGraceMs}ms after cancellation; refusing further requests until it stops`
@@ -98,8 +127,30 @@ export const createRequestQueue = ({
         failWaiting(entry.label)
       }, cancelGraceMs)
       if (typeof graceId.unref === "function") graceId.unref()
+    }
+
+    const timeoutId = setTimeout(() => {
+      if (settled) return
+      console.error(
+        `[Proxy][Queue] "${entry.label}" timed out after ${entry.timeoutMs}ms`
+      )
+      cancelRunning(new Error(`Request timeout after ${entry.timeoutMs}ms`))
     }, entry.timeoutMs)
     if (typeof timeoutId.unref === "function") timeoutId.unref()
+
+    if (entry.signal) {
+      const signal = entry.signal
+      const onCallerGone = () => {
+        if (settled) return
+        console.log(
+          `[Proxy][Queue] "${entry.label}" lost its client while running; cancelling it`
+        )
+        cancelRunning(new ClientClosedError(entry.label))
+      }
+      signal.addEventListener("abort", onCallerGone, { once: true })
+      entry.detach = () => signal.removeEventListener("abort", onCallerGone)
+      if (signal.aborted) onCallerGone()
+    }
 
     Promise.resolve()
       .then(() => entry.task(controller.signal))
@@ -116,6 +167,7 @@ export const createRequestQueue = ({
       .finally(() => {
         clearTimeout(timeoutId)
         if (graceId) clearTimeout(graceId)
+        entry.detach?.()
         if (stalled === entry) {
           console.log(
             `[Proxy][Queue] "${entry.label}" finally stopped; accepting requests again`
@@ -132,22 +184,48 @@ export const createRequestQueue = ({
 
   return <T>(
     task: (signal: AbortSignal) => Promise<T>,
-    timeoutMs: number = defaultTimeoutMs,
-    label = "task"
+    {
+      timeoutMs = defaultTimeoutMs,
+      label = "task",
+      signal
+    }: RequestQueueOptions = {}
   ): Promise<T> =>
     new Promise<T>((resolve, reject) => {
       if (stalled) {
         reject(new QueueStalledError(stalled.label))
         return
       }
-      queue.push({
+      if (signal?.aborted) {
+        reject(new ClientClosedError(label))
+        return
+      }
+      const entry: QueueEntry = {
         task: task as (signal: AbortSignal) => Promise<unknown>,
         timeoutMs,
         label,
         queuedAt: Date.now(),
+        ...(signal ? { signal } : {}),
         resolve: resolve as (value: unknown) => void,
         reject
-      })
+      }
+      if (signal) {
+        // While queued there is nothing to unwind, so the entry is simply
+        // dropped. Once it starts, `processQueue` replaces this listener with
+        // the running-stage one.
+        const onCallerGone = () => {
+          const index = queue.indexOf(entry)
+          if (index < 0) return
+          queue.splice(index, 1)
+          entry.detach?.()
+          console.log(
+            `[Proxy][Queue] "${label}" left the queue: its client closed the connection`
+          )
+          entry.reject(new ClientClosedError(label))
+        }
+        signal.addEventListener("abort", onCallerGone, { once: true })
+        entry.detach = () => signal.removeEventListener("abort", onCallerGone)
+      }
+      queue.push(entry)
       if (queue.length > 1) {
         console.log(
           `[Proxy][Queue] "${label}" queued behind ${queue.length - 1} pending request(s)`


### PR DESCRIPTION
The single-flight queue took no caller signal, so a request whose connection closed still held or claimed the slot.

**What changed**
- The queue accepts a caller `signal` and honours it per stage, because they are different problems: a request still **queued** is dropped and never starts; one already **running** is cancelled the way a deadline cancels it — task aborted, slot held until it unwinds — since a task that is still running has not left the single-flight boundary.
- Both routes bind that signal from one shared `bindRequestAbort`, **before** the queue, where a request can wait for as long as another turn is allowed to run. The image route was claiming a slot for an abandoned request too.
- Backend startup is deliberately *not* cancelled — the next request reuses it — but a request whose caller left no longer spends a turn behind it. This needed no widening of `AgentBackend`.
- `REQUEST_TIMEOUT_MS` 1 800 000 → 300 000. A slot lived `REQUEST_TIMEOUT_MS + 60_000` = 31 min while the extension abandons an agent decision after 120 s, so the old default only bought a slot that outlived every client able to hold it.
- A stream failure is emitted as an OpenAI `error` event instead of `[Proxy Error]` prose finished with `stop`, which read as a *completed* turn to every compatible client — that is how a provider error reached the extension as a decision with no tool call. `src/lib/providers/__tests__/provider-tools.test.ts` already covers the extension parsing that frame; nothing under `src/` changes here.

**Exit evidence** — 337/337 olc tests, 3 972 total
- Hold A, disconnect queued B, release A → B never starts (`startTurn` stays 1).
- Disconnect A mid-stream → the next request is admitted only after A unwinds (queue log: `Starting … after waiting 362ms`), and A's turn was aborted exactly once.
- Disconnect during `ensureReady` → `ensureReady` still ran once, `startTurn` zero times.
- Same for an abandoned image request.

**Not in this PR**
Parked-call semantics — every agent decision still parks a call that is never resumed. Recorded as a gap, not fixed here.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the OLC single-flight queue responsive to caller disconnects while preserving the invariant that a running task retains its slot until it unwinds. It also shortens the default request timeout and represents backend stream failures as OpenAI-compatible error events.

- Drops disconnected requests before they begin executing.
- Cancels running requests when their callers leave without admitting overlapping work.
- Binds image-request cancellation before asynchronous model resolution.
- Returns structured errors for streaming and non-streaming backend failures.
- Adds focused queue, route, and HTTP lifecycle coverage.
- Fixes the prior declaration-comment rule violation by converting the timeout explanation to JSDoc.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both previous findings resolved and no new actionable defects identified.

The image route now binds disconnect handling before model resolution, and the timeout declaration now uses JSDoc; the current changes introduce no remaining blocking or non-blocking findings.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/core/queue.ts | Adds stage-aware caller cancellation while retaining the queue slot until running work has unwound. |
| packages/olc/src/core/http.ts | Introduces shared disconnect binding that handles both future events and connections closed before listener registration. |
| packages/olc/src/core/chat-route.ts | Threads caller cancellation through queue admission and emits structured backend failure events. |
| packages/olc/src/core/image-route.ts | Binds cancellation before model resolution and propagates it into image queue admission. |
| packages/olc/src/config.ts | Reduces the default request timeout to five minutes and uses the required JSDoc declaration prose. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[HTTP request arrives] --> B[Bind caller abort signal]
  B --> C{Caller still connected?}
  C -- No --> D[Reject without entering queue]
  C -- Yes --> E[Enter single-flight queue]
  E --> F{Caller leaves while queued?}
  F -- Yes --> G[Remove queued entry; task never starts]
  F -- No --> H[Start task with queue abort signal]
  H --> I{Caller leaves or deadline expires?}
  I -- No --> J[Complete task and release slot]
  I -- Yes --> K[Abort running task]
  K --> L{Task unwinds within grace period?}
  L -- Yes --> M[Release slot and admit next request]
  L -- No --> N[Mark queue stalled and refuse new requests]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Update packages/olc/src/config.ts"](https://github.com/shishir435/ollama-client/commit/b304647e7d33737e6f4239b3101a71d1f7c66a09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61730365)</sub>

<!-- /greptile_comment -->