### PR TITLE
feat(agent): send the model a page, not the executor's bookkeeping

### DIFF
--- a/e2e/chromium/critical/__tests__/agent-click.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-click.spec.ts
@@ -14,7 +14,7 @@ const silentButton =
   '<button type="button" onclick="fetch(\'/effect\');">Continue</button>'
 
 const clickContinue = (observation: AgentFixtureObservation) =>
-  observation.visibleText.includes("Status: Active")
+  observation.text.includes("Status: Active")
     ? { type: "complete", summary: "Active" }
     : {
         type: "click",

--- a/e2e/chromium/critical/__tests__/agent-continuity.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-continuity.spec.ts
@@ -25,7 +25,7 @@ runAgentScenario({
   html: () =>
     `<!doctype html><title>Agent continuity</title><main>${agentConfirmingButton()}</main>`,
   decide: (observation: AgentFixtureObservation) =>
-    observation.visibleText.includes("Status: Active")
+    observation.text.includes("Status: Active")
       ? { type: "complete", summary: "Active" }
       : {
           type: "click",

--- a/e2e/chromium/critical/__tests__/agent-form.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-form.spec.ts
@@ -15,7 +15,7 @@ runAgentScenario({
   hosted: true,
   html: (path) => (path.startsWith("/details") ? AGENT_DETAILS_PAGE : formPage),
   decide(observation) {
-    if (observation.visibleText.includes("Status: Active"))
+    if (observation.text.includes("Status: Active"))
       return { type: "complete", summary: "Active" }
     const field = agentFixtureElement(
       observation,

--- a/e2e/chromium/critical/__tests__/agent-grounding.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-grounding.spec.ts
@@ -18,7 +18,7 @@ runAgentScenario({
   html: () =>
     '<!doctype html><title>Agent grounding</title><main><h1>Preferences</h1><label for="news">Newsletter</label><input id="news" type="checkbox" onchange="document.querySelector(\'main\').insertAdjacentHTML(\'beforeend\',\'<p>Status: Active</p>\')"></main>',
   decide(observation: AgentFixtureObservation, { step }) {
-    if (observation.visibleText.includes("Status: Active"))
+    if (observation.text.includes("Status: Active"))
       return { type: "complete", summary: "Active" }
     const box = agentFixtureElement(
       observation,

--- a/e2e/chromium/critical/__tests__/agent-modal.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-modal.spec.ts
@@ -1,0 +1,65 @@
+import type { AgentFixtureObservation } from "../../fixtures/agent-scenario"
+import {
+  agentFixtureElement,
+  firstObservation,
+  runAgentScenario
+} from "../../fixtures/agent-scenario"
+import { expect } from "../../fixtures/extension"
+
+/**
+ * A confirmation dialog puts two buttons on the page with the same job and a
+ * different owner. A flat element list gave a decision nothing to tell them
+ * apart with, so the run acted on the opener again and the dialog stayed up.
+ */
+runAgentScenario({
+  name: "modal",
+  goal: "Delete the item, confirming when asked.",
+  status: "completed",
+  html: () =>
+    `<!doctype html><title>Agent modal</title><main><h1>Items</h1><button onclick="document.querySelector('#confirm').hidden=false;this.disabled=true">Delete</button><div id="confirm" role="dialog" aria-label="Confirm delete" hidden><p>Delete this item?</p><button onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>');this.closest('[role=dialog]').hidden=true">Delete</button><button>Cancel</button></div></main>`,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("Status: Active"))
+      return { type: "complete", summary: "Active" }
+    const inDialog = agentFixtureElement(
+      observation,
+      (element) =>
+        element.name === "Delete" &&
+        Boolean(element.group?.startsWith("dialog")) &&
+        !element.disabled
+    )
+    const opener = agentFixtureElement(
+      observation,
+      (element) =>
+        element.name === "Delete" && !element.group?.startsWith("dialog")
+    )
+    return { type: "click", ref: (inDialog ?? opener)?.ref }
+  },
+  async verify({ page, snapshot, wire }) {
+    await expect(page.getByText("Status: Active")).toBeVisible()
+    expect(snapshot?.run?.result).toContain("Active")
+
+    // The opener is not clicked twice: the second decision can see that the
+    // dialog owns its own Delete.
+    const verified = snapshot?.steps.filter(
+      (step) => step.status === "verified"
+    )
+    expect(verified).toHaveLength(2)
+
+    expect(firstObservation(wire).modals ?? []).toEqual([])
+    const afterOpen = JSON.parse(
+      String(
+        (wire[1]?.request as { messages: { content: string }[] }).messages.at(
+          -1
+        )?.content
+      )
+    ).observation
+    expect(afterOpen.modals).toEqual([
+      { id: "dialog1", kind: "dialog", label: "Confirm delete" }
+    ])
+    expect(
+      afterOpen.elements.filter(
+        (element: { group?: string }) => element.group === "dialog1"
+      ).length
+    ).toBeGreaterThan(1)
+  }
+})

--- a/e2e/chromium/critical/__tests__/agent-navigation.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-navigation.spec.ts
@@ -17,7 +17,7 @@ runAgentScenario({
   // Real sites acknowledge navigation before the document finishes loading.
   navigationDelayMs: (path) => (path.startsWith("/details") ? 1_500 : 0),
   decide(observation) {
-    if (observation.visibleText.includes("Status: Active"))
+    if (observation.text.includes("Status: Active"))
       return { type: "complete", summary: "Active" }
     return {
       type: "click",

--- a/e2e/chromium/critical/__tests__/agent-perception.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-perception.spec.ts
@@ -8,7 +8,7 @@ import {
 import { expect } from "../../fixtures/extension"
 
 const clickContinue = (observation: AgentFixtureObservation) =>
-  observation.visibleText.includes("Status: Active")
+  observation.text.includes("Status: Active")
     ? { type: "complete", summary: "Active" }
     : {
         type: "click",
@@ -37,11 +37,11 @@ runAgentScenario({
     const observed = firstObservation(wire)
     const svg = observed.elements.find((element) => element.tag === "svg")
     expect(svg).toMatchObject({ role: "img", name: "Brand" })
-    for (const element of observed.elements) {
-      expect(typeof element.editable).toBe("boolean")
-      expect(typeof element.enabled).toBe("boolean")
-      expect(typeof element.visible).toBe("boolean")
-    }
+    // Field-level derivation is asserted where it happens, in the builder's
+    // own tests: the wire is projected now, so a default is absent rather
+    // than present and false.
+    expect(svg).not.toHaveProperty("editable")
+    expect(svg).not.toHaveProperty("disabled")
   }
 })
 
@@ -68,7 +68,7 @@ runAgentScenario({
     expect(observed.elements.length).toBeLessThanOrEqual(2_000)
     expect(
       observed.elements
-        .filter((element) => element.visible)
+        .filter((element) => !element.hidden)
         .map((element) => element.name)
     ).toEqual(["Continue"])
   }

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -20,7 +20,10 @@ import { expect, test } from "./extension"
  * every change to the agent had to edit.
  */
 
-/** The observation fields a scripted decision is allowed to read. */
+/**
+ * The observation as the model receives it: projected, so a field at its
+ * default is absent rather than present and false.
+ */
 export interface AgentFixtureElement {
   ref: string
   tag: string
@@ -30,16 +33,20 @@ export interface AgentFixtureElement {
   value?: string
   checked?: boolean
   href?: string
-  visible: boolean
-  enabled: boolean
-  editable: boolean
-  sensitive: boolean
+  group?: string
+  submits?: boolean
+  editable?: boolean
+  sensitive?: boolean
+  disabled?: boolean
+  hidden?: boolean
 }
 
 export interface AgentFixtureObservation {
   url: string
   title: string
-  visibleText: string
+  text: string
+  documentText?: string
+  modals?: { id: string; kind: string; label?: string }[]
   elements: AgentFixtureElement[]
 }
 

--- a/packages/contracts/src/agent-observation.ts
+++ b/packages/contracts/src/agent-observation.ts
@@ -44,7 +44,13 @@ export const AgentElementSchema = z
     visible: z.boolean(),
     enabled: z.boolean(),
     editable: z.boolean(),
-    sensitive: z.boolean()
+    sensitive: z.boolean(),
+    /**
+     * The landmark, form or dialog this element belongs to. Duplicate labels
+     * are common and a flat list gives a decision no way to tell two
+     * identically named controls apart; the group is what does.
+     */
+    group: z.string().min(1).max(80).optional()
   })
   .strict()
   .superRefine((element, context) => {
@@ -95,14 +101,44 @@ export const AgentDialogStateSchema = z.object({
 })
 export type AgentDialogState = z.infer<typeof AgentDialogStateSchema>
 
+/**
+ * An open in-page dialog or menu.
+ *
+ * Deliberately not `dialogs`, which is typed for `alert`, `confirm`, `prompt`
+ * and `beforeunload` — native dialogs block the page and are genuinely
+ * unobservable from a content script. A `<dialog open>` or `[role=dialog]` is
+ * ordinary DOM, and the run needs to know which one owns the controls it can
+ * see: acting on the opener behind a modal is the loop the fixtures showed.
+ */
+export const AgentModalStateSchema = z
+  .object({
+    id: z.string().min(1).max(80),
+    kind: z.enum(["dialog", "alertdialog", "menu", "listbox"]),
+    label: z.string().max(200).optional(),
+    modal: z.boolean().optional()
+  })
+  .strict()
+export type AgentModalState = z.infer<typeof AgentModalStateSchema>
+
 export const AgentObservationSchema = AgentSnapshotIdentitySchema.extend({
   url: z.url(),
   origin: z.url(),
   title: z.string().max(500),
   elements: z.array(AgentElementSchema).max(2_000),
   visibleText: z.string().max(100_000),
+  /**
+   * The document's own text, beyond the viewport, so a question the page
+   * answers below the fold does not have to be reached by scrolling — which
+   * costs an observation each time and is how a reading task exhausted its
+   * budget.
+   */
+  documentText: z.string().max(30_000).optional(),
+  /** Set when the document had more text than the cap allowed, so an absent
+   * fact is not read as a fact the page does not state. */
+  documentTextTruncated: z.boolean().optional(),
   scroll: AgentScrollStateSchema,
   dialogs: z.array(AgentDialogStateSchema).max(10),
+  modals: z.array(AgentModalStateSchema).max(10).optional(),
   capturedAt: z.number().int().nonnegative()
 }).strict()
 export type AgentObservation = z.infer<typeof AgentObservationSchema>

--- a/src/application/agent/__tests__/agent-model-port.test.ts
+++ b/src/application/agent/__tests__/agent-model-port.test.ts
@@ -8,6 +8,7 @@ import { AGENT_DECISION_TOOL_NAME } from "../agent-decision-parser"
 import type { AgentModelCompatibility } from "../agent-model-compatibility"
 import {
   AGENT_DECISION_TOOL,
+  agentContextWindow,
   createProviderAgentModelPort
 } from "../agent-model-port"
 
@@ -473,5 +474,69 @@ describe("createProviderAgentModelPort", () => {
     )
     const system = String(streamChat.mock.calls[0]?.[0]?.messages[0]?.content)
     expect(system).toContain('Only an outcome of "confirmed" happened')
+  })
+
+  it("asks for a context window the request actually fits in", async () => {
+    const streamChat = vi.fn(
+      async (_request: ChatRequest, emit: (chunk: ChatStreamMessage) => void) =>
+        emit(validChunk)
+    )
+    await modelPort(streamChat).decide(
+      { state, observation },
+      {
+        aborted: false
+      }
+    )
+    // Ollama applies its own default when a request asks for nothing, and
+    // what falls off the front is the system prompt and the tool schema.
+    const request = streamChat.mock.calls[0]?.[0]
+    expect(request?.num_ctx).toBeGreaterThanOrEqual(8_192)
+    expect(request?.num_ctx).toBeLessThanOrEqual(32_768)
+  })
+
+  it("grows the window with the page and stops at the ceiling", () => {
+    expect(agentContextWindow("")).toBe(8_192)
+    expect(agentContextWindow("x".repeat(40_000))).toBeGreaterThan(8_192)
+    expect(agentContextWindow("x".repeat(4_000_000))).toBe(32_768)
+  })
+
+  it("sends the projected observation, not the executor's bookkeeping", async () => {
+    const prompts: string[] = []
+    const streamChat = vi.fn(
+      async (
+        request: ChatRequest,
+        emit: (chunk: ChatStreamMessage) => void
+      ) => {
+        prompts.push(String(request.messages.at(-1)?.content))
+        emit(validChunk)
+      }
+    )
+    const grounded: AgentObservation = {
+      ...observation,
+      elements: [
+        {
+          ref: "e1",
+          verificationId: "verification-1",
+          frameId: 0,
+          tag: "button",
+          name: "Continue",
+          visible: true,
+          enabled: true,
+          editable: false,
+          sensitive: false
+        }
+      ]
+    }
+    await modelPort(streamChat).decide(
+      { state, observation: grounded },
+      { aborted: false }
+    )
+
+    const sent = JSON.parse(prompts[0]).observation
+    expect(sent.elements).toEqual([
+      { ref: "e1", tag: "button", name: "Continue" }
+    ])
+    expect(sent).not.toHaveProperty("documentId")
+    expect(sent.text).toBe(observation.visibleText)
   })
 })

--- a/src/application/agent/__tests__/agent-observation-projection.test.ts
+++ b/src/application/agent/__tests__/agent-observation-projection.test.ts
@@ -106,26 +106,44 @@ describe("projectAgentElement", () => {
   })
 
   it("bounds a label the page made into prose", () => {
-    const projected = projectAgentElement(
-      element({ name: "n".repeat(500), value: "v".repeat(500) })
-    )
-    expect(projected.name).toHaveLength(200)
-    expect(projected.value).toHaveLength(200)
+    expect(
+      projectAgentElement(element({ name: "n".repeat(500) })).name
+    ).toHaveLength(200)
   })
 
-  it("reduces select options to the enabled values", () => {
+  it("never alters a value the model has to reproduce", () => {
+    // A select's value must match an option exactly, and for any field the
+    // value is what says whether it already holds what the goal wants.
+    const exact = "v".repeat(900)
+    expect(projectAgentElement(element({ value: exact })).value).toBe(exact)
+  })
+
+  it("keeps every enabled option, exactly, with a label that adds something", () => {
     expect(
       projectAgentElement(
         element({
           tag: "select",
           options: [
-            { value: "a", label: "A", disabled: false },
+            { value: "a", label: "Apple", disabled: false },
             { value: "b", label: "B", disabled: true },
-            { value: "c", label: "C", disabled: false }
+            { value: "c", label: "c", disabled: false }
           ]
         })
       ).options
-    ).toEqual(["a", "c"])
+    ).toEqual([{ value: "a", label: "Apple" }, { value: "c" }])
+  })
+
+  it("makes no option unselectable, however many or long they are", () => {
+    // The executor requires exact equality, so a truncated value cannot be
+    // selected and an omitted option cannot be reached at all.
+    const options = Array.from({ length: 120 }, (_value, index) => ({
+      value: `${"v".repeat(300)}-${index}`,
+      label: `Option ${index}`,
+      disabled: false
+    }))
+    const projected = projectAgentElement(element({ tag: "select", options }))
+    expect(projected.options).toHaveLength(120)
+    expect(projected.options?.at(-1)?.value).toBe(options[119].value)
   })
 })
 

--- a/src/application/agent/__tests__/agent-observation-projection.test.ts
+++ b/src/application/agent/__tests__/agent-observation-projection.test.ts
@@ -1,0 +1,182 @@
+import type { AgentElement, AgentObservation } from "@ollama-client/contracts"
+import { describe, expect, it } from "vitest"
+
+import {
+  projectAgentElement,
+  projectAgentObservation
+} from "../agent-observation-projection"
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  verificationId: "verification-1",
+  frameId: 0,
+  tag: "button",
+  name: "Continue",
+  visible: true,
+  enabled: true,
+  editable: false,
+  sensitive: false,
+  ...overrides
+})
+
+const observation = (
+  overrides: Partial<AgentObservation> = {}
+): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  documentId: "document-1",
+  url: "https://example.com/",
+  origin: "https://example.com",
+  title: "Example",
+  elements: [element()],
+  visibleText: "Continue",
+  scroll: {
+    x: 0,
+    y: 40,
+    viewportWidth: 800,
+    viewportHeight: 600,
+    documentWidth: 800,
+    documentHeight: 4_000
+  },
+  dialogs: [],
+  capturedAt: 1,
+  ...overrides
+})
+
+describe("projectAgentElement", () => {
+  it("drops what only the executor uses", () => {
+    const projected = projectAgentElement(
+      element({ formFingerprint: "abcd1234", maySubmit: true })
+    )
+    expect(projected).not.toHaveProperty("verificationId")
+    expect(projected).not.toHaveProperty("frameId")
+    expect(projected).not.toHaveProperty("formFingerprint")
+  })
+
+  it("omits a flag that is already at its default", () => {
+    const projected = projectAgentElement(element())
+    // A row saying enabled, visible, not editable and not sensitive says
+    // nothing, and on a real page that noise is most of the payload.
+    expect(projected).toEqual({ ref: "e1", tag: "button", name: "Continue" })
+  })
+
+  it("states only the unusual side of each flag", () => {
+    expect(
+      projectAgentElement(
+        element({
+          enabled: false,
+          visible: false,
+          editable: true,
+          sensitive: true
+        })
+      )
+    ).toMatchObject({
+      disabled: true,
+      hidden: true,
+      editable: true,
+      sensitive: true
+    })
+  })
+
+  it("keeps what a decision has to act on", () => {
+    expect(
+      projectAgentElement(
+        element({
+          tag: "input",
+          type: "checkbox",
+          checked: false,
+          value: "on",
+          role: "checkbox",
+          group: 'form "signup"',
+          submitter: true
+        })
+      )
+    ).toEqual({
+      ref: "e1",
+      tag: "input",
+      role: "checkbox",
+      name: "Continue",
+      type: "checkbox",
+      value: "on",
+      checked: false,
+      group: 'form "signup"',
+      submits: true
+    })
+  })
+
+  it("bounds a label the page made into prose", () => {
+    const projected = projectAgentElement(
+      element({ name: "n".repeat(500), value: "v".repeat(500) })
+    )
+    expect(projected.name).toHaveLength(200)
+    expect(projected.value).toHaveLength(200)
+  })
+
+  it("reduces select options to the enabled values", () => {
+    expect(
+      projectAgentElement(
+        element({
+          tag: "select",
+          options: [
+            { value: "a", label: "A", disabled: false },
+            { value: "b", label: "B", disabled: true },
+            { value: "c", label: "C", disabled: false }
+          ]
+        })
+      ).options
+    ).toEqual(["a", "c"])
+  })
+})
+
+describe("projectAgentObservation", () => {
+  it("keeps the page's identity and drops the run's bookkeeping", () => {
+    const projected = projectAgentObservation(observation())
+    expect(projected).toMatchObject({
+      url: "https://example.com/",
+      title: "Example",
+      text: "Continue",
+      scroll: { y: 40, ofDocument: 4_000 }
+    })
+    expect(projected).not.toHaveProperty("snapshotId")
+    expect(projected).not.toHaveProperty("documentId")
+    expect(projected).not.toHaveProperty("generation")
+  })
+
+  it("carries open modals so a decision can act inside the top one", () => {
+    expect(
+      projectAgentObservation(
+        observation({
+          modals: [{ id: "dialog1", kind: "dialog", label: "Confirm" }]
+        })
+      ).modals
+    ).toEqual([{ id: "dialog1", kind: "dialog", label: "Confirm" }])
+  })
+
+  it("carries the document's own text and says when it was cut", () => {
+    const projected = projectAgentObservation(
+      observation({ documentText: "Full page", documentTextTruncated: true })
+    )
+    expect(projected.documentText).toBe("Full page")
+    expect(projected.documentTextTruncated).toBe(true)
+  })
+
+  it("is materially smaller than the observation it projects", () => {
+    const wide = observation({
+      elements: Array.from({ length: 200 }, (_value, index) =>
+        element({
+          ref: `e${index}`,
+          verificationId: `verification-${index}`,
+          formFingerprint: "abcd1234",
+          maySubmit: true,
+          type: "text",
+          tag: "input",
+          editable: true
+        })
+      )
+    })
+    const before = JSON.stringify(wide).length
+    const after = JSON.stringify(projectAgentObservation(wide)).length
+    expect(after).toBeLessThan(before / 2)
+  })
+})

--- a/src/application/agent/agent-model-port.ts
+++ b/src/application/agent/agent-model-port.ts
@@ -27,6 +27,7 @@ import {
   assertAgentModelCompatibility,
   resolveAgentModelCompatibility
 } from "./agent-model-compatibility"
+import { projectAgentObservation } from "./agent-observation-projection"
 
 const MAX_RETRIES_PER_DECISION = 2
 const MAX_MALFORMED_PER_RUN = 5
@@ -156,7 +157,12 @@ const decisionPrompt = (input: {
     ...(input.previousVerification
       ? { previousStepOutcome: input.previousVerification.outcome }
       : {}),
-    observation: input.observation
+    /**
+     * Projected, not raw. Most of an observation is the executor's business —
+     * frame ids, verification bindings, form fingerprints, flags already at
+     * their default — and on a real page that noise is most of the payload.
+     */
+    observation: projectAgentObservation(input.observation)
   })
 
 const providerSignal = (
@@ -172,6 +178,33 @@ const providerSignal = (
   }
 }
 
+const AGENT_RESPONSE_TOKENS = 1_024
+
+/**
+ * Ollama applies its own default context window when a request does not ask
+ * for one, and anything past it is dropped from the front — which is where
+ * the system prompt and the tool schema are. The result is a malformed
+ * decision rather than a context error, so nothing pointed at the cause.
+ *
+ * Sized from the request itself: a rough token estimate for the prompt, the
+ * system prompt and the tool schema, plus room for the answer, rounded up to
+ * a step and clamped. Too small silently truncates; too large asks a small
+ * machine for memory it does not have.
+ */
+const AGENT_CONTEXT_FLOOR = 8_192
+const AGENT_CONTEXT_CEILING = 32_768
+const AGENT_CONTEXT_STEP = 2_048
+const AGENT_FIXED_PROMPT_TOKENS = 1_200
+
+export const agentContextWindow = (prompt: string): number => {
+  const estimated =
+    Math.ceil(prompt.length / 3.5) +
+    AGENT_FIXED_PROMPT_TOKENS +
+    AGENT_RESPONSE_TOKENS
+  const stepped = Math.ceil(estimated / AGENT_CONTEXT_STEP) * AGENT_CONTEXT_STEP
+  return Math.min(AGENT_CONTEXT_CEILING, Math.max(AGENT_CONTEXT_FLOOR, stepped))
+}
+
 const collectDecision = async (input: {
   provider: LLMProvider
   state: AgentRunState
@@ -183,6 +216,7 @@ const collectDecision = async (input: {
   signal: AgentCancellationSignal
 }): Promise<AgentDecision> => {
   const calls = new Map<string, ToolCall>()
+  const prompt = decisionPrompt(input)
   let streamError: string | undefined
   const scoped = providerSignal(input.signal)
   try {
@@ -193,13 +227,14 @@ const collectDecision = async (input: {
           { role: "system", content: SYSTEM_PROMPT },
           {
             role: "user",
-            content: decisionPrompt(input)
+            content: prompt
           }
         ],
         tools: [AGENT_DECISION_TOOL],
         tool_choice: "required",
         think: false,
-        num_predict: 1_024
+        num_predict: AGENT_RESPONSE_TOKENS,
+        num_ctx: agentContextWindow(prompt)
       },
       (chunk) => {
         if (chunk.error) {

--- a/src/application/agent/agent-observation-projection.ts
+++ b/src/application/agent/agent-observation-projection.ts
@@ -25,7 +25,7 @@ export interface AgentProjectedElement {
   checked?: boolean
   focused?: boolean
   href?: string
-  options?: string[]
+  options?: { value: string; label?: string }[]
   /** The landmark, form or dialog this element belongs to. */
   group?: string
   /** Present only when true, because the default is what most rows are. */
@@ -51,51 +51,72 @@ export interface AgentProjectedObservation {
 }
 
 export const AGENT_PROJECTION_LIMITS = {
-  optionLabels: 25,
-  optionLabelChars: 60,
   /**
-   * A label longer than this is page prose rather than a name, and the
-   * observation's own 500-character cap is generous for a prompt: two
-   * thousand rows of it is most of a small model's window on its own.
+   * A name is prose the model reads and never has to reproduce, so it can be
+   * shortened: the observation's own 500-character cap is generous for a
+   * prompt, and two thousand rows of it is most of a small model's window.
+   *
+   * A `value` gets no such cap. For a select it has to match an option
+   * exactly, and for any field it is what tells the model whether the field
+   * already holds what the goal wants — an altered one is worse than a
+   * missing one.
    */
-  nameChars: 200,
-  valueChars: 200
+  nameChars: 200
 } as const
 
-const projectOptions = (element: AgentElement): string[] | undefined => {
+/**
+ * The one field that is not reduced.
+ *
+ * An option's value is the payload of a `select`, and the executor requires
+ * exact equality against the option the page actually holds — so a truncated
+ * value is unselectable and an omitted option is unreachable. Capping either
+ * does not make the page cheaper to read, it makes part of it impossible to
+ * use. Disabled options are dropped because the executor refuses them anyway,
+ * and a label travels only when it says something the value does not.
+ *
+ * The bound that matters is the observation's own: two hundred options, each
+ * at most two thousand characters.
+ */
+const projectOptions = (
+  element: AgentElement
+): AgentProjectedElement["options"] => {
   if (!element.options?.length) return undefined
-  return element.options
-    .filter((option) => !option.disabled)
-    .slice(0, AGENT_PROJECTION_LIMITS.optionLabels)
-    .map((option) =>
-      option.value.slice(0, AGENT_PROJECTION_LIMITS.optionLabelChars)
-    )
+  const enabled = element.options.filter((option) => !option.disabled)
+  return enabled.length > 0
+    ? enabled.map((option) => ({
+        value: option.value,
+        ...(option.label && option.label !== option.value
+          ? { label: option.label }
+          : {})
+      }))
+    : undefined
 }
 
 export const projectAgentElement = (
   element: AgentElement
-): AgentProjectedElement => ({
-  ref: element.ref,
-  tag: element.tag,
-  ...(element.role ? { role: element.role } : {}),
-  ...(element.name
-    ? { name: element.name.slice(0, AGENT_PROJECTION_LIMITS.nameChars) }
-    : {}),
-  ...(element.type ? { type: element.type } : {}),
-  ...(element.value !== undefined
-    ? { value: element.value.slice(0, AGENT_PROJECTION_LIMITS.valueChars) }
-    : {}),
-  ...(element.checked !== undefined ? { checked: element.checked } : {}),
-  ...(element.focused ? { focused: true } : {}),
-  ...(element.href ? { href: element.href } : {}),
-  ...(projectOptions(element) ? { options: projectOptions(element) } : {}),
-  ...(element.group ? { group: element.group } : {}),
-  ...(element.submitter || element.maySubmit ? { submits: true } : {}),
-  ...(element.editable ? { editable: true } : {}),
-  ...(element.sensitive ? { sensitive: true } : {}),
-  ...(element.enabled ? {} : { disabled: true }),
-  ...(element.visible ? {} : { hidden: true })
-})
+): AgentProjectedElement => {
+  const options = projectOptions(element)
+  return {
+    ref: element.ref,
+    tag: element.tag,
+    ...(element.role ? { role: element.role } : {}),
+    ...(element.name
+      ? { name: element.name.slice(0, AGENT_PROJECTION_LIMITS.nameChars) }
+      : {}),
+    ...(element.type ? { type: element.type } : {}),
+    ...(element.value !== undefined ? { value: element.value } : {}),
+    ...(element.checked !== undefined ? { checked: element.checked } : {}),
+    ...(element.focused ? { focused: true } : {}),
+    ...(element.href ? { href: element.href } : {}),
+    ...(options ? { options } : {}),
+    ...(element.group ? { group: element.group } : {}),
+    ...(element.submitter || element.maySubmit ? { submits: true } : {}),
+    ...(element.editable ? { editable: true } : {}),
+    ...(element.sensitive ? { sensitive: true } : {}),
+    ...(element.enabled ? {} : { disabled: true }),
+    ...(element.visible ? {} : { hidden: true })
+  }
+}
 
 export const projectAgentObservation = (
   observation: AgentObservation

--- a/src/application/agent/agent-observation-projection.ts
+++ b/src/application/agent/agent-observation-projection.ts
@@ -1,0 +1,116 @@
+import type { AgentElement, AgentObservation } from "@ollama-client/contracts"
+
+/**
+ * What the model is actually given for a page.
+ *
+ * The whole observation used to be serialized into the prompt, and most of it
+ * is not the model's business: `frameId` is always 0, `verificationId` is the
+ * executor's binding, a form fingerprint is a hash the run compares, and a
+ * flag whose value is the default says nothing. On a real page that noise is
+ * most of the payload, and a payload that large is what pushes the system
+ * prompt and the tool schema out of a small model's context window.
+ *
+ * The projection keeps the same shape rather than inventing a text format:
+ * refs stay authoritative and unambiguous, and every field that remains is
+ * one a decision can act on. The runtime keeps the exact observation for
+ * grounding and verification; this is only what travels.
+ */
+export interface AgentProjectedElement {
+  ref: string
+  tag: string
+  role?: string
+  name?: string
+  type?: string
+  value?: string
+  checked?: boolean
+  focused?: boolean
+  href?: string
+  options?: string[]
+  /** The landmark, form or dialog this element belongs to. */
+  group?: string
+  /** Present only when true, because the default is what most rows are. */
+  submits?: boolean
+  editable?: boolean
+  sensitive?: boolean
+  disabled?: boolean
+  hidden?: boolean
+}
+
+export interface AgentProjectedObservation {
+  url: string
+  title: string
+  scroll: { y: number; ofDocument: number }
+  /** Open dialogs and menus, so a decision can act inside the top one. */
+  modals?: { id: string; label?: string; kind: string }[]
+  /** Text inside the viewport. */
+  text: string
+  /** The rest of the document, when there is any and it fits. */
+  documentText?: string
+  documentTextTruncated?: boolean
+  elements: AgentProjectedElement[]
+}
+
+export const AGENT_PROJECTION_LIMITS = {
+  optionLabels: 25,
+  optionLabelChars: 60,
+  /**
+   * A label longer than this is page prose rather than a name, and the
+   * observation's own 500-character cap is generous for a prompt: two
+   * thousand rows of it is most of a small model's window on its own.
+   */
+  nameChars: 200,
+  valueChars: 200
+} as const
+
+const projectOptions = (element: AgentElement): string[] | undefined => {
+  if (!element.options?.length) return undefined
+  return element.options
+    .filter((option) => !option.disabled)
+    .slice(0, AGENT_PROJECTION_LIMITS.optionLabels)
+    .map((option) =>
+      option.value.slice(0, AGENT_PROJECTION_LIMITS.optionLabelChars)
+    )
+}
+
+export const projectAgentElement = (
+  element: AgentElement
+): AgentProjectedElement => ({
+  ref: element.ref,
+  tag: element.tag,
+  ...(element.role ? { role: element.role } : {}),
+  ...(element.name
+    ? { name: element.name.slice(0, AGENT_PROJECTION_LIMITS.nameChars) }
+    : {}),
+  ...(element.type ? { type: element.type } : {}),
+  ...(element.value !== undefined
+    ? { value: element.value.slice(0, AGENT_PROJECTION_LIMITS.valueChars) }
+    : {}),
+  ...(element.checked !== undefined ? { checked: element.checked } : {}),
+  ...(element.focused ? { focused: true } : {}),
+  ...(element.href ? { href: element.href } : {}),
+  ...(projectOptions(element) ? { options: projectOptions(element) } : {}),
+  ...(element.group ? { group: element.group } : {}),
+  ...(element.submitter || element.maySubmit ? { submits: true } : {}),
+  ...(element.editable ? { editable: true } : {}),
+  ...(element.sensitive ? { sensitive: true } : {}),
+  ...(element.enabled ? {} : { disabled: true }),
+  ...(element.visible ? {} : { hidden: true })
+})
+
+export const projectAgentObservation = (
+  observation: AgentObservation
+): AgentProjectedObservation => ({
+  url: observation.url,
+  title: observation.title,
+  scroll: {
+    y: Math.round(observation.scroll.y),
+    ofDocument: Math.max(1, Math.round(observation.scroll.documentHeight))
+  },
+  ...(observation.modals?.length ? { modals: observation.modals } : {}),
+  text: observation.visibleText,
+  ...(observation.documentText
+    ? { documentText: observation.documentText }
+    : {}),
+  ...(observation.documentTextTruncated ? { documentTextTruncated: true } : {}),
+  elements: observation.elements.map(projectAgentElement)
+})

--- a/src/lib/browser-agent/__tests__/navigation-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/navigation-actions.test.ts
@@ -458,6 +458,22 @@ describe("Agent navigation actions", () => {
     expect(decision.risk).toBe("critical")
   })
 
+  it("escalates page text the model read below the fold", async () => {
+    const decision = await decide(
+      navigate("https://example.com/search?q=confidential%20merger%20terms"),
+      observation({
+        visibleText: "Nothing here",
+        documentText:
+          "Nothing here Confidential merger terms and conditions apply"
+      })
+    )
+    // The model is given the document's text, so checking only the viewport
+    // would let the same words escape the classification they carry when they
+    // happen to be on screen.
+    expect(decision.type).toBe("approval_required")
+    expect(decision.risk).toBe("critical")
+  })
+
   it("does not block an observed link that carries the page's own data", async () => {
     const href = "https://example.com/next?token=session-token-value"
     const decision = await decide(

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -665,6 +665,18 @@ describe("Agent observation builder", () => {
     )
   })
 
+  it("declares truncation when the budget ends the walk, not just the cap", () => {
+    document.body.innerHTML = `<main>${Array.from(
+      { length: AGENT_OBSERVATION_LIMITS.budgetCheckInterval + 40 },
+      (_value, index) => `<p>paragraph ${index}</p>`
+    ).join("")}</main>`
+    const result = build(0, stalledClock())
+    // Running out of budget truncates as surely as running out of characters,
+    // and partial text that looks complete makes an absent fact read as a
+    // fact the page does not state.
+    expect(result.documentTextTruncated).toBe(true)
+  })
+
   it("omits the document text when the viewport already said it all", () => {
     document.body.innerHTML = "<main><p>All of it</p></main>"
     expect(build(0, unhurried).documentText).toBeUndefined()

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -572,4 +572,101 @@ describe("Agent observation builder", () => {
       `paragraph ${AGENT_OBSERVATION_LIMITS.budgetCheckInterval + 9}`
     )
   })
+
+  it("reports an open dialog and gives its controls its name", () => {
+    document.body.innerHTML =
+      '<main><button>Open</button><div role="dialog" aria-label="Confirm delete"><button>Delete</button><button>Cancel</button></div></main>'
+    const result = build(0, unhurried)
+    expect(result.modals).toEqual([
+      { id: "dialog1", kind: "dialog", label: "Confirm delete" }
+    ])
+    // "Delete" in a dialog and "Delete" in a row are different buttons, and a
+    // flat list gave a decision nothing to tell them apart with.
+    expect(
+      result.elements.map((element) => [element.name, element.group])
+    ).toEqual([
+      ["Open", "main"],
+      ["Confirm delete", "dialog1"],
+      ["Delete", "dialog1"],
+      ["Cancel", "dialog1"]
+    ])
+  })
+
+  it("reports a menu and a listbox by their own kind", () => {
+    document.body.innerHTML =
+      '<div role="menu" aria-label="Actions"><button>Edit</button></div><div role="listbox" aria-label="Sizes"><div role="option">S</div></div>'
+    expect(build(0, unhurried).modals).toEqual([
+      { id: "menu1", kind: "menu", label: "Actions" },
+      { id: "listbox1", kind: "listbox", label: "Sizes" }
+    ])
+  })
+
+  it("leaves the native dialog list empty, because it cannot be read", () => {
+    document.body.innerHTML = '<div role="dialog" aria-label="Modal"></div>'
+    // `dialogs` is typed for alert, confirm, prompt and beforeunload, which
+    // block the page and are unobservable from a content script.
+    expect(build(0, unhurried).dialogs).toEqual([])
+  })
+
+  it("reads a form's name from its attribute, not its shadowed property", () => {
+    // A form exposes its controls as named properties, so `form.name` here is
+    // the input element, and a label built from it threw.
+    document.body.innerHTML =
+      '<form action="/next"><input name="name"><button>Go</button></form>'
+    expect(() => build(0, unhurried)).not.toThrow()
+    expect(
+      build(0, unhurried).elements.map((element) => element.group)
+    ).toEqual(["form", "form"])
+  })
+
+  it("names the landmark or form an element sits in", () => {
+    document.body.innerHTML =
+      '<nav><a href="/a">Home</a></nav><form name="signup"><input name="email"><button>Join</button></form>'
+    expect(
+      build(0, unhurried).elements.map((element) => element.group)
+    ).toEqual(["nav", 'form "signup"', 'form "signup"'])
+  })
+
+  it("carries the document's text past the viewport", () => {
+    const rects = vi.spyOn(Element.prototype, "getClientRects")
+    document.body.innerHTML =
+      "<main><p id='seen'>Above the fold</p><p id='below'>Below the fold</p></main>"
+    const below = document.querySelector("#below") as HTMLElement
+    rects.mockImplementation(function (this: Element) {
+      const offscreen = this === below || below.contains(this)
+      return [
+        {
+          bottom: offscreen ? 5_000 : 20,
+          height: 20,
+          left: 0,
+          right: 100,
+          top: offscreen ? 4_980 : 0,
+          width: 100
+        } as DOMRect
+      ] as unknown as DOMRectList
+    })
+
+    const result = build(0, unhurried)
+    expect(result.visibleText).toBe("Above the fold")
+    // A fact below the fold is still a fact the page states, and reaching it
+    // by scrolling costs an observation each time.
+    expect(result.documentText).toBe("Above the fold Below the fold")
+    expect(result.documentTextTruncated).toBeUndefined()
+  })
+
+  it("says when the document had more text than it could carry", () => {
+    document.body.innerHTML = `<main><p>${"word ".repeat(
+      AGENT_OBSERVATION_LIMITS.documentTextChars
+    )}</p></main>`
+    const result = build(0, unhurried)
+    expect(result.documentTextTruncated).toBe(true)
+    expect((result.documentText ?? "").length).toBeLessThanOrEqual(
+      AGENT_OBSERVATION_LIMITS.documentTextChars
+    )
+  })
+
+  it("omits the document text when the viewport already said it all", () => {
+    document.body.innerHTML = "<main><p>All of it</p></main>"
+    expect(build(0, unhurried).documentText).toBeUndefined()
+  })
 })

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -549,11 +549,17 @@ const collectDocumentText = (
   const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
   let result = ""
   let truncated = false
-  for (
-    let node = walker.nextNode();
-    node && !pass.exhausted();
-    node = walker.nextNode()
-  ) {
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    /**
+     * Running out of budget truncates just as surely as running out of
+     * characters. Reporting only the second let a complex page send partial
+     * text that looked complete, and an absent fact then reads as a fact the
+     * page does not state.
+     */
+    if (pass.exhausted()) {
+      truncated = true
+      break
+    }
     const parent = node.parentElement
     if (!parent || isChainHidden(parent, pass)) continue
     const text = normalizedText(node.textContent ?? "")

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -17,9 +17,36 @@ export const AGENT_OBSERVATION_LIMITS = {
   selectOptions: 200,
   selectOptionLabelChars: 500,
   selectOptionValueChars: 2_000,
+  documentTextChars: 30_000,
+  modals: 10,
+  modalLabelChars: 200,
+  groupChars: 80,
   passBudgetMs: 500,
   budgetCheckInterval: 256
 } as const
+
+const MODAL_SELECTOR = [
+  "dialog[open]",
+  "[role='dialog']",
+  "[role='alertdialog']",
+  "[role='menu']",
+  "[role='listbox']"
+].join(",")
+
+const LANDMARK_SELECTOR = [
+  "main",
+  "nav",
+  "header",
+  "footer",
+  "aside",
+  "form",
+  "[role='main']",
+  "[role='navigation']",
+  "[role='banner']",
+  "[role='contentinfo']",
+  "[role='complementary']",
+  "[role='search']"
+].join(",")
 
 const INTERACTIVE_SELECTOR = [
   "a[href]",
@@ -508,6 +535,126 @@ const collectVisibleText = (
   return result
 }
 
+/**
+ * Rendered text wherever it sits in the document, not only where the viewport
+ * happens to be. `isVisible` requires viewport intersection, which is right
+ * for deciding what can be acted on and wrong for deciding what the page
+ * says: a fact below the fold is still a fact the page states.
+ */
+const collectDocumentText = (
+  root: Element,
+  limit: number,
+  pass: AgentObservationPass
+): { text: string; truncated: boolean } => {
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let result = ""
+  let truncated = false
+  for (
+    let node = walker.nextNode();
+    node && !pass.exhausted();
+    node = walker.nextNode()
+  ) {
+    const parent = node.parentElement
+    if (!parent || isChainHidden(parent, pass)) continue
+    const text = normalizedText(node.textContent ?? "")
+    if (!text) continue
+    if (result.length + text.length + 1 > limit) {
+      truncated = true
+      break
+    }
+    result += `${result ? " " : ""}${text}`
+  }
+  return { text: result, truncated }
+}
+
+/**
+ * Which landmark, form or open dialog owns an element.
+ *
+ * Two controls with the same accessible name are ordinary — "Delete" in a row
+ * and "Delete" in a confirmation are different buttons — and a flat list gives
+ * a decision nothing to tell them apart with. The nearest owning region is
+ * what does, and it is a structural label rather than page prose.
+ */
+const groupOf = (
+  element: Element,
+  modalIds: Map<Element, string>
+): string | undefined => {
+  for (
+    let current: Element | null = element;
+    current;
+    current = composedParent(current)
+  ) {
+    const modalId = modalIds.get(current)
+    if (modalId) return modalId
+    if (current === element) continue
+    if (!current.matches(LANDMARK_SELECTOR)) continue
+    const role =
+      current.getAttribute("role")?.toLowerCase() ||
+      current.tagName.toLowerCase()
+    /**
+     * Read from attributes, never from properties. A form exposes its own
+     * controls as named properties, so `form.name` on a form containing
+     * `<input name="name">` is that input element rather than a string — and
+     * a group label built from it threw, which made the page unobservable.
+     */
+    const label =
+      current.getAttribute("aria-label") ?? current.getAttribute("name")
+    const named = label ? `${role} "${normalizedText(label)}"` : role
+    return truncate(named, AGENT_OBSERVATION_LIMITS.groupChars)
+  }
+  return undefined
+}
+
+/**
+ * Open in-page dialogs and menus, keyed so an element can name its owner.
+ * Native `alert`/`confirm`/`prompt` block the page and remain unobservable;
+ * `dialogs` in the contract is for those and stays empty here.
+ */
+const collectModals = (
+  document: Document,
+  pass: AgentObservationPass
+): {
+  modals: NonNullable<AgentObservation["modals"]>
+  ids: Map<Element, string>
+} => {
+  const ids = new Map<Element, string>()
+  const modals: NonNullable<AgentObservation["modals"]> = []
+  for (const candidate of document.querySelectorAll(MODAL_SELECTOR)) {
+    if (modals.length >= AGENT_OBSERVATION_LIMITS.modals) break
+    if (!isVisible(candidate, pass)) continue
+    const role = candidate.getAttribute("role")?.toLowerCase()
+    const kind =
+      role === "alertdialog" || role === "menu" || role === "listbox"
+        ? role
+        : "dialog"
+    /** Numbered per kind, so `dialog1` and `menu1` can coexist. */
+    const ordinal = modals.filter((modal) => modal.kind === kind).length + 1
+    const id = `${kind}${ordinal}`
+    ids.set(candidate, id)
+    const label =
+      candidate.getAttribute("aria-label") ??
+      accessibleName(candidate, pass) ??
+      undefined
+    modals.push({
+      id,
+      kind,
+      ...(label
+        ? {
+            label: truncate(
+              normalizedText(label),
+              AGENT_OBSERVATION_LIMITS.modalLabelChars
+            )
+          }
+        : {}),
+      ...(candidate instanceof HTMLDialogElement &&
+      candidate.hasAttribute("open")
+        ? { modal: true }
+        : {})
+    })
+  }
+  return { modals, ids }
+}
+
 const accessibleName = (
   element: Element,
   pass: AgentObservationPass
@@ -622,7 +769,8 @@ const buildElementObservation = (
   element: Element,
   ref: string,
   verificationId: string | undefined,
-  pass: AgentObservationPass
+  pass: AgentObservationPass,
+  modalIds: Map<Element, string> = new Map()
 ): AgentElement => {
   const visible = isVisible(element, pass)
   const sensitive = !visible || isSensitiveAgentElement(element)
@@ -631,6 +779,7 @@ const buildElementObservation = (
   const href = visible ? elementHref(element) : undefined
   const submitter = isSubmitter(element)
   const maySubmit = submitter || maySubmitWithEnter(element)
+  const group = groupOf(element, modalIds)
   return {
     ref,
     ...(verificationId ? { verificationId } : {}),
@@ -647,7 +796,8 @@ const buildElementObservation = (
     visible,
     enabled: isEnabled(element),
     editable: isEditable(element),
-    sensitive
+    sensitive,
+    ...(group ? { group } : {})
   }
 }
 
@@ -735,13 +885,15 @@ export const buildAgentObservation = (input: {
       input.createSnapshotId ?? (() => globalThis.crypto.randomUUID())
   })
   const pass = createObservationPass(input.now)
+  const { modals, ids: modalIds } = collectModals(input.document, pass)
   const elements = selectObservedCandidates(input.document, pass).map(
     (element) =>
       buildElementObservation(
         element,
         snapshot.reference(element),
         snapshot.verificationId(element),
-        pass
+        pass,
+        modalIds
       )
   )
   const visibleText = input.document.body
@@ -751,6 +903,17 @@ export const buildAgentObservation = (input: {
         pass
       )
     : ""
+  /**
+   * Only sent when it says more than the viewport already did, so an ordinary
+   * short page does not pay for the field twice.
+   */
+  const documentText = input.document.body
+    ? collectDocumentText(
+        input.document.body,
+        AGENT_OBSERVATION_LIMITS.documentTextChars,
+        pass
+      )
+    : { text: "", truncated: false }
   const view = input.document.defaultView
   const root = input.document.documentElement
 
@@ -773,6 +936,11 @@ export const buildAgentObservation = (input: {
       documentHeight: Math.max(root.scrollHeight, root.clientHeight)
     },
     dialogs: [],
+    ...(modals.length > 0 ? { modals } : {}),
+    ...(documentText.text && documentText.text !== visibleText
+      ? { documentText: documentText.text }
+      : {}),
+    ...(documentText.truncated ? { documentTextTruncated: true } : {}),
     capturedAt: input.capturedAt ?? Date.now()
   })
 }

--- a/src/lib/browser-agent/resolved-effect.ts
+++ b/src/lib/browser-agent/resolved-effect.ts
@@ -307,8 +307,19 @@ const pageDataEvidence = (
   if (spans.some((span) => values.some((value) => overlaps(span, value)))) {
     return "field_value"
   }
-  const text = normalizeForComparison(observation.visibleText)
-  return spans.some((span) => containsCopiedText(span, text))
+  /**
+   * Both the viewport and the rest of the document, because the model is
+   * given both. Checking only what was on screen would let a destination
+   * built from text below the fold escape the classification that the same
+   * text carries when it happens to be visible.
+   */
+  const rendered = [
+    observation.visibleText,
+    ...(observation.documentText ? [observation.documentText] : [])
+  ].map(normalizeForComparison)
+  return spans.some((span) =>
+    rendered.some((text) => containsCopiedText(span, text))
+  )
     ? "visible_text"
     : undefined
 }

--- a/tools/checks/check-bundle-size.ts
+++ b/tools/checks/check-bundle-size.ts
@@ -207,8 +207,11 @@ const budgets: Budget[] = [
      * Durable step history — the receipt fields that survive a snapshot, the
      * bounded record built from them, and the prompt that carries it — took
      * the measured Chrome baseline to 228,969.
+     *
+     * The model-visible projection, the modal and grouping reporting, and the
+     * document-text collection took the measured Chrome baseline to 229,855.
      */
-    max: isFirefox ? 210_000 : 229_500
+    max: isFirefox ? 210_000 : 230_500
   }
 ]
 


### PR DESCRIPTION
The whole observation was serialized into every decision prompt, and most of it is not the model's business: frame ids that are always zero, verification bindings, form fingerprints, flags already at their default.

| page | raw | projected |
|---|---|---|
| form | 949 B (~271 tok) | **334 B (~95 tok)** |
| app-like, 1 202 controls | 334 KB (~95 k tok) | **140 KB (~40 k tok)** |
| text-heavy article | 22.6 KB | 22.2 KB — correct, its payload *is* the text |

The projection keeps the observation's shape rather than inventing a text format, so refs stay authoritative and the e2e fixtures stay readable; it states only the unusual side of each flag.

- **`num_ctx` is now set.** Nothing set one, so Ollama applied its own default and dropped everything past it from the front — where the system prompt and tool schema are. That surfaced as a malformed decision, never as a context error. Sized from the request, clamped 8 192–32 768.
- **Open dialogs and menus are reported** (G8/G16), in a new `modals` field — not `dialogs`, which is typed for native alert/confirm/prompt and stays empty because those block the page and cannot be read.
- **Every element names its landmark, form or dialog.** Two controls with the same accessible name are ordinary; a flat list gave a decision nothing to tell them apart with.
- **Bounded whole-document text**, moved here from PR 1 because it changes the prompt. Sent only when it says more than the viewport did, and it declares when it was cut.

New `@critical` `modal` scenario: opener then the dialog's own control, asserting two verified steps rather than the opener twice.

**Known limit worth a threshold in PR 8:** an app-like page still projects to ~40 k tokens, past the 32 768 ceiling. The element cap is the real bound, and lowering it would reintroduce the starvation PR 1 fixed — so this is measured and stated, not papered over.

Gate: 4 123 unit tests, 11/11 agent e2e. Background budget 229 500 → 230 500, measured 229 855.

Also fixed en route: `form.name` returns the input named "name", not the attribute — form-property shadowing made a group label an element instead of a string and threw, which the `form` fixture caught as an unobservable page.

**Not in this PR:** the tab inventory. It is a new port with a privacy decision attached (D2 was proposed, never confirmed), so it wants its own review rather than riding along.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces agent prompt size by projecting observations into a model-facing page representation while preserving exact actionable values. It also sizes Ollama context windows, reports modal ownership and document-wide text, and aligns navigation data-egress analysis with all text exposed to the model.
- Removes executor-only observation bookkeeping and default-valued flags from prompts.
- Preserves complete enabled select options and exact field values.
- Adds modal and structural grouping context for duplicate controls.
- Adds bounded document-wide text with explicit truncation reporting.
- Sets a request-derived Ollama context window between 8,192 and 32,768 tokens.
- Extends copied-page-data detection to off-viewport text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the changes since the previous review fully address the outstanding observation-truncation and data-egress findings without introducing a confirmed new defect.

Budget exhaustion now explicitly marks document text as truncated, and copied-page-data analysis now includes the document text exposed to the model. Complete select values and all enabled options are preserved; that earlier thread was manually resolved without explanation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/application/agent/agent-observation-projection.ts | Projects observations into a smaller model-facing representation while retaining complete actionable values. |
| src/application/agent/agent-model-port.ts | Sends projected observations and requests a bounded context window derived from prompt size. |
| src/lib/browser-agent/observation-builder.ts | Adds modal ownership, structural element groups, and bounded document-wide text with truncation metadata. |
| src/lib/browser-agent/resolved-effect.ts | Includes off-viewport document text when detecting page data copied into model-composed destinations. |
| packages/contracts/src/agent-observation.ts | Extends observation contracts with element groups, modal state, and bounded document text. |
| tools/checks/check-bundle-size.ts | Raises the Chromium background bundle budget to cover the measured cost of the new observation features. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Page[Browser page] --> Builder[Observation builder]
  Builder --> Full[Executor observation]
  Full --> Executor[Grounding and verification]
  Full --> Projection[Model-facing projection]
  Projection --> Prompt[Decision prompt]
  Prompt --> Model[Ollama model]
  Model --> Decision[Agent decision]
  Decision --> Policy[Effect and egress policy]
  Policy --> Executor
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): keep a select&#39;s options exac..."](https://github.com/shishir435/ollama-client/commit/df863a9f45425bfbb4fed30f6e09e66e3e89adb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61866860)</sub>

<!-- /greptile_comment -->