### PR TITLE
feat(agent): observe shadow-DOM controls and covered targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,20 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
   contract. A child receives only the element budget the frames before it
   left, and a child that cannot fit or cannot be read is listed as such rather
   than truncated or retried.
+- **Perception reads the composed tree, not the light DOM.** Candidate
+  selection and both text walks descend into open shadow roots at their host,
+  so a component's controls and text are observed like any other; every node
+  tree is walked once, so a `<slot>` never double-counts the light child it
+  projects. A closed shadow root reads as `null` and stays unread rather than
+  guessed at. The walk is `nodeType`-based, not `instanceof Element` — the same
+  observation runs against a child frame's own realm.
+- **A covered control is not a clickable one.** A laid-out, in-viewport element
+  whose click points all hit-test to some unrelated element is marked
+  `occluded`; it is still listed — the control exists — so the model dismisses
+  the cover or scrolls rather than clicking a point the pointer cannot reach.
+  An indeterminate hit test (no layout, or a `null` answer) reports no
+  occlusion: a covered control wrongly shown is recoverable, a reachable one
+  wrongly hidden is not.
 - **A child-frame effect happens on the frame's origin.** The resolver sets
   `frameUrl`/`frameOrigin` for a target outside the root frame; policy judges
   grants, grant offers and sign-in/payment paths against those, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   started on and the tabs it opened; adopting any other tab asks first. The
   debugger's frame tree is tracked and mapped onto extension frames only when
   the join is exact.
+- Agent Preview sees controls inside web components and knows which ones a
+  cover blocks. Observation now descends into open shadow roots, so a
+  component's controls and text are read like any other, while a closed root
+  stays unread rather than guessed at. A visible control whose click points are
+  all covered by an unrelated element is reported to the model as covered, so
+  it dismisses the overlay or scrolls rather than clicking where the pointer
+  cannot reach.
 
 ## [0.13.3]
 

--- a/packages/contracts/src/agent-observation.ts
+++ b/packages/contracts/src/agent-observation.ts
@@ -127,6 +127,15 @@ export const AgentElementSchema = z
     submitter: z.boolean().optional(),
     options: z.array(AgentSelectOptionSchema).max(200).optional(),
     visible: z.boolean(),
+    /**
+     * Set when the element is in the layout and the viewport yet another
+     * element covers the points a click would land on. It is still listed —
+     * the control exists — but a decision is told it is not reachable where it
+     * sits, so it dismisses the cover or scrolls rather than clicking a target
+     * the pointer would never reach. Absent means reachable; the field is only
+     * present when the hit test found the element covered.
+     */
+    occluded: z.boolean().optional(),
     enabled: z.boolean(),
     editable: z.boolean(),
     sensitive: z.boolean(),
@@ -151,6 +160,13 @@ export const AgentElementSchema = z
         code: "custom",
         path: ["href"],
         message: "Hidden element destinations must be omitted"
+      })
+    }
+    if (element.occluded && !element.visible) {
+      context.addIssue({
+        code: "custom",
+        path: ["occluded"],
+        message: "Only a laid-out element can be reported as occluded"
       })
     }
     if (element.formAction !== undefined && !element.maySubmit) {

--- a/src/application/agent/__tests__/agent-observation-projection.test.ts
+++ b/src/application/agent/__tests__/agent-observation-projection.test.ts
@@ -91,6 +91,12 @@ describe("projectAgentElement", () => {
     })
   })
 
