### PR TITLE
feat(agent): native mouse and keyboard input through the debugger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,10 +415,12 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
 - **Native input is chosen before the action and never swapped after it.**
   `chooseAgentInputBackend` (`native-input.ts`) decides `cdp` or `dom` from the
   command, the resolved target and whether the run holds the tab's debugger
-  and can place the target's frame. Link activation, form submission and
-  Enter-on-a-submitting-field stay on the guarded DOM paths whatever is
-  attached — those paths exist so page handlers cannot redirect an approved
-  destination, and a native click would hand it back to the page. Once a
+  and can place the target's frame. Link activation, form submission,
+  Enter-on-a-submitting-field and a newline typed into one stay on the
+  guarded DOM paths whatever is attached — those paths exist so page handlers
+  cannot redirect an approved destination, and a native click or Enter would
+  hand it back to the page. A chord on a character the key table cannot press
+  has no native form and goes to the DOM path too. Once a
   native step has been sent, a failure is an unresolved effect; it is not
   completed through the content script. Only a plan the debugger refused from
   its first step is a clean `AgentEffectNotAppliedError`.
@@ -442,8 +444,10 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
   state-changing event the plan did not send is `interference` (a real hand on
   the page), and the verifier pauses the step as unresolved rather than
   crediting or retrying it; stray `mousemove`s are ignored because the browser
-  synthesizes them after layout. `misdirected`, `partial`, `undelivered` and
-  `unknown` (the document navigated before it could answer) are told apart on
+  synthesizes them after layout. A key's release is not judged for target —
+  after Tab it lands on the next control. `misdirected`, `partial`,
+  `undelivered` and `unknown` (the document navigated before it could answer,
+  or the plan was inserted text with no events to match) are told apart on
   the receipt. Native and user events are both trusted, so this is the only
   discriminator there is — a user event that exactly matches the plan is
   indistinguishable, and the limitation is stated rather than papered over.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,6 +412,50 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
   joins the scope in the same claim that moves the run onto it. The debugger
   attachment follows the controlled tab in that write, before any page work
   is claimed there.
+- **Native input is chosen before the action and never swapped after it.**
+  `chooseAgentInputBackend` (`native-input.ts`) decides `cdp` or `dom` from the
+  command, the resolved target and whether the run holds the tab's debugger
+  and can place the target's frame. Link activation, form submission and
+  Enter-on-a-submitting-field stay on the guarded DOM paths whatever is
+  attached — those paths exist so page handlers cannot redirect an approved
+  destination, and a native click would hand it back to the page. Once a
+  native step has been sent, a failure is an unresolved effect; it is not
+  completed through the content script. Only a plan the debugger refused from
+  its first step is a clean `AgentEffectNotAppliedError`.
+- **A native plan is a sequence the runner owes a release for.**
+  `runAgentNativeInputPlan` sends one step at a time, checks cancellation
+  between steps, and on abort or dispatcher failure releases every held button
+  and key (reverse order) before throwing with the count dispatched. It never
+  re-sends a step. `Input.*` and `DOM.*` method names live only in the session
+  manager, behind `nativeInput(runId, tabId)`; the planner speaks in steps.
+- **The page picks the point, the debugger places the frame.** Preparation
+  (`prepareAgentNativeInputInDocument`) runs the same target guards as
+  synthetic execution, scrolls the element into view, takes the first
+  hit-testable point from the occlusion sampler, and arms an input record —
+  all in one synchronous pass. Coordinates are the frame's own viewport
+  pixels; the background adds the frame's root offset from the debugger's
+  frame tree (`DOM.getFrameOwner` + `DOM.getBoxModel`, one hop per session),
+  so a child document cannot steer a click by misreporting where it sits.
+- **Delivery is matched, not assumed.** The page records trusted
+  `mousemove/mousedown/mouseup/keydown/keyup/wheel` while a plan is in flight;
+  `assessAgentInputDelivery` matches the record against the plan. A
+  state-changing event the plan did not send is `interference` (a real hand on
+  the page), and the verifier pauses the step as unresolved rather than
+  crediting or retrying it; stray `mousemove`s are ignored because the browser
+  synthesizes them after layout. `misdirected`, `partial`, `undelivered` and
+  `unknown` (the document navigated before it could answer) are told apart on
+  the receipt. Native and user events are both trusted, so this is the only
+  discriminator there is — a user event that exactly matches the plan is
+  indistinguishable, and the limitation is stated rather than papered over.
+- `double_click` and `hover` are element actions in the DOM-mutation family;
+  `press_key` accepts chords (`Shift+Tab`, `Control+a`) through the grammar in
+  `packages/contracts/src/agent-keys.ts`. Select-all and move-to-end travel as
+  CDP editing commands, not platform shortcuts, so a plan is the same on every
+  OS. Native `<select>`, `check` and `uncheck` stay synthetic: a native option
+  popup cannot be driven, and a checked state is stated, not toggled.
+- Firefox has no debugger: `double_click` and `hover` degrade to synthetic
+  events there, the receipt says `backend: "dom"`, and the hover verifier
+  then needs page evidence, since no delivery record exists.
 - Read-only helpers: `src/lib/browser-sessions.ts`. Model tools: `src/lib/tools/internal/browser-session-tools.ts`.
 - `sessions` is an optional permission. Always check browser support **and** the live permission before reading recently-closed or synced-device sessions.
 - Session URLs must pass the same unreadable/never-read filters as other browser tools.

--- a/e2e/chromium/critical/__tests__/agent-native-input.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-native-input.spec.ts
@@ -16,15 +16,17 @@ import { expect } from "../../fixtures/extension"
  * events came from the browser's input pipeline.
  */
 
-const executedNatively = (outcome: AgentScenarioOutcome, action: string) =>
-  outcome.phases.some(
-    (line) =>
-      line.phase === "executed" &&
-      line.backend === "cdp" &&
-      outcome.phases.some(
-        (earlier) => earlier.phase === "executing" && earlier.action === action
-      )
+/**
+ * Every execution of `action` in this run went through the debugger. The
+ * executed record names its action, so a native click beside a key action that
+ * fell back to the DOM cannot vouch for it.
+ */
+const executedNatively = (outcome: AgentScenarioOutcome, action: string) => {
+  const executed = outcome.phases.filter(
+    (line) => line.phase === "executed" && line.action === action
   )
+  return executed.length > 0 && executed.every((line) => line.backend === "cdp")
+}
 
 /**
  * A listbox-backed dropdown built the way component libraries build them: a

--- a/e2e/chromium/critical/__tests__/agent-native-input.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-native-input.spec.ts
@@ -1,0 +1,217 @@
+import type {
+  AgentFixtureObservation,
+  AgentScenarioOutcome
+} from "../../fixtures/agent-scenario"
+import {
+  agentFixtureElement,
+  runAgentScenario
+} from "../../fixtures/agent-scenario"
+import { expect } from "../../fixtures/extension"
+
+/**
+ * Native input through the attached debugger: real pointer and key events a
+ * page cannot tell from a user's. Each fixture only reacts to what a synthetic
+ * DOM event cannot produce — a `mousedown` before a `click`, a `keydown` for
+ * every character, an arrow key on a focused listbox — so a pass proves the
+ * events came from the browser's input pipeline.
+ */
+
+const executedNatively = (outcome: AgentScenarioOutcome, action: string) =>
+  outcome.phases.some(
+    (line) =>
+      line.phase === "executed" &&
+      line.backend === "cdp" &&
+      outcome.phases.some(
+        (earlier) => earlier.phase === "executing" && earlier.action === action
+      )
+  )
+
+/**
+ * A listbox-backed dropdown built the way component libraries build them: a
+ * `combobox` button that opens on `mousedown` (not `click`), options that
+ * commit on `mouseup`, and a status line that reflects the committed value.
+ */
+const dropdownPage = `<!doctype html><title>Agent dropdown</title><main>
+<h1>Region</h1>
+<button id="opener" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-label="Region">Choose region</button>
+<ul id="list" role="listbox" aria-label="Regions" hidden>
+  <li role="option" tabindex="-1" data-value="north">North</li>
+  <li role="option" tabindex="-1" data-value="south">South</li>
+</ul>
+<p id="status">Status: unset</p>
+<script>
+  const opener = document.getElementById('opener')
+  const list = document.getElementById('list')
+  const status = document.getElementById('status')
+  let armed = false
+  opener.addEventListener('mousedown', () => { armed = true })
+  opener.addEventListener('click', () => {
+    if (!armed) return
+    armed = false
+    list.hidden = false
+    opener.setAttribute('aria-expanded', 'true')
+  })
+  for (const option of list.querySelectorAll('[role=option]')) {
+    let pressed = false
+    option.addEventListener('mousedown', () => { pressed = true })
+    option.addEventListener('mouseup', () => {
+      if (!pressed) return
+      pressed = false
+      status.textContent = 'Status: ' + option.dataset.value
+      list.hidden = true
+      opener.setAttribute('aria-expanded', 'false')
+      fetch('/effect')
+    })
+  }
+</script></main>`
+
+runAgentScenario({
+  name: "native dropdown",
+  goal: "Choose the South region and report the status.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => dropdownPage,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("Status: south"))
+      return { type: "complete", summary: "south" }
+    const option = agentFixtureElement(
+      observation,
+      (element) => element.role === "option" && element.name === "South"
+    )
+    if (option) return { type: "click", ref: option.ref }
+    return {
+      type: "click",
+      ref: agentFixtureElement(
+        observation,
+        (element) => element.role === "combobox"
+      )?.ref
+    }
+  },
+  async verify(outcome) {
+    await expect(outcome.page.getByText("Status: south")).toBeVisible()
+    expect(outcome.snapshot?.run?.result).toContain("south")
+    expect(
+      outcome.snapshot?.steps
+        .filter((step) => step.status === "verified")
+        .map((step) => step.command?.type)
+    ).toEqual(["click", "click"])
+    expect(executedNatively(outcome, "click")).toBe(true)
+    await expect.poll(outcome.effects).toBe(1)
+  }
+})
+
+/**
+ * A controlled field of the kind frameworks render: its displayed value is
+ * re-rendered from state on every `input` event, and the page also counts the
+ * character `keydown` events it saw, chords excluded. A value set from script
+ * produces no keydowns, so the count is what tells typed text from assigned
+ * text.
+ */
+const controlledPage = `<!doctype html><title>Agent controlled input</title><main>
+<h1>Profile</h1>
+<label for="name">Name</label>
+<input id="name" autocomplete="off">
+<p id="status">Keys: 0</p>
+<p id="value">Value: </p>
+<script>
+  const input = document.getElementById('name')
+  let state = ''
+  let keys = 0
+  input.addEventListener('keydown', (event) => {
+    if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) keys += 1
+    document.getElementById('status').textContent = 'Keys: ' + keys
+  })
+  input.addEventListener('input', () => {
+    state = input.value
+    input.value = state
+    document.getElementById('value').textContent = 'Value: ' + state
+  })
+</script></main>`
+
+runAgentScenario({
+  name: "native typing",
+  goal: "Enter Alice as the name and report how many keys the page counted.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => controlledPage,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("Value: Alice"))
+      return {
+        type: "complete",
+        summary: observation.text.match(/Keys: \d+/)?.[0] ?? ""
+      }
+    const field = agentFixtureElement(
+      observation,
+      (element) => element.tag === "input"
+    )
+    return { type: "clear_and_type", ref: field?.ref, text: "Alice" }
+  },
+  async verify(outcome) {
+    await expect(outcome.page.getByText("Value: Alice")).toBeVisible()
+    await expect(outcome.page.getByText("Keys: 5")).toBeVisible()
+    expect(outcome.snapshot?.run?.result).toContain("Keys: 5")
+    expect(executedNatively(outcome, "clear_and_type")).toBe(true)
+  }
+})
+
+/**
+ * Keyboard navigation inside a focused listbox: ArrowDown moves the active
+ * option and Enter commits it. Only a key event the browser itself delivers
+ * reaches the focused element with default handling intact.
+ */
+const listboxPage = `<!doctype html><title>Agent listbox</title><main>
+<h1>Size</h1>
+<ul id="sizes" role="listbox" tabindex="0" aria-label="Size" aria-activedescendant="s1">
+  <li id="s1" role="option" aria-selected="true">Small</li>
+  <li id="s2" role="option">Medium</li>
+  <li id="s3" role="option">Large</li>
+</ul>
+<p id="active">Active: Small</p>
+<p id="status">Status: none</p>
+<script>
+  const list = document.getElementById('sizes')
+  const options = [...list.querySelectorAll('[role=option]')]
+  let active = 0
+  const render = () => {
+    options.forEach((option, index) => option.setAttribute('aria-selected', String(index === active)))
+    list.setAttribute('aria-activedescendant', options[active].id)
+    document.getElementById('active').textContent = 'Active: ' + options[active].textContent
+  }
+  list.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowDown') { active = Math.min(active + 1, options.length - 1); render(); event.preventDefault() }
+    if (event.key === 'ArrowUp') { active = Math.max(active - 1, 0); render(); event.preventDefault() }
+    if (event.key === 'Enter') {
+      document.getElementById('status').textContent = 'Status: ' + options[active].textContent
+      fetch('/effect')
+    }
+  })
+</script></main>`
+
+runAgentScenario({
+  name: "native keyboard navigation",
+  goal: "Select the Large size with the keyboard and report the status.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => listboxPage,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("Status: Large"))
+      return { type: "complete", summary: "Large" }
+    const list = agentFixtureElement(
+      observation,
+      (element) => element.role === "listbox"
+    )
+    if (!list) return { type: "fail", reason: "no listbox" }
+    if (!list.focused) return { type: "click", ref: list.ref }
+    return {
+      type: "press_key",
+      ref: list.ref,
+      key: observation.text.includes("Active: Large") ? "Enter" : "ArrowDown"
+    }
+  },
+  async verify(outcome) {
+    await expect(outcome.page.getByText("Status: Large")).toBeVisible()
+    expect(outcome.snapshot?.run?.result).toContain("Large")
+    expect(executedNatively(outcome, "press_key")).toBe(true)
+    await expect.poll(outcome.effects).toBe(1)
+  }
+})

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -32,6 +32,7 @@ export interface AgentFixtureElement {
   type?: string
   value?: string
   checked?: boolean
+  focused?: boolean
   href?: string
   group?: string
   submits?: boolean
@@ -65,6 +66,8 @@ export interface AgentScenarioOutcome {
   wire: { request: unknown; decision?: unknown; response?: string }[]
   /** Live count, so an assertion can poll it. */
   effects: () => number
+  /** Structural run trace lines the worker logged, oldest first. */
+  phases: readonly Record<string, unknown>[]
 }
 
 export interface AgentScenario {
@@ -350,7 +353,15 @@ export const runAgentScenario = (scenario: AgentScenario): void => {
             ?.snapshot,
           messages,
           wire,
-          effects: () => effects
+          effects: () => effects,
+          phases: phases.flatMap((line) =>
+            Array.isArray(line)
+              ? line.filter(
+                  (part): part is Record<string, unknown> =>
+                    typeof part === "object" && part !== null && "phase" in part
+                )
+              : []
+          )
         })
       } finally {
         await testInfo.attach("agent-phases", {

--- a/packages/agent-runtime/src/__tests__/affordance-pointer.test.ts
+++ b/packages/agent-runtime/src/__tests__/affordance-pointer.test.ts
@@ -1,0 +1,171 @@
+import type {
+  AgentCommand,
+  AgentElement,
+  AgentObservation
+} from "@ollama-client/contracts"
+import { describe, expect, it } from "vitest"
+
+import { agentAffordanceFeedback, classifyAgentAffordance } from "../affordance"
+import { evaluateAgentPolicy } from "../policy"
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  frameId: 0,
+  tag: "div",
+  name: "Option",
+  visible: true,
+  enabled: true,
+  editable: false,
+  sensitive: false,
+  ...overrides
+})
+
+const observation = (elements: AgentElement[]): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1",
+  url: "https://example.com/",
+  origin: "https://example.com",
+  title: "Example",
+  frames: [
+    {
+      frameId: 0,
+      documentId: "document-1",
+      origin: "https://example.com",
+      url: "https://example.com/",
+      access: "ok",
+      snapshotId: "snapshot-1",
+      generation: 1
+    }
+  ],
+  elements,
+  visibleText: "",
+  scroll: {
+    x: 0,
+    y: 0,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 100
+  },
+  dialogs: [],
+  capturedAt: 1
+})
+
+const command = (partial: Partial<AgentCommand> & { type: string }) =>
+  ({
+    snapshotId: "snapshot-1",
+    generation: 1,
+    ref: "e1",
+    ...partial
+  }) as AgentCommand
+
+describe("Agent pointer affordances", () => {
+  it("lets a click reach the widget roles a custom dropdown is built from", () => {
+    for (const role of ["combobox", "option", "tab", "treeitem", "switch"]) {
+      expect(
+        classifyAgentAffordance(
+          command({ type: "click" }),
+          observation([element({ role })])
+        ),
+        role
+      ).toBeUndefined()
+    }
+    expect(
+      classifyAgentAffordance(
+        command({ type: "click" }),
+        observation([element({ role: "presentation" })])
+      )?.reason
+    ).toBe("not_clickable")
+  })
+
+  it("sends a double click on a link or submitter back to click", () => {
+    const link = classifyAgentAffordance(
+      command({ type: "double_click" }),
+      observation([element({ tag: "a", href: "https://example.com/next" })])
+    )
+    expect(link?.reason).toBe("use_click_instead")
+    expect(agentAffordanceFeedback(link as never)).toContain("a link")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "double_click" }),
+        observation([element({ tag: "button", submitter: true })])
+      )?.reason
+    ).toBe("use_click_instead")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "double_click" }),
+        observation([element({ tag: "input", type: "checkbox" })])
+      )?.reason
+    ).toBe("use_check_instead")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "double_click" }),
+        observation([element({ role: "listitem" })])
+      )
+    ).toBeUndefined()
+  })
+
+  it("lets a hover rest on a disabled control but not a hidden one", () => {
+    expect(
+      classifyAgentAffordance(
+        command({ type: "hover" }),
+        observation([element({ tag: "button", enabled: false })])
+      )
+    ).toBeUndefined()
+    expect(
+      classifyAgentAffordance(
+        command({ type: "hover" }),
+        observation([element({ visible: false })])
+      )?.reason
+    ).toBe("hidden_target")
+  })
+
+  it("treats a hover as low risk and a chord as an activation", () => {
+    const base = {
+      runId: "run",
+      stepId: "run:1",
+      allowedOrigins: ["https://example.com"],
+      scopedTabIds: [7],
+      now: 1
+    }
+    const hover = evaluateAgentPolicy({
+      ...base,
+      effect: {
+        command: command({ type: "hover" }),
+        target: { sensitive: false, maySubmit: false },
+        semanticEffects: ["hover"],
+        snapshotIdentity: {
+          snapshotId: "snapshot-1",
+          generation: 1,
+          tabId: 7,
+          frameId: 0,
+          documentId: "document-1"
+        },
+        sourceUrl: "https://example.com/",
+        sourceOrigin: "https://example.com"
+      }
+    })
+    expect(hover).toEqual({ type: "allow", risk: "low" })
+    const chord = evaluateAgentPolicy({
+      ...base,
+      effect: {
+        command: command({ type: "press_key", key: "Control+a" } as never),
+        target: { sensitive: false, maySubmit: false },
+        semanticEffects: ["activation"],
+        snapshotIdentity: {
+          snapshotId: "snapshot-1",
+          generation: 1,
+          tabId: 7,
+          frameId: 0,
+          documentId: "document-1"
+        },
+        sourceUrl: "https://example.com/",
+        sourceOrigin: "https://example.com"
+      }
+    })
+    expect(chord.type).toBe("approval_required")
+  })
+})

--- a/packages/agent-runtime/src/affordance.ts
+++ b/packages/agent-runtime/src/affordance.ts
@@ -30,6 +30,7 @@ export const AGENT_AFFORDANCE_REASONS = [
   "radio_uncheck",
   "not_clickable",
   "use_check_instead",
+  "use_click_instead",
   "image_submit",
   "not_focused"
 ] as const
