### PR TITLE
test(agent): prove recovery against the database, and freeze the benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   approvals, takeovers, and safe error vocabulary, while a new pure runtime
   package enforces legal run transitions and strict isolation from Chat. This
   foundation adds no browser permission, browser mutation, or visible Agent UI.
+- Agent Preview now completes ordinary tasks rather than only passing fixtures.
+  A page whose markup the observation could not read is observed; a wrong
+  command costs one retry with the reason instead of ending the run; each
+  decision sees what the run already did and why it turned out that way; the
+  model receives a page rather than the executor's bookkeeping, with the
+  context window sized to fit it; and an approval can be widened to a site for
+  the rest of one run, while a question the model asks is durable and
+  answerable. Submissions, destructive actions, payments, sign-ins and
+  sensitive fields keep asking every time. Startup recovery is now proven
+  against the real database at every phase a worker can be lost in, and a
+  frozen benchmark records what each task family actually costs.
 
 ## [0.13.3]
 

--- a/docs/src/content/docs/guides/agent-preview.md
+++ b/docs/src/content/docs/guides/agent-preview.md
@@ -53,8 +53,11 @@ card number or a one-time code, and it will not choose a file for you.
 
 ## What it will not do
 
-- **Only the tab you started it on.** It can open and switch to a tab, but it
-  will not wander into tabs you did not involve.
+- **One tab at a time.** Agent drives the tab it currently controls. It can
+  open a tab and switch to one, and every tab it acts on has to be readable
+  and on a site you allowed — an unfamiliar site is a new approval. It is not
+  restricted to tabs it opened itself, so treat "sites you allowed" rather
+  than "the tab you started on" as the boundary that holds.
 - **Only sites you allowed.** A destination on a new site is a new decision.
 - **Only what the page rendered.** Destinations come from links the page
   actually showed; a URL the model composed carrying data from your page is
@@ -65,6 +68,9 @@ card number or a one-time code, and it will not choose a file for you.
 ## Where it stops
 
 These are current limits, not design decisions.
+
+- **No tab allowlist.** Switching tabs is bounded by readability and the site
+  allowlist, not by which tabs the run has been involved with.
 
 - **One frame.** Content inside an iframe or a shadow root is not observed, so
   a control inside one cannot be used.

--- a/docs/src/content/docs/guides/agent-preview.md
+++ b/docs/src/content/docs/guides/agent-preview.md
@@ -1,0 +1,94 @@
+---
+title: Agent (Preview)
+description: What the supervised browser agent does, what it refuses, and where it stops.
+---
+
+Agent drives one browser tab towards a goal you write, one step at a time, and
+asks before anything that changes the page in a way you would not want undone.
+It is a Preview: the loop is real and supervised, and the list of what it
+cannot yet do is longer than the list of what it can.
+
+It is off unless you turn it on, and it never reads a page without the
+page-observation permission you grant explicitly.
+
+## How a step works
+
+Every step is the same six things, in order, and none of them is skipped.
+
+1. **Observe** — the tab's own content script reports the page: its URL, title,
+   the text you can see, the rest of the document's text, open dialogs, and
+   every interactive control with a short reference like `e1`.
+2. **Decide** — your selected model is asked for exactly one next action,
+   naming a control by its reference. Page content is supplied as data, never
+   as instructions.
+3. **Ground** — the action is resolved against the exact control the
+   observation reported. A reference the page no longer holds, or a command the
+   control cannot accept, is refused and the model is told why.
+4. **Authorize** — policy classifies what the action would actually do and
+   decides whether you are asked.
+5. **Execute** — the resolved action runs against that control and no other.
+6. **Verify** — the page is observed again and compared. A step is *confirmed*,
+   *refused*, or *unresolved* — and an unresolved step pauses the run rather
+   than being retried, because repeating an action that may already have
+   happened is how one click becomes two.
+
+## What it asks you about
+
+| Action | What happens |
+| --- | --- |
+| Reading, scrolling | Runs without asking |
+| Following a link within a site you already allowed | Runs without asking |
+| Clicking a control, typing into a field | Asks the first time |
+| Submitting a form, anything destructive | Asks every time |
+| Payment, sign-in, one-time codes, file pickers | Hands the page to you |
+
+When Agent asks about a click or a field, you can allow that kind of action on
+that site for the rest of the run. That offer is never made for a submission,
+anything destructive, a payment, a sign-in, or a sensitive field: those keep
+asking, every time, because a prompt you cannot turn off is the only kind that
+still means something.
+
+Anything Agent hands to you is yours to finish. It does not type a password, a
+card number or a one-time code, and it will not choose a file for you.
+
+## What it will not do
+
+- **Only the tab you started it on.** It can open and switch to a tab, but it
+  will not wander into tabs you did not involve.
+- **Only sites you allowed.** A destination on a new site is a new decision.
+- **Only what the page rendered.** Destinations come from links the page
+  actually showed; a URL the model composed carrying data from your page is
+  refused outright when that data is something you typed.
+- **Nothing it cannot verify.** A step whose effect cannot be observed pauses
+  the run and is reported as unresolved, not as done.
+
+## Where it stops
+
+These are current limits, not design decisions.
+
+- **One frame.** Content inside an iframe or a shadow root is not observed, so
+  a control inside one cannot be used.
+- **Native dialogs.** A JavaScript `alert`, `confirm` or `prompt` blocks the
+  page and cannot be seen or answered. In-page dialogs and menus are fine.
+- **No vision.** Only the page's structure and text; an image, a canvas or a
+  chart is not read.
+- **Large pages cost tokens.** A page with a thousand controls is a large
+  prompt, and a small local model may run out of room before it can answer.
+- **Twenty-five observations, ten minutes.** A run that passes either stops.
+- **A restart pauses the run.** If the browser stops the extension's worker
+  mid-step, the run comes back paused, with the interrupted step marked
+  unresolved, and waits for you.
+
+## Choosing a model
+
+Agent needs a model that supports tool calling, and a small one will struggle
+regardless. Tool calling is checked before a run starts and refused if
+missing. A model that answers but cannot follow the one-action-at-a-time
+contract will exhaust its retries and stop visibly rather than act on a
+half-understood answer.
+
+## If a run stops
+
+The panel keeps the reason. A paused run tells you why it paused; a failed run
+records what failed. Both stay on screen after the run ends, because the record
+is the only account of what happened.