+  it("tells the model a visible control is covered", () => {
+    expect(
+      projectAgentElement(element({ visible: true, occluded: true }))
+    ).toMatchObject({ occluded: true })
+  })
+
   it("keeps what a decision has to act on", () => {
     expect(
       projectAgentElement(

--- a/src/application/agent/agent-observation-projection.ts
+++ b/src/application/agent/agent-observation-projection.ts
@@ -34,6 +34,9 @@ export interface AgentProjectedElement {
   sensitive?: boolean
   disabled?: boolean
   hidden?: boolean
+  /** Present only when a cover sits over the control, so the model dismisses
+   * it or scrolls rather than clicking a point the pointer cannot reach. */
+  occluded?: boolean
 }
 
 /**
@@ -130,7 +133,8 @@ export const projectAgentElement = (
     ...(element.editable ? { editable: true } : {}),
     ...(element.sensitive ? { sensitive: true } : {}),
     ...(element.enabled ? {} : { disabled: true }),
-    ...(element.visible ? {} : { hidden: true })
+    ...(element.visible ? {} : { hidden: true }),
+    ...(element.occluded ? { occluded: true } : {})
   }
 }
 

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -829,3 +829,94 @@ describe("Agent observation occlusion", () => {
     expect(element?.occluded).toBeUndefined()
   })
 })
+
+describe("Agent observation flattened tree", () => {
+  const withShadow = (html: string): HTMLElement => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    host.attachShadow({ mode: "open" }).innerHTML = html
+    return host
+  }
+
+  it("reads projected content and not the slot's unused fallback", () => {
+    const host = withShadow("<slot><button>Fallback Act</button></slot>")
+    const light = document.createElement("button")
+    light.textContent = "Projected Act"
+    host.append(light)
+    const names = build().elements.map((element) => element.name)
+    expect(names).toContain("Projected Act")
+    expect(names).not.toContain("Fallback Act")
+  })
+
+  it("reads a slot's fallback only when nothing is projected", () => {
+    withShadow("<slot><button>Fallback Act</button></slot>")
+    expect(build().elements.map((element) => element.name)).toContain(
+      "Fallback Act"
+    )
+  })
+
+  it("orders projected text by the shadow tree, not the light DOM", () => {
+    const host = withShadow(
+      '<slot name="second"></slot><slot name="first"></slot>'
+    )
+    const first = document.createElement("span")
+    first.setAttribute("slot", "first")
+    first.textContent = "Alpha"
+    const second = document.createElement("span")
+    second.setAttribute("slot", "second")
+    second.textContent = "Beta"
+    host.append(first, second)
+    expect(build().visibleText).toContain("Beta Alpha")
+  })
+
+  it("names a shadow control from a label in its own shadow root", () => {
+    withShadow(
+      '<span id="lbl">Shadow Label</span><input aria-labelledby="lbl">'
+    )
+    const input = build().elements.find((element) => element.tag === "input")
+    expect(input?.name).toBe("Shadow Label")
+  })
+})
+
+describe("Agent observation fragmented occlusion", () => {
+  const rect = (top: number): DOMRect =>
+    ({
+      bottom: top + 20,
+      height: 20,
+      left: 0,
+      right: 100,
+      top,
+      width: 100
+    }) as DOMRect
+
+  const wrapped = (label: string): HTMLButtonElement => {
+    const button = document.createElement("button")
+    button.textContent = label
+    document.body.append(button)
+    vi.spyOn(button, "getClientRects").mockReturnValue([
+      rect(0),
+      rect(40)
+    ] as unknown as DOMRectList)
+    return button
+  }
+
+  it("keeps a wrapped control reachable when a later fragment is exposed", () => {
+    const button = wrapped("Wrapped")
+    const overlay = document.createElement("div")
+    document.body.append(overlay)
+    vi.spyOn(document, "elementFromPoint").mockImplementation((_x, y) =>
+      y < 30 ? overlay : button
+    )
+    const element = build().elements.find((one) => one.name === "Wrapped")
+    expect(element?.occluded).toBeUndefined()
+  })
+
+  it("marks a wrapped control only when every fragment is covered", () => {
+    wrapped("Wrapped")
+    const overlay = document.createElement("div")
+    document.body.append(overlay)
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(overlay)
+    const element = build().elements.find((one) => one.name === "Wrapped")
+    expect(element?.occluded).toBe(true)
+  })
+})

--- a/src/lib/browser-agent/__tests__/observation-builder.test.ts
+++ b/src/lib/browser-agent/__tests__/observation-builder.test.ts
@@ -718,3 +718,114 @@ describe("Agent observation builder", () => {
     expect(build(0, unhurried).documentText).toBeUndefined()
   })
 })
+
+describe("Agent observation shadow DOM", () => {
+  const attachOpen = (html: string): HTMLElement => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    host.attachShadow({ mode: "open" }).innerHTML = html
+    return host
+  }
+
+  it("collects an interactive control from inside an open shadow root", () => {
+    attachOpen("<button>Shadow Act</button>")
+    expect(build().elements.map((element) => element.name)).toContain(
+      "Shadow Act"
+    )
+  })
+
+  it("reads rendered text from inside an open shadow root", () => {
+    attachOpen("<p>Shadowed sentence</p>")
+    expect(build().visibleText).toContain("Shadowed sentence")
+  })
+
+  it("does not read a closed shadow root it cannot traverse", () => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    host.attachShadow({ mode: "closed" }).innerHTML =
+      "<button>Sealed Act</button>"
+    expect(build().elements.map((element) => element.name)).not.toContain(
+      "Sealed Act"
+    )
+  })
+
+  it("counts a control once whether or not a slot projects it", () => {
+    const host = attachOpen("<slot></slot>")
+    const light = document.createElement("button")
+    light.textContent = "Slotted Act"
+    host.append(light)
+    const refs = build().elements.filter(
+      (element) => element.name === "Slotted Act"
+    )
+    expect(refs).toHaveLength(1)
+  })
+
+  it("numbers a shadow control after its host, in a stable order", () => {
+    const first = document.createElement("button")
+    first.textContent = "Light One"
+    document.body.append(first)
+    attachOpen("<button>Shadow Two</button>")
+    const last = document.createElement("button")
+    last.textContent = "Light Three"
+    document.body.append(last)
+    expect(build().elements.map((element) => element.name)).toEqual([
+      "Light One",
+      "Shadow Two",
+      "Light Three"
+    ])
+  })
+})
+
+describe("Agent observation occlusion", () => {
+  const appendButton = (label: string): HTMLButtonElement => {
+    const button = document.createElement("button")
+    button.textContent = label
+    document.body.append(button)
+    return button
+  }
+
+  it("marks a control an unrelated element covers", () => {
+    appendButton("Buy")
+    const overlay = document.createElement("div")
+    document.body.append(overlay)
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(overlay)
+    const element = build().elements.find((one) => one.name === "Buy")
+    expect(element?.occluded).toBe(true)
+  })
+
+  it("leaves a control the hit test reaches unmarked", () => {
+    const button = appendButton("Buy")
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(button)
+    const element = build().elements.find((one) => one.name === "Buy")
+    expect(element?.occluded).toBeUndefined()
+  })
+
+  it("reaches a control the hit test lands on a descendant of", () => {
+    const button = document.createElement("button")
+    const label = document.createElement("span")
+    label.textContent = "Buy"
+    button.append(label)
+    document.body.append(button)
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(label)
+    const element = build().elements.find((one) => one.tag === "button")
+    expect(element?.occluded).toBeUndefined()
+  })
+
+  it("treats an indeterminate hit test as reachable, not covered", () => {
+    appendButton("Buy")
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(null)
+    const element = build().elements.find((one) => one.name === "Buy")
+    expect(element?.occluded).toBeUndefined()
+  })
+
+  it("never reports a hidden control as occluded", () => {
+    const button = appendButton("Buy")
+    button.setAttribute("hidden", "")
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(
+      document.createElement("div")
+    )
+    const element = build().elements.find((one) => one.tag === "button")
+    expect(element?.visible).toBe(false)
+    expect(element?.occluded).toBeUndefined()
+  })
+})

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -206,36 +206,60 @@ const composedContains = (ancestor: Element, node: Element): boolean => {
 const asElement = (node: Node): Element | null =>
   node.nodeType === 1 ? (node as Element) : null
 
-/** An element's open shadow root; a closed root reads as `null` and its
- * contents stay unread rather than being guessed at. */
-const openShadowRoot = (node: Node): ShadowRoot | null =>
-  asElement(node)?.shadowRoot ?? null
+/**
+ * A slot's assigned nodes in rendered order, or `null` when the element is not
+ * a filled slot. `localName` rather than `instanceof HTMLSlotElement` keeps it
+ * realm-safe. An empty result reads as `null` so the caller falls through to
+ * the slot's own children — its fallback content, which is what renders when
+ * nothing is assigned.
+ */
+const slotAssignedNodes = (element: Element): Node[] | null => {
+  if (element.localName !== "slot") return null
+  const slot = element as HTMLSlotElement
+  if (typeof slot.assignedNodes !== "function") return null
+  const assigned = slot.assignedNodes({ flatten: true })
+  return assigned.length > 0 ? assigned : null
+}
 
 /**
- * Every element and text node the composed tree reaches, in a stable
- * depth-first order that descends into open shadow roots at their host. A
- * child's own tree is walked exactly once whether or not a `<slot>` projects
- * it elsewhere, so nothing is double-counted; a host is yielded, then its
- * shadow content, then its light children. `document.querySelectorAll` and a
- * `TreeWalker` both stop at the shadow boundary, which is why a component's
- * controls and text were invisible to every collector below. Iterative so a
- * deep component tree cannot exhaust the stack.
+ * The flattened-tree children of a node: what actually renders in its place.
+ * A shadow host renders its shadow tree, so its light children are reached
+ * only through the slots that project them — never directly, which is what
+ * keeps unslotted light content out and stops a filled slot's fallback from
+ * being read. A filled slot renders its assigned nodes at that position; an
+ * empty one renders its fallback children. Everything else renders its own
+ * children.
+ */
+const flattenedChildren = (node: Node): Node[] => {
+  const element = asElement(node)
+  if (element) {
+    const shadow = element.shadowRoot
+    if (shadow) return Array.from(shadow.childNodes)
+    const assigned = slotAssignedNodes(element)
+    if (assigned) return assigned
+  }
+  return Array.from(node.childNodes)
+}
+
+/**
+ * Every element and text node the composed tree reaches, in rendered
+ * depth-first order across open shadow roots and slot projections. Each node
+ * tree is walked once — a slotted child through its slot, never also at its
+ * light-DOM position — so nothing is double-counted and the order matches what
+ * the user sees. A closed shadow root is unreachable and stays unread rather
+ * than guessed at. `document.querySelectorAll` and a `TreeWalker` both stop at
+ * the shadow boundary, which is why a component's controls and text were
+ * invisible to every collector below. Iterative so a deep component tree
+ * cannot exhaust the stack.
  */
 const composedDescendants = function* (
   root: Element | ShadowRoot | Document
 ): Generator<Node> {
   const stack: Node[] = []
-  const pushChildren = (node: Element | ShadowRoot | Document): void => {
-    const light = node.childNodes
-    for (let index = light.length - 1; index >= 0; index -= 1) {
-      stack.push(light[index])
-    }
-    const shadow = openShadowRoot(node as Node)
-    if (shadow) {
-      const shadowChildren = shadow.childNodes
-      for (let index = shadowChildren.length - 1; index >= 0; index -= 1) {
-        stack.push(shadowChildren[index])
-      }
+  const pushChildren = (node: Node): void => {
+    const children = flattenedChildren(node)
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index])
     }
   }
   pushChildren(root)
@@ -243,8 +267,7 @@ const composedDescendants = function* (
     const node = stack.pop()
     if (!node) continue
     yield node
-    const element = asElement(node)
-    if (element) pushChildren(element)
+    pushChildren(node)
   }
 }
 
@@ -402,14 +425,49 @@ const OCCLUSION_SAMPLES: ReadonlyArray<readonly [number, number]> = [
 ]
 
 /**
+ * A wrapped inline control renders as several client rects, so the hit test
+ * runs against each of them and stops at the first that is reachable. Bounded
+ * so a pathological control cannot spend the pass on hit tests; the cap only
+ * limits how many fragments are consulted, and a control reachable anywhere in
+ * its first few fragments is already answered.
+ */
+const OCCLUSION_MAX_FRAGMENTS = 6
+
+/** Reachable — hit is the element, its own composed subtree, or an ancestor
+ * that renders it — versus covered by a foreign element, versus indeterminate
+ * when the layout answers nothing. */
+type OcclusionProbe = "reachable" | "covered" | "indeterminate"
+
+const probeFragment = (
+  element: Element,
+  doc: Document,
+  rect: VisibleBounds
+): OcclusionProbe => {
+  const width = rect.right - rect.left
+  const height = rect.bottom - rect.top
+  for (const [fractionX, fractionY] of OCCLUSION_SAMPLES) {
+    const hit = doc.elementFromPoint(
+      rect.left + width * fractionX,
+      rect.top + height * fractionY
+    )
+    if (!hit) return "indeterminate"
+    if (composedContains(element, hit) || composedContains(hit, element)) {
+      return "reachable"
+    }
+  }
+  return "covered"
+}
+
+/**
  * Whether another element covers every point a click on `element` would land
- * on. `elementFromPoint` returns the topmost element in the composed tree, so
- * a hit on the element itself, on its own composed subtree, or on an ancestor
- * that renders it all count as reachable; only a hit on some unrelated element
- * at every sampled point means the control is covered. The hit test needs real
- * layout, so an environment without `elementFromPoint`, or one that answers
- * `null`, yields no occlusion rather than a guessed one — a covered control
- * wrongly shown is recoverable, a reachable control wrongly hidden is not.
+ * on, across every fragment it renders as. `elementFromPoint` returns the
+ * topmost element in the composed tree, so a hit on the element itself, on its
+ * own composed subtree, or on an ancestor that renders it counts as reachable;
+ * only a foreign element at every sampled point of every fragment means the
+ * control is covered. The hit test needs real layout, so an environment
+ * without `elementFromPoint`, or one that answers `null`, yields no occlusion
+ * rather than a guessed one — a covered control wrongly shown is recoverable, a
+ * reachable control wrongly hidden is not.
  */
 const isOccluded = (element: Element): boolean => {
   const doc = element.ownerDocument
@@ -421,29 +479,21 @@ const isOccluded = (element: Element): boolean => {
     right: view.innerWidth ?? 0,
     top: 0
   }
-  const rect = Array.from(element.getClientRects())
+  const rects = Array.from(element.getClientRects())
     .filter((box) => box.width > 0 && box.height > 0)
     .map((box) => intersectBounds(box, viewport))
-    .find((box): box is VisibleBounds => Boolean(box))
-  if (!rect) return false
-  const width = rect.right - rect.left
-  const height = rect.bottom - rect.top
-  for (const [fractionX, fractionY] of OCCLUSION_SAMPLES) {
-    const hit = doc.elementFromPoint(
-      rect.left + width * fractionX,
-      rect.top + height * fractionY
-    )
+    .filter((box): box is VisibleBounds => Boolean(box))
+    .slice(0, OCCLUSION_MAX_FRAGMENTS)
+  if (rects.length === 0) return false
+  for (const rect of rects) {
+    const probe = probeFragment(element, doc, rect)
     /*
-     * A point that hit-tests to nothing is indeterminate, not covered: the
-     * only safe conclusion when the layout cannot answer is that the control
-     * is reachable. A hit on the element or its own composed line is reachable
-     * outright. Everything left is a foreign element in front of this point,
-     * and the loop only reports occlusion once every sampled point is covered.
+     * One reachable fragment is enough to call the control clickable, and an
+     * indeterminate probe is the safe answer that it is: the layout could not
+     * confirm coverage, so the control is left unmarked. Only when every
+     * fragment is covered by a foreign element is the whole control covered.
      */
-    if (!hit) return false
-    if (composedContains(element, hit) || composedContains(hit, element)) {
-      return false
-    }
+    if (probe !== "covered") return false
   }
   return true
 }
@@ -789,11 +839,24 @@ const accessibleName = (
   element: Element,
   pass: AgentObservationPass
 ): string | undefined => {
+  /**
+   * IDREFs resolve within the element's own tree, so a control inside a shadow
+   * root is named by a label in that same shadow root — not by `getElementById`
+   * on the document, which cannot see into it. `getRootNode` is the shadow root
+   * for a shadow element and the document otherwise; both carry
+   * `getElementById`, and the duck-typed check stays sound across a child
+   * frame's realm.
+   */
+  const scope = element.getRootNode() as Partial<Document | ShadowRoot>
+  const byId: Document | ShadowRoot =
+    typeof scope.getElementById === "function"
+      ? (scope as Document | ShadowRoot)
+      : element.ownerDocument
   const labelledBy = element
     .getAttribute("aria-labelledby")
     ?.trim()
     .split(/\s+/)
-    .map((id) => element.ownerDocument.getElementById(id))
+    .map((id) => byId.getElementById(id))
     .filter((label): label is HTMLElement => label !== null)
     .map((label) =>
       collectVisibleText(label, AGENT_OBSERVATION_LIMITS.elementNameChars, pass)

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -180,6 +180,75 @@ const composedParent = (element: Element): Element | null => {
 }
 
 /**
+ * True when `ancestor` is `node` or lies on `node`'s composed-ancestor chain,
+ * crossing shadow boundaries the way `composedParent` does. `Node.contains`
+ * cannot answer this: it stops at the shadow boundary, so a control inside a
+ * component and the light-DOM host that renders it read as unrelated.
+ */
+const composedContains = (ancestor: Element, node: Element): boolean => {
+  for (
+    let current: Element | null = node;
+    current;
+    current = composedParent(current)
+  ) {
+    if (current === ancestor) return true
+  }
+  return false
+}
+
+/**
+ * A node's element view, or null. Tested by `nodeType` rather than
+ * `instanceof Element`, because a child frame's nodes belong to that frame's
+ * realm and fail an `instanceof` against this realm's constructor — the same
+ * observation runs against a child document, and an identity filter there
+ * would drop every element it holds.
+ */
+const asElement = (node: Node): Element | null =>
+  node.nodeType === 1 ? (node as Element) : null
+
+/** An element's open shadow root; a closed root reads as `null` and its
+ * contents stay unread rather than being guessed at. */
+const openShadowRoot = (node: Node): ShadowRoot | null =>
+  asElement(node)?.shadowRoot ?? null
+
+/**
+ * Every element and text node the composed tree reaches, in a stable
+ * depth-first order that descends into open shadow roots at their host. A
+ * child's own tree is walked exactly once whether or not a `<slot>` projects
+ * it elsewhere, so nothing is double-counted; a host is yielded, then its
+ * shadow content, then its light children. `document.querySelectorAll` and a
+ * `TreeWalker` both stop at the shadow boundary, which is why a component's
+ * controls and text were invisible to every collector below. Iterative so a
+ * deep component tree cannot exhaust the stack.
+ */
+const composedDescendants = function* (
+  root: Element | ShadowRoot | Document
+): Generator<Node> {
+  const stack: Node[] = []
+  const pushChildren = (node: Element | ShadowRoot | Document): void => {
+    const light = node.childNodes
+    for (let index = light.length - 1; index >= 0; index -= 1) {
+      stack.push(light[index])
+    }
+    const shadow = openShadowRoot(node as Node)
+    if (shadow) {
+      const shadowChildren = shadow.childNodes
+      for (let index = shadowChildren.length - 1; index >= 0; index -= 1) {
+        stack.push(shadowChildren[index])
+      }
+    }
+  }
+  pushChildren(root)
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node) continue
+    yield node
+    const element = asElement(node)
+    if (element) pushChildren(element)
+  }
+}
+
+/**
  * Memo for one observation. Visibility is now resolved for every interactive
  * candidate in the document rather than only the ones that fit the element
  * cap, and the text walk asks the same question once per parent, so resolving
@@ -319,6 +388,64 @@ const isVisible = (element: Element, pass: AgentObservationPass): boolean => {
   const result = resolveVisibility(element, pass)
   pass.visible.set(element, result)
   return result
+}
+
+/** Inset fractions of a rect to hit-test: the centre, then points pulled off
+ * each corner. One reachable point is enough to call the element clickable, so
+ * a control a fixed banner clips along one edge is not reported as covered. */
+const OCCLUSION_SAMPLES: ReadonlyArray<readonly [number, number]> = [
+  [0.5, 0.5],
+  [0.15, 0.15],
+  [0.85, 0.15],
+  [0.15, 0.85],
+  [0.85, 0.85]
+]
+
+/**
+ * Whether another element covers every point a click on `element` would land
+ * on. `elementFromPoint` returns the topmost element in the composed tree, so
+ * a hit on the element itself, on its own composed subtree, or on an ancestor
+ * that renders it all count as reachable; only a hit on some unrelated element
+ * at every sampled point means the control is covered. The hit test needs real
+ * layout, so an environment without `elementFromPoint`, or one that answers
+ * `null`, yields no occlusion rather than a guessed one — a covered control
+ * wrongly shown is recoverable, a reachable control wrongly hidden is not.
+ */
+const isOccluded = (element: Element): boolean => {
+  const doc = element.ownerDocument
+  const view = doc.defaultView
+  if (!view || typeof doc.elementFromPoint !== "function") return false
+  const viewport = {
+    bottom: view.innerHeight ?? 0,
+    left: 0,
+    right: view.innerWidth ?? 0,
+    top: 0
+  }
+  const rect = Array.from(element.getClientRects())
+    .filter((box) => box.width > 0 && box.height > 0)
+    .map((box) => intersectBounds(box, viewport))
+    .find((box): box is VisibleBounds => Boolean(box))
+  if (!rect) return false
+  const width = rect.right - rect.left
+  const height = rect.bottom - rect.top
+  for (const [fractionX, fractionY] of OCCLUSION_SAMPLES) {
+    const hit = doc.elementFromPoint(
+      rect.left + width * fractionX,
+      rect.top + height * fractionY
+    )
+    /*
+     * A point that hit-tests to nothing is indeterminate, not covered: the
+     * only safe conclusion when the layout cannot answer is that the control
+     * is reachable. A hit on the element or its own composed line is reachable
+     * outright. Everything left is a foreign element in front of this point,
+     * and the loop only reports occlusion once every sampled point is covered.
+     */
+    if (!hit) return false
+    if (composedContains(element, hit) || composedContains(hit, element)) {
+      return false
+    }
+  }
+  return true
 }
 
 export const isSensitiveAgentElement = (element: Element): boolean => {
@@ -518,13 +645,10 @@ const collectVisibleText = (
   limit: number,
   pass: AgentObservationPass
 ): string => {
-  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
   let result = ""
-  for (
-    let node = walker.nextNode();
-    node && result.length < limit && !pass.exhausted();
-    node = walker.nextNode()
-  ) {
+  for (const node of composedDescendants(root)) {
+    if (node.nodeType !== Node.TEXT_NODE) continue
+    if (result.length >= limit || pass.exhausted()) break
     const parent = node.parentElement
     if (!parent || !isVisible(parent, pass)) continue
     const text = normalizedText(node.textContent ?? "")
@@ -546,10 +670,10 @@ const collectDocumentText = (
   limit: number,
   pass: AgentObservationPass
 ): { text: string; truncated: boolean } => {
-  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
   let result = ""
   let truncated = false
-  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+  for (const node of composedDescendants(root)) {
+    if (node.nodeType !== Node.TEXT_NODE) continue
     /**
      * Running out of budget truncates just as surely as running out of
      * characters. Reporting only the second let a complex page send partial
@@ -780,6 +904,7 @@ const buildElementObservation = (
   modalIds: Map<Element, string> = new Map()
 ): AgentElement => {
   const visible = isVisible(element, pass)
+  const occluded = visible && isOccluded(element)
   const sensitive = !visible || isSensitiveAgentElement(element)
   const name = visible ? accessibleName(element, pass) : undefined
   const value = sensitive ? undefined : elementValue(element)
@@ -801,6 +926,7 @@ const buildElementObservation = (
     ...observedFormFields(element, maySubmit),
     ...(submitter ? { submitter: true } : {}),
     visible,
+    ...(occluded ? { occluded: true } : {}),
     enabled: isEnabled(element),
     editable: isEditable(element),
     sensitive,
@@ -847,7 +973,9 @@ const selectObservedCandidates = (
   const hiddenPositions: number[] = []
   let visibleCount = 0
 
-  for (const candidate of document.querySelectorAll(INTERACTIVE_SELECTOR)) {
+  for (const node of composedDescendants(document.documentElement)) {
+    const candidate = asElement(node)
+    if (!candidate?.matches(INTERACTIVE_SELECTOR)) continue
     /*
      * A truncated selection is the defect this function exists to prevent, so
      * running out of budget here is reported rather than absorbed: the run is


### PR DESCRIPTION
PR 3 of the agent readiness plan: DOM and accessibility perception.

- Observation descends into open shadow roots for candidate selection and both text walks, so a web component's controls and text are read like any other. A closed root stays unread rather than guessed at.
- The composed walk visits each node tree once, so a `<slot>` never double-counts the light child it projects, and it is realm-safe so a child frame's own document reads correctly.
- A visible, in-viewport control whose click points all hit-test to an unrelated element is marked `occluded` and surfaced to the model, so it dismisses the cover or scrolls instead of clicking where the pointer cannot reach. An indeterminate hit test reports no occlusion.

Exit criteria: shadow-root controls become usable; hidden/covered controls are no longer presented as immediately clickable.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands agent perception to the rendered composed tree and exposes whether visible controls are covered.
- Traverses open shadow roots and rendered slot assignments for controls and text.
- Resolves shadow-root-local `aria-labelledby` references.
- Samples all considered client fragments when determining whether a target is occluded.
- Adds the optional `occluded` observation field and projects it to the model.
- Adds focused tests for shadow DOM, slot flattening, accessible names, and fragmented controls.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable new defect or outstanding previous finding remains.

The current implementation follows rendered slot assignments, checks multiple visible fragments for reachability, and resolves shadow-local accessible-name references. All three previous threads were manually resolved, and the current code also addresses their underlying behaviors.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/browser-agent/observation-builder.ts | Implements composed-tree traversal, root-scoped accessible naming, and multi-fragment occlusion detection; the previously reported issues are addressed. |
| src/lib/browser-agent/__tests__/observation-builder.test.ts | Adds coverage for open and closed shadow roots, flattened slots, shadow labels, and fragmented target occlusion. |
| packages/contracts/src/agent-observation.ts | Adds an optional validated `occluded` field to the agent element contract. |
| src/application/agent/agent-observation-projection.ts | Projects the new occlusion state to the model while preserving existing hidden and disabled semantics. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Document observation] --> B[Walk composed descendants]
  B --> C{Open shadow host?}
  C -->|Yes| D[Traverse shadow-root children]
  C -->|No| E{Filled slot?}
  E -->|Yes| F[Traverse flattened assigned nodes]
  E -->|No| G[Traverse ordinary children]
  D --> H[Collect controls and rendered text]
  F --> H
  G --> H
  H --> I[Check visibility]
  I --> J{Visible control?}
  J -->|Yes| K[Hit-test visible client fragments]
  J -->|No| L[Report hidden]
  K --> M{Every sampled point covered?}
  M -->|Yes| N[Report occluded]
  M -->|No or indeterminate| O[Report reachable]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): follow slot assignments, sha..."](https://github.com/shishir435/ollama-client/commit/0693d081ccee2ecbc951b5430cebeccd43c5922a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62268128)</sub>

<!-- /greptile_comment -->