@@ -123,7 +124,25 @@ const reportable = (
 
 const TEXT_INPUT_TYPES = ["email", "number", "search", "tel", "text", "url"]
 const CLICKABLE_INPUT_TYPES = ["button", "image", "reset", "submit"]
-const CLICKABLE_ROLES = ["button", "link", "menuitem"]
+/**
+ * Widget roles a pointer activates. Custom dropdowns, tab strips and tree
+ * views are built from these rather than from `<button>`, and a model told it
+ * may only click buttons has no way to open the listbox it can see.
+ */
+const CLICKABLE_ROLES = [
+  "button",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "combobox",
+  "option",
+  "tab",
+  "treeitem",
+  "switch",
+  "gridcell",
+  "listbox"
+]
 
 const refusal = (
   reason: AgentAffordanceReason,
@@ -164,31 +183,53 @@ const isClickable = (element: AgentElement): boolean =>
     CLICKABLE_INPUT_TYPES.includes(inputType(element))) ||
   CLICKABLE_ROLES.includes(element.role?.toLowerCase() ?? "")
 
+const isCheckable = (element: AgentElement): boolean =>
+  element.tag === "input" && ["checkbox", "radio"].includes(inputType(element))
+
+/**
+ * A checkbox is refused to both pointer gestures, because `check` and
+ * `uncheck` state the intended value and can therefore be verified, while a
+ * click states a toggle. Saying so is the point: told to click a button
+ * instead, a model has no way to reach the box it can see.
+ */
+const classifyClick = (
+  element: AgentElement
+): AgentAffordanceRefusal | undefined => {
+  if (element.tag === "input" && inputType(element) === "image") {
+    return refusal("image_submit", element)
+  }
+  if (isCheckable(element)) return refusal("use_check_instead", element)
+  /** A rendered destination is activation enough, whatever the tag is. */
+  return element.href || isClickable(element)
+    ? undefined
+    : refusal("not_clickable", element)
+}
+
+/**
+ * A link or a submitter acts on the first click; the second would land on
+ * whatever page replaced it. `click` carries the guarded navigation and
+ * submission paths, so it is the one to use.
+ */
+const classifyDoubleClick = (
+  element: AgentElement
+): AgentAffordanceRefusal | undefined => {
+  if (isCheckable(element)) return refusal("use_check_instead", element)
+  return element.href || element.submitter
+    ? refusal("use_click_instead", element)
+    : undefined
+}
+
 const classifyTarget = (
   command: AgentCommand,
   element: AgentElement
 ): AgentAffordanceRefusal | undefined => {
   switch (command.type) {
     case "click":
-      if (element.tag === "input" && inputType(element) === "image") {
-        return refusal("image_submit", element)
-      }
-      /**
-       * A checkbox is refused, because `check` and `uncheck` state the
-       * intended value and can therefore be verified, while a click states a
-       * toggle. Saying so is the point: told to click a button instead, a
-       * model has no way to reach the box it can see.
-       */
-      if (
-        element.tag === "input" &&
-        ["checkbox", "radio"].includes(inputType(element))
-      ) {
-        return refusal("use_check_instead", element)
-      }
-      /** A rendered destination is activation enough, whatever the tag is. */
-      return element.href || isClickable(element)
-        ? undefined
-        : refusal("not_clickable", element)
+      return classifyClick(element)
+    case "double_click":
+      return classifyDoubleClick(element)
+    case "hover":
+      return undefined
     case "type":
     case "clear_and_type":
       return acceptsText(element)
@@ -245,6 +286,8 @@ export const classifyAgentAffordance = (
     return { reason: "ambiguous_ref", ref: command.ref }
   const element = candidates[0]
   if (!element.visible) return refusal("hidden_target", element)
+  /** A pointer may rest on a disabled control — that is how its tooltip shows. */
+  if (command.type === "hover") return undefined
   if (!element.enabled) return refusal("disabled_target", element)
   /** A scroll only needs a real element; it changes nothing about it. */
   return command.type === "scroll"
@@ -299,6 +342,8 @@ export const agentAffordanceFeedback = (
       return `${ref} is ${described(refused)} and is not an activatable control. Click a button, a link or a menuitem.`
     case "use_check_instead":
       return `${ref} is a ${refused.inputType === "radio" ? "radio button" : "checkbox"}. Use check or uncheck on it rather than click, so the intended value is stated.`
+    case "use_click_instead":
+      return `${ref} is ${refused.tag === "a" ? "a link" : "a submit control"}. Use click on it; a double click would act on the page it leaves.`
     case "image_submit":
       return `${ref} is an image submit control, which this agent cannot activate. Use a different control.`
     case "not_focused":

--- a/packages/agent-runtime/src/policy.ts
+++ b/packages/agent-runtime/src/policy.ts
@@ -34,6 +34,7 @@ const effectRisk = (effect: AgentSemanticEffect): AgentRisk => {
   switch (effect) {
     case "read":
     case "scroll":
+    case "hover":
       return "low"
     case "navigation":
       return "medium"

--- a/packages/agent-runtime/src/ports.ts
+++ b/packages/agent-runtime/src/ports.ts
@@ -124,6 +124,8 @@ export interface AgentDestination {
 export type AgentSemanticEffect =
   | "read"
   | "scroll"
+  /** A pointer arriving on a control and staying there; nothing is pressed. */
+  | "hover"
   | "navigation"
   | "activation"
   | "form_mutation"
@@ -171,12 +173,46 @@ export interface AuthorizedAgentEffect extends ResolvedAgentEffect {
       }
 }
 
+/**
+ * How an effect reached the page. `cdp` is native input through the attached
+ * debugger — real pointer and key events the page cannot tell from a user's;
+ * `dom` is the content script's synthetic events and value setters. Chosen
+ * before the action and recorded so the verifier knows what evidence it may
+ * expect, and never changed afterwards: an action whose native delivery is
+ * uncertain is not retried through the other backend.
+ */
+export type AgentInputBackend = "cdp" | "dom"
+
+/**
+ * What the page reported receiving while native input was in flight.
+ *
+ * `delivered`: exactly the planned events arrived, on the resolved target.
+ * `misdirected`: the planned events arrived, but on some other element.
+ * `partial`: the plan was cut short — some planned events arrived, the rest
+ * did not, typically because the document went away or the run was stopped.
+ * `undelivered`: no trusted input reached the document at all.
+ * `interference`: trusted input the plan did not send was observed — a real
+ * pointer or keyboard was in use while the agent acted, so what the page did
+ * cannot be attributed to the agent alone.
+ * `unknown`: the document could not be asked, usually because the action
+ * navigated it away; the verifier falls back to page evidence.
+ */
+export type AgentInputDelivery =
+  | "delivered"
+  | "misdirected"
+  | "partial"
+  | "undelivered"
+  | "interference"
+  | "unknown"
+
 export interface AgentExecutionReceipt {
   /** Ephemeral exact native submission destination. Contains form values; never persist or log. */
   submissionUrl?: string
   executedAt: number
   details?: string
   controlledTabId?: number
+  backend?: AgentInputBackend
+  inputDelivery?: AgentInputDelivery
 }
 
 export interface AgentVerificationEvidence {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,6 +8,7 @@
     "./agent": "./src/agent.ts",
     "./agent-command": "./src/agent-command.ts",
     "./agent-events": "./src/agent-events.ts",
+    "./agent-keys": "./src/agent-keys.ts",
     "./agent-observation": "./src/agent-observation.ts",
     "./agent-panel": "./src/agent-panel.ts",
     "./app-failure": "./src/app-failure.ts",

--- a/packages/contracts/src/__tests__/agent-keys.test.ts
+++ b/packages/contracts/src/__tests__/agent-keys.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import { AgentCommandSchema } from "../agent-command"
+import {
+  AgentKeyCombinationSchema,
+  formatAgentKeyCombination,
+  parseAgentKeyCombination
+} from "../agent-keys"
+
+describe("Agent key combinations", () => {
+  it("parses named keys, characters and modifier chords in canonical order", () => {
+    expect(parseAgentKeyCombination("Enter")).toEqual({
+      modifiers: [],
+      key: "Enter"
+    })
+    expect(parseAgentKeyCombination("a")).toEqual({ modifiers: [], key: "a" })
+    expect(parseAgentKeyCombination("Shift+Tab")).toEqual({
+      modifiers: ["Shift"],
+      key: "Tab"
+    })
+    expect(parseAgentKeyCombination("Shift+Control+a")).toEqual({
+      modifiers: ["Control", "Shift"],
+      key: "a"
+    })
+    expect(
+      formatAgentKeyCombination(
+        parseAgentKeyCombination("Shift+Control+a") as never
+      )
+    ).toBe("Control+Shift+a")
+  })
+
+  it("refuses unknown keys, repeated modifiers, empty tokens and whitespace", () => {
+    for (const value of [
+      "",
+      "F5",
+      "Control+",
+      "+a",
+      "Control+Control+a",
+      "shift+Tab",
+      " ",
+      "Enter ",
+      "ab",
+      "Control+ab"
+    ]) {
+      expect(parseAgentKeyCombination(value), value).toBeUndefined()
+      expect(AgentKeyCombinationSchema.safeParse(value).success, value).toBe(
+        false
+      )
+    }
+  })
+
+  it("admits chords through the press_key command and refuses invented keys", () => {
+    const grounded = { snapshotId: "s1", generation: 1, ref: "e1" }
+    expect(
+      AgentCommandSchema.safeParse({
+        ...grounded,
+        type: "press_key",
+        key: "Control+a"
+      }).success
+    ).toBe(true)
+    expect(
+      AgentCommandSchema.safeParse({
+        ...grounded,
+        type: "press_key",
+        key: "F12"
+      }).success
+    ).toBe(false)
+    expect(
+      AgentCommandSchema.safeParse({ ...grounded, type: "double_click" })
+        .success
+    ).toBe(true)
+    expect(
+      AgentCommandSchema.safeParse({ ...grounded, type: "hover" }).success
+    ).toBe(true)
+  })
+})

--- a/packages/contracts/src/agent-command.ts
+++ b/packages/contracts/src/agent-command.ts
@@ -1,5 +1,7 @@
 import { z } from "zod"
 
+import { AgentKeyCombinationSchema } from "./agent-keys"
+
 /**
  * The longest destination a command may name, matching the cap an observed
  * link carries. It also bounds the work the egress detector does per command.
@@ -36,6 +38,14 @@ export const AgentCommandSchema = z.discriminatedUnion("type", [
   }).strict(),
   GroundedCommandSchema.extend({ type: z.literal("extract_text") }).strict(),
   ElementCommandSchema.extend({ type: z.literal("click") }).strict(),
+  /**
+   * Pointer actions a synthetic DOM event cannot stand in for. A double click
+   * is two native clicks the page may read as one gesture, and a hover is a
+   * pointer that arrives and stays — neither exists without a real pointer,
+   * so both run on the native input backend where one is attached.
+   */
+  ElementCommandSchema.extend({ type: z.literal("double_click") }).strict(),
+  ElementCommandSchema.extend({ type: z.literal("hover") }).strict(),
   ElementCommandSchema.extend({
     type: z.literal("type"),
     text: z.string().min(1).max(500)
@@ -44,9 +54,13 @@ export const AgentCommandSchema = z.discriminatedUnion("type", [
     type: z.literal("clear_and_type"),
     text: z.string().max(500)
   }).strict(),
+  /**
+   * A key or a combination, `Shift+Tab` or `Control+a` included; see
+   * `agent-keys.ts` for the grammar. The target must already hold focus.
+   */
   ElementCommandSchema.extend({
     type: z.literal("press_key"),
-    key: z.enum(["Enter", "Escape", "Tab", "ArrowUp", "ArrowDown"])
+    key: AgentKeyCombinationSchema
   }).strict(),
   ElementCommandSchema.extend({
     type: z.literal("select"),

--- a/packages/contracts/src/agent-keys.ts
+++ b/packages/contracts/src/agent-keys.ts
@@ -1,0 +1,93 @@
+import { z } from "zod"
+
+/**
+ * The keys a `press_key` command may name, by their `KeyboardEvent.key` value.
+ * Bounded on purpose: a key the table does not know has no key code to
+ * dispatch natively, so admitting it would only produce a synthetic event the
+ * page can tell from a real one.
+ */
+export const AGENT_NAMED_KEYS = [
+  "Enter",
+  "Escape",
+  "Tab",
+  "Backspace",
+  "Delete",
+  "Space",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown"
+] as const
+export type AgentNamedKey = (typeof AGENT_NAMED_KEYS)[number]
+
+export const AGENT_KEY_MODIFIERS = ["Control", "Shift", "Alt", "Meta"] as const
+export type AgentKeyModifier = (typeof AGENT_KEY_MODIFIERS)[number]
+
+export const MAX_AGENT_KEY_COMBINATION_CHARS = 40
+
+export interface AgentKeyCombination {
+  /** Modifiers in canonical order, each at most once. */
+  modifiers: readonly AgentKeyModifier[]
+  /** A named key, or one printable character. */
+  key: AgentNamedKey | string
+}
+
+const isNamedKey = (value: string): value is AgentNamedKey =>
+  (AGENT_NAMED_KEYS as readonly string[]).includes(value)
+
+const isModifier = (value: string): value is AgentKeyModifier =>
+  (AGENT_KEY_MODIFIERS as readonly string[]).includes(value)
+
+/** One printable, non-space character: a letter, digit or punctuation mark. */
+const isPrintableCharacter = (value: string): boolean =>
+  [...value].length === 1 && !/[\s\p{C}]/u.test(value)
+
+/**
+ * Parses `Modifier+...+Key`, e.g. `Enter`, `Shift+Tab`, `Control+a`.
+ *
+ * Modifiers are case-sensitive names so `Alt` cannot be confused with a
+ * character key; the final token is a named key or a single character. The
+ * `+` character itself is spelled as the last token of a combination whose
+ * other tokens are modifiers, e.g. `Control++` is not accepted — a plus key is
+ * rare enough that ambiguity is not worth carrying.
+ */
+export const parseAgentKeyCombination = (
+  value: string
+): AgentKeyCombination | undefined => {
+  if (value.length === 0 || value.length > MAX_AGENT_KEY_COMBINATION_CHARS) {
+    return undefined
+  }
+  const tokens = value.split("+")
+  const key = tokens.pop()
+  if (key === undefined || tokens.some((token) => token.length === 0)) {
+    return undefined
+  }
+  if (!isNamedKey(key) && !isPrintableCharacter(key)) return undefined
+  const modifiers: AgentKeyModifier[] = []
+  for (const token of tokens) {
+    if (!isModifier(token) || modifiers.includes(token)) return undefined
+    modifiers.push(token)
+  }
+  modifiers.sort(
+    (first, second) =>
+      AGENT_KEY_MODIFIERS.indexOf(first) - AGENT_KEY_MODIFIERS.indexOf(second)
+  )
+  return { modifiers, key }
+}
+
+export const formatAgentKeyCombination = (
+  combination: AgentKeyCombination
+): string => [...combination.modifiers, combination.key].join("+")
+
+export const AgentKeyCombinationSchema = z
+  .string()
+  .min(1)
+  .max(MAX_AGENT_KEY_COMBINATION_CHARS)
+  .refine((value) => parseAgentKeyCombination(value) !== undefined, {
+    message:
+      "A key is a named key or one character, optionally preceded by Control, Shift, Alt or Meta joined with +"
+  })

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./agent"
 export * from "./agent-command"
 export * from "./agent-events"
+export * from "./agent-keys"
 export * from "./agent-observation"
 export * from "./agent-panel"
 export * from "./app-failure"

--- a/src/application/agent/agent-decision-parser.ts
+++ b/src/application/agent/agent-decision-parser.ts
@@ -58,6 +58,8 @@ const COMMAND_FIELDS: Record<string, readonly string[]> = {
   find: ["query"],
   extract_text: [],
   click: ["ref"],
+  double_click: ["ref"],
+  hover: ["ref"],
   type: ["ref", "text"],
   clear_and_type: ["ref", "text"],
   select: ["ref", "value"],

--- a/src/application/agent/agent-model-port.ts
+++ b/src/application/agent/agent-model-port.ts
@@ -44,6 +44,8 @@ const agentDecisionParameters = (): ToolParameterSchema => ({
       enum: [
         "read",
         "click",
+        "double_click",
+        "hover",
         "type",
         "clear_and_type",
         "select",
@@ -70,7 +72,7 @@ const agentDecisionParameters = (): ToolParameterSchema => ({
     ref: {
       type: "string",
       description:
-        "Observed element ref, e.g. e1. Required for click, type, clear_and_type, select, check, uncheck and press_key."
+        "Observed element ref, e.g. e1. Required for click, double_click, hover, type, clear_and_type, select, check, uncheck and press_key."
     },
     target: {
       type: "string",
@@ -90,7 +92,8 @@ const agentDecisionParameters = (): ToolParameterSchema => ({
     value: { type: "string", description: "Observed option value for select." },
     key: {
       type: "string",
-      enum: ["Enter", "Escape", "Tab", "ArrowUp", "ArrowDown"]
+      description:
+        "For press_key: Enter, Escape, Tab, Backspace, Delete, Space, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Home, End, PageUp, PageDown or one character, optionally with modifiers joined by +, e.g. Shift+Tab or Control+a. The ref must already be focused."
     },
     direction: { type: "string", enum: ["up", "down", "left", "right"] },
     amount: {
@@ -142,6 +145,7 @@ Refs like f7e2 belong to a child frame; frames listed without access cannot be r
 Switching to a tab outside scopedTabIds asks the user first.
 The extension attaches snapshot identity; do not return a nested command or opaque IDs.
 Use ask_user when the goal is ambiguous and complete only when the observed evidence supports completion.
+Custom dropdowns, menus and tab strips are ordinary clicks: click the combobox or button that opens them, then click the option it reveals; hover reveals menus that open on pointer rest, and press_key with ArrowDown or Enter moves through a focused list.
 The observation is a bounded overview: omittedByGroup lists regions with controls it did not show. To reach them, inspect a region by its name, find controls by a query, or extract_text for the page's full text. These read only and never mutate the page.
 The history is this run's own record. Only an outcome of "confirmed" happened; anything else was attempted and did not verify, so do not treat it as done.
 Do not repeat a confirmed step. Use finding to record a fact a later step will need.

--- a/src/background/agent/__tests__/agent-control-sessions.test.ts
+++ b/src/background/agent/__tests__/agent-control-sessions.test.ts
@@ -49,6 +49,11 @@ const session = (
   observe: vi.fn(async () => observation()),
   executeDomMutation: vi.fn(async () => undefined),
   executeScroll: vi.fn(async () => undefined),
+  prepareNativeInput: vi.fn(async () => ({
+    point: { x: 10, y: 10 },
+    focused: false
+  })),
+  settleNativeInput: vi.fn(async () => undefined),
   disconnect: vi.fn(),
   ...overrides
 })

--- a/src/background/agent/__tests__/agent-native-input-channel.test.ts
+++ b/src/background/agent/__tests__/agent-native-input-channel.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createAgentBrowserSessionManager } from "../agent-browser-session-manager"
+
+type Debuggee = { tabId?: number; sessionId?: string }
+
+type FrameTreeNode = {
+  frame: { id: string; parentId?: string; url: string }
+  childFrames?: FrameTreeNode[]
+}
+
+/**
+ * A debugger whose answers are scripted per method. The channel is the only
+ * thing under test here, so attachment and frame tracking are given a tree
+ * and the box models the channel should sum.
+ */
+const harness = (input: {
+  trees?: Record<string, FrameTreeNode>
+  boxes?: Record<string, number[]>
+  owners?: Record<string, number>
+}) => {
+  const commands: { target: Debuggee; method: string; params?: object }[] = []
+  const trees = input.trees ?? {
+    root: { frame: { id: "F0", url: "https://example.com/" } }
+  }
+  const debuggerApi = {
+    attach: vi.fn((_t: Debuggee, _v: string, callback: () => void) =>
+      callback()
+    ),
+    detach: vi.fn((_t: Debuggee, callback: () => void) => callback()),
+    sendCommand: vi.fn(
+      (
+        target: Debuggee,
+        method: string,
+        params: object | undefined,
+        callback: (result?: unknown) => void
+      ) => {
+        commands.push({ target, method, params })
+        switch (method) {
+          case "Page.getFrameTree":
+            callback({ frameTree: trees[target.sessionId ?? "root"] })
+            return
+          case "DOM.getFrameOwner": {
+            const frameId = (params as { frameId: string }).frameId
+            callback({ backendNodeId: input.owners?.[frameId] ?? 1 })
+            return
+          }
+          case "DOM.getBoxModel": {
+            const id = (params as { backendNodeId: number }).backendNodeId
+            callback({
+              model: { content: input.boxes?.[String(id)] ?? [0, 0] }
+            })
+            return
+          }
+          case "Page.getLayoutMetrics":
+            callback({
+              cssLayoutViewport: { clientWidth: 800, clientHeight: 600 }
+            })
+            return
+          default:
+            callback({})
+        }
+      }
+    ),
+    onDetach: { addListener: vi.fn(), removeListener: vi.fn() },
+    onEvent: { addListener: vi.fn(), removeListener: vi.fn() }
+  }
+  const tabs = {
+    onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
+    onUpdated: { addListener: vi.fn(), removeListener: vi.fn() }
+  }
+  const manager = createAgentBrowserSessionManager({
+    debugger: debuggerApi,
+    tabs,
+    classifyAccess: async () => "ok",
+    readLastError: () => undefined
+  })
+  const sent = (method: string) =>
+    commands.filter((command) => command.method === method)
+  return { manager, commands, sent }
+}
+
+describe("Agent native input channel", () => {
+  it("is absent without an attachment and for a tab the run does not hold", async () => {
+    const { manager } = harness({})
+    expect(manager.nativeInput("run-1", 7)).toBeUndefined()
+    await manager.attach("run-1", 7)
+    expect(manager.nativeInput("run-1", 8)).toBeUndefined()
+    expect(manager.nativeInput("run-1", 7)).toBeDefined()
+    await manager.detach("run-1")
+    expect(manager.nativeInput("run-1", 7)).toBeUndefined()
+  })
+
+  it("translates mouse, key, text and wheel steps to Input commands on the tab target", async () => {
+    const { manager, sent } = harness({})
+    await manager.attach("run-1", 7)
+    const channel = manager.nativeInput("run-1", 7)
+    if (!channel) throw new Error("channel missing")
+    await channel.dispatch({
+      kind: "mouse",
+      type: "mousePressed",
+      x: 10,
+      y: 20,
+      button: "left",
+      clickCount: 1,
+      modifiers: 0
+    })
+    await channel.dispatch({
+      kind: "key",
+      type: "keyDown",
+      key: "Tab",
+      code: "Tab",
+      keyCode: 9,
+      modifiers: 8
+    })
+    await channel.dispatch({
+      kind: "key",
+      type: "keyDown",
+      key: "a",
+      code: "KeyA",
+      keyCode: 65,
+      text: "a",
+      modifiers: 0,
+      commands: ["selectAll"]
+    })
+    await channel.dispatch({ kind: "insertText", text: "é" })
+    await channel.dispatch({ kind: "wheel", x: 1, y: 2, deltaX: 0, deltaY: 80 })
+
+    const mouse = sent("Input.dispatchMouseEvent")
+    expect(mouse[0]).toEqual({
+      target: { tabId: 7 },
+      method: "Input.dispatchMouseEvent",
+      params: {
+        type: "mousePressed",
+        x: 10,
+        y: 20,
+        button: "left",
+        clickCount: 1,
+        modifiers: 0,
+        buttons: 1
+      }
+    })
+    expect(mouse[1]?.params).toMatchObject({ type: "mouseWheel", deltaY: 80 })
+    const keys = sent("Input.dispatchKeyEvent")
+    /* A key without text is a rawKeyDown, so a chord never also types its letter. */
+    expect(keys[0]?.params).toMatchObject({
+      type: "rawKeyDown",
+      key: "Tab",
+      windowsVirtualKeyCode: 9,
+      modifiers: 8
+    })
+    expect(keys[1]?.params).toMatchObject({
+      type: "keyDown",
+      text: "a",
+      unmodifiedText: "a",
+      commands: ["selectAll"]
+    })
+    expect(sent("Input.insertText")[0]?.params).toEqual({ text: "é" })
+  })
+
+  it("refuses to dispatch through a channel whose attachment was released", async () => {
+    const { manager } = harness({})
+    await manager.attach("run-1", 7)
+    const channel = manager.nativeInput("run-1", 7)
+    await manager.detach("run-1")
+    await expect(
+      channel?.dispatch({ kind: "insertText", text: "x" })
+    ).rejects.toThrow(/no longer attached/)
+  })
+
+  it("places the root frame at the origin and an out-of-process child by its owner's box in the parent session", async () => {
+    const { manager, sent } = harness({
+      trees: {
+        root: {
+          frame: { id: "F0", url: "https://example.com/" },
+          childFrames: [
+            {
+              frame: { id: "F1", parentId: "F0", url: "https://embed.example/" }
+            }
+          ]
+        },
+        "session-1": {
+          frame: { id: "F1", parentId: "F0", url: "https://embed.example/" },
+          childFrames: [
+            {
+              frame: {
+                id: "F2",
+                parentId: "F1",
+                url: "https://embed.example/inner"
+              }
+            }
+          ]
+        }
+      },
+      owners: { F1: 11, F2: 22 },
+      boxes: { "11": [100, 50, 400, 50, 400, 250, 100, 250], "22": [10, 5] }
+    })
+    await manager.attach("run-1", 7)
+    const channel = manager.nativeInput("run-1", 7)
+    if (!channel) throw new Error("channel missing")
+    expect(await channel.frameOffset(0, [])).toEqual({ x: 0, y: 0 })
+    const frames = [
+      { frameId: 0, url: "https://example.com/" },
+      { frameId: 5, parentFrameId: 0, url: "https://embed.example/" }
+    ]
+    expect(await channel.frameOffset(5, frames)).toEqual({ x: 100, y: 50 })
+    expect(sent("DOM.getFrameOwner")[0]).toMatchObject({
+      target: { tabId: 7 },
+      params: { frameId: "F1" }
+    })
+    expect(sent("DOM.enable")).toHaveLength(1)
+    /* An unknown or ambiguous frame is not placed. */
+    expect(await channel.frameOffset(9, frames)).toBeUndefined()
+    expect(await channel.viewportCentre()).toEqual({ x: 400, y: 300 })
+  })
+
+  it("sums a same-process grandchild once per session rather than once per frame", async () => {
+    const { manager } = harness({
+      trees: {
+        root: {
+          frame: { id: "F0", url: "https://example.com/" },
+          childFrames: [
+            {
+              frame: { id: "F1", parentId: "F0", url: "https://example.com/a" },
+              childFrames: [
+                {
+                  frame: {
+                    id: "F2",
+                    parentId: "F1",
+                    url: "https://example.com/b"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      owners: { F1: 11, F2: 22 },
+      boxes: { "11": [100, 50], "22": [130, 70] }
+    })
+    await manager.attach("run-1", 7)
+    const channel = manager.nativeInput("run-1", 7)
+    const frames = [
+      { frameId: 0, url: "https://example.com/" },
+      { frameId: 5, parentFrameId: 0, url: "https://example.com/a" },
+      { frameId: 6, parentFrameId: 5, url: "https://example.com/b" }
+    ]
+    /*
+     * Both owners render in the root session, whose box models are already in
+     * root-viewport coordinates: the grandchild's own owner box is the answer.
+     */
+    expect(await channel?.frameOffset(6, frames)).toEqual({ x: 130, y: 70 })
+  })
+})

--- a/src/background/agent/__tests__/agent-run-service.test.ts
+++ b/src/background/agent/__tests__/agent-run-service.test.ts
@@ -50,6 +50,8 @@ const service = (
     observe: vi.fn(),
     executeDomMutation: vi.fn(),
     executeScroll: vi.fn(),
+    prepareNativeInput: vi.fn(),
+    settleNativeInput: vi.fn(),
     release: vi.fn()
   }
   const created = createAgentRunService({
@@ -112,6 +114,7 @@ const browserSessions = () => {
         if (listener === next) listener = undefined
       }
     }),
+    nativeInput: vi.fn(() => undefined),
     dispose: vi.fn(async () => undefined)
   } satisfies AgentBrowserSessionManager
   return {

--- a/src/background/agent/__tests__/agent-run-start.smoke.test.ts
+++ b/src/background/agent/__tests__/agent-run-start.smoke.test.ts
@@ -97,6 +97,8 @@ const startService = (
       observe: vi.fn(),
       executeDomMutation: vi.fn(),
       executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn(),
       release: vi.fn()
     },
     buildController: () => ({
@@ -281,6 +283,8 @@ describe("starting an Agent run against the real engine", () => {
           observe: vi.fn(),
           executeDomMutation: vi.fn(),
           executeScroll: vi.fn(),
+          prepareNativeInput: vi.fn(),
+          settleNativeInput: vi.fn(),
           release: vi.fn()
         },
         buildController: () => controller,
@@ -328,6 +332,8 @@ describe("starting an Agent run against the real engine", () => {
           observe: vi.fn(),
           executeDomMutation: vi.fn(),
           executeScroll: vi.fn(),
+          prepareNativeInput: vi.fn(),
+          settleNativeInput: vi.fn(),
           release: vi.fn()
         },
         buildController: () => controller,

--- a/src/background/agent/agent-browser-adapters.ts
+++ b/src/background/agent/agent-browser-adapters.ts
@@ -8,12 +8,20 @@ import type { AgentSnapshotIdentity } from "@ollama-client/contracts"
 import type { AgentCommandExecutorAdapter } from "@/lib/browser-agent/command-executor"
 import type { AgentDomMutationInstruction } from "@/lib/browser-agent/control-port"
 import type { AgentEffectVerifierAdapter } from "@/lib/browser-agent/effect-verifier"
+import {
+  type AgentInputPlatform,
+  runAgentNativeInputPlan
+} from "@/lib/browser-agent/native-input"
 import type { AgentEffectResolverAdapter } from "@/lib/browser-agent/resolved-effect"
 import { browser } from "@/lib/browser-api"
 import {
   classifyAgentTabAccess,
   queryActiveTab
 } from "@/lib/browser-tab-access"
+import type {
+  AgentBrowserSessionManager,
+  AgentExtensionFrame
+} from "./agent-browser-session-manager"
 import type { AgentControlSessionRegistry } from "./agent-control-sessions"
 import { waitForAgentNavigation } from "./agent-navigation-settlement"
 import type { AgentTabHistory } from "./agent-tab-history"
@@ -23,6 +31,16 @@ export interface AgentBrowserAdapters {
   resolver: AgentEffectResolverAdapter
   executor: AgentCommandExecutorAdapter
   verifier: AgentEffectVerifierAdapter
+}
+
+/** The platform's primary editing modifier, read once from the worker's own UA. */
+const detectPlatform = (): AgentInputPlatform => {
+  const navigatorLike = globalThis.navigator as
+    | { userAgentData?: { platform?: string }; platform?: string }
+    | undefined
+  const platform =
+    navigatorLike?.userAgentData?.platform ?? navigatorLike?.platform ?? ""
+  return /mac/i.test(platform) ? "mac" : "other"
 }
 
 /**
@@ -36,10 +54,29 @@ export interface AgentBrowserAdapters {
 export const createAgentBrowserAdapters = (input: {
   runId: string
   sessions: AgentControlSessionRegistry
+  /** Absent means no native backend: every action runs through the content script. */
+  browserSessions?: AgentBrowserSessionManager
   history: AgentTabHistory
   now?: () => number
+  platform?: AgentInputPlatform
+  listFrames?: (tabId: number) => Promise<readonly AgentExtensionFrame[]>
 }): AgentBrowserAdapters => {
   const now = input.now ?? (() => Date.now())
+  const platform = input.platform ?? detectPlatform()
+  const listFrames =
+    input.listFrames ??
+    (async (tabId: number): Promise<AgentExtensionFrame[]> => {
+      const frames = (await browser.webNavigation.getAllFrames({ tabId })) as
+        | { frameId: number; parentFrameId?: number; url: string }[]
+        | null
+      return (frames ?? []).map((frame) => ({
+        frameId: frame.frameId,
+        ...(frame.parentFrameId !== undefined && frame.parentFrameId >= 0
+          ? { parentFrameId: frame.parentFrameId }
+          : {}),
+        url: frame.url
+      }))
+    })
 
   const abortSignal = (
     signal: AgentCancellationSignal
@@ -77,6 +114,75 @@ export const createAgentBrowserAdapters = (input: {
       return await browser.tabs.get(tabId)
     } catch {
       return undefined
+    }
+  }
+
+  const targetFrame = (effect: AuthorizedAgentEffect): AgentSnapshotIdentity =>
+    effect.target.frame ?? effect.snapshotIdentity
+
+  const nativeChannel = (effect: AuthorizedAgentEffect) =>
+    input.browserSessions?.nativeInput(
+      input.runId,
+      effect.snapshotIdentity.tabId
+    )
+
+  /**
+   * The native half of the executor adapter, present only when a session
+   * manager was supplied. Facts are read immediately before the action; the
+   * frame offset is resolved from the debugger's tree, never from the page.
+   */
+  const nativeAdapter: Pick<
+    AgentCommandExecutorAdapter,
+    | "nativeControl"
+    | "prepareNativeInput"
+    | "dispatchNativeInput"
+    | "settleNativeInput"
+    | "viewportCentre"
+  > = {
+    async nativeControl(effect) {
+      const channel = nativeChannel(effect)
+      const cdpControl = input.browserSessions?.capabilities.cdpControl ?? false
+      if (!channel) {
+        return { cdpControl, attached: false, frameMapped: false, platform }
+      }
+      const frame = targetFrame(effect)
+      const frames = frame.frameId === 0 ? [] : await listFrames(frame.tabId)
+      const offset = await channel.frameOffset(frame.frameId, frames)
+      return {
+        cdpControl,
+        attached: true,
+        frameMapped: offset !== undefined,
+        ...(offset ? { frameOffset: offset } : {}),
+        platform
+      }
+    },
+    async prepareNativeInput(effect, signal) {
+      return input.sessions.prepareNativeInput(
+        {
+          runId: input.runId,
+          tabId: effect.snapshotIdentity.tabId,
+          instruction: mutationInstruction(effect)
+        },
+        abortSignal(signal)
+      )
+    },
+    async dispatchNativeInput(effect, plan, signal) {
+      const channel = nativeChannel(effect)
+      if (!channel) throw new Error("Agent debugger is no longer attached")
+      return runAgentNativeInputPlan(plan, channel, signal)
+    },
+    async settleNativeInput(effect, signal) {
+      return input.sessions.settleNativeInput(
+        {
+          runId: input.runId,
+          tabId: effect.snapshotIdentity.tabId,
+          frameId: targetFrame(effect).frameId
+        },
+        abortSignal(signal)
+      )
+    },
+    async viewportCentre(effect) {
+      return nativeChannel(effect)?.viewportCentre()
     }
   }
 
@@ -146,6 +252,7 @@ export const createAgentBrowserAdapters = (input: {
           abortSignal(signal)
         )
       },
+      ...(input.browserSessions ? nativeAdapter : {}),
       async activateTab(tabId) {
         await browser.tabs.update(tabId, { active: true })
       },

--- a/src/background/agent/agent-browser-session-manager.ts
+++ b/src/background/agent/agent-browser-session-manager.ts
@@ -1,3 +1,4 @@
+import type { AgentNativeInputStep } from "@/lib/browser-agent/native-input"
 import { browser } from "@/lib/browser-api"
 import { classifyAgentTabAccess } from "@/lib/browser-tab-access"
 
@@ -121,6 +122,28 @@ export interface AgentCdpFrameTree {
   frames: readonly AgentCdpFrame[]
 }
 
+/**
+ * The typed surface native input reaches the debugger through. Steps are the
+ * planner's own vocabulary — a mouse move, a key down, text to insert — and
+ * are translated to protocol messages here, so nothing above this file names
+ * a CDP method or holds a target. A frame's offset is read from the tracked
+ * tree the same way, and nothing else about the page is exposed.
+ */
+export interface AgentNativeInputChannel {
+  dispatch(step: AgentNativeInputStep): Promise<void>
+  /**
+   * Where an extension frame's viewport origin sits in the root viewport, in
+   * CSS pixels, or nothing when the frame cannot be placed exactly. The root
+   * frame is at the origin.
+   */
+  frameOffset(
+    frameId: number,
+    frames: readonly AgentExtensionFrame[]
+  ): Promise<{ x: number; y: number } | undefined>
+  /** The root layout viewport's centre, for input that targets no element. */
+  viewportCentre(): Promise<{ x: number; y: number } | undefined>
+}
+
 export interface AgentBrowserSessionManager {
   readonly capabilities: AgentBrowserCapabilities
   attach(runId: string, tabId: number): Promise<void>
@@ -142,6 +165,12 @@ export interface AgentBrowserSessionManager {
   subscribe(
     listener: (event: AgentBrowserSessionInterruption) => void
   ): () => void
+  /**
+   * The native input channel for the run's attached tab, or nothing when the
+   * run does not hold that tab's debugger. Asked immediately before an action
+   * and used for that action alone.
+   */
+  nativeInput(runId: string, tabId: number): AgentNativeInputChannel | undefined
   dispose(): Promise<void>
 }
 
@@ -156,7 +185,65 @@ interface Attachment {
   ready: Promise<void>
   tracking: "pending" | "tracking" | "unavailable"
   frames: Map<string, AgentCdpFrame>
+  /** Sessions whose `DOM` domain has been enabled for box-model reads. */
+  domEnabled: Set<string>
 }
+
+/** CDP `Input` mouse button and event names for the planner's steps. */
+const MOUSE_EVENT_TYPES = {
+  mouseMoved: "mouseMoved",
+  mousePressed: "mousePressed",
+  mouseReleased: "mouseReleased"
+} as const
+
+const isBoxModel = (
+  value: unknown
+): value is { model: { content: number[] } } =>
+  typeof value === "object" &&
+  value !== null &&
+  "model" in value &&
+  Array.isArray((value as { model?: { content?: unknown } }).model?.content)
+
+const isFrameOwner = (value: unknown): value is { backendNodeId: number } =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { backendNodeId?: unknown }).backendNodeId === "number"
+
+const isLayoutMetrics = (
+  value: unknown
+): value is {
+  cssLayoutViewport: { clientWidth: number; clientHeight: number }
+} => {
+  const viewport = (value as { cssLayoutViewport?: unknown } | null)
+    ?.cssLayoutViewport as { clientWidth?: unknown; clientHeight?: unknown }
+  return (
+    typeof viewport?.clientWidth === "number" &&
+    typeof viewport.clientHeight === "number"
+  )
+}
+
+/**
+ * A key with text is a `keyDown`, which Chromium turns into a character; one
+ * without is a `rawKeyDown`, which produces no character even for a printable
+ * key — how a modifier chord avoids also typing its letter.
+ */
+const keyEventParams = (
+  step: Extract<AgentNativeInputStep, { kind: "key" }>
+): object => ({
+  type: step.type === "keyUp" ? "keyUp" : step.text ? "keyDown" : "rawKeyDown",
+  key: step.key,
+  modifiers: step.modifiers,
+  ...(step.code ? { code: step.code } : {}),
+  ...(step.keyCode !== undefined
+    ? {
+        windowsVirtualKeyCode: step.keyCode,
+        nativeVirtualKeyCode: step.keyCode
+      }
+    : {}),
+  ...(step.text ? { text: step.text, unmodifiedText: step.text } : {}),
+  ...(step.location !== undefined ? { location: step.location } : {}),
+  ...(step.commands?.length ? { commands: [...step.commands] } : {})
+})
 
 const debuggerApi = (): DebuggerApi | undefined =>
   (
@@ -600,6 +687,142 @@ export const createAgentBrowserSessionManager = (input?: {
     }
   }
 
+  const sessionTarget = (attachment: Attachment, sessionId?: string) =>
+    sessionId ? { ...attachment.target, sessionId } : attachment.target
+
+  const ensureDom = async (attachment: Attachment, sessionId?: string) => {
+    const key = sessionId ?? ""
+    if (attachment.domEnabled.has(key)) return
+    await send(sessionTarget(attachment, sessionId), "DOM.enable")
+    attachment.domEnabled.add(key)
+  }
+
+  /**
+   * The top of a frame's session: the frame itself when its parent renders in
+   * another session, else the same for its parent. A box model read in a
+   * session is reported in that session's top frame's viewport, so a frame's
+   * offset is its owner's box plus the offset of the top of the session that
+   * owner renders in — one hop per session, not one per frame.
+   */
+  const sessionTop = (
+    attachment: Attachment,
+    frame: AgentCdpFrame
+  ): AgentCdpFrame => {
+    let current = frame
+    for (;;) {
+      const parent = current.parentCdpFrameId
+        ? attachment.frames.get(current.parentCdpFrameId)
+        : undefined
+      if (!parent || parent.sessionId !== current.sessionId) return current
+      current = parent
+    }
+  }
+
+  const ownerOffset = async (
+    attachment: Attachment,
+    frame: AgentCdpFrame,
+    parent: AgentCdpFrame
+  ): Promise<{ x: number; y: number } | undefined> => {
+    await ensureDom(attachment, parent.sessionId)
+    const target = sessionTarget(attachment, parent.sessionId)
+    const owner = await send(target, "DOM.getFrameOwner", {
+      frameId: frame.cdpFrameId
+    })
+    if (!isFrameOwner(owner)) return undefined
+    const box = await send(target, "DOM.getBoxModel", {
+      backendNodeId: owner.backendNodeId
+    })
+    if (!isBoxModel(box) || box.model.content.length < 2) return undefined
+    const [x, y] = box.model.content
+    return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : undefined
+  }
+
+  const frameOffsetOf = async (
+    attachment: Attachment,
+    mapping: AgentFrameMapping
+  ): Promise<{ x: number; y: number } | undefined> => {
+    if (!mapping.mapped) return undefined
+    const offset = { x: 0, y: 0 }
+    let current = mapping.frame
+    /* Bounded by the tree's own size: a cycle is a tree the browser never reports. */
+    for (let depth = 0; depth <= attachment.frames.size; depth += 1) {
+      if (!current.parentCdpFrameId) return offset
+      const parent = attachment.frames.get(current.parentCdpFrameId)
+      if (!parent) return undefined
+      const owner = await ownerOffset(attachment, current, parent)
+      if (!owner) return undefined
+      offset.x += owner.x
+      offset.y += owner.y
+      current = sessionTop(attachment, parent)
+    }
+    return undefined
+  }
+
+  const dispatchStep = async (
+    attachment: Attachment,
+    step: AgentNativeInputStep
+  ): Promise<void> => {
+    switch (step.kind) {
+      case "mouse":
+        await send(attachment.target, "Input.dispatchMouseEvent", {
+          type: MOUSE_EVENT_TYPES[step.type],
+          x: step.x,
+          y: step.y,
+          button: step.button,
+          clickCount: step.clickCount,
+          modifiers: step.modifiers,
+          ...(step.type === "mousePressed" ? { buttons: 1 } : {})
+        })
+        return
+      case "wheel":
+        await send(attachment.target, "Input.dispatchMouseEvent", {
+          type: "mouseWheel",
+          x: step.x,
+          y: step.y,
+          deltaX: step.deltaX,
+          deltaY: step.deltaY
+        })
+        return
+      case "insertText":
+        await send(attachment.target, "Input.insertText", { text: step.text })
+        return
+      case "key":
+        await send(
+          attachment.target,
+          "Input.dispatchKeyEvent",
+          keyEventParams(step)
+        )
+        return
+    }
+  }
+
+  const channelFor = (attachment: Attachment): AgentNativeInputChannel => ({
+    dispatch: (step) => {
+      if (attachments.get(attachment.runId) !== attachment) {
+        return Promise.reject(new Error("Agent debugger is no longer attached"))
+      }
+      return dispatchStep(attachment, step)
+    },
+    async frameOffset(frameId, frames) {
+      if (attachments.get(attachment.runId) !== attachment) return undefined
+      if (frameId === 0) return { x: 0, y: 0 }
+      if (attachment.tracking !== "tracking") return undefined
+      return frameOffsetOf(
+        attachment,
+        mapExtensionFrame(attachment, frameId, frames)
+      )
+    },
+    async viewportCentre() {
+      if (attachments.get(attachment.runId) !== attachment) return undefined
+      const metrics = await send(attachment.target, "Page.getLayoutMetrics")
+      if (!isLayoutMetrics(metrics)) return undefined
+      return {
+        x: metrics.cssLayoutViewport.clientWidth / 2,
+        y: metrics.cssLayoutViewport.clientHeight / 2
+      }
+    }
+  })
+
   cdp?.onDetach.addListener(onDebuggerDetach)
   cdp?.onEvent?.addListener(onDebuggerEvent)
   tabs.onRemoved.addListener(onTabRemoved)
@@ -631,7 +854,8 @@ export const createAgentBrowserSessionManager = (input?: {
         rawAttach: Promise.resolve(),
         ready: Promise.resolve(),
         tracking: "pending",
-        frames: new Map()
+        frames: new Map(),
+        domEnabled: new Set()
       }
       attachment.rawAttach = cdp
         ? callDebugger(
@@ -690,6 +914,12 @@ export const createAgentBrowserSessionManager = (input?: {
     subscribe(listener) {
       listeners.add(listener)
       return () => listeners.delete(listener)
+    },
+    nativeInput(runId, tabId) {
+      if (!cdp) return undefined
+      const attachment = attachments.get(runId)
+      if (!attachment?.attached || attachment.tabId !== tabId) return undefined
+      return channelFor(attachment)
     },
     async dispose() {
       cdp?.onDetach.removeListener(onDebuggerDetach)

--- a/src/background/agent/agent-control-sessions.ts
+++ b/src/background/agent/agent-control-sessions.ts
@@ -6,6 +6,8 @@ import type {
   AgentControlBrowserFrame,
   AgentControlSession,
   AgentDomMutationInstruction,
+  AgentInputTraceWire,
+  AgentNativeInputPreparedResult,
   AgentScrollInstruction
 } from "@/lib/browser-agent/control-port"
 import { openAgentControlSession } from "@/lib/browser-agent/control-port"
@@ -68,6 +70,25 @@ export interface AgentControlSessionRegistry {
     },
     signal?: AbortSignal
   ): Promise<void>
+  /**
+   * Native input's page-side halves. Preparation rechecks the target and arms
+   * the document's input record; settlement reads that record back once the
+   * debugger has sent the plan. Neither retries: a preparation whose port died
+   * is stale, and a settlement whose port died is a document that navigated —
+   * reported as such, so the verifier reads page evidence instead.
+   */
+  prepareNativeInput(
+    input: {
+      runId: string
+      tabId: number
+      instruction: AgentDomMutationInstruction
+    },
+    signal?: AbortSignal
+  ): Promise<AgentNativeInputPreparedResult>
+  settleNativeInput(
+    input: { runId: string; tabId: number; frameId: number },
+    signal?: AbortSignal
+  ): Promise<AgentInputTraceWire | undefined>
   release(runId: string): void
 }
 
@@ -242,6 +263,26 @@ export const createAgentControlSessionRegistry = (input?: {
       const session = await acquire(runId, tabId, frameId)
       try {
         await session.executeScroll(instruction, signal)
+      } catch (error) {
+        drop(runId, tabId, frameId)
+        throw error
+      }
+    },
+    async prepareNativeInput({ runId, tabId, instruction }, signal) {
+      const frameId = instruction.frame.frameId
+      const session = await acquire(runId, tabId, frameId)
+      try {
+        return await session.prepareNativeInput(instruction, signal)
+      } catch (error) {
+        drop(runId, tabId, frameId)
+        throw error
+      }
+    },
+    async settleNativeInput({ runId, tabId, frameId }, signal) {
+      const session = sessions.get(key(runId, tabId, frameId))
+      if (!session) return undefined
+      try {
+        return await session.settleNativeInput(signal)
       } catch (error) {
         drop(runId, tabId, frameId)
         throw error

--- a/src/background/agent/agent-run-controller.ts
+++ b/src/background/agent/agent-run-controller.ts
@@ -11,6 +11,7 @@ import {
 import { createProviderAgentModelPort } from "@/application/agent/agent-model-port"
 import { logger } from "@/lib/logger"
 import { createAgentBrowserAdapters } from "./agent-browser-adapters"
+import type { AgentBrowserSessionManager } from "./agent-browser-session-manager"
 import type { AgentControlSessionRegistry } from "./agent-control-sessions"
 import { createAgentEffectPort } from "./agent-effect-port"
 import type { AgentSupervision } from "./agent-supervision"
@@ -79,6 +80,8 @@ const withDecisionTimeout = (
 export interface BuildAgentControllerInput {
   runId: string
   sessions: AgentControlSessionRegistry
+  /** Absent means no native input: every action runs on the DOM backend. */
+  browserSessions?: AgentBrowserSessionManager
   history: AgentTabHistory
   persistence: AgentPersistencePort
   supervision: AgentSupervision
@@ -104,6 +107,7 @@ export const buildAgentController: BuildAgentController = (input) => {
   const adapters = createAgentBrowserAdapters({
     runId: input.runId,
     sessions: input.sessions,
+    browserSessions: input.browserSessions,
     history: input.history,
     now: input.now
   })
@@ -164,7 +168,9 @@ export const buildAgentController: BuildAgentController = (input) => {
         })
         const receipt = await effect.execute(authorized, signal)
         traceAgentRun(input.runId, "executed", {
-          executedAt: receipt.executedAt
+          executedAt: receipt.executedAt,
+          backend: receipt.backend,
+          inputDelivery: receipt.inputDelivery
         })
         return receipt
       },

--- a/src/background/agent/agent-run-controller.ts
+++ b/src/background/agent/agent-run-controller.ts
@@ -168,6 +168,7 @@ export const buildAgentController: BuildAgentController = (input) => {
         })
         const receipt = await effect.execute(authorized, signal)
         traceAgentRun(input.runId, "executed", {
+          action: authorized.command.type,
           executedAt: receipt.executedAt,
           backend: receipt.backend,
           inputDelivery: receipt.inputDelivery

--- a/src/background/agent/agent-run-service.ts
+++ b/src/background/agent/agent-run-service.ts
@@ -276,6 +276,7 @@ export const createAgentRunService = (input?: {
       frames: () => ({ status: "unavailable", frames: [] }),
       mapFrame: () => ({ mapped: false, reason: "tracking_unavailable" }),
       subscribe: () => () => undefined,
+      nativeInput: () => undefined,
       dispose: async () => undefined
     } satisfies AgentBrowserSessionManager)
 
@@ -383,6 +384,7 @@ export const createAgentRunService = (input?: {
     const controller = build({
       runId: state.id,
       sessions,
+      browserSessions,
       history,
       persistence,
       supervision,

--- a/src/contents/agent-control.ts
+++ b/src/contents/agent-control.ts
@@ -8,6 +8,10 @@ import {
   attachAgentControlContentPort
 } from "@/lib/browser-agent/control-port"
 import { createAgentElementReferenceStore } from "@/lib/browser-agent/element-references"
+import {
+  createAgentInputWatch,
+  prepareAgentNativeInputInDocument
+} from "@/lib/browser-agent/native-input-page"
 import { buildAgentObservation } from "@/lib/browser-agent/observation-builder"
 import { browser } from "@/lib/browser-api"
 
@@ -27,6 +31,7 @@ export const installAgentControlContentScript = (): void => {
     let references:
       | ReturnType<typeof createAgentElementReferenceStore>
       | undefined
+    const watch = createAgentInputWatch(document)
     attachAgentControlContentPort(rawPort as unknown as AgentControlPort, {
       buildObservation(request) {
         references ??= createAgentElementReferenceStore({
@@ -64,6 +69,25 @@ export const installAgentControlContentScript = (): void => {
           document,
           references
         })
+      },
+      prepareNativeInput(request) {
+        if (!references) {
+          throw new Error("Agent native input has no observed snapshot")
+        }
+        return prepareAgentNativeInputInDocument({
+          effect: request.instruction,
+          references,
+          watch
+        })
+      },
+      settleNativeInput() {
+        const trace = watch.settle()
+        return trace
+          ? {
+              events: [...trace.events],
+              ...(trace.overflow ? { overflow: true } : {})
+            }
+          : undefined
       }
     })
   }) as Parameters<typeof browser.runtime.onConnect.addListener>[0])

--- a/src/features/agent/lib/presentation.ts
+++ b/src/features/agent/lib/presentation.ts
@@ -34,7 +34,7 @@ const commandLabel = (command?: AgentCommand): string => {
     case "clear_and_type":
       return "Replace text in field"
     case "press_key":
-      return `Press ${command.key}`
+      return `Press ${agentPlainText(command.key, AGENT_PAGE_TEXT_LIMIT)}`
     case "type":
       return "Type in field"
     case "select":
@@ -49,6 +49,10 @@ const commandLabel = (command?: AgentCommand): string => {
       return "Go forward"
     case "click":
       return "Click control"
+    case "double_click":
+      return "Double-click control"
+    case "hover":
+      return "Hover over control"
     case "read":
       return "Read page"
     case "inspect":

--- a/src/lib/browser-agent/__tests__/control-port-native-input.test.ts
+++ b/src/lib/browser-agent/__tests__/control-port-native-input.test.ts
@@ -1,0 +1,197 @@
+import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
+import { describe, expect, it, vi } from "vitest"
+
+import { MESSAGE_KEYS } from "@/lib/constants"
+import {
+  AGENT_CONTROL_VERSION,
+  type AgentControlPort,
+  type AgentDomMutationInstruction,
+  AgentPrepareNativeInputRequestSchema,
+  AgentSettleNativeInputRequestSchema,
+  attachAgentControlContentPort,
+  createAgentControlSession
+} from "../control-port"
+
+class FakeEvent<T extends (...args: never[]) => unknown> {
+  private listeners = new Set<T>()
+  addListener(listener: T) {
+    this.listeners.add(listener)
+  }
+  removeListener(listener: T) {
+    this.listeners.delete(listener)
+  }
+  emit(...args: Parameters<T>) {
+    for (const listener of [...this.listeners]) listener(...args)
+  }
+}
+
+const binding = {
+  runId: "run-1",
+  tabId: 7,
+  frameId: 0 as const,
+  nonce: "0123456789abcdef",
+  documentId: "document-1"
+}
+
+const identity = {
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1"
+}
+
+const instruction = (
+  type: "click" | "double_click" | "hover" | "select" = "click"
+): AgentDomMutationInstruction =>
+  ({
+    command: {
+      type,
+      ref: "e1",
+      snapshotId: "snapshot-1",
+      generation: 1,
+      ...(type === "select" ? { value: "x" } : {})
+    },
+    target: {
+      ref: "e1",
+      frameId: 0,
+      tag: "div",
+      sensitive: false,
+      maySubmit: false
+    },
+    snapshotIdentity: identity,
+    frame: identity
+  }) as AgentDomMutationInstruction
+
+const createPort = () => {
+  const onMessage = new FakeEvent<(message: unknown) => void>()
+  const onDisconnect = new FakeEvent<() => void>()
+  const port: AgentControlPort = {
+    name: MESSAGE_KEYS.AGENT.CONTROL_PORT,
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage,
+    onDisconnect
+  }
+  return { port, onMessage, onDisconnect }
+}
+
+/** Wires a background session straight into a content port, both ends real. */
+const connected = (handlers: {
+  prepare?: () => { point: { x: number; y: number }; focused: boolean }
+  settle?: () => { events: never[] } | undefined
+}) => {
+  const background = createPort()
+  const content = createPort()
+  vi.mocked(background.port.postMessage).mockImplementation((raw) =>
+    queueMicrotask(() => content.onMessage.emit(raw))
+  )
+  vi.mocked(content.port.postMessage).mockImplementation((raw) =>
+    queueMicrotask(() => background.onMessage.emit(raw))
+  )
+  const prepareNativeInput = vi.fn(
+    handlers.prepare ?? (() => ({ point: { x: 3, y: 4 }, focused: true }))
+  )
+  const settleNativeInput = vi.fn(handlers.settle ?? (() => ({ events: [] })))
+  attachAgentControlContentPort(content.port, {
+    buildObservation: vi.fn(),
+    executeDomMutation: vi.fn(),
+    executeScroll: vi.fn(),
+    prepareNativeInput,
+    settleNativeInput
+  })
+  const session = createAgentControlSession({
+    port: background.port,
+    binding,
+    sender: { tabId: 7, frameId: 0, documentId: "document-1" }
+  })
+  return { session, background, content, prepareNativeInput, settleNativeInput }
+}
+
+describe("Agent control port native input", () => {
+  it("carries a preparation to the page and its point and focus back, then the record", async () => {
+    const { session, background, prepareNativeInput } = connected({})
+    await expect(
+      session.prepareNativeInput(instruction("hover"))
+    ).resolves.toEqual({
+      point: { x: 3, y: 4 },
+      focused: true
+    })
+    const request = AgentPrepareNativeInputRequestSchema.parse(
+      vi.mocked(background.port.postMessage).mock.calls[0]?.[0]
+    )
+    expect(request.instruction.command.type).toBe("hover")
+    expect(prepareNativeInput).toHaveBeenCalledOnce()
+    await expect(session.settleNativeInput()).resolves.toEqual({ events: [] })
+    const settle = AgentSettleNativeInputRequestSchema.parse(
+      vi.mocked(background.port.postMessage).mock.calls[1]?.[0]
+    )
+    expect(settle.sequence).toBe(2)
+  })
+
+  it("turns a typed page-side refusal into a non-applied effect, and any other failure into a control failure", async () => {
+    const refused = connected({
+      prepare: () => {
+        throw new AgentEffectNotAppliedError("covered")
+      }
+    })
+    await expect(
+      refused.session.prepareNativeInput(instruction())
+    ).rejects.toBeInstanceOf(AgentEffectNotAppliedError)
+
+    const broken = connected({
+      prepare: () => {
+        throw new Error("layout unavailable")
+      }
+    })
+    await expect(
+      broken.session.prepareNativeInput(instruction())
+    ).rejects.toMatchObject({ reason: "execution_failed" })
+  })
+
+  it("reports an unarmed document as having no record", async () => {
+    const { session } = connected({ settle: () => undefined })
+    await expect(session.settleNativeInput()).resolves.toBeUndefined()
+  })
+
+  it("refuses to prepare a command that is not an element interaction before sending it", () => {
+    const { session, background, prepareNativeInput } = connected({})
+    expect(() =>
+      session.prepareNativeInput({
+        ...instruction(),
+        command: {
+          type: "scroll",
+          direction: "down",
+          snapshotId: "snapshot-1",
+          generation: 1
+        }
+      } as never)
+    ).toThrow(/only DOM mutation commands/)
+    expect(background.port.postMessage).not.toHaveBeenCalled()
+    expect(prepareNativeInput).not.toHaveBeenCalled()
+  })
+
+  it("closes the port on a preparation whose frame binding is not this document", () => {
+    const content = createPort()
+    const prepareNativeInput = vi.fn()
+    attachAgentControlContentPort(content.port, {
+      buildObservation: vi.fn(),
+      executeDomMutation: vi.fn(),
+      executeScroll: vi.fn(),
+      prepareNativeInput,
+      settleNativeInput: vi.fn()
+    })
+    content.onMessage.emit({
+      version: AGENT_CONTROL_VERSION,
+      type: "agent_prepare_native_input",
+      ...binding,
+      sequence: 1,
+      instruction: {
+        ...instruction(),
+        frame: { ...identity, documentId: "document-2" }
+      }
+    })
+    expect(prepareNativeInput).not.toHaveBeenCalled()
+    expect(content.port.disconnect).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/browser-agent/__tests__/control-port.test.ts
+++ b/src/lib/browser-agent/__tests__/control-port.test.ts
@@ -419,7 +419,9 @@ describe("Agent control port", () => {
     attachAgentControlContentPort(port, {
       buildObservation: () => observation(),
       executeDomMutation: vi.fn(),
-      executeScroll
+      executeScroll,
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -443,7 +445,9 @@ describe("Agent control port", () => {
     attachAgentControlContentPort(live.port, {
       buildObservation: () => observation(),
       executeDomMutation: vi.fn(),
-      executeScroll
+      executeScroll,
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     live.onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -464,7 +468,9 @@ describe("Agent control port", () => {
       attachAgentControlContentPort(port, {
         buildObservation: () => observation(),
         executeDomMutation: vi.fn(),
-        executeScroll: vi.fn()
+        executeScroll: vi.fn(),
+        prepareNativeInput: vi.fn(),
+        settleNativeInput: vi.fn()
       })
     ).toBe(true)
     onMessage.emit({
@@ -492,7 +498,9 @@ describe("Agent control port", () => {
     attachAgentControlContentPort(port, {
       buildObservation: () => observation(),
       executeDomMutation,
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -524,7 +532,9 @@ describe("Agent control port", () => {
     attachAgentControlContentPort(port, {
       buildObservation: () => observation(),
       executeDomMutation,
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -629,7 +639,9 @@ describe("Agent control failures", () => {
         throw new Error("Agent observations are main-frame only")
       },
       executeDomMutation: vi.fn(),
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -657,7 +669,9 @@ describe("Agent control failures", () => {
       buildObservation: () =>
         observation({ visibleText: secret }) as AgentObservation,
       executeDomMutation: vi.fn(),
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -685,7 +699,9 @@ describe("Agent control failures", () => {
         return observation()
       },
       executeDomMutation: vi.fn(),
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -716,7 +732,9 @@ describe("Agent control failures", () => {
       executeDomMutation: () => {
         throw new Error("detached")
       },
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,
@@ -845,7 +863,9 @@ describe("Agent control port across frames", () => {
     attachAgentControlContentPort(port, {
       buildObservation: () => observation(),
       executeDomMutation,
-      executeScroll: vi.fn()
+      executeScroll: vi.fn(),
+      prepareNativeInput: vi.fn(),
+      settleNativeInput: vi.fn()
     })
     onMessage.emit({
       version: AGENT_CONTROL_VERSION,

--- a/src/lib/browser-agent/__tests__/dom-mutation-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/dom-mutation-actions.test.ts
@@ -490,6 +490,46 @@ describe("Agent DOM mutation execution", () => {
     expect(JSON.stringify(receipt)).not.toContain("new")
   })
 
+  it("spells a chord out as key and modifier flags on the synthetic events", async () => {
+    const input = document.createElement("input")
+    document.body.append(input)
+    input.focus()
+    const action = command({
+      type: "press_key",
+      ref: "e1",
+      key: "Control+Shift+é"
+    })
+    const { effect, references } = await liveEffect(action, input)
+    const seen: KeyboardEvent[] = []
+    input.addEventListener("keydown", (event) => seen.push(event))
+    input.addEventListener("keyup", (event) => seen.push(event))
+    executeAgentDomMutationInDocument({
+      effect,
+      document,
+      references,
+      signal
+    })
+    expect(seen.map((event) => event.type)).toEqual(["keydown", "keyup"])
+    for (const event of seen) {
+      expect(event.key).toBe("é")
+      expect(event.ctrlKey).toBe(true)
+      expect(event.shiftKey).toBe(true)
+      expect(event.altKey).toBe(false)
+      expect(event.metaKey).toBe(false)
+    }
+
+    const tab = command({ type: "press_key", ref: "e1", key: "Shift+Tab" })
+    const live = await liveEffect(tab, input)
+    seen.length = 0
+    executeAgentDomMutationInDocument({
+      effect: live.effect,
+      document,
+      references: live.references,
+      signal
+    })
+    expect(seen[0]).toMatchObject({ key: "Tab", code: "Tab", shiftKey: true })
+  })
+
   it("sets select and checked state through native controls", async () => {
     const select = document.createElement("select")
     const first = document.createElement("option")

--- a/src/lib/browser-agent/__tests__/native-input-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input-actions.test.ts
@@ -1,0 +1,468 @@
+import {
+  type AgentCancellationSignal,
+  AgentEffectNotAppliedError,
+  type AgentVerificationInput,
+  type AuthorizedAgentEffect
+} from "@ollama-client/agent-runtime"
+import type { AgentElement, AgentObservation } from "@ollama-client/contracts"
+import { type AgentCommand, AgentCommandSchema } from "@ollama-client/contracts"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type AgentCommandExecutorAdapter,
+  type AgentNativeControlFacts,
+  executeDomMutationAgentEffect,
+  executeReadOnlyAgentEffect
+} from "../command-executor"
+import {
+  type AgentEffectVerifierAdapter,
+  verifyDomMutationAgentEffect,
+  verifyReadOnlyAgentEffect
+} from "../effect-verifier"
+import type { AgentNativeInputPlan } from "../native-input"
+import {
+  type AgentEffectResolverAdapter,
+  resolveDomMutationAgentEffect,
+  resolveReadOnlyAgentEffect
+} from "../resolved-effect"
+
+/**
+ * The executor's contract with the native backend: chosen before the action,
+ * never swapped after it, and recorded on the receipt the verifier reads.
+ */
+
+const signal: AgentCancellationSignal = { aborted: false }
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  frameId: 0,
+  tag: "button",
+  name: "Open",
+  visible: true,
+  enabled: true,
+  editable: false,
+  sensitive: false,
+  ...overrides
+})
+
+const observation = (
+  overrides: Partial<AgentObservation> = {}
+): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1",
+  url: "https://example.com/app",
+  origin: "https://example.com",
+  title: "App",
+  frames: [
+    {
+      frameId: 0,
+      documentId: "document-1",
+      origin: "https://example.com",
+      url: "https://example.com/app",
+      access: "ok",
+      snapshotId: "snapshot-1",
+      generation: 1
+    }
+  ],
+  elements: [element()],
+  visibleText: "Open",
+  scroll: {
+    x: 0,
+    y: 0,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 100
+  },
+  dialogs: [],
+  capturedAt: 1,
+  ...overrides
+})
+
+const command = (input: Record<string, unknown>): AgentCommand =>
+  AgentCommandSchema.parse({
+    ...input,
+    snapshotId: "snapshot-1",
+    generation: 1
+  })
+
+const resolverAdapter: AgentEffectResolverAdapter = {
+  getTab: async (tabId) => ({ id: tabId, url: observation().url }),
+  classifyAccess: async () => "ok",
+  resolveHistoryDestination: async () => undefined
+}
+
+const authorize = async (
+  action: AgentCommand,
+  before = observation()
+): Promise<AuthorizedAgentEffect> => ({
+  ...(await (action.type === "scroll"
+    ? resolveReadOnlyAgentEffect
+    : resolveDomMutationAgentEffect)({
+    command: action,
+    observation: before,
+    adapter: resolverAdapter
+  })),
+  authorization: { type: "policy", risk: "low", authorizedAt: 2 }
+})
+
+const facts = (
+  overrides: Partial<AgentNativeControlFacts> = {}
+): AgentNativeControlFacts => ({
+  cdpControl: true,
+  attached: true,
+  frameMapped: true,
+  frameOffset: { x: 0, y: 0 },
+  platform: "other",
+  ...overrides
+})
+
+const adapter = (
+  overrides: Partial<AgentCommandExecutorAdapter> = {}
+): AgentCommandExecutorAdapter => ({
+  getTab: async (tabId) => ({ id: tabId, url: observation().url }),
+  getFrame: async () => ({ documentId: "document-1", url: observation().url }),
+  classifyAccess: async () => "ok",
+  scroll: vi.fn(),
+  mutate: vi.fn(async () => undefined),
+  nativeControl: vi.fn(async () => facts()),
+  prepareNativeInput: vi.fn(async () => ({
+    point: { x: 5, y: 5 },
+    focused: false
+  })),
+  dispatchNativeInput: vi.fn(async (_effect, plan: AgentNativeInputPlan) => ({
+    dispatched: plan.steps.length
+  })),
+  settleNativeInput: vi.fn(async () => ({
+    events: [
+      { type: "mousemove" as const, x: 5, y: 5, onTarget: true },
+      { type: "mousedown" as const, x: 5, y: 5, onTarget: true },
+      { type: "mouseup" as const, x: 5, y: 5, onTarget: true }
+    ]
+  })),
+  viewportCentre: vi.fn(async () => ({ x: 50, y: 50 })),
+  activateTab: vi.fn(),
+  goHistory: vi.fn(),
+  resolveHistoryDestination: async () => undefined,
+  wait: vi.fn(async () => undefined),
+  navigate: vi.fn(),
+  createTab: vi.fn(),
+  now: () => 10,
+  ...overrides
+})
+
+describe("native input execution", () => {
+  it("runs an activation click natively and records backend and delivery", async () => {
+    const executor = adapter()
+    const receipt = await executeDomMutationAgentEffect({
+      effect: await authorize(command({ type: "click", ref: "e1" })),
+      adapter: executor,
+      signal
+    })
+    expect(receipt).toMatchObject({
+      backend: "cdp",
+      inputDelivery: "delivered"
+    })
+    expect(executor.mutate).not.toHaveBeenCalled()
+    expect(executor.prepareNativeInput).toHaveBeenCalledOnce()
+    expect(executor.dispatchNativeInput).toHaveBeenCalledOnce()
+  })
+
+  it("keeps a submitter click on the guarded DOM path even with a debugger attached", async () => {
+    const executor = adapter()
+    const before = observation({
+      elements: [
+        element({
+          submitter: true,
+          maySubmit: true,
+          formAction: "https://example.com/submit",
+          formMethod: "post"
+        })
+      ]
+    })
+    const receipt = await executeDomMutationAgentEffect({
+      effect: await authorize(command({ type: "click", ref: "e1" }), before),
+      adapter: executor,
+      signal
+    })
+    expect(receipt.backend).toBe("dom")
+    expect(executor.mutate).toHaveBeenCalledOnce()
+    expect(executor.dispatchNativeInput).not.toHaveBeenCalled()
+  })
+
+  it("falls to the DOM backend before acting when the frame cannot be placed", async () => {
+    const executor = adapter({
+      nativeControl: vi.fn(async () =>
+        facts({ frameMapped: false, frameOffset: undefined })
+      )
+    })
+    const receipt = await executeDomMutationAgentEffect({
+      effect: await authorize(command({ type: "hover", ref: "e1" })),
+      adapter: executor,
+      signal
+    })
+    expect(receipt.backend).toBe("dom")
+    expect(executor.prepareNativeInput).not.toHaveBeenCalled()
+    expect(executor.mutate).toHaveBeenCalledOnce()
+  })
+
+  it("never completes a plan on the DOM backend after native dispatch failed mid-way", async () => {
+    const { AgentNativeInputFailedError } = await import("../native-input")
+    const executor = adapter({
+      dispatchNativeInput: vi.fn(async () => {
+        throw new AgentNativeInputFailedError(2, new Error("detached"))
+      })
+    })
+    await expect(
+      executeDomMutationAgentEffect({
+        effect: await authorize(command({ type: "click", ref: "e1" })),
+        adapter: executor,
+        signal
+      })
+    ).rejects.toBeInstanceOf(AgentNativeInputFailedError)
+    expect(executor.mutate).not.toHaveBeenCalled()
+  })
+
+  it("treats a plan the debugger refused from its first step as a clean non-application", async () => {
+    const { AgentNativeInputFailedError } = await import("../native-input")
+    const executor = adapter({
+      dispatchNativeInput: vi.fn(async () => {
+        throw new AgentNativeInputFailedError(0, new Error("detached"))
+      })
+    })
+    await expect(
+      executeDomMutationAgentEffect({
+        effect: await authorize(command({ type: "click", ref: "e1" })),
+        adapter: executor,
+        signal
+      })
+    ).rejects.toBeInstanceOf(AgentEffectNotAppliedError)
+    expect(executor.mutate).not.toHaveBeenCalled()
+  })
+
+  it("reports delivery as unknown when the document cannot be asked afterwards", async () => {
+    const executor = adapter({
+      settleNativeInput: vi.fn(async () => {
+        throw new Error("Agent control port closed")
+      })
+    })
+    const receipt = await executeDomMutationAgentEffect({
+      effect: await authorize(command({ type: "click", ref: "e1" })),
+      adapter: executor,
+      signal
+    })
+    expect(receipt).toMatchObject({ backend: "cdp", inputDelivery: "unknown" })
+  })
+
+  it("reports interference when the page received input the plan did not send", async () => {
+    const executor = adapter({
+      settleNativeInput: vi.fn(async () => ({
+        events: [
+          { type: "mousemove" as const, x: 5, y: 5, onTarget: true },
+          { type: "mousedown" as const, x: 5, y: 5, onTarget: true },
+          { type: "mouseup" as const, x: 5, y: 5, onTarget: true },
+          { type: "keydown" as const, key: "x", onTarget: false }
+        ]
+      }))
+    })
+    const receipt = await executeDomMutationAgentEffect({
+      effect: await authorize(command({ type: "click", ref: "e1" })),
+      adapter: executor,
+      signal
+    })
+    expect(receipt.inputDelivery).toBe("interference")
+  })
+
+  it("scrolls with a native wheel at the viewport centre when no element is named", async () => {
+    const executor = adapter()
+    const receipt = await executeReadOnlyAgentEffect({
+      effect: await authorize(command({ type: "scroll", direction: "down" })),
+      adapter: executor,
+      signal
+    })
+    expect(receipt.backend).toBe("cdp")
+    const plan = (
+      executor.dispatchNativeInput as unknown as {
+        mock: { calls: unknown[][] }
+      }
+    ).mock.calls[0]?.[1] as AgentNativeInputPlan
+    expect(plan.steps).toEqual([
+      { kind: "wheel", x: 50, y: 50, deltaX: 0, deltaY: 80 }
+    ])
+    expect(executor.scroll).not.toHaveBeenCalled()
+  })
+
+  it("keeps a referenced scroll on scrollIntoView", async () => {
+    const executor = adapter()
+    const receipt = await executeReadOnlyAgentEffect({
+      effect: await authorize(
+        command({ type: "scroll", direction: "down", ref: "e1" })
+      ),
+      adapter: executor,
+      signal
+    })
+    expect(receipt.backend).toBe("dom")
+    expect(executor.scroll).toHaveBeenCalledOnce()
+  })
+})
+
+const verifierAdapter = (
+  after: AgentObservation
+): AgentEffectVerifierAdapter => ({
+  observe: async () => after,
+  getActiveTabId: async () => 7,
+  getTab: async () => ({ url: after.url }),
+  classifyAccess: async () => "ok",
+  now: () => 10
+})
+
+const verify = async (
+  action: AgentCommand,
+  receipt: AgentVerificationInput["receipt"],
+  after: AgentObservation,
+  before = observation()
+) => {
+  const verification: AgentVerificationInput = {
+    effect: await authorize(action, before),
+    receipt,
+    before,
+    allowedOrigins: ["https://example.com"]
+  }
+  const run =
+    action.type === "scroll"
+      ? verifyReadOnlyAgentEffect
+      : verifyDomMutationAgentEffect
+  return run({ verification, adapter: verifierAdapter(after), signal })
+}
+
+describe("native input verification", () => {
+  it("leaves a step unresolved when a user's input was observed during it", async () => {
+    const result = await verify(
+      command({ type: "click", ref: "e1" }),
+      { executedAt: 5, backend: "cdp", inputDelivery: "interference" },
+      observation({ visibleText: "Opened" })
+    )
+    expect(result.outcome).toBe("ambiguous")
+    expect(result.evidence.summary).toMatch(/User input/)
+  })
+
+  it("does the same for input that landed elsewhere or was cut short", async () => {
+    for (const inputDelivery of ["misdirected", "partial"] as const) {
+      const result = await verify(
+        command({ type: "type", ref: "e1", text: "x" }),
+        { executedAt: 5, backend: "cdp", inputDelivery },
+        observation({ elements: [element({ value: "x" })] }),
+        observation({
+          elements: [
+            element({ tag: "input", type: "text", editable: true, value: "" })
+          ]
+        })
+      )
+      expect(result.outcome, inputDelivery).toBe("ambiguous")
+    }
+  })
+
+  it("confirms a hover on delivery alone, and needs page change or delivery to confirm at all", async () => {
+    const delivered = await verify(
+      command({ type: "hover", ref: "e1" }),
+      { executedAt: 5, backend: "cdp", inputDelivery: "delivered" },
+      observation()
+    )
+    expect(delivered.outcome).toBe("confirmed")
+    const unknown = await verify(
+      command({ type: "hover", ref: "e1" }),
+      { executedAt: 5, backend: "dom" },
+      observation()
+    )
+    expect(unknown.outcome).toBe("ambiguous")
+    const reacted = await verify(
+      command({ type: "hover", ref: "e1" }),
+      { executedAt: 5, backend: "dom" },
+      observation({ visibleText: "Open Menu" })
+    )
+    expect(reacted.outcome).toBe("confirmed")
+  })
+
+  it("confirms a native scroll that moved an inner container by its visible text", async () => {
+    const result = await verify(
+      command({ type: "scroll", direction: "down" }),
+      { executedAt: 5, backend: "cdp" },
+      observation({ visibleText: "Further down" })
+    )
+    expect(result.outcome).toBe("confirmed")
+    const synthetic = await verify(
+      command({ type: "scroll", direction: "down" }),
+      { executedAt: 5, backend: "dom" },
+      observation({ visibleText: "Further down" })
+    )
+    expect(synthetic.outcome).toBe("negative")
+  })
+
+  it("reads a Shift+Tab as focus traversal", async () => {
+    const before = observation({
+      elements: [
+        element({ tag: "input", type: "text", editable: true, focused: true }),
+        element({
+          ref: "e2",
+          name: "Other",
+          tag: "input",
+          type: "text",
+          editable: true
+        })
+      ]
+    })
+    const result = await verify(
+      command({ type: "press_key", ref: "e1", key: "Shift+Tab" }),
+      { executedAt: 5, backend: "cdp", inputDelivery: "delivered" },
+      observation({
+        elements: [
+          element({ tag: "input", type: "text", editable: true }),
+          element({
+            ref: "e2",
+            name: "Other",
+            tag: "input",
+            type: "text",
+            editable: true,
+            focused: true
+          })
+        ]
+      }),
+      before
+    )
+    expect(result.evidence.summary).toBe(
+      "Keyboard focus moved to another control"
+    )
+  })
+})
+
+describe("activation evidence after a native click", () => {
+  it("does not credit a silent button for merely taking focus", async () => {
+    const result = await verify(
+      command({ type: "click", ref: "e1" }),
+      { executedAt: 5, backend: "cdp", inputDelivery: "delivered" },
+      observation({ elements: [element({ focused: true })] })
+    )
+    expect(result.outcome).toBe("ambiguous")
+  })
+
+  it("confirms a click that lands focus on a widget that takes input", async () => {
+    const before = observation({
+      elements: [element({ tag: "ul", role: "listbox", name: "Size" })]
+    })
+    const result = await verify(
+      command({ type: "click", ref: "e1" }),
+      { executedAt: 5, backend: "cdp", inputDelivery: "delivered" },
+      observation({
+        elements: [
+          element({ tag: "ul", role: "listbox", name: "Size", focused: true })
+        ]
+      }),
+      before
+    )
+    expect(result.outcome).toBe("confirmed")
+    expect(result.evidence.summary).toMatch(/took focus/)
+  })
+})

--- a/src/lib/browser-agent/__tests__/native-input-page.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input-page.test.ts
@@ -1,0 +1,195 @@
+import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentDomMutationInstruction } from "../control-port"
+import { createAgentElementReferenceStore } from "../element-references"
+import {
+  createAgentInputWatch,
+  prepareAgentNativeInputInDocument
+} from "../native-input-page"
+import { buildAgentElementObservation } from "../observation-builder"
+
+const identity = {
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1"
+}
+
+const rect = (top: number, left: number, size = 20) =>
+  ({
+    top,
+    left,
+    bottom: top + size,
+    right: left + size,
+    width: size,
+    height: size
+  }) as DOMRect
+
+beforeEach(() => {
+  document.body.replaceChildren()
+  vi.spyOn(Element.prototype, "getClientRects").mockReturnValue([
+    rect(10, 10)
+  ] as unknown as DOMRectList)
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+    rect(10, 10)
+  )
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+const observed = () => {
+  const button = document.createElement("button")
+  button.textContent = "Open"
+  document.body.append(button)
+  const references = createAgentElementReferenceStore({
+    documentId: identity.documentId,
+    frameId: 0
+  })
+  const snapshot = references.beginSnapshot({
+    minimumGeneration: 0,
+    createSnapshotId: () => identity.snapshotId
+  })
+  const ref = snapshot.reference(button)
+  const element = buildAgentElementObservation(button, ref, 0)
+  const instruction: AgentDomMutationInstruction = {
+    command: {
+      type: "click",
+      snapshotId: identity.snapshotId,
+      generation: 1,
+      ref
+    },
+    target: {
+      ref,
+      frameId: 0,
+      tag: element.tag,
+      accessibleName: element.name,
+      inputType: element.type,
+      observedValue: element.value,
+      observedChecked: element.checked,
+      observedFocused: element.focused,
+      sensitive: false,
+      maySubmit: false
+    },
+    snapshotIdentity: identity,
+    frame: identity
+  }
+  return { button, references, instruction }
+}
+
+describe("native input preparation", () => {
+  it("returns a reachable frame-local point and arms the watch on the checked element", () => {
+    const { button, references, instruction } = observed()
+    document.elementFromPoint = () => button
+    const watch = createAgentInputWatch(document, { trusted: () => true })
+    const prepared = prepareAgentNativeInputInDocument({
+      effect: instruction,
+      references,
+      watch
+    })
+    expect(prepared).toEqual({ point: { x: 20, y: 20 }, focused: false })
+    button.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, clientX: 20, clientY: 20 })
+    )
+    expect(watch.settle()).toEqual({
+      events: [{ type: "mousedown", x: 20, y: 20, onTarget: true }]
+    })
+  })
+
+  it("refuses a target whose every click point another element covers", () => {
+    const { references, instruction } = observed()
+    const cover = document.createElement("div")
+    document.body.append(cover)
+    document.elementFromPoint = () => cover
+    expect(() =>
+      prepareAgentNativeInputInDocument({
+        effect: instruction,
+        references,
+        watch: createAgentInputWatch(document)
+      })
+    ).toThrow(AgentEffectNotAppliedError)
+  })
+
+  it("refuses a target that was replaced after approval, before arming anything", () => {
+    const { button, references, instruction } = observed()
+    button.replaceWith(button.cloneNode(true))
+    const watch = createAgentInputWatch(document)
+    expect(() =>
+      prepareAgentNativeInputInDocument({
+        effect: instruction,
+        references,
+        watch
+      })
+    ).toThrow(AgentEffectNotAppliedError)
+    expect(watch.settle()).toBeUndefined()
+  })
+
+  it("brings an off-screen target into view before choosing its point", () => {
+    const { button, references, instruction } = observed()
+    vi.mocked(Element.prototype.getBoundingClientRect).mockReturnValue(
+      rect(5_000, 10)
+    )
+    const scrolled = vi.fn()
+    button.scrollIntoView = scrolled
+    document.elementFromPoint = () => button
+    prepareAgentNativeInputInDocument({
+      effect: instruction,
+      references,
+      watch: createAgentInputWatch(document)
+    })
+    expect(scrolled).toHaveBeenCalledWith({
+      block: "center",
+      inline: "center",
+      behavior: "instant"
+    })
+  })
+})
+
+describe("native input watch", () => {
+  it("records only trusted input, marks foreign targets, and overflows rather than truncating silently", () => {
+    const target = document.createElement("input")
+    const other = document.createElement("button")
+    document.body.append(target, other)
+    let trusted = true
+    const watch = createAgentInputWatch(document, { trusted: () => trusted })
+    watch.arm(target)
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", bubbles: true })
+    )
+    other.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, clientX: 1, clientY: 2 })
+    )
+    trusted = false
+    target.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "a", bubbles: true })
+    )
+    target.dispatchEvent(new Event("input", { bubbles: true }))
+    expect(watch.settle()).toEqual({
+      events: [
+        { type: "keydown", key: "a", onTarget: true },
+        { type: "mousedown", x: 1, y: 2, onTarget: false }
+      ]
+    })
+    /* A settled watch records nothing further. */
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "b", bubbles: true })
+    )
+    expect(watch.settle()).toBeUndefined()
+  })
+
+  it("replaces an earlier watch when armed again", () => {
+    const first = document.createElement("input")
+    const second = document.createElement("input")
+    document.body.append(first, second)
+    const watch = createAgentInputWatch(document, { trusted: () => true })
+    watch.arm(first)
+    watch.arm(second)
+    second.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", bubbles: true })
+    )
+    expect(watch.settle()?.events).toEqual([
+      { type: "keydown", key: "a", onTarget: true }
+    ])
+  })
+})

--- a/src/lib/browser-agent/__tests__/native-input.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input.test.ts
@@ -162,6 +162,15 @@ describe("native input planning", () => {
     expect(kinds(selectAll.steps)[0]).toBe("keyDown:Meta")
   })
 
+  it("inserts a printable key the table cannot press, and refuses to chord it", () => {
+    const inserted = plan({ type: "press_key", key: "é" })
+    expect(inserted.steps).toEqual([{ kind: "insertText", text: "é" }])
+    expect(inserted.expected).toEqual([])
+    expect(() => plan({ type: "press_key", key: "Control+é" })).toThrow(
+      /chord has no native definition/
+    )
+  })
+
   it("refuses to plan an action that has no native form", () => {
     expect(() => plan({ type: "select", value: "x" })).toThrow(
       /no native input plan/
@@ -321,6 +330,35 @@ describe("native input delivery", () => {
     ).toBe("unknown")
   })
 
+  it("lets a key's release land on whatever took focus, and claims nothing for inserted text", () => {
+    const tab = plan({ type: "press_key", key: "Shift+Tab" })
+    expect(
+      assessAgentInputDelivery(tab, {
+        events: [
+          { type: "keydown", key: "Shift", onTarget: true },
+          { type: "keydown", key: "Tab", onTarget: true },
+          { type: "keyup", key: "Tab", onTarget: false },
+          { type: "keyup", key: "Shift", onTarget: false }
+        ]
+      })
+    ).toBe("delivered")
+    expect(
+      assessAgentInputDelivery(tab, {
+        events: [
+          { type: "keydown", key: "Shift", onTarget: false },
+          { type: "keydown", key: "Tab", onTarget: false },
+          { type: "keyup", key: "Tab", onTarget: false },
+          { type: "keyup", key: "Shift", onTarget: false }
+        ]
+      })
+    ).toBe("misdirected")
+    expect(
+      assessAgentInputDelivery(plan({ type: "press_key", key: "é" }), {
+        events: []
+      })
+    ).toBe("unknown")
+  })
+
   it("matches keys by name and tolerates sub-pixel pointer rounding", () => {
     const chord = plan({ type: "press_key", key: "Shift+Tab" })
     expect(
@@ -395,6 +433,62 @@ describe("native input backend choice", () => {
         }
       })
     ).toEqual({ backend: "dom", reason: "guarded_submission" })
+  })
+
+  it("keeps a newline typed into a submitting field off the native path", () => {
+    const submitting = { ...target, maySubmit: true }
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "type", text: "Alice\n" }),
+          target: submitting
+        }
+      })
+    ).toEqual({ backend: "dom", reason: "guarded_submission" })
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "clear_and_type", text: "a\rb" }),
+          target: submitting
+        }
+      }).reason
+    ).toBe("guarded_submission")
+    /* A textarea's newline is a newline; without submit semantics it stays native. */
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: { command: command({ type: "type", text: "a\nb" }), target }
+      }).backend
+    ).toBe("cdp")
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "type", text: "Alice" }),
+          target: submitting
+        }
+      }).backend
+    ).toBe("cdp")
+  })
+
+  it("sends a chord on a key the table cannot press to the DOM backend", () => {
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "press_key", key: "Control+é" }),
+          target
+        }
+      })
+    ).toEqual({ backend: "dom", reason: "key_not_native" })
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: { command: command({ type: "press_key", key: "é" }), target }
+      }).backend
+    ).toBe("cdp")
   })
 
   it("falls to the DOM backend without control, without attachment, or with an unplaced frame", () => {

--- a/src/lib/browser-agent/__tests__/native-input.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input.test.ts
@@ -1,0 +1,418 @@
+import type { AgentCommand } from "@ollama-client/contracts"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type AgentInputTrace,
+  AgentNativeInputCancelledError,
+  AgentNativeInputFailedError,
+  type AgentNativeInputStep,
+  assessAgentInputDelivery,
+  chooseAgentInputBackend,
+  planAgentNativeInput,
+  runAgentNativeInputPlan
+} from "../native-input"
+
+const grounded = { snapshotId: "s1", generation: 1 }
+const command = (partial: Record<string, unknown>) =>
+  ({ ...grounded, ref: "e1", ...partial }) as AgentCommand
+
+const plan = (
+  partial: Record<string, unknown>,
+  overrides: Partial<Parameters<typeof planAgentNativeInput>[0]> = {}
+) =>
+  planAgentNativeInput({
+    command: command(partial),
+    point: { x: 10, y: 20 },
+    frameOffset: { x: 100, y: 200 },
+    focused: false,
+    platform: "other",
+    ...overrides
+  })
+
+const kinds = (steps: readonly AgentNativeInputStep[]) =>
+  steps.map((step) =>
+    step.kind === "mouse"
+      ? step.type
+      : step.kind === "key"
+        ? `${step.type}:${step.key}`
+        : step.kind === "insertText"
+          ? `insert:${step.text}`
+          : "wheel"
+  )
+
+describe("native input planning", () => {
+  it("clicks at the frame point offset into the root viewport and expects frame-local events", () => {
+    const built = plan({ type: "click" })
+    expect(kinds(built.steps)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "mouseReleased"
+    ])
+    const pressed = built.steps[1] as Extract<
+      AgentNativeInputStep,
+      { kind: "mouse" }
+    >
+    expect(pressed).toMatchObject({
+      x: 110,
+      y: 220,
+      button: "left",
+      clickCount: 1
+    })
+    expect(built.expected).toEqual([
+      { type: "mousemove", x: 10, y: 20 },
+      { type: "mousedown", x: 10, y: 20 },
+      { type: "mouseup", x: 10, y: 20 }
+    ])
+  })
+
+  it("double-clicks with a rising click count and hovers with a move alone", () => {
+    const twice = plan({ type: "double_click" })
+    expect(kinds(twice.steps)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "mouseReleased",
+      "mousePressed",
+      "mouseReleased"
+    ])
+    expect(
+      twice.steps
+        .filter((step) => step.kind === "mouse" && step.type === "mousePressed")
+        .map((step) => (step as { clickCount: number }).clickCount)
+    ).toEqual([1, 2])
+    expect(kinds(plan({ type: "hover" }).steps)).toEqual(["mouseMoved"])
+  })
+
+  it("focuses an unfocused field with a real click before typing, and not a focused one", () => {
+    const unfocused = plan({ type: "type", text: "ab" })
+    expect(kinds(unfocused.steps).slice(0, 3)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "mouseReleased"
+    ])
+    const focused = plan({ type: "type", text: "ab" }, { focused: true })
+    expect(kinds(focused.steps)).toEqual([
+      "keyDown:End",
+      "keyUp:End",
+      "keyDown:a",
+      "keyUp:a",
+      "keyDown:b",
+      "keyUp:b"
+    ])
+    const end = focused.steps[0] as Extract<
+      AgentNativeInputStep,
+      { kind: "key" }
+    >
+    expect(end.commands).toEqual(["moveToEndOfDocument"])
+  })
+
+  it("clears with a platform select-all command and a backspace, and inserts characters it cannot type", () => {
+    const mac = plan(
+      { type: "clear_and_type", text: "é1" },
+      { focused: true, platform: "mac" }
+    )
+    expect(kinds(mac.steps)).toEqual([
+      "keyDown:Meta",
+      "keyDown:a",
+      "keyUp:a",
+      "keyUp:Meta",
+      "keyDown:Backspace",
+      "keyUp:Backspace",
+      "insert:é",
+      "keyDown:1",
+      "keyUp:1"
+    ])
+    const selectAll = mac.steps[1] as Extract<
+      AgentNativeInputStep,
+      { kind: "key" }
+    >
+    expect(selectAll.commands).toEqual(["selectAll"])
+    expect(selectAll.modifiers).toBe(4)
+    const other = plan({ type: "clear_and_type", text: "x" }, { focused: true })
+    expect(kinds(other.steps)[0]).toBe("keyDown:Control")
+  })
+
+  it("types a newline as Enter and expects each key the page should see", () => {
+    const built = plan({ type: "type", text: "a\nb" }, { focused: true })
+    expect(kinds(built.steps)).toContain("keyDown:Enter")
+    expect(built.expected.filter((event) => event.type === "keydown")).toEqual([
+      { type: "keydown", key: "End" },
+      { type: "keydown", key: "a" },
+      { type: "keydown", key: "Enter" },
+      { type: "keydown", key: "b" }
+    ])
+  })
+
+  it("holds modifiers around a chord and releases them in reverse", () => {
+    const built = plan({ type: "press_key", key: "Control+Shift+Tab" })
+    expect(kinds(built.steps)).toEqual([
+      "keyDown:Control",
+      "keyDown:Shift",
+      "keyDown:Tab",
+      "keyUp:Tab",
+      "keyUp:Shift",
+      "keyUp:Control"
+    ])
+    const tab = built.steps[2] as Extract<AgentNativeInputStep, { kind: "key" }>
+    expect(tab.modifiers).toBe(2 | 8)
+    expect(tab.text).toBeUndefined()
+    const selectAll = plan(
+      { type: "press_key", key: "Control+a" },
+      { platform: "mac" }
+    )
+    expect(kinds(selectAll.steps)[0]).toBe("keyDown:Meta")
+  })
+
+  it("refuses to plan an action that has no native form", () => {
+    expect(() => plan({ type: "select", value: "x" })).toThrow(
+      /no native input plan/
+    )
+  })
+})
+
+/** Fails the step at `failAt` once; the release that follows goes through. */
+const recordingDispatcher = (failAt?: number) => {
+  const sent: AgentNativeInputStep[] = []
+  let failed = false
+  return {
+    sent,
+    dispatch: vi.fn(async (step: AgentNativeInputStep) => {
+      if (failAt !== undefined && sent.length === failAt && !failed) {
+        failed = true
+        throw new Error("debugger detached")
+      }
+      sent.push(step)
+    })
+  }
+}
+
+describe("native input running", () => {
+  it("releases a held button and held keys when cancelled mid-plan, and sends nothing else", async () => {
+    const built = plan({ type: "press_key", key: "Shift+Tab" })
+    let aborted = false
+    const dispatcher = recordingDispatcher()
+    dispatcher.dispatch.mockImplementation(async (step) => {
+      dispatcher.sent.push(step)
+      /* Stop after Shift and Tab are both down. */
+      if (dispatcher.sent.length === 2) aborted = true
+    })
+    const error = await runAgentNativeInputPlan(built, dispatcher, {
+      get aborted() {
+        return aborted
+      }
+    }).catch((error: unknown) => error)
+    expect(error).toBeInstanceOf(AgentNativeInputCancelledError)
+    expect((error as AgentNativeInputCancelledError).dispatched).toBe(2)
+    expect(kinds(dispatcher.sent)).toEqual([
+      "keyDown:Shift",
+      "keyDown:Tab",
+      "keyUp:Tab",
+      "keyUp:Shift"
+    ])
+  })
+
+  it("releases a pressed mouse button when the debugger fails mid-click", async () => {
+    const built = plan({ type: "click" })
+    const dispatcher = recordingDispatcher(2)
+    const error = await runAgentNativeInputPlan(built, dispatcher, {
+      aborted: false
+    }).catch((error: unknown) => error)
+    expect(error).toBeInstanceOf(AgentNativeInputFailedError)
+    expect((error as AgentNativeInputFailedError).dispatched).toBe(2)
+    expect(kinds(dispatcher.sent)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "mouseReleased"
+    ])
+    /* The failing step is not re-sent: the runner never retries. */
+    expect(dispatcher.dispatch).toHaveBeenCalledTimes(4)
+  })
+
+  it("reports a plan the debugger refused from the first step as nothing dispatched", async () => {
+    const dispatcher = recordingDispatcher(0)
+    const error = await runAgentNativeInputPlan(
+      plan({ type: "hover" }),
+      dispatcher,
+      {
+        aborted: false
+      }
+    ).catch((error: unknown) => error)
+    expect((error as AgentNativeInputFailedError).dispatched).toBe(0)
+    expect(dispatcher.sent).toEqual([])
+  })
+
+  it("does not start a plan the run already cancelled", async () => {
+    const dispatcher = recordingDispatcher()
+    await expect(
+      runAgentNativeInputPlan(plan({ type: "click" }), dispatcher, {
+        aborted: true
+      })
+    ).rejects.toBeInstanceOf(AgentNativeInputCancelledError)
+    expect(dispatcher.dispatch).not.toHaveBeenCalled()
+  })
+})
+
+describe("native input delivery", () => {
+  const click = plan({ type: "click" })
+  const event = (
+    type: AgentInputTrace["events"][number]["type"],
+    extra: Partial<AgentInputTrace["events"][number]> = {}
+  ) => ({ type, x: 10, y: 20, onTarget: true, ...extra })
+
+  it("is delivered when exactly the plan arrived on the target", () => {
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [event("mousemove"), event("mousedown"), event("mouseup")]
+      })
+    ).toBe("delivered")
+  })
+
+  it("ignores stray pointer motion but not a foreign press or key", () => {
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [
+          event("mousemove", { x: 300, y: 300 }),
+          event("mousemove"),
+          event("mousedown"),
+          event("mouseup")
+        ]
+      })
+    ).toBe("delivered")
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [
+          event("mousemove"),
+          event("mousedown"),
+          event("mouseup"),
+          event("mousedown", { x: 300, y: 300 })
+        ]
+      })
+    ).toBe("interference")
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [
+          event("keydown", { key: "x" }),
+          event("mousemove"),
+          event("mousedown"),
+          event("mouseup")
+        ]
+      })
+    ).toBe("interference")
+  })
+
+  it("tells misdirected, partial, undelivered and unknown apart", () => {
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [
+          event("mousemove"),
+          event("mousedown", { onTarget: false }),
+          event("mouseup", { onTarget: false })
+        ]
+      })
+    ).toBe("misdirected")
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [event("mousemove"), event("mousedown")]
+      })
+    ).toBe("partial")
+    expect(assessAgentInputDelivery(click, { events: [] })).toBe("undelivered")
+    expect(assessAgentInputDelivery(click, undefined)).toBe("unknown")
+    expect(
+      assessAgentInputDelivery(click, { events: [], overflow: true })
+    ).toBe("unknown")
+  })
+
+  it("matches keys by name and tolerates sub-pixel pointer rounding", () => {
+    const chord = plan({ type: "press_key", key: "Shift+Tab" })
+    expect(
+      assessAgentInputDelivery(chord, {
+        events: [
+          { type: "keydown", key: "Shift", onTarget: true },
+          { type: "keydown", key: "Tab", onTarget: true },
+          { type: "keyup", key: "Tab", onTarget: true },
+          { type: "keyup", key: "Shift", onTarget: true }
+        ]
+      })
+    ).toBe("delivered")
+    expect(
+      assessAgentInputDelivery(click, {
+        events: [
+          event("mousemove", { x: 10.4 }),
+          event("mousedown", { y: 20.6 }),
+          event("mouseup")
+        ]
+      })
+    ).toBe("delivered")
+  })
+})
+
+describe("native input backend choice", () => {
+  const target = { sensitive: false, maySubmit: false }
+  const cdp = { cdpControl: true, attached: true, frameMapped: true }
+
+  it("goes native for activation, gestures, text and chords when attached", () => {
+    for (const type of [
+      "click",
+      "double_click",
+      "hover",
+      "type",
+      "press_key"
+    ]) {
+      expect(
+        chooseAgentInputBackend({
+          ...cdp,
+          effect: { command: command({ type, text: "x", key: "Tab" }), target }
+        }).backend,
+        type
+      ).toBe("cdp")
+    }
+  })
+
+  it("keeps guarded navigation and submission on the DOM backend whatever is attached", () => {
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "click" }),
+          target: { ...target, href: "https://example.com/next" }
+        }
+      })
+    ).toEqual({ backend: "dom", reason: "guarded_navigation" })
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "click" }),
+          target: { ...target, submitter: true }
+        }
+      })
+    ).toEqual({ backend: "dom", reason: "guarded_submission" })
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: {
+          command: command({ type: "press_key", key: "Enter" }),
+          target: { ...target, maySubmit: true }
+        }
+      })
+    ).toEqual({ backend: "dom", reason: "guarded_submission" })
+  })
+
+  it("falls to the DOM backend without control, without attachment, or with an unplaced frame", () => {
+    const effect = { command: command({ type: "click" }), target }
+    expect(
+      chooseAgentInputBackend({ ...cdp, effect, cdpControl: false }).reason
+    ).toBe("no_native_control")
+    expect(
+      chooseAgentInputBackend({ ...cdp, effect, attached: false }).reason
+    ).toBe("no_native_control")
+    expect(
+      chooseAgentInputBackend({ ...cdp, effect, frameMapped: false }).reason
+    ).toBe("frame_unmapped")
+    expect(
+      chooseAgentInputBackend({
+        ...cdp,
+        effect: { command: command({ type: "check" }), target }
+      })
+    ).toEqual({ backend: "dom", reason: "action_not_native" })
+  })
+})