--- a/docs/src/seo/doc-ia.mjs
+++ b/docs/src/seo/doc-ia.mjs
@@ -32,6 +32,7 @@ export const DOC_SECTIONS = [
         label: "Context, Images, and Tools",
         slug: "guides/context-and-tools"
       },
+      { label: "Agent (Preview)", slug: "guides/agent-preview" },
       {
         label: "Fix Ollama CORS errors",
         slug: "guides/troubleshooting/ollama-cors-error"

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -1,0 +1,130 @@
+import type { AgentFixtureObservation } from "../../fixtures/agent-scenario"
+import {
+  agentConfirmingButton,
+  agentFixtureElement,
+  runAgentScenario
+} from "../../fixtures/agent-scenario"
+import { expect } from "../../fixtures/extension"
+import type { AgentAttemptRecord } from "../agent-benchmark"
+import {
+  approvalsAsked,
+  countDuplicateEffects,
+  writeAgentBenchmarkReport
+} from "../agent-benchmark"
+
+/**
+ * The frozen benchmark: one attempt per task family, recorded rather than
+ * asserted.
+ *
+ * Deliberately not tagged `@critical`. A gate says pass or fail; this says
+ * what happened, in counts a later pass can be compared against, and the
+ * thresholds in the plan's section 01 are meant to be assigned from a clean
+ * pass rather than guessed before one exists. It is also why nothing here
+ * publishes a rate: a handful of attempts cannot support one.
+ */
+
+const attempts: AgentAttemptRecord[] = []
+const backend = process.env.AGENT_BENCHMARK_BACKEND ?? "fixture"
+
+const record = (
+  family: string,
+  scenario: string,
+  startedAt: number,
+  outcome: Parameters<Parameters<typeof runAgentScenario>[0]["verify"]>[0]
+): void => {
+  const run = outcome.snapshot?.run
+  const steps = outcome.snapshot?.steps ?? []
+  const asked = approvalsAsked(outcome.messages)
+  attempts.push({
+    family,
+    scenario,
+    attempt: 1,
+    backend,
+    terminalStatus: run?.status ?? "unknown",
+    ...(run?.pauseReason ? { pauseReason: run.pauseReason } : {}),
+    ...(run?.error?.code ? { errorCode: run.error.code } : {}),
+    steps: new Set(steps.map((step) => step.stepId)).size,
+    observations: run?.observationCount ?? 0,
+    modelCalls: outcome.wire.length,
+    approvalsAsked: asked.length,
+    approvalsGranted: run?.grants?.length ?? 0,
+    duplicateEffects: countDuplicateEffects(steps),
+    wallMs: Date.now() - startedAt,
+    ...(run?.error?.code
+      ? { firstLimitation: run.error.code }
+      : run?.pauseReason
+        ? { firstLimitation: run.pauseReason }
+        : {})
+  })
+}
+
+const clickContinue = (observation: AgentFixtureObservation) =>
+  observation.text.includes("Status: Active")
+    ? { type: "complete", summary: "Active" }
+    : {
+        type: "click",
+        ref: agentFixtureElement(
+          observation,
+          (element) => element.name === "Continue"
+        )?.ref
+      }
+
+let startedAt = Date.now()
+
+runAgentScenario({
+  name: "benchmark read-and-extract",
+  gated: false,
+  goal: "Report the status shown on the page.",
+  status: "completed",
+  html: () =>
+    "<!doctype html><title>Benchmark read</title><main><h1>Account</h1><p>Status: Active</p></main>",
+  decide: () => ({ type: "complete", summary: "Active" }),
+  verify: (outcome) => {
+    record("read-and-extract", "benchmark read-and-extract", startedAt, outcome)
+    startedAt = Date.now()
+    expect(outcome.snapshot?.run?.status).toBe("completed")
+  }
+})
+
+runAgentScenario({
+  name: "benchmark single-action",
+  gated: false,
+  goal: "Click Continue and report the status.",
+  status: "completed",
+  html: () =>
+    `<!doctype html><title>Benchmark click</title><main>${agentConfirmingButton()}</main>`,
+  decide: clickContinue,
+  verify: (outcome) => {
+    record("single-action", "benchmark single-action", startedAt, outcome)
+    startedAt = Date.now()
+    // One click, never two: the whole series exists to keep this true.
+    expect(countDuplicateEffects(outcome.snapshot?.steps ?? [])).toBe(0)
+  }
+})
+
+runAgentScenario({
+  name: "benchmark form-preparation",
+  gated: false,
+  goal: "Fill in the name field. Do not submit.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () =>
+    '<!doctype html><title>Benchmark form</title><main><div><label for="given">given</label><input id="given" name="given"></div></main>',
+  decide(observation: AgentFixtureObservation) {
+    const field = agentFixtureElement(
+      observation,
+      (element) => element.name === "given"
+    )
+    return field && !field.value
+      ? { type: "clear_and_type", ref: field.ref, text: "Alice" }
+      : { type: "complete", summary: "Filled." }
+  },
+  verify: (outcome) => {
+    record("form-preparation", "benchmark form-preparation", startedAt, outcome)
+    startedAt = Date.now()
+    const path = writeAgentBenchmarkReport(attempts, backend)
+    // Written last, so one pass produces one report naming every family.
+    expect(attempts).toHaveLength(3)
+    expect(path).toContain("agent-benchmark-")
+  }
+})

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -8,7 +8,8 @@ import { expect } from "../../fixtures/extension"
 import type { AgentAttemptRecord } from "../agent-benchmark"
 import {
   approvalsAsked,
-  countDuplicateEffects,
+  countRepeatedTargets,
+  recordAttempt,
   writeAgentBenchmarkReport
 } from "../agent-benchmark"
 
@@ -24,7 +25,15 @@ import {
  */
 
 const attempts: AgentAttemptRecord[] = []
-const backend = process.env.AGENT_BENCHMARK_BACKEND ?? "fixture"
+
+/**
+ * Derived from the one variable that actually changes how a scenario runs, so
+ * a fixture pass cannot be labelled hosted. A report whose backend field is
+ * whatever an operator typed is a report that cannot be compared.
+ */
+const backend = process.env.AGENT_HOSTED_MODEL
+  ? `hosted:${process.env.AGENT_HOSTED_MODEL}`
+  : "fixture"
 
 const record = (
   family: string,
@@ -35,7 +44,8 @@ const record = (
   const run = outcome.snapshot?.run
   const steps = outcome.snapshot?.steps ?? []
   const asked = approvalsAsked(outcome.messages)
-  attempts.push({
+  const targets = countRepeatedTargets(steps)
+  recordAttempt(attempts, {
     family,
     scenario,
     attempt: 1,
@@ -48,7 +58,8 @@ const record = (
     modelCalls: outcome.wire.length,
     approvalsAsked: asked.length,
     approvalsGranted: run?.grants?.length ?? 0,
-    duplicateEffects: countDuplicateEffects(steps),
+    repeatedTargets: targets.repeated,
+    ambiguousTargets: targets.ambiguous,
     wallMs: Date.now() - startedAt,
     ...(run?.error?.code
       ? { firstLimitation: run.error.code }
@@ -98,7 +109,7 @@ runAgentScenario({
     record("single-action", "benchmark single-action", startedAt, outcome)
     startedAt = Date.now()
     // One click, never two: the whole series exists to keep this true.
-    expect(countDuplicateEffects(outcome.snapshot?.steps ?? [])).toBe(0)
+    expect(countRepeatedTargets(outcome.snapshot?.steps ?? []).repeated).toBe(0)
   }
 })
 
@@ -122,9 +133,11 @@ runAgentScenario({
   verify: (outcome) => {
     record("form-preparation", "benchmark form-preparation", startedAt, outcome)
     startedAt = Date.now()
-    const path = writeAgentBenchmarkReport(attempts, backend)
-    // Written last, so one pass produces one report naming every family.
+    // Checked before writing, so a retry that lost an earlier scenario
+    // cannot produce a report that looks complete.
     expect(attempts).toHaveLength(3)
-    expect(path).toContain("agent-benchmark-")
+    expect(writeAgentBenchmarkReport(attempts, backend)).toContain(
+      "agent-benchmark-"
+    )
   }
 })

--- a/e2e/chromium/benchmark/agent-benchmark.ts
+++ b/e2e/chromium/benchmark/agent-benchmark.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import type { AgentPanelMessage } from "@ollama-client/contracts"
+
+/**
+ * The frozen record of one benchmark pass.
+ *
+ * The point of a benchmark is that a later run can be compared with an
+ * earlier one, so what it records has to be the same every time and has to be
+ * safe to keep. Every field here is a count, a label or a hash: no page text,
+ * no entered text, no URL, nothing a fixture happened to render. A report
+ * that carried page content could not be attached to an issue, which is the
+ * only reason to write one.
+ */
+export interface AgentAttemptRecord {
+  family: string
+  scenario: string
+  attempt: number
+  backend: string
+  terminalStatus: string
+  /** Why it stopped, when it stopped for a reason. */
+  pauseReason?: string
+  errorCode?: string
+  steps: number
+  observations: number
+  modelCalls: number
+  approvalsAsked: number
+  approvalsGranted: number
+  /** Verified steps whose command and target repeat an earlier verified step. */
+  duplicateEffects: number
+  wallMs: number
+  /** The first thing that stopped it going further, as a label. */
+  firstLimitation?: string
+}
+
+export interface AgentBenchmarkReport {
+  measuredAt: string
+  backend: string
+  attempts: AgentAttemptRecord[]
+  families: {
+    family: string
+    attempts: number
+    completed: number
+    medianWallMs: number
+    duplicateEffects: number
+  }[]
+}
+
+const median = (values: number[]): number => {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[middle - 1] + sorted[middle]) / 2)
+    : sorted[middle]
+}
+
+/**
+ * A repeated effect is the failure this whole series exists to prevent, so it
+ * is counted rather than inferred: two verified steps with the same command
+ * type on the same target are one click that became two.
+ */
+export const countDuplicateEffects = (
+  steps: {
+    status: string
+    command?: { type: string }
+    target?: { ref?: string; tag?: string; name?: string }
+  }[]
+): number => {
+  const seen = new Set<string>()
+  let duplicates = 0
+  for (const step of steps) {
+    if (step.status !== "verified" || !step.command) continue
+    const key = JSON.stringify([
+      step.command.type,
+      step.target?.tag,
+      step.target?.name
+    ])
+    if (seen.has(key)) duplicates += 1
+    else seen.add(key)
+  }
+  return duplicates
+}
+
+export const summarizeAttempts = (
+  attempts: AgentAttemptRecord[]
+): AgentBenchmarkReport["families"] => {
+  const families = new Map<string, AgentAttemptRecord[]>()
+  for (const attempt of attempts) {
+    families.set(attempt.family, [
+      ...(families.get(attempt.family) ?? []),
+      attempt
+    ])
+  }
+  return [...families.entries()]
+    .map(([family, records]) => ({
+      family,
+      attempts: records.length,
+      completed: records.filter(
+        (record) => record.terminalStatus === "completed"
+      ).length,
+      medianWallMs: median(records.map((record) => record.wallMs)),
+      duplicateEffects: records.reduce(
+        (total, record) => total + record.duplicateEffects,
+        0
+      )
+    }))
+    .sort((left, right) => left.family.localeCompare(right.family))
+}
+
+/**
+ * Counts only, and no rate. One pass of a handful of attempts cannot support
+ * a success rate, and publishing one from this would be the claim the audit
+ * refused to make.
+ */
+export const writeAgentBenchmarkReport = (
+  attempts: AgentAttemptRecord[],
+  backend: string
+): string => {
+  const report: AgentBenchmarkReport = {
+    measuredAt: new Date().toISOString(),
+    backend,
+    attempts,
+    families: summarizeAttempts(attempts)
+  }
+  const directory = resolve("artifacts/e2e/benchmark")
+  mkdirSync(directory, { recursive: true })
+  const path = resolve(directory, `agent-benchmark-${Date.now()}.json`)
+  writeFileSync(path, JSON.stringify(report, null, 2))
+  return path
+}
+
+export const approvalsAsked = (messages: AgentPanelMessage[]): string[] => [
+  ...new Set(
+    messages.flatMap((message) =>
+      message.type === "agent_snapshot" &&
+      message.snapshot.pending?.kind === "approval"
+        ? [message.snapshot.pending.request.id]
+        : []
+    )
+  )
+]

--- a/e2e/chromium/benchmark/agent-benchmark.ts
+++ b/e2e/chromium/benchmark/agent-benchmark.ts
@@ -26,8 +26,15 @@ export interface AgentAttemptRecord {
   modelCalls: number
   approvalsAsked: number
   approvalsGranted: number
-  /** Verified steps whose command and target repeat an earlier verified step. */
-  duplicateEffects: number
+  /**
+   * Verified steps whose recorded identity repeats an earlier one. Not proof
+   * of a repeated effect: a page with two identically named controls of the
+   * same role produces the same identity for both, and a receipt does not
+   * record enough to tell them apart.
+   */
+  repeatedTargets: number
+  /** Verified steps whose identity another verified step also carries. */
+  ambiguousTargets: number
   wallMs: number
   /** The first thing that stopped it going further, as a label. */
   firstLimitation?: string
@@ -42,7 +49,8 @@ export interface AgentBenchmarkReport {
     attempts: number
     completed: number
     medianWallMs: number
-    duplicateEffects: number
+    repeatedTargets: number
+    ambiguousTargets: number
   }[]
 }
 
@@ -56,30 +64,45 @@ const median = (values: number[]): number => {
 }
 
 /**
- * A repeated effect is the failure this whole series exists to prevent, so it
- * is counted rather than inferred: two verified steps with the same command
- * type on the same target are one click that became two.
+ * A repeated effect is the failure the whole series exists to prevent, so it
+ * is measured — but measured for what a receipt can actually say.
+ *
+ * A receipt records the command, the target's role, tag and bounded name, and
+ * the page. Two distinct controls can share all of that: the modal fixture
+ * has a Delete inside the dialog and a Delete behind it. So a repeat here is
+ * a repeated *identity*, and the count of identities more than one step
+ * carries is reported beside it, so a number can be read as suspicion rather
+ * than as proof. Distinguishing them needs the owning group in the receipt,
+ * which the receipt does not yet carry.
  */
-export const countDuplicateEffects = (
+export const countRepeatedTargets = (
   steps: {
     status: string
     command?: { type: string }
-    target?: { ref?: string; tag?: string; name?: string }
+    sourceUrl?: string
+    target?: { ref?: string; tag?: string; role?: string; name?: string }
   }[]
-): number => {
-  const seen = new Set<string>()
-  let duplicates = 0
+): { repeated: number; ambiguous: number } => {
+  const counts = new Map<string, number>()
   for (const step of steps) {
     if (step.status !== "verified" || !step.command) continue
     const key = JSON.stringify([
       step.command.type,
       step.target?.tag,
-      step.target?.name
+      step.target?.role,
+      step.target?.name,
+      step.sourceUrl
     ])
-    if (seen.has(key)) duplicates += 1
-    else seen.add(key)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
   }
-  return duplicates
+  let repeated = 0
+  let ambiguous = 0
+  for (const count of counts.values()) {
+    if (count <= 1) continue
+    repeated += count - 1
+    ambiguous += count
+  }
+  return { repeated, ambiguous }
 }
 
 export const summarizeAttempts = (
@@ -100,8 +123,12 @@ export const summarizeAttempts = (
         (record) => record.terminalStatus === "completed"
       ).length,
       medianWallMs: median(records.map((record) => record.wallMs)),
-      duplicateEffects: records.reduce(
-        (total, record) => total + record.duplicateEffects,
+      repeatedTargets: records.reduce(
+        (total, record) => total + record.repeatedTargets,
+        0
+      ),
+      ambiguousTargets: records.reduce(
+        (total, record) => total + record.ambiguousTargets,
         0
       )
     }))
@@ -113,6 +140,25 @@ export const summarizeAttempts = (
  * a success rate, and publishing one from this would be the claim the audit
  * refused to make.
  */
+/**
+ * One attempt per family and scenario. Playwright retries a failed test, and
+ * a module-level list would then hold the abandoned attempt as well as the
+ * one that finished — so a later record for the same scenario replaces the
+ * earlier one rather than joining it.
+ */
+export const recordAttempt = (
+  attempts: AgentAttemptRecord[],
+  attempt: AgentAttemptRecord
+): void => {
+  const existing = attempts.findIndex(
+    (candidate) =>
+      candidate.family === attempt.family &&
+      candidate.scenario === attempt.scenario
+  )
+  if (existing >= 0) attempts.splice(existing, 1, attempt)
+  else attempts.push(attempt)
+}
+
 export const writeAgentBenchmarkReport = (
   attempts: AgentAttemptRecord[],
   backend: string

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -75,6 +75,12 @@ export interface AgentScenario {
   approvalScope?: "once" | "run_origin"
   /** What the panel's textarea replies with, when the run asks something. */
   answer?: string
+  /**
+   * Left off the `@critical` gate. A benchmark scenario records what happened
+   * rather than asserting a threshold, so a gate that ran it would be
+   * measuring rather than gating.
+   */
+  gated?: boolean
   /** Names the test and the scenario in its attachments. */
   name: string
   goal: string
@@ -113,9 +119,11 @@ const readObservation = (request: {
 
 export const runAgentScenario = (scenario: AgentScenario): void => {
   /** Synthetic page data only. No user profile or credentials enter this harness. */
-  test(`@critical Agent ${scenario.name} through production boundaries`, async ({
-    extension
-  }, testInfo) => {
+  const title =
+    scenario.gated === false
+      ? `Agent ${scenario.name} through production boundaries`
+      : `@critical Agent ${scenario.name} through production boundaries`
+  test(title, async ({ extension }, testInfo) => {
     const liveModel = process.env.AGENT_HOSTED_MODEL
     test.setTimeout(liveModel ? 240_000 : (scenario.timeoutMs ?? 60_000))
     test.skip(

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "e2e:release:run": "pnpm e2e:chromium:critical && pnpm verify:sw-turn-recovery && pnpm verify:opfs-migration && pnpm verify:firefox-opfs-migration",
     "e2e:chromium": "playwright test",
     "e2e:chromium:critical": "playwright test --grep @critical",
+    "e2e:chromium:agent-benchmark": "playwright test --project=chromium-agent-benchmark",
     "e2e:chromium:provider-critical": "playwright test provider-streaming.spec.ts --grep @critical",
     "e2e:chromium:provider-full": "playwright test provider-streaming.spec.ts",
     "e2e:headed": "E2E_HEADFUL=1 playwright test --grep @critical",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,22 @@ export default defineConfig({
         agentObservationGrant: true
       }
     },
+    {
+      /**
+       * Not in the `@critical` gate. It records what happened rather than
+       * asserting a threshold, because the thresholds are meant to come from
+       * a clean pass rather than be guessed before one exists.
+       */
+      ...chromiumProject(
+        "chromium-agent-benchmark",
+        "**/benchmark-agent.spec.ts",
+        "build/chrome-mv3-prod"
+      ),
+      metadata: {
+        extensionBuildPath: "build/chrome-mv3-prod",
+        agentObservationGrant: true
+      }
+    },
     chromiumProject(
       "chromium-production",
       "**/install-and-boot.spec.ts",

--- a/src/background/agent/__tests__/agent-recovery.smoke.test.ts
+++ b/src/background/agent/__tests__/agent-recovery.smoke.test.ts
@@ -1,0 +1,350 @@
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import type { AgentRunState } from "@ollama-client/contracts"
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest"
+
+import { SQLITE_DB_KEY, SQLITE_DB_NAME, SQLITE_DB_STORE } from "@/lib/constants"
+import { createChatDbEngine } from "@/lib/persistence/chat-db-engine"
+
+/**
+ * Startup recovery, driven through the real engine at every phase a worker can
+ * die in.
+ *
+ * Recovery was asserted against a mocked repository, which proves the function
+ * calls the helpers it means to and nothing about whether the SQL underneath
+ * moves the run. Every transition here is a compare-and-set against the
+ * status the row actually holds, so a predecessor list that disagrees with the
+ * recovery path typechecks and fails only in a browser, on a run the user
+ * cared about.
+ *
+ * The other half of the promise — that a real terminated worker reaches this
+ * state at all — needs the browser and is a separate runner; see
+ * `tools/verify/verify-sw-turn-recovery.ts` for the shape it has to take,
+ * because Playwright pins extension service workers alive and cannot kill one.
+ */
+
+const TIMEOUT = 25_000
+
+const require = createRequire(import.meta.url)
+const wasmPath = require.resolve("@sqlite.org/sqlite-wasm/sqlite3.wasm")
+let wasmBuffer: ArrayBuffer
+
+beforeAll(() => {
+  const wasm = readFileSync(wasmPath)
+  wasmBuffer = wasm.buffer.slice(
+    wasm.byteOffset,
+    wasm.byteOffset + wasm.byteLength
+  )
+})
+
+const installOwner = () => {
+  const engine = createChatDbEngine({ wasmBinary: Promise.resolve(wasmBuffer) })
+  const ready = engine.submit({ op: "setBackend", backend: "legacy" })
+  globalThis.__persistenceHostCall = async (request) => {
+    await ready
+    return engine.submit(request)
+  }
+}
+
+const clearSqliteStore = (): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open(SQLITE_DB_NAME, 1)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(SQLITE_DB_STORE)) {
+        db.createObjectStore(SQLITE_DB_STORE)
+      }
+    }
+    request.onerror = () => reject(request.error)
+    request.onsuccess = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(SQLITE_DB_STORE)) {
+        db.close()
+        resolve()
+        return
+      }
+      const tx = db.transaction([SQLITE_DB_STORE], "readwrite")
+      tx.objectStore(SQLITE_DB_STORE).delete(SQLITE_DB_KEY)
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+  })
+
+beforeEach(async () => {
+  await clearSqliteStore()
+}, TIMEOUT)
+
+afterEach(() => {
+  globalThis.__persistenceHostCall = undefined
+})
+
+const runState = (
+  status: AgentRunState["status"],
+  overrides: Partial<AgentRunState> = {}
+): AgentRunState => ({
+  version: 1,
+  id: "run-recovery",
+  goal: "Inspect the page",
+  status,
+  stepCount: 1,
+  observationCount: 1,
+  controlledTabId: 7,
+  providerId: "ollama",
+  modelId: "model",
+  allowedOrigins: ["https://example.com"],
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  ...overrides
+})
+
+const command = {
+  type: "click",
+  ref: "e1",
+  snapshotId: "snapshot-1",
+  generation: 1
+} as const
+
+const boot = async () => {
+  vi.resetModules()
+  installOwner()
+  return import("@/lib/repositories/agent-runs")
+}
+
+type Repo = Awaited<ReturnType<typeof boot>>
+
+/**
+ * The legal route from `submitted` to each phase. A run may only be created
+ * in `submitted`, so the fixture claims its way there rather than writing the
+ * status directly — which also means every hop is the same compare-and-set
+ * the controller uses, and a route the state machine forbids cannot be tested
+ * into existence.
+ */
+const ROUTES: Record<string, readonly AgentRunState["status"][]> = {
+  observing: ["observing"],
+  deciding: ["observing", "deciding"],
+  awaiting_approval: ["observing", "deciding", "awaiting_approval"],
+  awaiting_takeover: ["observing", "deciding", "awaiting_takeover"],
+  executing: ["observing", "deciding", "awaiting_approval", "executing"],
+  verifying: [
+    "observing",
+    "deciding",
+    "awaiting_approval",
+    "executing",
+    "verifying"
+  ],
+  pause_requested: ["observing", "pause_requested"],
+  cancelling: ["observing", "cancelling"]
+}
+
+const walkTo = async (
+  repo: Repo,
+  runId: string,
+  status: AgentRunState["status"],
+  onPhase?: (phase: AgentRunState["status"]) => Promise<void>
+): Promise<void> => {
+  let from: AgentRunState["status"] = "submitted"
+  for (const phase of ROUTES[status] ?? []) {
+    const claimed = await repo.claimAgentRunPhase({
+      runId,
+      phase,
+      expected: [from],
+      patch: { updatedAt: 1_700_000_000_000 }
+    })
+    if (!claimed.claimed) {
+      throw new Error(`Could not claim ${phase} from ${from}`)
+    }
+    from = phase
+    await onPhase?.(phase)
+  }
+}
+
+/** A run interrupted mid-phase, with the receipts that phase would have left. */
+const seed = async (
+  status: AgentRunState["status"],
+  steps: ("planned" | "approved" | "executing" | "executed")[],
+  runId = "run-recovery"
+) => {
+  const repo = await boot()
+  await repo.createAgentRun(runState("submitted", { id: runId }))
+  let appended = false
+  const append = async () => {
+    if (appended) return
+    appended = true
+    for (const [index, stepStatus] of steps.entries()) {
+      await repo.appendAgentStep({
+        runId,
+        stepId: `${runId}:1`,
+        status: stepStatus,
+        command,
+        at: 1_700_000_000_000 + index,
+        ...(stepStatus === "planned"
+          ? { target: { ref: "e1", tag: "button", name: "Continue" } }
+          : {})
+      })
+    }
+  }
+  /**
+   * Written from `deciding`, where the controller writes them: claiming
+   * `executing` refuses a run with no durable planned step, so a fixture that
+   * appended afterwards could not reach the phase it means to test.
+   */
+  await walkTo(repo, runId, status, async (phase) => {
+    if (phase === "deciding") await append()
+  })
+  await append()
+  const recovery = await import("../agent-recovery")
+  return { repo, recovery }
+}
+
+describe("agent startup recovery against the real engine", () => {
+  it(
+    "settles a cancellation without reissuing anything",
+    async () => {
+      const { repo, recovery } = await seed("cancelling", [
+        "planned",
+        "approved",
+        "executing"
+      ])
+      await recovery.recoverAgentRuns()
+
+      const run = await repo.getAgentRun("run-recovery")
+      expect(run?.state?.status).toBe("cancelled")
+      // A user's stop is not a failure and not an uncertainty.
+      expect(
+        (await repo.listAgentSteps("run-recovery")).map((step) => step.status)
+      ).toEqual(["planned", "approved", "executing"])
+    },
+    TIMEOUT
+  )
+
+  it.each([
+    ["executing", ["planned", "approved", "executing"]],
+    ["verifying", ["planned", "approved", "executing", "executed"]]
+  ] as const)(
+    "marks an effect interrupted in %s as uncertain and pauses",
+    async (status, steps) => {
+      const { repo, recovery } = await seed(status, [...steps])
+      await recovery.recoverAgentRuns()
+
+      const run = await repo.getAgentRun("run-recovery")
+      expect(run?.state).toMatchObject({
+        status: "paused",
+        pauseReason: "unresolved_effect"
+      })
+      // The effect may already have happened, so it is recorded as unknown
+      // rather than repeated — one click must not become two.
+      const recovered = await repo.listAgentSteps("run-recovery")
+      expect(recovered.at(-1)).toMatchObject({
+        status: "uncertain",
+        stepId: "run-recovery:1"
+      })
+      expect(
+        recovered.filter((step) => step.status === "uncertain")
+      ).toHaveLength(1)
+    },
+    TIMEOUT
+  )
+
+  it.each([
+    ["awaiting_approval", "panel_closed"],
+    ["awaiting_takeover", "takeover"],
+    ["observing", "panel_closed"],
+    ["deciding", "panel_closed"],
+    ["pause_requested", "panel_closed"]
+  ] as const)(
+    "pauses a run interrupted in %s with reason %s",
+    async (status, reason) => {
+      const { repo, recovery } = await seed(status, ["planned"])
+      await recovery.recoverAgentRuns()
+
+      const run = await repo.getAgentRun("run-recovery")
+      expect(run?.state).toMatchObject({
+        status: "paused",
+        pauseReason: reason
+      })
+      // Recovery never observes, decides or executes; a read-only phase
+      // leaves its receipts exactly as it found them.
+      expect(
+        (await repo.listAgentSteps("run-recovery")).map((step) => step.status)
+      ).toEqual(["planned"])
+    },
+    TIMEOUT
+  )
+
+  it(
+    "leaves a settled run alone, so its record survives the restart",
+    async () => {
+      const { repo } = await seed("deciding", ["planned"])
+      const settled = await repo.transitionAgentRun({
+        runId: "run-recovery",
+        from: "deciding",
+        to: "completed",
+        patch: { result: "Done", updatedAt: 1_700_000_000_000 }
+      })
+      expect(settled.transitioned).toBe(true)
+      const recovery = await import("../agent-recovery")
+      await recovery.recoverAgentRuns()
+
+      const run = await repo.getAgentRun("run-recovery")
+      expect(run?.state).toMatchObject({ status: "completed", result: "Done" })
+    },
+    TIMEOUT
+  )
+
+  it(
+    "recovers every interrupted run, not only the first",
+    async () => {
+      const { repo } = await seed("deciding", ["planned"], "run-a")
+      await repo.createAgentRun(runState("submitted", { id: "run-b" }))
+      await walkTo(repo, "run-b", "awaiting_takeover")
+      await repo.createAgentRun(runState("submitted", { id: "run-c" }))
+      await walkTo(repo, "run-c", "cancelling")
+      const recovery = await import("../agent-recovery")
+      await recovery.recoverAgentRuns()
+
+      expect([
+        (await repo.getAgentRun("run-a"))?.state?.status,
+        (await repo.getAgentRun("run-b"))?.state?.status,
+        (await repo.getAgentRun("run-c"))?.state?.status
+      ]).toEqual(["paused", "paused", "cancelled"])
+    },
+    TIMEOUT
+  )
+
+  it(
+    "is safe to run twice, because a restart can be interrupted too",
+    async () => {
+      const { repo, recovery } = await seed("executing", [
+        "planned",
+        "approved",
+        "executing"
+      ])
+      await recovery.recoverAgentRuns()
+      await recovery.recoverAgentRuns()
+
+      const recovered = await repo.listAgentSteps("run-recovery")
+      expect(
+        recovered.filter((step) => step.status === "uncertain")
+      ).toHaveLength(1)
+      expect((await repo.getAgentRun("run-recovery"))?.state).toMatchObject({
+        status: "paused",
+        pauseReason: "unresolved_effect"
+      })
+    },
+    TIMEOUT
+  )
+})

--- a/src/background/agent/__tests__/agent-recovery.smoke.test.ts
+++ b/src/background/agent/__tests__/agent-recovery.smoke.test.ts
@@ -45,8 +45,11 @@ beforeAll(() => {
   )
 })
 
+const owners: ReturnType<typeof createChatDbEngine>[] = []
+
 const installOwner = () => {
   const engine = createChatDbEngine({ wasmBinary: Promise.resolve(wasmBuffer) })
+  owners.push(engine)
   const ready = engine.submit({ op: "setBackend", backend: "legacy" })
   globalThis.__persistenceHostCall = async (request) => {
     await ready
@@ -88,9 +91,17 @@ beforeEach(async () => {
   await clearSqliteStore()
 }, TIMEOUT)
 
-afterEach(() => {
+afterEach(async () => {
+  // Every test here mutates, which leaves the legacy backend's one-second
+  // save timer alive. Under coverage that timer can fire after the next test
+  // has cleared IndexedDB and overwrite its fixture with this test's image.
+  await Promise.all(
+    owners
+      .splice(0)
+      .map((engine) => engine.submit({ op: "flush" }).catch(() => undefined))
+  )
   globalThis.__persistenceHostCall = undefined
-})
+}, TIMEOUT)
 
 const runState = (
   status: AgentRunState["status"],


### PR DESCRIPTION
Startup recovery was asserted against a fully mocked repository — two tests — which proves the function calls the helpers it means to and nothing about whether the SQL underneath moves the run. Every transition it makes is a compare-and-set against the status the row actually holds, so a predecessor list that disagrees with the recovery path typechecks and fails only in a browser.

**11 tests now drive the real engine** at every phase a worker can be lost in:
- a cancellation settles without reissuing anything
- an effect interrupted mid-execute or mid-verify is marked uncertain **exactly once** and the run pauses unresolved, because repeating an action that may already have happened is how one click becomes two
- a read-only phase pauses with its receipts untouched
- a settled run keeps its record
- recovery is idempotent, since a restart can be interrupted too

The fixture claims its way to each phase rather than writing a status, so every hop is the transition the controller uses — which is how it surfaced that claiming `executing` refuses a run with no durable planned step.

**Benchmark** under `e2e/chromium/benchmark/`: one attempt per task family, counts, labels and hashes only so a report can be attached to an issue. No rate is published — a handful of attempts cannot support one, and the section 01 thresholds are meant to come from a clean pass rather than be guessed before one exists.

It leaked into the gate on the first try, matching `agent-*.spec.ts` *and* inheriting the harness's `@critical` tag; `--list` showed six extra entries. Both causes fixed, so the gate is 25 tests with none of them a benchmark.

Plus the Agent Preview guide: what it does, what it asks about, what it will not do, and where it stops.

**My plan was wrong about one thing.** It called for killing the MV3 worker from a Playwright spec, but this repo's own `verify-sw-turn-recovery.ts` documents that Playwright pins extension service workers alive — which is why it launches Chromium directly and kills through DevTools. A real terminated-worker agent run therefore needs its own dev-only agent-verify entrypoint, the same shape as `persistence-verify.html`. That is noted in the test's docstring and left as a separate PR rather than faked here.

`BROWSER_AGENT_AUDIT*.md` were never committed, so there is nothing to retire.

Gate: 4 154 unit tests, 13/13 agent gate, 3/3 benchmark, docs build 93 pages.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds real-database coverage for Agent startup recovery, introduces a frozen three-family browser benchmark, and documents the Agent Preview’s capabilities and boundaries.
- Exercises recovery transitions and idempotency through the real SQLite engine.
- Flushes legacy database owners after each recovery test to prevent delayed persistence from leaking across tests.
- Separates benchmark scenarios from the critical gate and records comparable, content-free metrics.
- Correctly describes site-based tab boundaries rather than promising an unenforced tab allowlist.
- Adds the Agent Preview guide to the documentation navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

All previous findings are resolved in the current code, and the changes since the previous review address cleanup, retry recording, target ambiguity, backend labeling, and tab-boundary documentation without introducing a new failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/background/agent/__tests__/agent-recovery.smoke.test.ts | Adds comprehensive real-engine recovery coverage and flushes every test-owned legacy engine during cleanup. |
| e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts | Defines three non-gating benchmark scenarios with backend labels derived from the actual execution mode. |
| e2e/chromium/benchmark/agent-benchmark.ts | Records privacy-safe benchmark metrics, replaces retry records by scenario, and distinguishes repeated from ambiguous target identities. |
| e2e/chromium/fixtures/agent-scenario.ts | Allows benchmark scenarios to opt out of the critical-test tag without changing existing gated scenarios. |
| playwright.config.ts | Adds an isolated Playwright project for the Agent benchmark. |
| docs/src/content/docs/guides/agent-preview.md | Documents Agent behavior, approvals, limitations, and the actual site-based tab boundary. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Interrupted Agent run] --> B{Persisted phase}
    B -->|cancelling| C[Finalize as cancelled]
    B -->|executing or verifying| D[Append one uncertain receipt]
    D --> E[Pause as unresolved_effect]
    B -->|observing, deciding, approval, takeover, pause requested| F[Pause with phase-specific reason]
    B -->|already settled| G[Leave record unchanged]
    C --> H[Second recovery is a no-op]
    E --> H
    F --> H
    G --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): measure what the receipts ca..."](https://github.com/shishir435/ollama-client/commit/0ffa84d515a9412ea61204399a4b012a7bc07150) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61997585)</sub>

<!-- /greptile_comment -->