--- a/src/lib/browser-agent/command-executor.ts
+++ b/src/lib/browser-agent/command-executor.ts
@@ -9,6 +9,19 @@ import type { AgentSnapshotIdentity } from "@ollama-client/contracts"
 import type { TabAccess } from "@/lib/browser-tab-access"
 import type { AgentElementReferenceStore } from "./element-references"
 import {
+  type AgentInputBackendChoice,
+  type AgentInputPlatform,
+  type AgentInputPoint,
+  type AgentInputTrace,
+  AgentNativeInputCancelledError,
+  AgentNativeInputFailedError,
+  type AgentNativeInputPlan,
+  assessAgentInputDelivery,
+  chooseAgentInputBackend,
+  planAgentNativeInput,
+  planAgentWheel
+} from "./native-input"
+import {
   type AgentFormSubmitter,
   buildAgentElementObservation,
   resolveAgentFormSubmitter
@@ -374,6 +387,77 @@ const executeKey = (
   element.dispatchEvent(new KeyboardEvent("keyup", init))
 }
 
+/**
+ * The live element an approved instruction still names, or a typed refusal.
+ *
+ * Every check here is one the approval was given against: the snapshot the
+ * reference was bound in, the element it resolves to, the form state around
+ * it and the observed facts about it. Native and synthetic execution share the
+ * function so the two backends cannot drift in what they refuse.
+ */
+export const resolveAgentMutationTarget = (
+  effect: AgentDomMutationInstruction,
+  references: AgentElementReferenceStore
+): Element => {
+  const ref = effect.target.ref
+  if (!ref) throw new Error("Agent mutation target has no reference")
+  const identity = effect.frame
+  if (!references.matches(identity)) {
+    throw new AgentEffectNotAppliedError("Agent mutation snapshot is stale")
+  }
+  const element = references.resolve(ref, identity)
+  if (!element)
+    throw new AgentEffectNotAppliedError("Agent mutation target is stale")
+  if (!references.matchesFormState(ref, identity)) {
+    throw new AgentEffectNotAppliedError(
+      "Agent mutation form state changed after approval"
+    )
+  }
+  assertUnchangedMutationTarget(effect, element)
+  if (effect.target.sensitive || effect.target.formHasSensitiveControl) {
+    throw new Error("Agent cannot mutate a sensitive control")
+  }
+  return element
+}
+
+const pointerEventInit = (element: Element): MouseEventInit => {
+  const rect = element.getBoundingClientRect()
+  return {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+    view: element.ownerDocument.defaultView ?? undefined
+  }
+}
+
+/**
+ * The synthetic stand-ins for pointer gestures, used only where no debugger is
+ * attached. A page can tell them from a real pointer; the receipt records the
+ * backend so the verifier expects nothing a synthetic event cannot produce.
+ */
+const executeSyntheticPointer = (
+  type: "double_click" | "hover",
+  element: Element
+): void => {
+  const init = pointerEventInit(element)
+  if (type === "hover") {
+    element.dispatchEvent(new MouseEvent("mouseover", init))
+    element.dispatchEvent(
+      new MouseEvent("mouseenter", { ...init, bubbles: false })
+    )
+    element.dispatchEvent(new MouseEvent("mousemove", init))
+    return
+  }
+  if (!(element instanceof HTMLElement)) {
+    throw new Error("Agent double-click target is no longer supported")
+  }
+  element.click()
+  element.click()
+  element.dispatchEvent(new MouseEvent("dblclick", { ...init, detail: 2 }))
+}
+
 /** Executes a previously resolved mutation against the still-live snapshot. */
 export const executeAgentDomMutationInDocument = (input: {
   effect: AgentDomMutationInstruction
@@ -382,27 +466,7 @@ export const executeAgentDomMutationInDocument = (input: {
   signal: AgentCancellationSignal
 }): string | undefined => {
   if (input.signal.aborted) throw new Error("Agent mutation cancelled")
-  const ref = input.effect.target.ref
-  if (!ref) throw new Error("Agent mutation target has no reference")
-  const identity = input.effect.frame
-  if (!input.references.matches(identity)) {
-    throw new AgentEffectNotAppliedError("Agent mutation snapshot is stale")
-  }
-  const element = input.references.resolve(ref, identity)
-  if (!element)
-    throw new AgentEffectNotAppliedError("Agent mutation target is stale")
-  if (!input.references.matchesFormState(ref, identity)) {
-    throw new AgentEffectNotAppliedError(
-      "Agent mutation form state changed after approval"
-    )
-  }
-  assertUnchangedMutationTarget(input.effect, element)
-  if (
-    input.effect.target.sensitive ||
-    input.effect.target.formHasSensitiveControl
-  ) {
-    throw new Error("Agent cannot mutate a sensitive control")
-  }
+  const element = resolveAgentMutationTarget(input.effect, input.references)
 
   switch (input.effect.command.type) {
     case "click":
@@ -431,9 +495,31 @@ export const executeAgentDomMutationInDocument = (input: {
       break
     case "press_key":
       return executeKey(input.effect, element)
+    case "double_click":
+    case "hover":
+      executeSyntheticPointer(input.effect.command.type, element)
+      break
     default:
       throw new Error("Agent action is not a DOM mutation")
   }
+}
+
+/**
+ * What the executor learns about native control before choosing a backend,
+ * all read in one go so the choice and the offset it will use come from the
+ * same moment. `frameOffset` is set only when the target's frame is placed.
+ */
+export interface AgentNativeControlFacts {
+  cdpControl: boolean
+  attached: boolean
+  frameMapped: boolean
+  frameOffset?: AgentInputPoint
+  platform: AgentInputPlatform
+}
+
+export interface AgentNativeInputPreparation {
+  point: AgentInputPoint
+  focused: boolean
 }
 
 export interface AgentCommandExecutorAdapter {
@@ -453,6 +539,32 @@ export interface AgentCommandExecutorAdapter {
     effect: AuthorizedAgentEffect,
     signal: AgentCancellationSignal
   ): Promise<string | undefined>
+  /**
+   * Native input, in the order the executor calls it: the facts a backend is
+   * chosen on, the page-side recheck that arms the input record and yields the
+   * pointer target, the debugger dispatch of a plan, and the record read back.
+   * Absent means this browser has no native backend.
+   */
+  nativeControl?(
+    effect: AuthorizedAgentEffect
+  ): Promise<AgentNativeControlFacts>
+  prepareNativeInput?(
+    effect: AuthorizedAgentEffect,
+    signal: AgentCancellationSignal
+  ): Promise<AgentNativeInputPreparation>
+  dispatchNativeInput?(
+    effect: AuthorizedAgentEffect,
+    plan: AgentNativeInputPlan,
+    signal: AgentCancellationSignal
+  ): Promise<{ dispatched: number }>
+  settleNativeInput?(
+    effect: AuthorizedAgentEffect,
+    signal: AgentCancellationSignal
+  ): Promise<AgentInputTrace | undefined>
+  /** The root viewport's centre, where a native wheel is aimed. */
+  viewportCentre?(
+    effect: AuthorizedAgentEffect
+  ): Promise<AgentInputPoint | undefined>
   activateTab(tabId: number): Promise<void>
   goHistory(tabId: number, direction: "back" | "forward"): Promise<void>
   resolveHistoryDestination(
@@ -562,6 +674,185 @@ const receipt = (
   ...(controlledTabId === undefined ? {} : { controlledTabId })
 })
 
+/**
+ * Which backend an action runs on, decided before anything touches the page.
+ * A browser without native control, or an adapter that does not offer it, is
+ * the DOM backend by construction.
+ */
+const chooseBackend = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter
+): Promise<{
+  choice: AgentInputBackendChoice
+  facts?: AgentNativeControlFacts
+}> => {
+  if (!adapter.nativeControl) {
+    return {
+      choice: chooseAgentInputBackend({
+        effect,
+        cdpControl: false,
+        attached: false,
+        frameMapped: false
+      })
+    }
+  }
+  const facts = await adapter.nativeControl(effect)
+  return {
+    facts,
+    choice: chooseAgentInputBackend({
+      effect,
+      cdpControl: facts.cdpControl,
+      attached: facts.attached,
+      frameMapped: facts.frameMapped && facts.frameOffset !== undefined
+    })
+  }
+}
+
+/**
+ * Runs an element action as native input.
+ *
+ * The page rechecks the target and arms its record; nothing has been sent by
+ * then, so a refusal there is a clean stale-target failure. Once the first
+ * step goes out the action is committed: a plan that cannot finish reports
+ * how far it got and is never completed by other means, and a plan that
+ * finished is followed by asking the document what it received. A document
+ * that cannot answer — it navigated, typically — leaves delivery unknown and
+ * the verifier reading page evidence.
+ */
+const executeNative = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  facts: AgentNativeControlFacts,
+  signal: AgentCancellationSignal
+): Promise<AgentExecutionReceipt> => {
+  if (
+    !adapter.prepareNativeInput ||
+    !adapter.dispatchNativeInput ||
+    !adapter.settleNativeInput ||
+    !facts.frameOffset
+  ) {
+    throw new Error("Agent native input adapter is incomplete")
+  }
+  const prepared = await adapter.prepareNativeInput(effect, signal)
+  const plan = planAgentNativeInput({
+    command: effect.command,
+    point: prepared.point,
+    frameOffset: facts.frameOffset,
+    focused: prepared.focused,
+    platform: facts.platform
+  })
+  try {
+    await adapter.dispatchNativeInput(effect, plan, signal)
+  } catch (error) {
+    /**
+     * A first step the debugger refused to send never reached the page, so
+     * the target is simply re-observed. Anything after that may have acted,
+     * and is reported as such rather than completed on the DOM backend.
+     */
+    if (
+      error instanceof AgentNativeInputFailedError &&
+      error.dispatched === 0
+    ) {
+      throw new AgentEffectNotAppliedError(
+        "Agent native input could not be sent"
+      )
+    }
+    if (
+      error instanceof AgentNativeInputCancelledError &&
+      error.dispatched === 0
+    ) {
+      throw new AgentEffectNotAppliedError("Agent native input was cancelled")
+    }
+    throw error
+  }
+  let trace: AgentInputTrace | undefined
+  let settled = true
+  try {
+    trace = await adapter.settleNativeInput(effect, signal)
+  } catch {
+    settled = false
+  }
+  return {
+    ...receipt(adapter, effect.command.type),
+    backend: "cdp",
+    inputDelivery: settled ? assessAgentInputDelivery(plan, trace) : "unknown"
+  }
+}
+
+/** The DOM backend, recorded as such so the verifier expects no native record. */
+const executeSynthetic = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  signal: AgentCancellationSignal
+): Promise<AgentExecutionReceipt> => {
+  const submissionUrl = await adapter.mutate(effect, signal)
+  return {
+    ...receipt(adapter, effect.command.type),
+    backend: "dom",
+    ...(submissionUrl ? { submissionUrl } : {})
+  }
+}
+
+/** An element action on whichever backend was chosen for it, and only that one. */
+const executeElementAction = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  signal: AgentCancellationSignal
+): Promise<AgentExecutionReceipt> => {
+  const { choice, facts } = await chooseBackend(effect, adapter)
+  if (choice.backend === "cdp" && facts) {
+    return executeNative(effect, adapter, facts, signal)
+  }
+  return executeSynthetic(effect, adapter, signal)
+}
+
+/** How long a native wheel is given to settle before the page is re-observed. */
+const WHEEL_SETTLE_MS = 150
+
+/**
+ * A scroll without a target goes native when it can: a wheel at the viewport
+ * centre scrolls whatever container sits there, which is the document on a
+ * page and the application's own scroller on a page that never scrolls. A
+ * referenced scroll keeps `scrollIntoView`, which names its destination.
+ */
+const executeScroll = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter,
+  signal: AgentCancellationSignal
+): Promise<AgentExecutionReceipt> => {
+  if (effect.command.type !== "scroll") throw new Error("Invalid scroll effect")
+  const native =
+    !effect.command.ref && adapter.nativeControl && adapter.dispatchNativeInput
+      ? await adapter.nativeControl(effect)
+      : undefined
+  const centre =
+    native?.cdpControl && native.attached
+      ? await adapter.viewportCentre?.(effect)
+      : undefined
+  if (centre && adapter.dispatchNativeInput) {
+    const amount =
+      effect.command.amount ??
+      (effect.command.direction === "up" || effect.command.direction === "down"
+        ? centre.y * 2 * 0.8
+        : centre.x * 2 * 0.8)
+    const plan = planAgentWheel({
+      point: centre,
+      direction: effect.command.direction,
+      amount
+    })
+    await adapter.dispatchNativeInput(effect, plan, signal)
+    await adapter.wait(WHEEL_SETTLE_MS, signal)
+    return { ...receipt(adapter, "scroll"), backend: "cdp" }
+  }
+  await adapter.scroll(
+    effect.command,
+    effect.snapshotIdentity,
+    effect.target.frame ?? effect.snapshotIdentity,
+    signal
+  )
+  return { ...receipt(adapter, "scroll"), backend: "dom" }
+}
+
 export const READ_ONLY_AGENT_EXECUTORS = {
   async read(effect, adapter) {
     await assertSource(effect, adapter, true)
@@ -592,16 +883,7 @@ export const READ_ONLY_AGENT_EXECUTORS = {
   },
   async scroll(effect, adapter, signal) {
     await assertSource(effect, adapter, true)
-    if (effect.command.type !== "scroll") {
-      throw new Error("Invalid scroll effect")
-    }
-    await adapter.scroll(
-      effect.command,
-      effect.snapshotIdentity,
-      effect.target.frame ?? effect.snapshotIdentity,
-      signal
-    )
-    return receipt(adapter, "scroll")
+    return executeScroll(effect, adapter, signal)
   },
   async switch_tab(effect, adapter) {
     if (effect.command.type !== "switch_tab" || !effect.destination) {
@@ -726,24 +1008,25 @@ export const DOM_MUTATION_AGENT_EXECUTORS = {
         effect.snapshotIdentity.tabId,
         effect.destination.url
       )
-    } else {
-      const submissionUrl = await adapter.mutate(effect, signal)
-      return {
-        ...receipt(adapter, "click"),
-        ...(submissionUrl ? { submissionUrl } : {})
-      }
+      return { ...receipt(adapter, "click"), backend: "dom" }
     }
-    return receipt(adapter, "click")
+    return executeElementAction(effect, adapter, signal)
+  },
+  async double_click(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    return executeElementAction(effect, adapter, signal)
+  },
+  async hover(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    return executeElementAction(effect, adapter, signal)
   },
   async type(effect, adapter, signal) {
     await assertSource(effect, adapter, true)
-    await adapter.mutate(effect, signal)
-    return receipt(adapter, "type")
+    return executeElementAction(effect, adapter, signal)
   },
   async clear_and_type(effect, adapter, signal) {
     await assertSource(effect, adapter, true)
-    await adapter.mutate(effect, signal)
-    return receipt(adapter, "clear_and_type")
+    return executeElementAction(effect, adapter, signal)
   },
   async select(effect, adapter, signal) {
     await assertSource(effect, adapter, true)
@@ -765,11 +1048,7 @@ export const DOM_MUTATION_AGENT_EXECUTORS = {
     if (effect.destination) {
       await assertReadable(adapter, effect.destination.url)
     }
-    const submissionUrl = await adapter.mutate(effect, signal)
-    return {
-      ...receipt(adapter, "press_key"),
-      ...(submissionUrl ? { submissionUrl } : {})
-    }
+    return executeElementAction(effect, adapter, signal)
   }
 } satisfies Record<DomMutationAgentAction, Executor>
 

--- a/src/lib/browser-agent/command-executor.ts
+++ b/src/lib/browser-agent/command-executor.ts
@@ -4,7 +4,10 @@ import type {
   AuthorizedAgentEffect
 } from "@ollama-client/agent-runtime"
 import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
-import type { AgentSnapshotIdentity } from "@ollama-client/contracts"
+import {
+  type AgentSnapshotIdentity,
+  parseAgentKeyCombination
+} from "@ollama-client/contracts"
 
 import type { TabAccess } from "@/lib/browser-tab-access"
 import type { AgentElementReferenceStore } from "./element-references"
@@ -16,6 +19,7 @@ import {
   AgentNativeInputCancelledError,
   AgentNativeInputFailedError,
   type AgentNativeInputPlan,
+  agentNativeKeyDefinition,
   assessAgentInputDelivery,
   chooseAgentInputBackend,
   planAgentNativeInput,
@@ -377,8 +381,25 @@ const executeKey = (
   if (effect.command.key === "Enter" && effect.target.maySubmit) {
     return submitWithoutPageHandlers(effect, element)
   }
-  const init = {
-    key: effect.command.key,
+  /**
+   * The chord is spelled out as a page would see it from a keyboard: the key
+   * itself in `key`, each modifier as its flag, and the code and virtual key
+   * where the table knows them. The command's own string is the grammar, not
+   * an event field — `Control+é` is a chord, not a key named that.
+   */
+  const combination = parseAgentKeyCombination(effect.command.key)
+  if (!combination) throw new Error("Agent key combination is invalid")
+  const definition = agentNativeKeyDefinition(combination.key)
+  const init: KeyboardEventInit = {
+    key: definition?.key ?? combination.key,
+    ...(definition?.code ? { code: definition.code } : {}),
+    ...(definition?.keyCode !== undefined
+      ? { keyCode: definition.keyCode }
+      : {}),
+    ctrlKey: combination.modifiers.includes("Control"),
+    shiftKey: combination.modifiers.includes("Shift"),
+    altKey: combination.modifiers.includes("Alt"),
+    metaKey: combination.modifiers.includes("Meta"),
     bubbles: true,
     cancelable: true,
     composed: true

--- a/src/lib/browser-agent/control-port.ts
+++ b/src/lib/browser-agent/control-port.ts
@@ -167,6 +167,8 @@ const AgentDomMutationCommandSchema = AgentCommandSchema.refine(
   (command) =>
     [
       "click",
+      "double_click",
+      "hover",
       "type",
       "clear_and_type",
       "select",
@@ -327,10 +329,127 @@ export const AgentScrollResponseSchema = z
   .strict()
 export type AgentScrollResponse = z.infer<typeof AgentScrollResponseSchema>
 
+/**
+ * Native input is prepared in the page and dispatched from the background.
+ * The page rechecks the approved target, brings it into view, picks the point
+ * a pointer can reach and starts recording what the document receives; the
+ * background sends the events through the debugger; the page is then asked
+ * what arrived. Coordinates are the frame's own viewport pixels — the
+ * background places the frame, never the page.
+ */
+export const AgentPrepareNativeInputRequestSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.literal("agent_prepare_native_input"),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.number().int().nonnegative(),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1),
+    instruction: AgentDomMutationInstructionSchema
+  })
+  .strict()
+export type AgentPrepareNativeInputRequest = z.infer<
+  typeof AgentPrepareNativeInputRequestSchema
+>
+
+const AgentInputPointSchema = z
+  .object({ x: z.number().finite(), y: z.number().finite() })
+  .strict()
+
+export const AgentPrepareNativeInputResponseSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.enum([
+      "agent_native_input_prepared",
+      "agent_native_input_rejected"
+    ]),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.number().int().nonnegative(),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1),
+    point: AgentInputPointSchema.optional(),
+    focused: z.boolean().optional()
+  })
+  .strict()
+export type AgentPrepareNativeInputResponse = z.infer<
+  typeof AgentPrepareNativeInputResponseSchema
+>
+
+export interface AgentNativeInputPreparedResult {
+  point: { x: number; y: number }
+  focused: boolean
+}
+
+export const AgentSettleNativeInputRequestSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.literal("agent_settle_native_input"),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.number().int().nonnegative(),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1)
+  })
+  .strict()
+export type AgentSettleNativeInputRequest = z.infer<
+  typeof AgentSettleNativeInputRequestSchema
+>
+
+/** Structural only: event types, coordinates and key names, never page text. */
+const AgentRecordedInputEventSchema = z
+  .object({
+    type: z.enum([
+      "mousemove",
+      "mousedown",
+      "mouseup",
+      "keydown",
+      "keyup",
+      "wheel"
+    ]),
+    x: z.number().finite().optional(),
+    y: z.number().finite().optional(),
+    key: z.string().max(40).optional(),
+    onTarget: z.boolean()
+  })
+  .strict()
+
+export const AgentInputTraceSchema = z
+  .object({
+    events: z.array(AgentRecordedInputEventSchema).max(2_200),
+    overflow: z.boolean().optional()
+  })
+  .strict()
+
+export const AgentSettleNativeInputResponseSchema = z
+  .object({
+    version: z.literal(AGENT_CONTROL_VERSION),
+    type: z.literal("agent_native_input_settled"),
+    runId: z.string().min(1),
+    tabId: z.number().int().nonnegative(),
+    frameId: z.number().int().nonnegative(),
+    nonce: z.string().min(16).max(256),
+    sequence: z.number().int().positive(),
+    documentId: z.string().min(1),
+    /** Absent when nothing was armed on this document. */
+    trace: AgentInputTraceSchema.optional()
+  })
+  .strict()
+export type AgentSettleNativeInputResponse = z.infer<
+  typeof AgentSettleNativeInputResponseSchema
+>
+export type AgentInputTraceWire = z.infer<typeof AgentInputTraceSchema>
+
 const AgentControlRequestSchema = z.union([
   AgentObserveRequestSchema,
   AgentExecuteRequestSchema,
-  AgentExecuteScrollRequestSchema
+  AgentExecuteScrollRequestSchema,
+  AgentPrepareNativeInputRequestSchema,
+  AgentSettleNativeInputRequestSchema
 ])
 type AgentControlRequest = z.infer<typeof AgentControlRequestSchema>
 
@@ -376,6 +495,13 @@ export interface AgentControlSession {
     instruction: AgentScrollInstruction,
     signal?: AbortSignal
   ): Promise<void>
+  prepareNativeInput(
+    instruction: AgentDomMutationInstruction,
+    signal?: AbortSignal
+  ): Promise<AgentNativeInputPreparedResult>
+  settleNativeInput(
+    signal?: AbortSignal
+  ): Promise<AgentInputTraceWire | undefined>
   disconnect(): void
 }
 
@@ -539,6 +665,61 @@ export const validateAgentScrollResponse = (
   }
 }
 
+const assertBoundResponse = (
+  response: {
+    runId: string
+    tabId: number
+    frameId: number
+    nonce: string
+    sequence: number
+    documentId: string
+  },
+  binding: AgentControlBinding,
+  sequence: number,
+  what: string
+): void => {
+  if (
+    response.runId !== binding.runId ||
+    response.tabId !== binding.tabId ||
+    response.frameId !== binding.frameId ||
+    response.nonce !== binding.nonce ||
+    response.sequence !== sequence ||
+    response.documentId !== binding.documentId
+  ) {
+    throw new Error(`Agent ${what} response binding mismatch`)
+  }
+}
+
+export const validateAgentPrepareNativeInputResponse = (
+  raw: unknown,
+  binding: AgentControlBinding,
+  sequence: number
+): AgentNativeInputPreparedResult => {
+  const failure = readAgentControlFailure(raw, binding, sequence)
+  if (failure) throw failure
+  const response = AgentPrepareNativeInputResponseSchema.parse(raw)
+  assertBoundResponse(response, binding, sequence, "native input preparation")
+  if (response.type === "agent_native_input_rejected") {
+    throw new AgentEffectNotAppliedError()
+  }
+  if (!response.point || response.focused === undefined) {
+    throw new Error("Agent native input preparation is incomplete")
+  }
+  return { point: response.point, focused: response.focused }
+}
+
+export const validateAgentSettleNativeInputResponse = (
+  raw: unknown,
+  binding: AgentControlBinding,
+  sequence: number
+): AgentInputTraceWire | undefined => {
+  const failure = readAgentControlFailure(raw, binding, sequence)
+  if (failure) throw failure
+  const response = AgentSettleNativeInputResponseSchema.parse(raw)
+  assertBoundResponse(response, binding, sequence, "native input settlement")
+  return response.trace
+}
+
 export const createAgentControlSession = (input: {
   port: AgentControlPort
   binding: AgentControlBinding
@@ -689,6 +870,57 @@ export const createAgentControlSession = (input: {
         signal
       )
     },
+    prepareNativeInput(instruction, signal) {
+      if (inFlight) {
+        return Promise.reject(
+          new Error("Agent control request already in flight")
+        )
+      }
+      sequence += 1
+      const expectedSequence = sequence
+      const request: AgentPrepareNativeInputRequest = {
+        version: AGENT_CONTROL_VERSION,
+        type: "agent_prepare_native_input",
+        ...input.binding,
+        sequence: expectedSequence,
+        instruction: AgentDomMutationInstructionSchema.parse(instruction)
+      }
+      return exchange(
+        request,
+        (raw) =>
+          validateAgentPrepareNativeInputResponse(
+            raw,
+            input.binding,
+            expectedSequence
+          ),
+        signal
+      )
+    },
+    settleNativeInput(signal) {
+      if (inFlight) {
+        return Promise.reject(
+          new Error("Agent control request already in flight")
+        )
+      }
+      sequence += 1
+      const expectedSequence = sequence
+      const request: AgentSettleNativeInputRequest = {
+        version: AGENT_CONTROL_VERSION,
+        type: "agent_settle_native_input",
+        ...input.binding,
+        sequence: expectedSequence
+      }
+      return exchange(
+        request,
+        (raw) =>
+          validateAgentSettleNativeInputResponse(
+            raw,
+            input.binding,
+            expectedSequence
+          ),
+        signal
+      )
+    },
     disconnect() {
       input.port.disconnect()
     }
@@ -808,13 +1040,114 @@ const controlFailureReason = (
     : "observation_build_failed"
 }
 
+/** Only a typed, pre-effect rejection may authorize re-observation instead of uncertainty. */
+const runContentPreparation = (
+  prepare: () => AgentNativeInputPreparedResult
+): Pick<AgentPrepareNativeInputResponse, "type" | "point" | "focused"> => {
+  try {
+    const prepared = prepare()
+    return {
+      type: "agent_native_input_prepared",
+      point: prepared.point,
+      focused: prepared.focused
+    }
+  } catch (error) {
+    if (error instanceof AgentEffectNotAppliedError)
+      return { type: "agent_native_input_rejected" }
+    throw error
+  }
+}
+
+export interface AgentControlContentHandlers {
+  buildObservation(request: AgentObserveRequest): AgentObservation
+  executeDomMutation(request: AgentExecuteRequest): string | undefined
+  executeScroll(request: AgentExecuteScrollRequest): void
+  prepareNativeInput(
+    request: AgentPrepareNativeInputRequest
+  ): AgentNativeInputPreparedResult
+  settleNativeInput(
+    request: AgentSettleNativeInputRequest
+  ): AgentInputTraceWire | undefined
+}
+
+type AgentControlResponse =
+  | AgentObserveResponse
+  | AgentExecuteResponse
+  | AgentScrollResponse
+  | AgentPrepareNativeInputResponse
+  | AgentSettleNativeInputResponse
+  | AgentControlFailureResponse
+
+const answerAccepted = (
+  request: AgentControlRequest,
+  binding: AgentControlBinding,
+  handlers: AgentControlContentHandlers
+): AgentControlResponse => {
+  const envelope = {
+    version: AGENT_CONTROL_VERSION,
+    ...binding,
+    sequence: request.sequence
+  } as const
+  switch (request.type) {
+    case "agent_prepare_native_input":
+      return {
+        ...envelope,
+        ...runContentPreparation(() => handlers.prepareNativeInput(request))
+      }
+    case "agent_settle_native_input": {
+      const trace = handlers.settleNativeInput(request)
+      return {
+        ...envelope,
+        type: "agent_native_input_settled",
+        ...(trace ? { trace } : {})
+      }
+    }
+    case "agent_execute_scroll":
+      handlers.executeScroll(request)
+      return { ...envelope, type: "agent_scroll_executed" }
+    case "agent_execute_dom_mutation":
+      return {
+        ...envelope,
+        ...runContentMutation(() => handlers.executeDomMutation(request))
+      }
+    case "agent_observe":
+      return {
+        ...envelope,
+        type: "agent_observation",
+        observation: AgentObservationSchema.parse(
+          handlers.buildObservation(request)
+        )
+      }
+  }
+}
+
+/**
+ * The reply to one accepted request, or the bound failure that stands in for
+ * it when the handler threw. Either way the reply carries the request's own
+ * binding and sequence, so it can be matched to nothing else.
+ */
+const answerControlRequest = (
+  request: AgentControlRequest,
+  binding: AgentControlBinding,
+  handlers: AgentControlContentHandlers
+): AgentControlResponse => {
+  try {
+    return answerAccepted(request, binding, handlers)
+  } catch (error) {
+    return {
+      version: AGENT_CONTROL_VERSION,
+      type: "agent_control_failed",
+      ...binding,
+      sequence: request.sequence,
+      reason: controlFailureReason(request.type, error),
+      issues: agentControlSchemaIssues(error)
+    }
+  }
+}
+
 export const attachAgentControlContentPort = (
   port: AgentControlPort,
-  handlers: {
-    buildObservation(request: AgentObserveRequest): AgentObservation
-    executeDomMutation(request: AgentExecuteRequest): string | undefined
-    executeScroll(request: AgentExecuteScrollRequest): void
-  }
+  handlers: AgentControlContentHandlers
 ): boolean => {
   if (port.name !== MESSAGE_KEYS.AGENT.CONTROL_PORT) return false
   let binding: AgentControlBinding | undefined
@@ -853,7 +1186,8 @@ export const attachAgentControlContentPort = (
      */
     if (
       (request.type === "agent_execute_dom_mutation" ||
-        request.type === "agent_execute_scroll") &&
+        request.type === "agent_execute_scroll" ||
+        request.type === "agent_prepare_native_input") &&
       (request.instruction.frame.tabId !== request.tabId ||
         request.instruction.frame.frameId !== request.frameId ||
         request.instruction.frame.documentId !== request.documentId ||
@@ -863,66 +1197,9 @@ export const attachAgentControlContentPort = (
       return
     }
 
-    try {
-      if (
-        request.type === "agent_execute_dom_mutation" ||
-        request.type === "agent_execute_scroll"
-      ) {
-        let mutation: Pick<AgentExecuteResponse, "type" | "submissionUrl"> = {
-          type: "agent_dom_mutation_executed"
-        }
-        if (request.type === "agent_execute_scroll") {
-          handlers.executeScroll(request)
-        } else {
-          mutation = runContentMutation(() =>
-            handlers.executeDomMutation(request)
-          )
-        }
-        binding = nextBinding
-        lastSequence = request.sequence
-        const response: AgentExecuteResponse | AgentScrollResponse =
-          request.type === "agent_execute_scroll"
-            ? {
-                version: AGENT_CONTROL_VERSION,
-                type: "agent_scroll_executed",
-                ...nextBinding,
-                sequence: request.sequence
-              }
-            : {
-                version: AGENT_CONTROL_VERSION,
-                ...mutation,
-                ...nextBinding,
-                sequence: request.sequence
-              }
-        port.postMessage(response)
-        return
-      }
-      const observation = AgentObservationSchema.parse(
-        handlers.buildObservation(request)
-      )
-      binding = nextBinding
-      lastSequence = request.sequence
-      const response: AgentObserveResponse = {
-        version: AGENT_CONTROL_VERSION,
-        type: "agent_observation",
-        ...nextBinding,
-        sequence: request.sequence,
-        observation
-      }
-      port.postMessage(response)
-    } catch (error) {
-      binding = nextBinding
-      lastSequence = request.sequence
-      const failure: AgentControlFailureResponse = {
-        version: AGENT_CONTROL_VERSION,
-        type: "agent_control_failed",
-        ...nextBinding,
-        sequence: request.sequence,
-        reason: controlFailureReason(request.type, error),
-        issues: agentControlSchemaIssues(error)
-      }
-      port.postMessage(failure)
-    }
+    binding = nextBinding
+    lastSequence = request.sequence
+    port.postMessage(answerControlRequest(request, nextBinding, handlers))
   })
   return true
 }

--- a/src/lib/browser-agent/effect-verifier.ts
+++ b/src/lib/browser-agent/effect-verifier.ts
@@ -238,6 +238,22 @@ export const READ_ONLY_AGENT_VERIFIERS = {
         adapter.now()
       )
     }
+    /**
+     * A native wheel scrolls whatever container sits under the pointer, and
+     * an application whose document never scrolls still shows new content.
+     * The window position is silent about that; the visible text is not.
+     */
+    if (
+      input.receipt.backend === "cdp" &&
+      after.visibleText !== input.before.visibleText
+    ) {
+      return result(
+        "confirmed",
+        "scroll",
+        "Visible content changed as requested",
+        adapter.now()
+      )
+    }
     const atBoundary =
       (input.effect.command.direction === "up" && before.y <= 0) ||
       (input.effect.command.direction === "left" && before.x <= 0) ||
@@ -461,6 +477,12 @@ const mutationTargetAfter = (
   return { type: "one", element: matches[0] }
 }
 
+/**
+ * What counts as the page having changed. Focus is deliberately left out: a
+ * native click moves focus onto the control it lands on, and a silent button
+ * that merely took focus is not a button that did something. Focus traversal
+ * has its own explicit check in the key verifier.
+ */
 const pageEvidence = (observation: AgentObservation): string =>
   JSON.stringify({
     url: observation.url,
@@ -474,12 +496,57 @@ const pageEvidence = (observation: AgentObservation): string =>
       type: element.type,
       value: element.value,
       checked: element.checked,
-      focused: element.focused,
       href: element.href,
       visible: element.visible,
       enabled: element.enabled
     }))
   })
+
+/**
+ * Native input the page did not receive as planned settles the step before any
+ * page evidence is read. Interference means a hand other than the agent's was
+ * on the page during the action, so whatever changed cannot be attributed; a
+ * partial or misdirected plan means the resolved control was not the one that
+ * received the input. Either is an unresolved effect the user has to look at,
+ * never a confirmed one and never a clean negative to retry.
+ */
+const deliveryProblem = (
+  input: AgentVerificationInput,
+  kind: string,
+  now: number
+): AgentVerificationResult | undefined => {
+  switch (input.receipt.inputDelivery) {
+    case "interference":
+      return result(
+        "ambiguous",
+        kind,
+        "User input was observed while the action ran",
+        now
+      )
+    case "misdirected":
+      return result(
+        "ambiguous",
+        kind,
+        "Native input reached an element other than the target",
+        now
+      )
+    case "partial":
+      return result(
+        "ambiguous",
+        kind,
+        "Native input was cut short before the plan completed",
+        now
+      )
+    default:
+      return undefined
+  }
+}
+
+const withDelivery =
+  (kind: string, verifier: Verifier): Verifier =>
+  async (input, adapter, signal) =>
+    deliveryProblem(input, kind, adapter.now()) ??
+    verifier(input, adapter, signal)
 
 const verifyValueMutation: Verifier = async (input, adapter, signal) => {
   const after = await observeAfter(input, adapter, signal)
@@ -617,6 +684,37 @@ const verifySubmission: Verifier = async (input, adapter, signal) => {
   )
 }
 
+/**
+ * Widgets whose job is to receive input once they hold focus. A click that
+ * lands focus on one of these has done what a click on them does — the typing
+ * or arrow keys come next. A button or a link taking focus proves nothing of
+ * the kind, so they are not in the set.
+ */
+const FOCUS_RECEIVING_ROLES = new Set([
+  "combobox",
+  "grid",
+  "gridcell",
+  "listbox",
+  "option",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "tab",
+  "textbox",
+  "tree",
+  "treeitem"
+])
+const FOCUS_RECEIVING_TAGS = new Set(["input", "select", "textarea"])
+
+const receivesInputOnFocus = (
+  target: AgentVerificationInput["effect"]["target"]
+): boolean =>
+  FOCUS_RECEIVING_ROLES.has(target.role?.toLowerCase() ?? "") ||
+  (FOCUS_RECEIVING_TAGS.has(target.tag ?? "") &&
+    !["button", "submit", "reset", "image"].includes(
+      target.inputType?.toLowerCase() ?? ""
+    ))
+
 const verifyActivation: Verifier = async (input, adapter, signal) => {
   if (input.effect.semanticEffects.includes("submission")) {
     return verifySubmission(input, adapter, signal)
@@ -639,6 +737,20 @@ const verifyActivation: Verifier = async (input, adapter, signal) => {
       adapter.now()
     )
   }
+  const target = mutationTargetAfter(input, after)
+  if (
+    target.type === "one" &&
+    target.element.focused === true &&
+    !input.effect.target.observedFocused &&
+    receivesInputOnFocus(input.effect.target)
+  ) {
+    return result(
+      "confirmed",
+      "activation",
+      "Control took focus and is ready for input",
+      adapter.now()
+    )
+  }
   return result(
     "ambiguous",
     "activation",
@@ -646,6 +758,42 @@ const verifyActivation: Verifier = async (input, adapter, signal) => {
     adapter.now()
   )
 }
+
+/**
+ * A hover has no state of its own to read back. A page that reacted — a menu
+ * opened, a tooltip appeared — is evidence enough; a page that did not is
+ * still confirmed when the document reported the pointer arriving on the
+ * control, because that is all a hover promises. Without either the pointer
+ * may have gone anywhere, and the step stays unresolved.
+ */
+const verifyHover: Verifier = async (input, adapter, signal) => {
+  const after = await observeAfter(input, adapter, signal)
+  if (pageEvidence(after) !== pageEvidence(input.before)) {
+    return result(
+      "confirmed",
+      "hover",
+      "Pointer hover produced an observable page change",
+      adapter.now()
+    )
+  }
+  if (input.receipt.inputDelivery === "delivered") {
+    return result(
+      "confirmed",
+      "hover",
+      "Pointer reached the control",
+      adapter.now()
+    )
+  }
+  return result(
+    "ambiguous",
+    "hover",
+    "Pointer hover produced no conclusive page evidence",
+    adapter.now()
+  )
+}
+
+const isFocusTraversal = (key: string): boolean =>
+  key === "Tab" || key === "Shift+Tab"
 
 const verifyKey: Verifier = async (input, adapter, signal) => {
   if (input.effect.semanticEffects.includes("submission")) {
@@ -655,7 +803,7 @@ const verifyKey: Verifier = async (input, adapter, signal) => {
   const target = mutationTargetAfter(input, after)
   if (
     input.effect.command.type === "press_key" &&
-    input.effect.command.key === "Tab" &&
+    isFocusTraversal(input.effect.command.key) &&
     target.type === "one" &&
     !target.element.focused &&
     after.elements.some((element) => element.focused)
@@ -684,13 +832,15 @@ const verifyKey: Verifier = async (input, adapter, signal) => {
 }
 
 export const DOM_MUTATION_AGENT_VERIFIERS = {
-  click: verifyActivation,
-  type: verifyValueMutation,
-  clear_and_type: verifyValueMutation,
+  click: withDelivery("activation", verifyActivation),
+  double_click: withDelivery("activation", verifyActivation),
+  hover: withDelivery("hover", verifyHover),
+  type: withDelivery("field", verifyValueMutation),
+  clear_and_type: withDelivery("field", verifyValueMutation),
   select: verifyValueMutation,
   check: verifyCheckedMutation,
   uncheck: verifyCheckedMutation,
-  press_key: verifyKey
+  press_key: withDelivery("keyboard", verifyKey)
 } satisfies Record<DomMutationAgentAction, Verifier>
 
 export const verifyDomMutationAgentEffect = async (input: {

--- a/src/lib/browser-agent/native-input-page.ts
+++ b/src/lib/browser-agent/native-input-page.ts
@@ -1,0 +1,201 @@
+import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
+
+import { resolveAgentMutationTarget } from "./command-executor"
+import type { AgentDomMutationInstruction } from "./control-port"
+import type { AgentElementReferenceStore } from "./element-references"
+import type {
+  AgentInputPoint,
+  AgentInputTrace,
+  AgentRecordedInputEvent,
+  AgentRecordedInputEventType
+} from "./native-input"
+import { findAgentReachablePoint } from "./observation-builder"
+
+/**
+ * The page's half of native input: the recheck a pointer needs immediately
+ * before it is sent, and the record of what the document then received.
+ *
+ * Coordinates never leave this frame's own viewport. The background adds the
+ * frame's offset in the root viewport itself, from the debugger's frame tree,
+ * so a child document cannot steer a click by misreporting where it sits.
+ */
+
+export interface AgentNativeInputPreparation {
+  /** Where to send the pointer, in this frame's viewport CSS pixels. */
+  point: AgentInputPoint
+  /** Whether the target already holds focus. */
+  focused: boolean
+}
+
+const RECORDED_EVENT_TYPES: readonly AgentRecordedInputEventType[] = [
+  "mousemove",
+  "mousedown",
+  "mouseup",
+  "keydown",
+  "keyup",
+  "wheel"
+]
+
+const isRecordedType = (type: string): type is AgentRecordedInputEventType =>
+  (RECORDED_EVENT_TYPES as readonly string[]).includes(type)
+
+/**
+ * Enough for the longest plan — five hundred characters typed is a thousand
+ * key events plus a click — with room for the events a page produces around
+ * them. Past the cap the record is marked as overflowed, not truncated
+ * silently, so an unbounded page cannot hide interference behind the cap.
+ */
+export const MAX_AGENT_RECORDED_INPUT_EVENTS = 2_200
+
+const composedTargetOf = (event: Event): Element | undefined => {
+  const path =
+    typeof event.composedPath === "function" ? event.composedPath() : []
+  const candidate = path[0] ?? event.target
+  return candidate && typeof candidate === "object" && "nodeType" in candidate
+    ? (candidate as Node).nodeType === 1
+      ? (candidate as Element)
+      : ((candidate as Node).parentElement ?? undefined)
+    : undefined
+}
+
+const composedParent = (element: Element): Element | null => {
+  if (element.parentElement) return element.parentElement
+  const root = element.getRootNode()
+  return root && "host" in root ? ((root as ShadowRoot).host ?? null) : null
+}
+
+const withinTarget = (target: Element, candidate: Element | undefined) => {
+  for (
+    let node: Element | null = candidate ?? null;
+    node;
+    node = composedParent(node)
+  ) {
+    if (node === target) return true
+  }
+  return false
+}
+
+const recordOf = (
+  event: Event,
+  target: Element,
+  trusted: (event: Event) => boolean
+): AgentRecordedInputEvent | undefined => {
+  if (!trusted(event) || !isRecordedType(event.type)) return undefined
+  const onTarget = withinTarget(target, composedTargetOf(event))
+  if (event instanceof KeyboardEvent) {
+    return { type: event.type, key: event.key, onTarget }
+  }
+  if (event instanceof MouseEvent) {
+    return { type: event.type, x: event.clientX, y: event.clientY, onTarget }
+  }
+  return undefined
+}
+
+export interface AgentInputWatch {
+  /** Starts recording trusted input against `target`; replaces any earlier watch. */
+  arm(target: Element): void
+  /** Stops recording and returns what was seen since `arm`. */
+  settle(): AgentInputTrace | undefined
+}
+
+/**
+ * Records the trusted input events a document receives while a plan is in
+ * flight. Native events from the debugger and events from a physical mouse
+ * are both trusted, so the record itself cannot tell them apart; the
+ * background matches it against the plan, and whatever the plan did not send
+ * was the user.
+ */
+export const createAgentInputWatch = (
+  document: Document,
+  options?: {
+    /** Overridable so a test runtime, whose dispatched events are never trusted, can drive the record. */
+    trusted?: (event: Event) => boolean
+  }
+): AgentInputWatch => {
+  const trusted = options?.trusted ?? ((event: Event) => event.isTrusted)
+  let active:
+    | { events: AgentRecordedInputEvent[]; overflow: boolean; stop(): void }
+    | undefined
+
+  return {
+    arm(target) {
+      active?.stop()
+      const view = document.defaultView
+      const events: AgentRecordedInputEvent[] = []
+      const state = { events, overflow: false, stop: () => undefined }
+      const listener = (event: Event) => {
+        if (events.length >= MAX_AGENT_RECORDED_INPUT_EVENTS) {
+          state.overflow = true
+          return
+        }
+        const record = recordOf(event, target, trusted)
+        if (record) events.push(record)
+      }
+      const scope: EventTarget = view ?? document
+      for (const type of RECORDED_EVENT_TYPES) {
+        scope.addEventListener(type, listener, { capture: true, passive: true })
+      }
+      state.stop = () => {
+        for (const type of RECORDED_EVENT_TYPES) {
+          scope.removeEventListener(type, listener, { capture: true })
+        }
+      }
+      active = state
+    },
+    settle() {
+      if (!active) return undefined
+      const { events, overflow, stop } = active
+      stop()
+      active = undefined
+      return { events, ...(overflow ? { overflow: true } : {}) }
+    }
+  }
+}
+
+const fullyInViewport = (element: Element): boolean => {
+  const view = element.ownerDocument.defaultView
+  if (!view) return true
+  const rect = element.getBoundingClientRect()
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= view.innerHeight &&
+    rect.right <= view.innerWidth
+  )
+}
+
+/**
+ * Rechecks the approved target and picks the point a native pointer goes to.
+ *
+ * The same guards as synthetic execution run first, so a target that changed
+ * since approval is refused before anything is aimed at it. The element is
+ * brought into view if it is not, its reachable point is taken from the same
+ * hit test that reported occlusion, and the watch is armed against it — all
+ * in one synchronous pass, so nothing the page does between these steps can
+ * move the point away from the element that was checked.
+ */
+export const prepareAgentNativeInputInDocument = (input: {
+  effect: AgentDomMutationInstruction
+  references: AgentElementReferenceStore
+  watch: AgentInputWatch
+}): AgentNativeInputPreparation => {
+  const element = resolveAgentMutationTarget(input.effect, input.references)
+  if (!fullyInViewport(element)) {
+    element.scrollIntoView({
+      block: "center",
+      inline: "center",
+      behavior: "instant"
+    })
+  }
+  const point = findAgentReachablePoint(element)
+  if (!point) {
+    throw new AgentEffectNotAppliedError(
+      "Agent target is covered by another element"
+    )
+  }
+  input.watch.arm(element)
+  return {
+    point,
+    focused: element === element.ownerDocument.activeElement
+  }
+}

--- a/src/lib/browser-agent/native-input.ts
+++ b/src/lib/browser-agent/native-input.ts
@@ -1,0 +1,672 @@
+import type {
+  AgentCancellationSignal,
+  AgentInputBackend,
+  AgentInputDelivery,
+  AuthorizedAgentEffect
+} from "@ollama-client/agent-runtime"
+import {
+  type AgentCommand,
+  type AgentKeyModifier,
+  parseAgentKeyCombination
+} from "@ollama-client/contracts"
+
+/**
+ * Native input planning, delivery and accounting, with no browser in it.
+ *
+ * A plan is the exact sequence of pointer and keyboard events an action needs;
+ * the runner sends them one at a time through a dispatcher and owes the page a
+ * release for everything it pressed, however the sequence ends. What the page
+ * then reports having received is matched back against the plan, so the run
+ * can tell its own input from a user's hand on the same mouse.
+ */
+
+/** Actions that run as native input when a debugger is attached. */
+export const NATIVE_INPUT_AGENT_ACTIONS = [
+  "click",
+  "double_click",
+  "hover",
+  "type",
+  "clear_and_type",
+  "press_key"
+] as const
+export type NativeInputAgentAction = (typeof NATIVE_INPUT_AGENT_ACTIONS)[number]
+
+export interface AgentInputPoint {
+  x: number
+  y: number
+}
+
+export type AgentInputPlatform = "mac" | "other"
+
+/** CDP `Input` modifier bits. */
+const MODIFIER_BITS: Record<AgentKeyModifier, number> = {
+  Alt: 1,
+  Control: 2,
+  Meta: 4,
+  Shift: 8
+}
+
+export interface AgentNativeKeyDefinition {
+  key: string
+  code?: string
+  keyCode?: number
+  /** Present for a key that inserts text; absent for a control key. */
+  text?: string
+  location?: number
+}
+
+const NAMED_KEY_DEFINITIONS: Record<string, AgentNativeKeyDefinition> = {
+  Enter: { key: "Enter", code: "Enter", keyCode: 13, text: "\r" },
+  Escape: { key: "Escape", code: "Escape", keyCode: 27 },
+  Tab: { key: "Tab", code: "Tab", keyCode: 9 },
+  Backspace: { key: "Backspace", code: "Backspace", keyCode: 8 },
+  Delete: { key: "Delete", code: "Delete", keyCode: 46 },
+  Space: { key: " ", code: "Space", keyCode: 32, text: " " },
+  ArrowUp: { key: "ArrowUp", code: "ArrowUp", keyCode: 38 },
+  ArrowDown: { key: "ArrowDown", code: "ArrowDown", keyCode: 40 },
+  ArrowLeft: { key: "ArrowLeft", code: "ArrowLeft", keyCode: 37 },
+  ArrowRight: { key: "ArrowRight", code: "ArrowRight", keyCode: 39 },
+  Home: { key: "Home", code: "Home", keyCode: 36 },
+  End: { key: "End", code: "End", keyCode: 35 },
+  PageUp: { key: "PageUp", code: "PageUp", keyCode: 33 },
+  PageDown: { key: "PageDown", code: "PageDown", keyCode: 34 },
+  Control: { key: "Control", code: "ControlLeft", keyCode: 17, location: 1 },
+  Shift: { key: "Shift", code: "ShiftLeft", keyCode: 16, location: 1 },
+  Alt: { key: "Alt", code: "AltLeft", keyCode: 18, location: 1 },
+  Meta: { key: "Meta", code: "MetaLeft", keyCode: 91, location: 1 }
+}
+
+/** US-layout punctuation: the character, its `code`, and its virtual key. */
+const PUNCTUATION_DEFINITIONS: Record<string, [code: string, keyCode: number]> =
+  {
+    "`": ["Backquote", 192],
+    "~": ["Backquote", 192],
+    "-": ["Minus", 189],
+    _: ["Minus", 189],
+    "=": ["Equal", 187],
+    "+": ["Equal", 187],
+    "[": ["BracketLeft", 219],
+    "{": ["BracketLeft", 219],
+    "]": ["BracketRight", 221],
+    "}": ["BracketRight", 221],
+    "\\": ["Backslash", 220],
+    "|": ["Backslash", 220],
+    ";": ["Semicolon", 186],
+    ":": ["Semicolon", 186],
+    "'": ["Quote", 222],
+    '"': ["Quote", 222],
+    ",": ["Comma", 188],
+    "<": ["Comma", 188],
+    ".": ["Period", 190],
+    ">": ["Period", 190],
+    "/": ["Slash", 191],
+    "?": ["Slash", 191],
+    "!": ["Digit1", 49],
+    "@": ["Digit2", 50],
+    "#": ["Digit3", 51],
+    $: ["Digit4", 52],
+    "%": ["Digit5", 53],
+    "^": ["Digit6", 54],
+    "&": ["Digit7", 55],
+    "*": ["Digit8", 56],
+    "(": ["Digit9", 57],
+    ")": ["Digit0", 48]
+  }
+
+/**
+ * The native definition of one character, or nothing for a character the
+ * table has no key for — those are inserted as text rather than typed, since a
+ * key event with an invented code is a synthetic event by another name.
+ */
+export const agentNativeKeyDefinition = (
+  key: string
+): AgentNativeKeyDefinition | undefined => {
+  const named = NAMED_KEY_DEFINITIONS[key]
+  if (named) return named
+  if ([...key].length !== 1) return undefined
+  if (/^[a-z]$/i.test(key)) {
+    return {
+      key,
+      code: `Key${key.toUpperCase()}`,
+      keyCode: key.toUpperCase().charCodeAt(0),
+      text: key
+    }
+  }
+  if (/^[0-9]$/.test(key)) {
+    return { key, code: `Digit${key}`, keyCode: key.charCodeAt(0), text: key }
+  }
+  if (key === " ") return NAMED_KEY_DEFINITIONS.Space
+  const punctuation = PUNCTUATION_DEFINITIONS[key]
+  if (punctuation) {
+    return { key, code: punctuation[0], keyCode: punctuation[1], text: key }
+  }
+  return undefined
+}
+
+export type AgentNativeInputStep =
+  | {
+      kind: "mouse"
+      type: "mouseMoved" | "mousePressed" | "mouseReleased"
+      x: number
+      y: number
+      button: "none" | "left"
+      clickCount: number
+      modifiers: number
+    }
+  | {
+      kind: "key"
+      type: "keyDown" | "keyUp"
+      key: string
+      code?: string
+      keyCode?: number
+      text?: string
+      location?: number
+      modifiers: number
+      /** Editing commands the key carries, e.g. `selectAll`. */
+      commands?: readonly string[]
+    }
+  | { kind: "insertText"; text: string }
+  | {
+      kind: "wheel"
+      x: number
+      y: number
+      deltaX: number
+      deltaY: number
+    }
+
+/**
+ * One DOM event the page is expected to report if the plan arrived. Pointer
+ * coordinates are in the target frame's own viewport; keys carry their `key`.
+ */
+export interface AgentExpectedInputEvent {
+  type: "mousemove" | "mousedown" | "mouseup" | "keydown" | "keyup" | "wheel"
+  x?: number
+  y?: number
+  key?: string
+}
+
+export interface AgentNativeInputPlan {
+  steps: readonly AgentNativeInputStep[]
+  expected: readonly AgentExpectedInputEvent[]
+}
+
+const modifierMask = (modifiers: readonly AgentKeyModifier[]): number =>
+  modifiers.reduce((mask, modifier) => mask | MODIFIER_BITS[modifier], 0)
+
+const primaryModifier = (platform: AgentInputPlatform): AgentKeyModifier =>
+  platform === "mac" ? "Meta" : "Control"
+
+interface PlanBuilder {
+  steps: AgentNativeInputStep[]
+  expected: AgentExpectedInputEvent[]
+}
+
+const pushMouse = (
+  builder: PlanBuilder,
+  type: "mouseMoved" | "mousePressed" | "mouseReleased",
+  root: AgentInputPoint,
+  local: AgentInputPoint,
+  clickCount: number
+): void => {
+  builder.steps.push({
+    kind: "mouse",
+    type,
+    x: root.x,
+    y: root.y,
+    button: type === "mouseMoved" ? "none" : "left",
+    clickCount,
+    modifiers: 0
+  })
+  builder.expected.push({
+    type:
+      type === "mouseMoved"
+        ? "mousemove"
+        : type === "mousePressed"
+          ? "mousedown"
+          : "mouseup",
+    x: local.x,
+    y: local.y
+  })
+}
+
+const pushKey = (
+  builder: PlanBuilder,
+  type: "keyDown" | "keyUp",
+  definition: AgentNativeKeyDefinition,
+  modifiers: number,
+  commands?: readonly string[]
+): void => {
+  builder.steps.push({
+    kind: "key",
+    type,
+    key: definition.key,
+    ...(definition.code ? { code: definition.code } : {}),
+    ...(definition.keyCode !== undefined
+      ? { keyCode: definition.keyCode }
+      : {}),
+    ...(type === "keyDown" && definition.text ? { text: definition.text } : {}),
+    ...(definition.location !== undefined
+      ? { location: definition.location }
+      : {}),
+    modifiers,
+    ...(commands && type === "keyDown" ? { commands } : {})
+  })
+  builder.expected.push({
+    type: type === "keyDown" ? "keydown" : "keyup",
+    key: definition.key
+  })
+}
+
+/** Presses a key with modifiers held around it, releasing in reverse order. */
+const pushCombination = (
+  builder: PlanBuilder,
+  modifiers: readonly AgentKeyModifier[],
+  definition: AgentNativeKeyDefinition,
+  commands?: readonly string[]
+): void => {
+  let mask = 0
+  for (const modifier of modifiers) {
+    pushKey(builder, "keyDown", NAMED_KEY_DEFINITIONS[modifier], mask)
+    mask |= MODIFIER_BITS[modifier]
+  }
+  pushKey(builder, "keyDown", definition, mask, commands)
+  pushKey(builder, "keyUp", definition, mask)
+  for (const modifier of [...modifiers].reverse()) {
+    mask &= ~MODIFIER_BITS[modifier]
+    pushKey(builder, "keyUp", NAMED_KEY_DEFINITIONS[modifier], mask)
+  }
+}
+
+const pushText = (builder: PlanBuilder, text: string): void => {
+  let pending = ""
+  const flush = () => {
+    if (pending) builder.steps.push({ kind: "insertText", text: pending })
+    pending = ""
+  }
+  for (const character of text) {
+    if (character === "\n" || character === "\r") {
+      flush()
+      pushCombination(builder, [], NAMED_KEY_DEFINITIONS.Enter)
+      continue
+    }
+    const definition = agentNativeKeyDefinition(character)
+    if (!definition || !definition.text) {
+      pending += character
+      continue
+    }
+    flush()
+    pushKey(builder, "keyDown", definition, 0)
+    pushKey(builder, "keyUp", definition, 0)
+  }
+  flush()
+}
+
+const clickAt = (
+  builder: PlanBuilder,
+  root: AgentInputPoint,
+  local: AgentInputPoint,
+  clicks: number
+): void => {
+  pushMouse(builder, "mouseMoved", root, local, 0)
+  for (let count = 1; count <= clicks; count += 1) {
+    pushMouse(builder, "mousePressed", root, local, count)
+    pushMouse(builder, "mouseReleased", root, local, count)
+  }
+}
+
+export interface AgentNativeInputPlanInput {
+  command: AgentCommand
+  /** The target's chosen point in its own frame's viewport. */
+  point: AgentInputPoint
+  /** Where that frame's viewport origin sits in the root viewport. */
+  frameOffset: AgentInputPoint
+  /** Whether the target already holds focus, so typing needs no click first. */
+  focused: boolean
+  platform: AgentInputPlatform
+}
+
+/**
+ * The full native sequence for one command. Text entry focuses the control
+ * with a real click when it is not focused already — that is what a user
+ * does, and it is what a controlled input listens for — then moves the caret
+ * to the end (`type`) or selects everything and deletes it (`clear_and_type`)
+ * through editing commands, which do the same thing on every platform.
+ */
+export const planAgentNativeInput = (
+  input: AgentNativeInputPlanInput
+): AgentNativeInputPlan => {
+  const builder: PlanBuilder = { steps: [], expected: [] }
+  const root = {
+    x: input.point.x + input.frameOffset.x,
+    y: input.point.y + input.frameOffset.y
+  }
+  const primary = primaryModifier(input.platform)
+  switch (input.command.type) {
+    case "click":
+      clickAt(builder, root, input.point, 1)
+      break
+    case "double_click":
+      clickAt(builder, root, input.point, 2)
+      break
+    case "hover":
+      pushMouse(builder, "mouseMoved", root, input.point, 0)
+      break
+    case "type":
+    case "clear_and_type": {
+      if (!input.focused) clickAt(builder, root, input.point, 1)
+      if (input.command.type === "clear_and_type") {
+        pushCombination(
+          builder,
+          [primary],
+          agentNativeKeyDefinition("a") as AgentNativeKeyDefinition,
+          ["selectAll"]
+        )
+        pushCombination(builder, [], NAMED_KEY_DEFINITIONS.Backspace)
+      } else {
+        pushCombination(builder, [], NAMED_KEY_DEFINITIONS.End, [
+          "moveToEndOfDocument"
+        ])
+      }
+      pushText(builder, input.command.text)
+      break
+    }
+    case "press_key": {
+      const combination = parseAgentKeyCombination(input.command.key)
+      if (!combination) throw new Error("Agent key combination is invalid")
+      const definition = agentNativeKeyDefinition(combination.key)
+      if (!definition) throw new Error("Agent key has no native definition")
+      const withModifiers = {
+        ...definition,
+        ...(combination.modifiers.length > 0 ? { text: undefined } : {})
+      }
+      const isSelectAll =
+        combination.key.toLowerCase() === "a" &&
+        combination.modifiers.length === 1 &&
+        (combination.modifiers[0] === "Control" ||
+          combination.modifiers[0] === "Meta")
+      pushCombination(
+        builder,
+        isSelectAll ? [primary] : combination.modifiers,
+        withModifiers,
+        isSelectAll ? ["selectAll"] : undefined
+      )
+      break
+    }
+    default:
+      throw new Error(
+        `Agent action has no native input plan: ${input.command.type}`
+      )
+  }
+  return builder
+}
+
+export const planAgentWheel = (input: {
+  point: AgentInputPoint
+  direction: "up" | "down" | "left" | "right"
+  amount: number
+}): AgentNativeInputPlan => ({
+  steps: [
+    {
+      kind: "wheel",
+      x: input.point.x,
+      y: input.point.y,
+      deltaX:
+        input.direction === "left"
+          ? -input.amount
+          : input.direction === "right"
+            ? input.amount
+            : 0,
+      deltaY:
+        input.direction === "up"
+          ? -input.amount
+          : input.direction === "down"
+            ? input.amount
+            : 0
+    }
+  ],
+  expected: [{ type: "wheel", x: input.point.x, y: input.point.y }]
+})
+
+export interface AgentNativeInputDispatcher {
+  dispatch(step: AgentNativeInputStep): Promise<void>
+}
+
+/** The run stopped while input was in flight; every held key and button was released first. */
+export class AgentNativeInputCancelledError extends Error {
+  constructor(readonly dispatched: number) {
+    super("Agent native input cancelled")
+    this.name = "AgentNativeInputCancelledError"
+  }
+}
+
+/** A step could not be sent; whatever was held was released, best effort. */
+export class AgentNativeInputFailedError extends Error {
+  constructor(
+    readonly dispatched: number,
+    override readonly cause: unknown
+  ) {
+    super("Agent native input failed mid-sequence")
+    this.name = "AgentNativeInputFailedError"
+  }
+}
+
+interface HeldInput {
+  button?: { x: number; y: number; clickCount: number }
+  keys: Map<string, Extract<AgentNativeInputStep, { kind: "key" }>>
+}
+
+const releaseSteps = (held: HeldInput): AgentNativeInputStep[] => {
+  const steps: AgentNativeInputStep[] = []
+  if (held.button) {
+    steps.push({
+      kind: "mouse",
+      type: "mouseReleased",
+      x: held.button.x,
+      y: held.button.y,
+      button: "left",
+      clickCount: held.button.clickCount,
+      modifiers: 0
+    })
+  }
+  for (const key of [...held.keys.values()].reverse()) {
+    steps.push({
+      kind: "key",
+      type: "keyUp",
+      key: key.key,
+      ...(key.code ? { code: key.code } : {}),
+      ...(key.keyCode !== undefined ? { keyCode: key.keyCode } : {}),
+      ...(key.location !== undefined ? { location: key.location } : {}),
+      modifiers: 0
+    })
+  }
+  return steps
+}
+
+const track = (held: HeldInput, step: AgentNativeInputStep): void => {
+  if (step.kind === "mouse") {
+    if (step.type === "mousePressed") {
+      held.button = { x: step.x, y: step.y, clickCount: step.clickCount }
+    } else if (step.type === "mouseReleased") {
+      held.button = undefined
+    }
+    return
+  }
+  if (step.kind === "key") {
+    if (step.type === "keyDown") held.keys.set(step.key, step)
+    else held.keys.delete(step.key)
+  }
+}
+
+/**
+ * Sends a plan one step at a time.
+ *
+ * Cancellation is honoured between steps, never by dropping the sequence
+ * where it stands: a pressed button or a held modifier is released before the
+ * runner throws, so a stopped run leaves the page with nothing held down. A
+ * step the dispatcher could not send is treated the same way. Neither path
+ * re-sends anything — the count of steps that went out is what the caller
+ * learns, and it is enough to know that the page may have acted.
+ */
+export const runAgentNativeInputPlan = async (
+  plan: AgentNativeInputPlan,
+  dispatcher: AgentNativeInputDispatcher,
+  signal: AgentCancellationSignal
+): Promise<{ dispatched: number }> => {
+  const held: HeldInput = { keys: new Map() }
+  let dispatched = 0
+  const release = async () => {
+    for (const step of releaseSteps(held)) {
+      try {
+        await dispatcher.dispatch(step)
+      } catch {
+        /* Releasing is best effort; the failure that got us here is reported. */
+      }
+    }
+  }
+  for (const step of plan.steps) {
+    if (signal.aborted) {
+      await release()
+      throw new AgentNativeInputCancelledError(dispatched)
+    }
+    try {
+      await dispatcher.dispatch(step)
+    } catch (error) {
+      await release()
+      throw new AgentNativeInputFailedError(dispatched, error)
+    }
+    dispatched += 1
+    track(held, step)
+  }
+  return { dispatched }
+}
+
+export type AgentRecordedInputEventType = AgentExpectedInputEvent["type"]
+
+/** One trusted input event the page recorded while a plan was in flight. */
+export interface AgentRecordedInputEvent {
+  type: AgentRecordedInputEventType
+  x?: number
+  y?: number
+  key?: string
+  /** Whether the event's composed target was the resolved element or inside it. */
+  onTarget: boolean
+}
+
+export interface AgentInputTrace {
+  events: readonly AgentRecordedInputEvent[]
+  /** The record hit its cap; what came after it is unknown. */
+  overflow?: boolean
+}
+
+/** Events that change state when a hand produces them; a stray mousemove does not. */
+const INTERFERENCE_TYPES = new Set([
+  "mousedown",
+  "mouseup",
+  "keydown",
+  "keyup",
+  "wheel"
+])
+
+const POINTER_TOLERANCE_PX = 1.5
+
+const matchesExpected = (
+  expected: AgentExpectedInputEvent,
+  recorded: AgentRecordedInputEvent
+): boolean => {
+  if (expected.type !== recorded.type) return false
+  if (expected.key !== undefined) return expected.key === recorded.key
+  if (expected.x === undefined || expected.y === undefined) return true
+  return (
+    recorded.x !== undefined &&
+    recorded.y !== undefined &&
+    Math.abs(recorded.x - expected.x) <= POINTER_TOLERANCE_PX &&
+    Math.abs(recorded.y - expected.y) <= POINTER_TOLERANCE_PX
+  )
+}
+
+/**
+ * Reads the page's record against the plan.
+ *
+ * Every event the plan sent is looked for in order; an event of a
+ * state-changing type that the plan did not send is interference, whatever
+ * else matched, because the page's next state is then the product of two
+ * hands. Only when nothing foreign arrived does the count of matched events
+ * decide between delivered, partial and undelivered, and only a fully
+ * delivered plan is asked whether it landed on the resolved target.
+ */
+export const assessAgentInputDelivery = (
+  plan: AgentNativeInputPlan,
+  trace: AgentInputTrace | undefined
+): AgentInputDelivery => {
+  if (!trace || trace.overflow) return "unknown"
+  let next = 0
+  let interference = false
+  const matched: AgentRecordedInputEvent[] = []
+  for (const recorded of trace.events) {
+    const expected = plan.expected[next]
+    if (expected && matchesExpected(expected, recorded)) {
+      matched.push(recorded)
+      next += 1
+      continue
+    }
+    if (INTERFERENCE_TYPES.has(recorded.type)) interference = true
+  }
+  if (interference) return "interference"
+  if (plan.expected.length === 0) return "delivered"
+  if (matched.length === 0) return "undelivered"
+  if (matched.length < plan.expected.length) return "partial"
+  return matched.every((event) => event.onTarget) ? "delivered" : "misdirected"
+}
+
+export interface AgentInputBackendChoice {
+  backend: AgentInputBackend
+  reason:
+    | "native"
+    | "guarded_navigation"
+    | "guarded_submission"
+    | "action_not_native"
+    | "no_native_control"
+    | "frame_unmapped"
+}
+
+/**
+ * Decides, before anything is sent, which backend an action runs on.
+ *
+ * Link activation and form submission keep the guarded DOM paths whatever is
+ * attached: those paths exist so page handlers cannot redirect an approved
+ * destination, and a native click would hand that destination back to the
+ * page. Everything else that has a native plan goes native when the run
+ * holds the debugger for this tab and the target's frame is one the debugger
+ * can place. The choice is final for the action.
+ */
+export const chooseAgentInputBackend = (input: {
+  effect: Pick<AuthorizedAgentEffect, "command" | "target">
+  cdpControl: boolean
+  attached: boolean
+  frameMapped: boolean
+}): AgentInputBackendChoice => {
+  const { command, target } = input.effect
+  if (
+    !(NATIVE_INPUT_AGENT_ACTIONS as readonly string[]).includes(command.type)
+  ) {
+    return { backend: "dom", reason: "action_not_native" }
+  }
+  if (command.type === "click" && target.href) {
+    return { backend: "dom", reason: "guarded_navigation" }
+  }
+  if (command.type === "click" && target.submitter) {
+    return { backend: "dom", reason: "guarded_submission" }
+  }
+  if (
+    command.type === "press_key" &&
+    command.key === "Enter" &&
+    target.maySubmit
+  ) {
+    return { backend: "dom", reason: "guarded_submission" }
+  }
+  if (!input.cdpControl || !input.attached) {
+    return { backend: "dom", reason: "no_native_control" }
+  }
+  if (!input.frameMapped) return { backend: "dom", reason: "frame_unmapped" }
+  return { backend: "cdp", reason: "native" }
+}

--- a/src/lib/browser-agent/native-input.ts
+++ b/src/lib/browser-agent/native-input.ts
@@ -374,7 +374,18 @@ export const planAgentNativeInput = (
       const combination = parseAgentKeyCombination(input.command.key)
       if (!combination) throw new Error("Agent key combination is invalid")
       const definition = agentNativeKeyDefinition(combination.key)
-      if (!definition) throw new Error("Agent key has no native definition")
+      /**
+       * A printable character the key table cannot type is inserted as text,
+       * which is what pressing it does. Chorded, it has no native form at all
+       * and the backend choice sends it to the DOM path before this runs.
+       */
+      if (!definition) {
+        if (combination.modifiers.length > 0) {
+          throw new Error("Agent key chord has no native definition")
+        }
+        builder.steps.push({ kind: "insertText", text: combination.key })
+        break
+      }
       const withModifiers = {
         ...definition,
         ...(combination.modifiers.length > 0 ? { text: undefined } : {})
@@ -612,10 +623,18 @@ export const assessAgentInputDelivery = (
     if (INTERFERENCE_TYPES.has(recorded.type)) interference = true
   }
   if (interference) return "interference"
-  if (plan.expected.length === 0) return "delivered"
+  /* A plan of inserted text alone leaves no events to match; nothing is claimed. */
+  if (plan.expected.length === 0) return "unknown"
   if (matched.length === 0) return "undelivered"
   if (matched.length < plan.expected.length) return "partial"
-  return matched.every((event) => event.onTarget) ? "delivered" : "misdirected"
+  /**
+   * A key's release lands wherever focus is by then: after Tab it is the next
+   * control, after Enter it may be a dialog. Only the press has to have reached
+   * the resolved target for the plan to count as delivered there.
+   */
+  return matched.every((event) => event.type === "keyup" || event.onTarget)
+    ? "delivered"
+    : "misdirected"
 }
 
 export interface AgentInputBackendChoice {
@@ -625,8 +644,21 @@ export interface AgentInputBackendChoice {
     | "guarded_navigation"
     | "guarded_submission"
     | "action_not_native"
+    | "key_not_native"
     | "no_native_control"
     | "frame_unmapped"
+}
+
+const containsNewline = (text: string): boolean => /[\r\n]/.test(text)
+
+/** A chord on a character the key table cannot press has no native form. */
+const chordLacksNativeKey = (key: string): boolean => {
+  const combination = parseAgentKeyCombination(key)
+  return (
+    combination !== undefined &&
+    combination.modifiers.length > 0 &&
+    agentNativeKeyDefinition(combination.key) === undefined
+  )
 }
 
 /**
@@ -663,6 +695,21 @@ export const chooseAgentInputBackend = (input: {
     target.maySubmit
   ) {
     return { backend: "dom", reason: "guarded_submission" }
+  }
+  /**
+   * A newline typed natively is a real Enter, and a real Enter in a field
+   * that submits is an implicit submission the page would handle itself. The
+   * DOM path assigns the value instead and never presses anything.
+   */
+  if (
+    (command.type === "type" || command.type === "clear_and_type") &&
+    target.maySubmit &&
+    containsNewline(command.text)
+  ) {
+    return { backend: "dom", reason: "guarded_submission" }
+  }
+  if (command.type === "press_key" && chordLacksNativeKey(command.key)) {
+    return { backend: "dom", reason: "key_not_native" }
   }
   if (!input.cdpControl || !input.attached) {
     return { backend: "dom", reason: "no_native_control" }

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -469,6 +469,53 @@ const probeFragment = (
  * rather than a guessed one — a covered control wrongly shown is recoverable, a
  * reachable control wrongly hidden is not.
  */
+/**
+ * The point a native pointer should be sent to: the first sampled point of the
+ * first fragment that hit-tests back to the element itself. A layout that
+ * cannot answer yields the first fragment's centre, mirroring the observation's
+ * choice to leave such a control unmarked; a control covered at every sample
+ * yields nothing, and the caller refuses rather than click the cover.
+ */
+export const findAgentReachablePoint = (
+  element: Element
+): { x: number; y: number } | undefined => {
+  const doc = element.ownerDocument
+  const view = doc.defaultView
+  const viewport = {
+    bottom: view?.innerHeight ?? 0,
+    left: 0,
+    right: view?.innerWidth ?? 0,
+    top: 0
+  }
+  const rects = Array.from(element.getClientRects())
+    .filter((box) => box.width > 0 && box.height > 0)
+    .map((box) => intersectBounds(box, viewport))
+    .filter((box): box is VisibleBounds => Boolean(box))
+    .slice(0, OCCLUSION_MAX_FRAGMENTS)
+  if (rects.length === 0) return undefined
+  const centre = (rect: VisibleBounds) => ({
+    x: rect.left + (rect.right - rect.left) / 2,
+    y: rect.top + (rect.bottom - rect.top) / 2
+  })
+  if (!view || typeof doc.elementFromPoint !== "function") {
+    return centre(rects[0])
+  }
+  for (const rect of rects) {
+    const width = rect.right - rect.left
+    const height = rect.bottom - rect.top
+    for (const [fractionX, fractionY] of OCCLUSION_SAMPLES) {
+      const x = rect.left + width * fractionX
+      const y = rect.top + height * fractionY
+      const hit = doc.elementFromPoint(x, y)
+      if (!hit) return centre(rect)
+      if (composedContains(element, hit) || composedContains(hit, element)) {
+        return { x, y }
+      }
+    }
+  }
+  return undefined
+}
+
 const isOccluded = (element: Element): boolean => {
   const doc = element.ownerDocument
   const view = doc.defaultView

--- a/src/lib/browser-agent/resolved-effect.ts
+++ b/src/lib/browser-agent/resolved-effect.ts
@@ -411,6 +411,8 @@ export const resolveNavigationAgentEffect = async (input: {
 
 export const DOM_MUTATION_AGENT_ACTIONS = [
   "click",
+  "double_click",
+  "hover",
   "type",
   "clear_and_type",
   "select",
@@ -587,6 +589,13 @@ export const resolveDomMutationAgentEffect = async (input: {
       destination = semantics.destination
       break
     }
+    /** The classifier refused links and submitters; what is left activates. */
+    case "double_click":
+      effects.push("activation")
+      break
+    case "hover":
+      effects.push("hover")
+      break
     case "type": {
       if (!element.sensitive) {
         const current = element.value ?? ""

--- a/tools/checks/check-bundle-size.ts
+++ b/tools/checks/check-bundle-size.ts
@@ -226,8 +226,13 @@ const budgets: Budget[] = [
      * its budget partition, the three read-only inspection commands, and the
      * durable findings store — took it to 237,205. Firefox carries no Agent
      * code and is unchanged.
+     *
+     * Native input — the plan builder and its key table, the cancellation-safe
+     * runner, the delivery matcher, the debugger input channel with its frame
+     * placement, and the two new control-port messages — took it to 243,113.
+     * Firefox carries no Agent code and is unchanged.
      */
-    max: isFirefox ? 210_000 : 238_000
+    max: isFirefox ? 210_000 : 244_000
   }
 ]
 


### PR DESCRIPTION
PR 5 of the readiness plan.

Element actions run as real pointer and key events when the run holds the tab's debugger: click, double_click, hover, typing, key chords (`Shift+Tab`, `Control+a`), and a wheel scroll at the viewport centre.

- Backend chosen before the action, never swapped after a step is sent. Link navigation and form submission keep the guarded DOM paths.
- Page rechecks the target and picks the point; the debugger places the frame from its own tree.
- What the document received is matched against the plan: a user's hand on the page is reported as interference and pauses the step, not credited.
- Cancellation releases held buttons and keys before stopping; nothing is re-sent.
- Focus alone no longer counts as page change (a native click focusing a silent button was confirming it and clicking twice). A click that lands focus on an input-taking widget is confirmed.

Validation: typecheck, lint, 4325 unit tests; 16/16 agent e2e including new dropdown, controlled-input and keyboard-listbox scenarios on the cdp backend. Background budget recorded at 243,113.

Limits: native and user events are both trusted, so input exactly matching the plan is indistinguishable. Pinch zoom and transformed iframes are PR 6. `select`/`check`/`uncheck` stay synthetic. press_key still escalates as activation (PR 8).





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds debugger-backed native mouse, keyboard, and wheel input while preserving guarded DOM execution for navigation and submission.
- Adds native click, double-click, hover, typing, key-chord, and viewport-scroll planning and dispatch.
- Rechecks targets and records delivered input for interference and misdirection detection.
- Releases held keys and mouse buttons after cancellation or dispatch failure.
- Adds contracts, policy handling, verification logic, unit coverage, and Chromium end-to-end scenarios.
- The changes since the previous review fix synthetic DOM chord events by parsing the combination and setting the correct key and modifier fields.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest revision fixes the remaining DOM chord fallback issue, and the earlier findings are resolved.

Synthetic fallback now parses combinations such as Control+é into the character key and proper modifier flags before emitting keydown and keyup. The other previous findings are reflected as fixed in the current code or were manually resolved, and no new actionable failure or repository-rule violation remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/browser-agent/native-input.ts | Defines backend selection, native input plans, cancellation cleanup, and delivery matching; the reviewed follow-up leaves no outstanding defect. |
| src/lib/browser-agent/command-executor.ts | Integrates native execution and now correctly constructs synthetic chord events for the DOM fallback. |
| src/lib/browser-agent/native-input-page.ts | Revalidates page targets, chooses reachable coordinates, and records trusted input delivery. |
| src/background/agent/agent-browser-session-manager.ts | Exposes debugger input dispatch and frame-placement support for controlled tabs. |
| packages/contracts/src/agent-keys.ts | Defines and validates named keys, printable characters, and modifier combinations. |
| e2e/chromium/critical/__tests__/agent-native-input.spec.ts | Exercises native dropdown, controlled-input, and keyboard-listbox flows with action-correlated backend assertions. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Run as Agent run
    participant Page as Content script
    participant Debugger as Debugger session
    participant Browser as Browser input pipeline
    Run->>Run: Choose CDP or guarded DOM backend
    Run->>Page: Recheck target, choose point, arm input watch
    Page-->>Run: Frame-local point and focus state
    Run->>Debugger: Dispatch native input plan
    Debugger->>Browser: Input mouse/key/wheel events
    Browser->>Page: Trusted page events
    Run->>Page: Settle input watch
    Page-->>Run: Delivery trace
    Run->>Run: Match trace and verify effect
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): spell a chord out on the syn..."](https://github.com/shishir435/ollama-client/commit/d4c98f15371db37c6d1c8aab5e652630f5dc5c36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62347437)</sub>

<!-- /greptile_comment -->