### PR TITLE
feat(agent): edit rich-text documents and drag items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,36 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
 - Firefox has no debugger: `double_click` and `hover` degrade to synthetic
   events there, the receipt says `backend: "dom"`, and the hover verifier
   then needs page evidence, since no delivery record exists.
+- **An editor is edited through the browser's own editing pipeline, never by
+  writing its DOM.** A `contenteditable` host is observed as a control of type
+  `contenteditable` whose value is its flattened text; `type` appends,
+  `clear_and_type` replaces all, and `replace_text` replaces one exact
+  occurrence of `find`. The page-side helpers (`editor-page.ts`) place the
+  selection or caret and drive `execCommand`/`insertText`, so a rich-text
+  editor that rebuilds its DOM from its own model keeps the change. Value
+  comparison flattens markup the one way every side does (`editor-text.ts`), so
+  a paragraph rendered as `<p>` on one read and `<div><br></div>` on the next
+  is not a spurious change. Typed text never presses Enter — a newline is
+  inserted as a line break, allowed only in a `multiline` field — because Enter
+  is a submission or send that `press_key` must choose on purpose.
+- **A drag is grounded on both ends and verified by the arrangement it
+  leaves.** `drag` names a source `ref` and a destination `to`, both observed
+  and in one frame; the destination is rechecked before the pointer moves. The
+  native channel presses on the source and, if a held move makes the browser
+  start an HTML5 drag (`Input.dragIntercepted`), drives it with drag events and
+  drops with the drag data — otherwise the move stays a pointer drag a
+  library reads. A stopped drag is cancelled, never dropped. The verifier
+  confirms only a changed arrangement — the item moved past its destination,
+  into another region, among different neighbours, or off the page — never the
+  page merely having changed. Firefox and the DOM backend send the synthetic
+  pointer-and-HTML5 sequence in `drag-page.ts`.
+- **A file chooser is the user's, and the debugger holds it back.**
+  `Page.setInterceptFileChooserDialog` is enabled on attach, so a click on a
+  file input opens nothing; the run records `file_selection`, policy raises a
+  `file_upload` takeover, and detaching for the takeover lets the user's own
+  click open the chooser. A chooser the page opened mid-action is reported on
+  the receipt (`fileChooser`) and settles the step as the user's whatever else
+  happened.
 - **A screenshot is an observation's companion, never a record.** The
   controller pictures the tab (`AgentScreenshotPort`) only after the DOM
   observation is in hand and only for a model whose `vision` the model port

--- a/e2e/chromium/critical/__tests__/agent-editing.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-editing.spec.ts
@@ -25,21 +25,52 @@ const executedNatively = (outcome: AgentScenarioOutcome, action: string) => {
 }
 
 /**
- * A rich-text editor of the kind a document app renders: a contenteditable
- * whose paragraphs are real elements, and a Save button that snapshots the
- * editor's text into a status line only when clicked. The editor holds a typo
- * the task fixes with an in-place edit.
+ * A controlled rich-text editor of the kind a framework renders: it keeps the
+ * document in its own model string and rebuilds the editor's DOM from that
+ * model on every `input`, restoring the caret by character offset. A change
+ * written into the DOM behind its back would be discarded on the next
+ * keystroke, so a passing edit proves the agent went through the editing
+ * pipeline (native `insertText`), not a raw DOM write. Save snapshots the
+ * model into a status line only when clicked.
  */
 const documentPage = `<!doctype html><title>Agent editor</title><main>
 <h1>Report</h1>
-<div id="doc" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Report body"><p>The quick brown fax jumps.</p></div>
+<div id="doc" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Report body"></div>
 <button id="save" type="button">Save</button>
 <p id="status">Saved: none</p>
 <script>
   const doc = document.getElementById('doc')
+  let model = 'The quick brown fax jumps.'
+  const caretOffset = () => {
+    const selection = getSelection()
+    if (!selection || selection.rangeCount === 0) return model.length
+    const range = selection.getRangeAt(0)
+    const pre = range.cloneRange()
+    pre.selectNodeContents(doc)
+    pre.setEnd(range.endContainer, range.endOffset)
+    return pre.toString().length
+  }
+  const render = (offset) => {
+    doc.innerHTML = ''
+    const paragraph = document.createElement('p')
+    const text = document.createTextNode(model)
+    paragraph.append(text)
+    doc.append(paragraph)
+    const range = document.createRange()
+    range.setStart(text, Math.min(offset, model.length))
+    range.collapse(true)
+    const selection = getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+  render(0)
+  doc.addEventListener('input', () => {
+    const offset = caretOffset()
+    model = doc.textContent.replace(/\\s+/g, ' ')
+    render(offset)
+  })
   document.getElementById('save').addEventListener('click', () => {
-    document.getElementById('status').textContent =
-      'Saved: ' + doc.textContent.replace(/\\s+/g, ' ').trim()
+    document.getElementById('status').textContent = 'Saved: ' + model
     fetch('/effect')
   })
 </script></main>`

--- a/e2e/chromium/critical/__tests__/agent-editing.spec.ts
+++ b/e2e/chromium/critical/__tests__/agent-editing.spec.ts
@@ -1,0 +1,157 @@
+import type {
+  AgentFixtureObservation,
+  AgentScenarioOutcome
+} from "../../fixtures/agent-scenario"
+import {
+  agentFixtureElement,
+  runAgentScenario
+} from "../../fixtures/agent-scenario"
+import { expect } from "../../fixtures/extension"
+
+/**
+ * Editors and drag interactions through the native backend: a rich-text
+ * document edited in place and saved, and a board item dragged into another
+ * column. Each fixture reacts only to what the real editing and pointer
+ * pipelines produce — a contenteditable that re-renders from its own model on
+ * `input`, a drop that moves a node — so a pass proves the effect reached the
+ * page, and each scenario verifies the resulting state rather than the click.
+ */
+
+const executedNatively = (outcome: AgentScenarioOutcome, action: string) => {
+  const executed = outcome.phases.filter(
+    (line) => line.phase === "executed" && line.action === action
+  )
+  return executed.length > 0 && executed.every((line) => line.backend === "cdp")
+}
+
+/**
+ * A rich-text editor of the kind a document app renders: a contenteditable
+ * whose paragraphs are real elements, and a Save button that snapshots the
+ * editor's text into a status line only when clicked. The editor holds a typo
+ * the task fixes with an in-place edit.
+ */
+const documentPage = `<!doctype html><title>Agent editor</title><main>
+<h1>Report</h1>
+<div id="doc" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Report body"><p>The quick brown fax jumps.</p></div>
+<button id="save" type="button">Save</button>
+<p id="status">Saved: none</p>
+<script>
+  const doc = document.getElementById('doc')
+  document.getElementById('save').addEventListener('click', () => {
+    document.getElementById('status').textContent =
+      'Saved: ' + doc.textContent.replace(/\\s+/g, ' ').trim()
+    fetch('/effect')
+  })
+</script></main>`
+
+runAgentScenario({
+  name: "rich text editing",
+  goal: "Fix the typo 'fax' to 'fox' in the report, then save it.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => documentPage,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("Saved: The quick brown fox jumps."))
+      return { type: "complete", summary: "saved fox" }
+    const editor = agentFixtureElement(
+      observation,
+      (element) => element.type === "contenteditable"
+    )
+    if (editor?.value?.includes("fax")) {
+      return { type: "replace_text", ref: editor.ref, find: "fax", text: "fox" }
+    }
+    return {
+      type: "click",
+      ref: agentFixtureElement(
+        observation,
+        (element) => element.name === "Save"
+      )?.ref
+    }
+  },
+  async verify(outcome) {
+    await expect(
+      outcome.page.getByText("Saved: The quick brown fox jumps.")
+    ).toBeVisible()
+    await expect(outcome.page.locator("#doc")).toHaveText(
+      "The quick brown fox jumps."
+    )
+    expect(outcome.snapshot?.run?.result).toContain("saved fox")
+    expect(
+      outcome.snapshot?.steps
+        .filter((step) => step.status === "verified")
+        .map((step) => step.command?.type)
+    ).toEqual(["replace_text", "click"])
+    expect(executedNatively(outcome, "replace_text")).toBe(true)
+    await expect.poll(outcome.effects).toBe(1)
+  }
+})
+
+/**
+ * A two-column board whose cards are HTML5-draggable and whose columns accept
+ * a drop by cancelling `dragover`; a dropped card is moved in the DOM and its
+ * new column recorded. Only a real drag — the debugger's, or a user's — makes
+ * the browser fire `dragstart` and deliver the drop, so a moved card proves
+ * the pointer gesture reached the page.
+ */
+const boardPage = `<!doctype html><title>Agent board</title>
+<style>
+  main { display: flex; gap: 24px; align-items: flex-start; padding: 16px; }
+  ul { list-style: none; margin: 0; padding: 12px; width: 200px; min-height: 160px; border: 1px solid #ccc; }
+  li { padding: 12px; margin: 4px 0; border: 1px solid #999; background: #eee; cursor: grab; }
+</style>
+<main>
+<ul id="todo" role="list" aria-label="To do">
+  <li id="task" role="listitem" draggable="true">Ship release</li>
+</ul>
+<ul id="done" role="list" aria-label="Done"></ul>
+</main>
+<p id="status">In: To do</p>
+<script>
+  const task = document.getElementById("task")
+  task.addEventListener('dragstart', (event) => {
+    event.dataTransfer.setData("text/plain", "task")
+    event.dataTransfer.effectAllowed = 'move'
+  })
+  const done = document.getElementById('done')
+  done.addEventListener('dragover', (event) => event.preventDefault())
+  done.addEventListener('drop', (event) => {
+    event.preventDefault()
+    done.append(task)
+    document.getElementById('status').textContent = 'In: Done'
+    fetch('/effect')
+  })
+</script>`
+
+runAgentScenario({
+  name: "board item move",
+  goal: "Move the 'Ship release' card into the Done column.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => boardPage,
+  decide(observation: AgentFixtureObservation) {
+    if (observation.text.includes("In: Done"))
+      return { type: "complete", summary: "moved to Done" }
+    const card = agentFixtureElement(
+      observation,
+      (element) => element.draggable === true
+    )
+    const done = agentFixtureElement(
+      observation,
+      (element) => element.name === "Done"
+    )
+    if (!card || !done) return { type: "fail", reason: "board not observed" }
+    return { type: "drag", ref: card.ref, to: done.ref }
+  },
+  async verify(outcome) {
+    await expect(outcome.page.getByText("In: Done")).toBeVisible()
+    await expect(outcome.page.locator("#done #task")).toHaveCount(1)
+    expect(outcome.snapshot?.run?.result).toContain("moved to Done")
+    expect(
+      outcome.snapshot?.steps
+        .filter((step) => step.status === "verified")
+        .map((step) => step.command?.type)
+    ).toEqual(["drag"])
+    expect(executedNatively(outcome, "drag")).toBe(true)
+    await expect.poll(outcome.effects).toBe(1)
+  }
+})

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -37,6 +37,8 @@ export interface AgentFixtureElement {
   group?: string
   submits?: boolean
   editable?: boolean
+  multiline?: boolean
+  draggable?: boolean
   sensitive?: boolean
   disabled?: boolean
   hidden?: boolean

--- a/packages/agent-runtime/src/__tests__/affordance-editing.test.ts
+++ b/packages/agent-runtime/src/__tests__/affordance-editing.test.ts
@@ -1,0 +1,305 @@
+import type {
+  AgentCommand,
+  AgentElement,
+  AgentObservation
+} from "@ollama-client/contracts"
+import { describe, expect, it } from "vitest"
+
+import { agentAffordanceFeedback, classifyAgentAffordance } from "../affordance"
+import { evaluateAgentPolicy } from "../policy"
+import type { ResolvedAgentEffect } from "../ports"
+
+/**
+ * Editing and dragging, as the classifier and policy see them: what a field
+ * may receive, where an edit is grounded, what a drag needs on both ends, and
+ * how a drop and a file chooser are priced.
+ */
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  frameId: 0,
+  tag: "div",
+  type: "contenteditable",
+  value: "Hello world",
+  visible: true,
+  enabled: true,
+  editable: true,
+  sensitive: false,
+  multiline: true,
+  ...overrides
+})
+
+const observation = (elements: AgentElement[]): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1",
+  url: "https://example.com/",
+  origin: "https://example.com",
+  title: "Example",
+  frames: [
+    {
+      frameId: 0,
+      documentId: "document-1",
+      origin: "https://example.com",
+      url: "https://example.com/",
+      access: "ok",
+      snapshotId: "snapshot-1",
+      generation: 1
+    }
+  ],
+  elements,
+  visibleText: "",
+  scroll: {
+    x: 0,
+    y: 0,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 100
+  },
+  dialogs: [],
+  capturedAt: 1
+})
+
+const command = (partial: Record<string, unknown>) =>
+  ({
+    snapshotId: "snapshot-1",
+    generation: 1,
+    ref: "e1",
+    ...partial
+  }) as AgentCommand
+
+describe("editor affordances", () => {
+  it("accepts typed text into an editing host and refuses it into a plain div", () => {
+    expect(
+      classifyAgentAffordance(
+        command({ type: "type", text: "hi" }),
+        observation([element()])
+      )
+    ).toBeUndefined()
+    expect(
+      classifyAgentAffordance(
+        command({ type: "type", text: "hi" }),
+        observation([element({ type: undefined, editable: false })])
+      )?.reason
+    ).toBe("not_text_field")
+  })
+
+  it("refuses a line break into a single-line field and says how to confirm instead", () => {
+    const refused = classifyAgentAffordance(
+      command({ type: "type", text: "a\nb" }),
+      observation([element({ multiline: undefined })])
+    )
+    expect(refused?.reason).toBe("newline_in_single_line")
+    expect(agentAffordanceFeedback(refused as never)).toContain("press_key")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "clear_and_type", text: "a\nb" }),
+        observation([
+          element({ tag: "input", type: "text", multiline: undefined })
+        ])
+      )?.reason
+    ).toBe("newline_in_single_line")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "type", text: "a\nb" }),
+        observation([element({ tag: "textarea", type: "textarea" })])
+      )
+    ).toBeUndefined()
+  })
+
+  it("grounds a replacement in the observed value, once", () => {
+    expect(
+      classifyAgentAffordance(
+        command({ type: "replace_text", find: "world", text: "there" }),
+        observation([element()])
+      )
+    ).toBeUndefined()
+    expect(
+      classifyAgentAffordance(
+        command({ type: "replace_text", find: "nope", text: "there" }),
+        observation([element()])
+      )?.reason
+    ).toBe("text_not_found")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "replace_text", find: "l", text: "L" }),
+        observation([element()])
+      )?.reason
+    ).toBe("text_ambiguous")
+    /* A sensitive field shows no value; policy hands the step over anyway. */
+    expect(
+      classifyAgentAffordance(
+        command({ type: "replace_text", find: "x", text: "y" }),
+        observation([
+          element({
+            tag: "input",
+            type: "password",
+            sensitive: true,
+            value: undefined
+          })
+        ])
+      )
+    ).toBeUndefined()
+  })
+
+  it("lets a file input be clicked so policy can hand the chooser to the user", () => {
+    expect(
+      classifyAgentAffordance(
+        command({ type: "click" }),
+        observation([
+          element({
+            tag: "input",
+            type: "file",
+            sensitive: true,
+            value: undefined,
+            multiline: undefined
+          })
+        ])
+      )
+    ).toBeUndefined()
+  })
+})
+
+describe("drag affordances", () => {
+  const item = element({
+    ref: "e1",
+    tag: "li",
+    type: undefined,
+    value: undefined,
+    editable: false,
+    multiline: undefined,
+    draggable: true,
+    name: "Task A"
+  })
+  const column = element({
+    ref: "e2",
+    tag: "ul",
+    type: undefined,
+    value: undefined,
+    editable: false,
+    multiline: undefined,
+    role: "list",
+    name: "Done"
+  })
+
+  it("accepts a visible destination in the same frame and refuses every other", () => {
+    expect(
+      classifyAgentAffordance(
+        command({ type: "drag", to: "e2" }),
+        observation([item, column])
+      )
+    ).toBeUndefined()
+    expect(
+      classifyAgentAffordance(
+        command({ type: "drag", to: "e9" }),
+        observation([item, column])
+      )
+    ).toEqual({ reason: "unknown_destination", ref: "e9" })
+    expect(
+      classifyAgentAffordance(
+        command({ type: "drag", to: "e2" }),
+        observation([item, { ...column, visible: false }])
+      )?.reason
+    ).toBe("hidden_destination")
+    expect(
+      classifyAgentAffordance(
+        command({ type: "drag", to: "e1" }),
+        observation([item, column])
+      )?.reason
+    ).toBe("drag_onto_itself")
+    const framed = observation([item, { ...column, ref: "f3e1", frameId: 3 }])
+    framed.frames.push({
+      frameId: 3,
+      parentFrameId: 0,
+      documentId: "document-3",
+      origin: "https://example.com",
+      url: "https://example.com/frame",
+      access: "ok",
+      snapshotId: "snapshot-3",
+      generation: 1
+    })
+    expect(
+      classifyAgentAffordance(command({ type: "drag", to: "f3e1" }), framed)
+        ?.reason
+    ).toBe("cross_frame_drag")
+  })
+
+  it("names the destination ref in every drag refusal", () => {
+    for (const reason of [
+      "unknown_destination",
+      "hidden_destination",
+      "cross_frame_drag",
+      "drag_onto_itself"
+    ] as const) {
+      expect(agentAffordanceFeedback({ reason, ref: "e2" })).toContain(
+        'Ref "e2"'
+      )
+    }
+  })
+})
+
+describe("editing and drag policy", () => {
+  const effect = (
+    semanticEffects: ResolvedAgentEffect["semanticEffects"]
+  ): ResolvedAgentEffect => ({
+    command: command({ type: "drag", to: "e2" }),
+    target: { sensitive: false, maySubmit: false, accessibleName: "Task A" },
+    semanticEffects,
+    snapshotIdentity: {
+      snapshotId: "snapshot-1",
+      generation: 1,
+      tabId: 7,
+      frameId: 0,
+      documentId: "document-1"
+    },
+    sourceUrl: "https://example.com/",
+    sourceOrigin: "https://example.com"
+  })
+  const decide = (
+    resolved: ResolvedAgentEffect,
+    grants?: {
+      origin: string
+      effects: ("activation" | "form_mutation")[]
+      grantedAt: number
+    }[]
+  ) =>
+    evaluateAgentPolicy({
+      runId: "run-1",
+      stepId: "step-1",
+      effect: resolved,
+      allowedOrigins: ["https://example.com"],
+      scopedTabIds: [7],
+      ...(grants ? { grants } : {}),
+      now: 100
+    })
+
+  it("asks approval for every drag and never offers or spends a grant on one", () => {
+    const decision = decide(effect(["drag"]))
+    expect(decision.type).toBe("approval_required")
+    expect(decision.risk).toBe("high")
+    if (decision.type === "approval_required") {
+      expect(decision.request.grantable).toBeUndefined()
+    }
+    expect(
+      decide(effect(["drag"]), [
+        {
+          origin: "https://example.com",
+          effects: ["activation", "form_mutation"],
+          grantedAt: 1
+        }
+      ]).type
+    ).toBe("approval_required")
+  })
+
+  it("hands a file chooser to the user as a file upload takeover", () => {
+    const decision = decide(effect(["file_selection"]))
+    expect(decision.type).toBe("takeover_required")
+    if (decision.type === "takeover_required") {
+      expect(decision.request.reason).toBe("file_upload")
+      expect(decision.request.instruction).toContain("choose the file")
+    }
+  })
+})

--- a/packages/agent-runtime/src/affordance.ts
+++ b/packages/agent-runtime/src/affordance.ts
@@ -33,6 +33,15 @@ export const AGENT_AFFORDANCE_REASONS = [
   "use_click_instead",
   "image_submit",
   "not_focused",
+  /** Editing: the text a command names is not there, or the field cannot hold it. */
+  "newline_in_single_line",
+  "text_not_found",
+  "text_ambiguous",
+  /** Drag: the destination cannot be grounded beside the source. */
+  "unknown_destination",
+  "hidden_destination",
+  "cross_frame_drag",
+  "drag_onto_itself",
   /** Visual grounding: a point that cannot be turned into a control. */
   "no_screenshot",
   "point_outside_image",
@@ -96,6 +105,7 @@ const REPORTABLE_INPUT_TYPES = new Set([
   "button",
   "checkbox",
   "color",
+  "contenteditable",
   "date",
   "datetime-local",
   "email",
@@ -169,6 +179,10 @@ const refusal = (
 const inputType = (element: AgentElement): string =>
   element.type?.toLowerCase() ?? ""
 
+/** An editing host: a rich-text editor's document, or a bare editable region. */
+const isEditor = (element: AgentElement): boolean =>
+  element.editable && inputType(element) === "contenteditable"
+
 const acceptsText = (element: AgentElement): boolean => {
   if (
     element.sensitive &&
@@ -180,7 +194,57 @@ const acceptsText = (element: AgentElement): boolean => {
   const supportedInput =
     element.tag === "input" &&
     TEXT_INPUT_TYPES.includes(element.type?.toLowerCase() ?? "text")
-  return (supportedInput || element.tag === "textarea") && element.editable
+  return (
+    (supportedInput || element.tag === "textarea" || isEditor(element)) &&
+    element.editable
+  )
+}
+
+const containsNewline = (text: string): boolean => /[\r\n]/.test(text)
+
+/**
+ * Typed text may hold a line break only where the field can hold one. In a
+ * single-line field the break would stand for Enter — and Enter is a
+ * completion signal, submitting a form or sending a message, that the model
+ * has to press on purpose through `press_key` so policy sees it as one.
+ */
+const classifyTypedText = (
+  element: AgentElement,
+  text: string
+): AgentAffordanceRefusal | undefined => {
+  if (!acceptsText(element)) return refusal("not_text_field", element)
+  if (containsNewline(text) && !element.multiline) {
+    return refusal("newline_in_single_line", element)
+  }
+  return undefined
+}
+
+const countOccurrences = (value: string, find: string): number => {
+  let count = 0
+  let from = 0
+  for (;;) {
+    const index = value.indexOf(find, from)
+    if (index < 0) return count
+    count += 1
+    from = index + find.length
+  }
+}
+
+/**
+ * An in-place edit is grounded in the value the model read: the text it
+ * names has to be there, once. A sensitive field shows no value, so nothing
+ * is checked here — policy sends the whole step to the user anyway.
+ */
+const classifyReplacement = (
+  element: AgentElement,
+  command: Extract<AgentCommand, { type: "replace_text" }>
+): AgentAffordanceRefusal | undefined => {
+  const typed = classifyTypedText(element, command.text)
+  if (typed) return typed
+  if (element.sensitive) return undefined
+  const occurrences = countOccurrences(element.value ?? "", command.find)
+  if (occurrences === 0) return refusal("text_not_found", element)
+  return occurrences > 1 ? refusal("text_ambiguous", element) : undefined
 }
 
 const isClickable = (element: AgentElement): boolean =>
@@ -205,6 +269,12 @@ const classifyClick = (
     return refusal("image_submit", element)
   }
   if (isCheckable(element)) return refusal("use_check_instead", element)
+  /**
+   * A file input opens the browser's chooser, which is the user's to answer;
+   * the click is accepted here so policy can hand the step over rather than
+   * the model being told the control does not exist.
+   */
+  if (element.tag === "input" && inputType(element) === "file") return undefined
   /** A rendered destination is activation enough, whatever the tag is. */
   return element.href || isClickable(element)
     ? undefined
@@ -238,9 +308,9 @@ const classifyTarget = (
       return undefined
     case "type":
     case "clear_and_type":
-      return acceptsText(element)
-        ? undefined
-        : refusal("not_text_field", element)
+      return classifyTypedText(element, command.text)
+    case "replace_text":
+      return classifyReplacement(element, command)
     case "select": {
       if (element.tag !== "select" || !element.editable || !element.options) {
         return refusal("not_select", element)
@@ -296,9 +366,38 @@ export const classifyAgentAffordance = (
   if (command.type === "hover") return undefined
   if (!element.enabled) return refusal("disabled_target", element)
   /** A scroll only needs a real element; it changes nothing about it. */
-  return command.type === "scroll"
-    ? undefined
-    : classifyTarget(command, element)
+  if (command.type === "scroll") return undefined
+  if (command.type === "drag")
+    return classifyDrag(command, element, observation)
+  return classifyTarget(command, element)
+}
+
+/**
+ * A drag is grounded twice. The destination has to be an element the
+ * observation lists and shows — a drop on a hidden element is a drop on
+ * nothing — and it has to share the source's frame, because one pointer
+ * gesture cannot cross documents. Nothing is said about whether the source
+ * can be dragged: pointer-based libraries mark nothing, so the verifier
+ * answers that from the page's own arrangement afterwards.
+ */
+const classifyDrag = (
+  command: Extract<AgentCommand, { type: "drag" }>,
+  source: AgentElement,
+  observation: AgentObservation
+): AgentAffordanceRefusal | undefined => {
+  if (command.to === command.ref) return refusal("drag_onto_itself", source)
+  const destinations = observation.elements.filter(
+    (element) => element.ref === command.to
+  )
+  if (destinations.length !== 1) {
+    return { reason: "unknown_destination", ref: command.to }
+  }
+  const destination = destinations[0]
+  if (!destination.visible) return refusal("hidden_destination", destination)
+  if (destination.frameId !== source.frameId) {
+    return refusal("cross_frame_drag", destination)
+  }
+  return undefined
 }
 
 /**
@@ -354,6 +453,20 @@ export const agentAffordanceFeedback = (
       return `${ref} is an image submit control, which this agent cannot activate. Use a different control.`
     case "not_focused":
       return `${ref} is not focused, so a key press would not reach it. Click or type into it first.`
+    case "newline_in_single_line":
+      return `${ref} is a single-line field, so typed text cannot contain a line break. Type the text without it; to confirm or send, use press_key with Enter on the focused field.`
+    case "text_not_found":
+      return `${ref} does not contain the text named in find. Use an exact run of its observed value.`
+    case "text_ambiguous":
+      return `${ref} contains the text named in find more than once. Name a longer run that occurs exactly once.`
+    case "unknown_destination":
+      return `${ref} is not in the current observation, so nothing can be dragged onto it. Use a destination ref the observation lists.`
+    case "hidden_destination":
+      return `${ref} is not visible, so nothing can be dropped on it. Choose a visible destination, or scroll first.`
+    case "cross_frame_drag":
+      return `${ref} is in a different frame from the dragged element. A drag stays within one frame; choose a destination in the same frame.`
+    case "drag_onto_itself":
+      return `${ref} is both the dragged element and the destination. Name a different element to drop it on.`
     case "no_screenshot":
       return `${ref} cannot be grounded by a point: no screenshot was attached to this observation. Use an element ref from the observation.`
     case "point_outside_image":

--- a/packages/agent-runtime/src/history.ts
+++ b/packages/agent-runtime/src/history.ts
@@ -94,6 +94,7 @@ const actionOf = (step: AgentStepReadout): string => {
   }
   if (command.type === "press_key") return `press ${command.key}`
   if (command.type === "scroll") return `scroll ${command.direction}`
+  if (command.type === "drag") return `drag onto ${command.to}`
   return command.type
 }
 

--- a/packages/agent-runtime/src/policy.ts
+++ b/packages/agent-runtime/src/policy.ts
@@ -40,6 +40,8 @@ const effectRisk = (effect: AgentSemanticEffect): AgentRisk => {
       return "medium"
     case "activation":
     case "form_mutation":
+    /** A drop rearranges or hands off whatever was picked up; never granted. */
+    case "drag":
       return "high"
     case "download":
       return "high"
@@ -48,6 +50,7 @@ const effectRisk = (effect: AgentSemanticEffect): AgentRisk => {
     case "authentication":
     case "payment":
     case "sensitive_input":
+    case "file_selection":
       return "critical"
   }
 }
@@ -56,6 +59,13 @@ const takeoverReason = (
   input: AgentPolicyInput
 ): AgentTakeoverRequest["reason"] | undefined => {
   const effects = input.effect.semanticEffects
+  /**
+   * A file chooser names the user's own files; the run neither sees them nor
+   * chooses among them, so opening one is the user's step from the start. It
+   * is decided before the sensitive-input class a file input also carries,
+   * because the takeover instruction the user reads has to be about the file.
+   */
+  if (effects.includes("file_selection")) return "file_upload"
   if (input.effect.target.sensitive || effects.includes("sensitive_input")) {
     return "sensitive_input"
   }
@@ -63,6 +73,11 @@ const takeoverReason = (
   if (effects.includes("payment")) return "payment"
   return undefined
 }
+
+const takeoverInstruction = (reason: AgentTakeoverRequest["reason"]): string =>
+  reason === "file_upload"
+    ? "Take control of the page, choose the file yourself, then explicitly continue."
+    : "Take control of the page, complete the sensitive step, then explicitly continue."
 
 const makeTakeoverRequest = (
   input: AgentPolicyInput,
@@ -72,8 +87,7 @@ const makeTakeoverRequest = (
   runId: input.runId,
   stepId: input.stepId,
   reason,
-  instruction:
-    "Take control of the page, complete the sensitive step, then explicitly continue.",
+  instruction: takeoverInstruction(reason),
   createdAt: input.now
 })
 

--- a/packages/agent-runtime/src/ports.ts
+++ b/packages/agent-runtime/src/ports.ts
@@ -147,8 +147,24 @@ export interface ResolvedAgentTarget {
    * confirms the control is still what lies under it before anything is sent.
    */
   point?: { x: number; y: number }
+  /**
+   * Where a drag ends: the observed element the pointer is released over,
+   * grounded like the source so a drop is an effect on a control the run
+   * named, and re-checked before the pointer moves.
+   */
+  drop?: AgentDropTarget
   sensitive: boolean
   maySubmit: boolean
+}
+
+/** The destination of a drag, in the terms its later recheck compares. */
+export interface AgentDropTarget {
+  ref: string
+  verificationId?: string
+  frameId: number
+  tag: string
+  role?: string
+  accessibleName?: string
 }
 
 export interface AgentDestination {
@@ -172,12 +188,16 @@ export type AgentSemanticEffect =
   | "navigation"
   | "activation"
   | "form_mutation"
+  /** A pointer picks a control up and releases it over another. */
+  | "drag"
   | "submission"
   | "destructive"
   | "download"
   | "authentication"
   | "payment"
   | "sensitive_input"
+  /** Opening the browser's file chooser, which only the user can answer. */
+  | "file_selection"
 
 export interface ResolvedAgentEffect {
   command: AgentCommand
@@ -256,6 +276,12 @@ export interface AgentExecutionReceipt {
   controlledTabId?: number
   backend?: AgentInputBackend
   inputDelivery?: AgentInputDelivery
+  /**
+   * The page asked the browser for a file while the action ran and the run's
+   * debugger held the chooser back. Nothing was chosen; the step cannot be
+   * finished by the run and is left for the user.
+   */
+  fileChooser?: boolean
 }
 
 export interface AgentVerificationEvidence {

--- a/packages/contracts/src/__tests__/agent.test.ts
+++ b/packages/contracts/src/__tests__/agent.test.ts
@@ -17,6 +17,8 @@ describe("agent contract schemas", () => {
       { type: "click", ref: "e1", ...ground },
       { type: "type", ref: "e1", text: "hello", ...ground },
       { type: "clear_and_type", ref: "e1", text: "hello", ...ground },
+      { type: "replace_text", ref: "e1", find: "old", text: "", ...ground },
+      { type: "drag", ref: "e1", to: "e2", ...ground },
       { type: "press_key", ref: "e1", key: "Enter", ...ground },
       { type: "select", ref: "e1", value: "one", ...ground },
       { type: "check", ref: "e1", ...ground },

--- a/packages/contracts/src/agent-command.ts
+++ b/packages/contracts/src/agent-command.ts
@@ -75,6 +75,27 @@ export const AgentCommandSchema = z.discriminatedUnion("type", [
     text: z.string().max(500)
   }).strict(),
   /**
+   * Editing in place. `find` is an exact run of the target's observed value
+   * that occurs once; it is replaced with `text`, which may be empty. This is
+   * how a word in the middle of a document is corrected without retyping the
+   * document, and how the caret is placed: at the replacement, never guessed.
+   */
+  ElementCommandSchema.extend({
+    type: z.literal("replace_text"),
+    find: z.string().min(1).max(500),
+    text: z.string().max(500)
+  }).strict(),
+  /**
+   * A pointer drag from the element `ref` to the element `to`, both observed.
+   * The destination is grounded like the source — a drop is an effect on it —
+   * and the two must share a frame, since a pointer cannot be placed across
+   * documents from either of them.
+   */
+  ElementCommandSchema.extend({
+    type: z.literal("drag"),
+    to: z.string().min(1)
+  }).strict(),
+  /**
    * A key or a combination, `Shift+Tab` or `Control+a` included; see
    * `agent-keys.ts` for the grammar. The target must already hold focus.
    */

--- a/packages/contracts/src/agent-observation.ts
+++ b/packages/contracts/src/agent-observation.ts
@@ -126,6 +126,21 @@ export const AgentElementSchema = z
     maySubmit: z.boolean().optional(),
     submitter: z.boolean().optional(),
     options: z.array(AgentSelectOptionSchema).max(200).optional(),
+    /**
+     * Set for a control whose value may hold line breaks: a `<textarea>`, or
+     * an editing host declared multiline. A newline typed into anything else
+     * is refused, because a single-line field has no place for it and the
+     * Enter it would stand for is a completion signal the model must press
+     * on purpose. Absent means single-line.
+     */
+    multiline: z.boolean().optional(),
+    /**
+     * Set when the page marks the element as something a pointer can pick
+     * up — `draggable="true"`, or an ARIA description saying so. Advisory:
+     * pointer-based drag libraries mark nothing, so its absence refuses no
+     * drag; its presence tells the model where a drag is meant to start.
+     */
+    draggable: z.boolean().optional(),
     visible: z.boolean(),
     /**
      * Set when the element is in the layout and the viewport yet another

--- a/src/application/agent/__tests__/agent-editing-decisions.test.ts
+++ b/src/application/agent/__tests__/agent-editing-decisions.test.ts
@@ -1,0 +1,152 @@
+import type { AgentElement, AgentObservation } from "@ollama-client/contracts"
+import { describe, expect, it } from "vitest"
+
+import {
+  AGENT_DECISION_TOOL_NAME,
+  parseAgentDecisionToolCalls
+} from "../agent-decision-parser"
+import { AGENT_DECISION_TOOL } from "../agent-model-port"
+import { projectAgentElement } from "../agent-observation-projection"
+
+/**
+ * The editing and drag commands as the model meets them: offered by the tool,
+ * accepted by the parser with their own fields, and told about a field's
+ * shape in the projection.
+ */
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  frameId: 0,
+  tag: "div",
+  type: "contenteditable",
+  value: "Hello world",
+  visible: true,
+  enabled: true,
+  editable: true,
+  sensitive: false,
+  multiline: true,
+  ...overrides
+})
+
+const observation: AgentObservation = {
+  snapshotId: "snapshot-2",
+  generation: 2,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1",
+  url: "https://example.com/",
+  origin: "https://example.com",
+  title: "Example",
+  frames: [
+    {
+      frameId: 0,
+      documentId: "document-1",
+      origin: "https://example.com",
+      url: "https://example.com/",
+      access: "ok",
+      snapshotId: "snapshot-2",
+      generation: 2
+    }
+  ],
+  elements: [
+    element(),
+    element({
+      ref: "e2",
+      tag: "li",
+      type: undefined,
+      value: undefined,
+      editable: false,
+      multiline: undefined,
+      draggable: true,
+      name: "Task A"
+    }),
+    element({
+      ref: "e3",
+      tag: "ul",
+      role: "list",
+      type: undefined,
+      value: undefined,
+      editable: false,
+      multiline: undefined,
+      name: "Done"
+    })
+  ],
+  visibleText: "",
+  scroll: {
+    x: 0,
+    y: 0,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 100
+  },
+  dialogs: [],
+  capturedAt: 1
+}
+
+const decide = (args: Record<string, unknown>) =>
+  parseAgentDecisionToolCalls(
+    [{ id: "c1", name: AGENT_DECISION_TOOL_NAME, arguments: args }],
+    observation
+  )
+
+describe("editing decisions", () => {
+  it("offers replace_text and drag with their fields", () => {
+    const properties = AGENT_DECISION_TOOL.parameters.properties as Record<
+      string,
+      { enum?: string[] }
+    >
+    expect(properties.type.enum).toEqual(
+      expect.arrayContaining(["replace_text", "drag"])
+    )
+    expect(properties.find).toBeDefined()
+    expect(properties.to).toBeDefined()
+  })
+
+  it("keeps find and to on their commands and grounds them", () => {
+    expect(
+      decide({ type: "replace_text", ref: "e1", find: "world", text: "there" })
+    ).toEqual({
+      type: "command",
+      command: {
+        type: "replace_text",
+        ref: "e1",
+        find: "world",
+        text: "there",
+        snapshotId: "snapshot-2",
+        generation: 2
+      }
+    })
+    expect(decide({ type: "drag", ref: "e2", to: "e3" })).toEqual({
+      type: "command",
+      command: {
+        type: "drag",
+        ref: "e2",
+        to: "e3",
+        snapshotId: "snapshot-2",
+        generation: 2
+      }
+    })
+    expect(() =>
+      decide({ type: "replace_text", ref: "e1", find: "nope", text: "x" })
+    ).toThrow(/text_not_found/)
+    expect(() => decide({ type: "drag", ref: "e2", to: "e9" })).toThrow(
+      /unknown_destination/
+    )
+  })
+
+  it("projects a field's shape and a drag mark, and nothing at their defaults", () => {
+    expect(projectAgentElement(element())).toMatchObject({
+      type: "contenteditable",
+      editable: true,
+      multiline: true
+    })
+    expect(projectAgentElement(observation.elements[1])).toMatchObject({
+      draggable: true
+    })
+    expect(
+      projectAgentElement(element({ multiline: undefined }))
+    ).not.toHaveProperty("multiline")
+    expect(projectAgentElement(element())).not.toHaveProperty("draggable")
+  })
+})

--- a/src/application/agent/agent-decision-parser.ts
+++ b/src/application/agent/agent-decision-parser.ts
@@ -69,6 +69,8 @@ const COMMAND_FIELDS: Record<string, readonly string[]> = {
   hover: ["ref"],
   type: ["ref", "text"],
   clear_and_type: ["ref", "text"],
+  replace_text: ["ref", "find", "text"],
+  drag: ["ref", "to"],
   select: ["ref", "value"],
   check: ["ref"],
   uncheck: ["ref"],

--- a/src/application/agent/agent-model-port.ts
+++ b/src/application/agent/agent-model-port.ts
@@ -53,6 +53,8 @@ const agentDecisionParameters = (vision: boolean): ToolParameterSchema => ({
         "hover",
         "type",
         "clear_and_type",
+        "replace_text",
+        "drag",
         "select",
         "check",
         "uncheck",
@@ -77,7 +79,17 @@ const agentDecisionParameters = (vision: boolean): ToolParameterSchema => ({
     ref: {
       type: "string",
       description:
-        "Observed element ref, e.g. e1. Required for click, double_click, hover, type, clear_and_type, select, check, uncheck and press_key."
+        "Observed element ref, e.g. e1. Required for click, double_click, hover, type, clear_and_type, replace_text, drag, select, check, uncheck and press_key."
+    },
+    to: {
+      type: "string",
+      description:
+        "For drag: the observed ref of the element to drop ref onto, in the same frame."
+    },
+    find: {
+      type: "string",
+      description:
+        "For replace_text: an exact run of the field's observed value that occurs once; it is replaced by text."
     },
     target: {
       type: "string",
@@ -92,7 +104,7 @@ const agentDecisionParameters = (vision: boolean): ToolParameterSchema => ({
     text: {
       type: "string",
       description:
-        "Text to enter for type or clear_and_type (at most 500 characters)."
+        "Text to enter for type, clear_and_type or replace_text (at most 500 characters). A line break is allowed only in a multiline field and starts a new paragraph; it never presses Enter."
     },
     value: { type: "string", description: "Observed option value for select." },
     key: {
@@ -184,6 +196,8 @@ Switching to a tab outside scopedTabIds asks the user first.
 The extension attaches snapshot identity; do not return a nested command or opaque IDs.
 Use ask_user when the goal is ambiguous and complete only when the observed evidence supports completion.
 Custom dropdowns, menus and tab strips are ordinary clicks: click the combobox or button that opens them, then click the option it reveals; hover reveals menus that open on pointer rest, and press_key with ArrowDown or Enter moves through a focused list.
+An element with type "contenteditable" is a rich-text editor whose value is its text: type appends, clear_and_type replaces everything, replace_text replaces one exact occurrence of find. Typed text never presses Enter; to send or confirm, press_key Enter on the focused field on purpose.
+drag moves ref onto to: a board item onto a column, a row onto another row. Elements marked draggable are where a drag starts.
 The observation is a bounded overview: omittedByGroup lists regions with controls it did not show. To reach them, inspect a region by its name, find controls by a query, or extract_text for the page's full text. These read only and never mutate the page.
 The history is this run's own record. Only an outcome of "confirmed" happened; anything else was attempted and did not verify, so do not treat it as done.
 Do not repeat a confirmed step. Use finding to record a fact a later step will need.

--- a/src/application/agent/agent-observation-projection.ts
+++ b/src/application/agent/agent-observation-projection.ts
@@ -31,6 +31,10 @@ export interface AgentProjectedElement {
   /** Present only when true, because the default is what most rows are. */
   submits?: boolean
   editable?: boolean
+  /** The field may hold line breaks; typed text into any other may not. */
+  multiline?: boolean
+  /** The page marks this as something a pointer picks up. */
+  draggable?: boolean
   sensitive?: boolean
   disabled?: boolean
   hidden?: boolean
@@ -165,6 +169,8 @@ export const projectAgentElement = (
     ...(element.group ? { group: element.group } : {}),
     ...(element.submitter || element.maySubmit ? { submits: true } : {}),
     ...(element.editable ? { editable: true } : {}),
+    ...(element.multiline ? { multiline: true } : {}),
+    ...(element.draggable ? { draggable: true } : {}),
     ...(element.sensitive ? { sensitive: true } : {}),
     ...(element.enabled ? {} : { disabled: true }),
     ...(element.visible ? {} : { hidden: true }),

--- a/src/background/agent/__tests__/agent-browser-session-manager.test.ts
+++ b/src/background/agent/__tests__/agent-browser-session-manager.test.ts
@@ -389,6 +389,7 @@ describe("Agent browser session frame tracking", () => {
     expect(host.commands.map((command) => command.method)).toEqual([
       "Page.enable",
       "Target.setAutoAttach",
+      "Page.setInterceptFileChooserDialog",
       "Page.getFrameTree"
     ])
     expect(host.commands[1]?.params).toMatchObject({

--- a/src/background/agent/__tests__/agent-drag-channel.test.ts
+++ b/src/background/agent/__tests__/agent-drag-channel.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createAgentBrowserSessionManager } from "../agent-browser-session-manager"
+
+type Debuggee = { tabId?: number; sessionId?: string }
+type EventListener = (
+  source: Debuggee,
+  method: string,
+  params?: unknown
+) => void
+
+/**
+ * The drag and file-chooser halves of the native channel. A held pointer move
+ * either becomes an HTML5 drag the browser reports, after which the channel
+ * speaks drag events, or stays a pointer move; a file chooser the page opens
+ * is counted, never shown, and charged to the action that asks.
+ */
+const harness = (input: { interceptsDrag?: boolean } = {}) => {
+  const commands: { method: string; params?: object }[] = []
+  const listeners = new Set<EventListener>()
+  const debuggerApi = {
+    attach: vi.fn((_t: Debuggee, _v: string, callback: () => void) =>
+      callback()
+    ),
+    detach: vi.fn((_t: Debuggee, callback: () => void) => callback()),
+    sendCommand: vi.fn(
+      (
+        target: Debuggee,
+        method: string,
+        params: object | undefined,
+        callback: (result?: unknown) => void
+      ) => {
+        commands.push({ method, params })
+        if (method === "Page.getFrameTree") {
+          callback({
+            frameTree: { frame: { id: "F0", url: "https://e.com/" } }
+          })
+          return
+        }
+        callback({})
+        /* The browser answers a held move that starts a drag with an event. */
+        if (
+          input.interceptsDrag &&
+          method === "Input.dispatchMouseEvent" &&
+          (params as { buttons?: number }).buttons === 1
+        ) {
+          for (const listener of listeners) {
+            listener(target, "Input.dragIntercepted", {
+              data: { items: [], dragOperationsMask: 1 }
+            })
+          }
+        }
+      }
+    ),
+    onDetach: { addListener: vi.fn(), removeListener: vi.fn() },
+    onEvent: {
+      addListener: (listener: EventListener) => listeners.add(listener),
+      removeListener: (listener: EventListener) => listeners.delete(listener)
+    }
+  }
+  const tabs = {
+    onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
+    onUpdated: { addListener: vi.fn(), removeListener: vi.fn() }
+  }
+  const manager = createAgentBrowserSessionManager({
+    debugger: debuggerApi,
+    tabs,
+    classifyAccess: async () => "ok",
+    readLastError: () => undefined
+  })
+  const fire = (method: string, params?: unknown) => {
+    for (const listener of listeners) listener({ tabId: 7 }, method, params)
+  }
+  const sent = (method: string) =>
+    commands.filter((command) => command.method === method)
+  return { manager, commands, sent, fire }
+}
+
+const channelOf = async (host: ReturnType<typeof harness>) => {
+  await host.manager.attach("run-1", 7)
+  const channel = host.manager.nativeInput("run-1", 7)
+  if (!channel) throw new Error("channel missing")
+  return channel
+}
+
+describe("Agent native drag channel", () => {
+  it("drives an intercepted HTML5 drag with drag events and drops with the drag data", async () => {
+    const host = harness({ interceptsDrag: true })
+    const channel = await channelOf(host)
+    await channel.dispatch({ kind: "drag", type: "move", x: 20, y: 20 })
+    await channel.dispatch({ kind: "drag", type: "move", x: 40, y: 40 })
+    await channel.dispatch({ kind: "drag", type: "drop", x: 60, y: 60 })
+    expect(
+      host.sent("Input.setInterceptDrags").map((command) => command.params)
+    ).toEqual([{ enabled: true }, { enabled: false }])
+    expect(
+      host.sent("Input.dispatchDragEvent").map((command) => command.params)
+    ).toEqual([
+      expect.objectContaining({ type: "dragEnter", x: 20, y: 20 }),
+      expect.objectContaining({ type: "dragOver", x: 40, y: 40 }),
+      expect.objectContaining({
+        type: "drop",
+        x: 60,
+        y: 60,
+        data: { items: [], dragOperationsMask: 1 }
+      })
+    ])
+    /* The release went into the drag, not as a mouse button. */
+    expect(
+      host
+        .sent("Input.dispatchMouseEvent")
+        .filter(
+          (command) =>
+            (command.params as { type: string }).type === "mouseReleased"
+        )
+    ).toHaveLength(0)
+  })
+
+  it("keeps a pointer-based drag as held mouse moves and a real release", async () => {
+    vi.useFakeTimers()
+    try {
+      const host = harness()
+      const channel = await channelOf(host)
+      const first = channel.dispatch({
+        kind: "drag",
+        type: "move",
+        x: 20,
+        y: 20
+      })
+      await vi.advanceTimersByTimeAsync(200)
+      await first
+      await channel.dispatch({ kind: "drag", type: "move", x: 40, y: 40 })
+      await channel.dispatch({ kind: "drag", type: "drop", x: 60, y: 60 })
+      expect(host.sent("Input.dispatchDragEvent")).toHaveLength(0)
+      expect(
+        host.sent("Input.dispatchMouseEvent").map((command) => command.params)
+      ).toEqual([
+        expect.objectContaining({
+          type: "mouseMoved",
+          x: 20,
+          y: 20,
+          buttons: 1
+        }),
+        expect.objectContaining({
+          type: "mouseMoved",
+          x: 40,
+          y: 40,
+          buttons: 1
+        }),
+        expect.objectContaining({ type: "mouseReleased", x: 60, y: 60 })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("cancels an intercepted drag without dropping", async () => {
+    const host = harness({ interceptsDrag: true })
+    const channel = await channelOf(host)
+    await channel.dispatch({ kind: "drag", type: "move", x: 20, y: 20 })
+    await channel.dispatch({ kind: "drag", type: "cancel", x: 20, y: 20 })
+    expect(
+      host
+        .sent("Input.dispatchDragEvent")
+        .map((command) => (command.params as { type: string }).type)
+    ).toEqual(["dragEnter", "dragCancel"])
+  })
+
+  it("holds file choosers back on attach and charges one to the first action that asks", async () => {
+    const host = harness()
+    const channel = await channelOf(host)
+    expect(
+      host
+        .sent("Page.setInterceptFileChooserDialog")
+        .map((command) => command.params)
+    ).toEqual([{ enabled: true }])
+    expect(channel.consumeFileChooser()).toBe(false)
+    host.fire("Page.fileChooserOpened", { frameId: "F0", mode: "selectSingle" })
+    expect(channel.consumeFileChooser()).toBe(true)
+    expect(channel.consumeFileChooser()).toBe(false)
+  })
+})

--- a/src/background/agent/__tests__/agent-drag-channel.test.ts
+++ b/src/background/agent/__tests__/agent-drag-channel.test.ts
@@ -179,4 +179,17 @@ describe("Agent native drag channel", () => {
     expect(channel.consumeFileChooser()).toBe(true)
     expect(channel.consumeFileChooser()).toBe(false)
   })
+
+  it("discards a chooser opened before the action's own window opens", async () => {
+    const host = harness()
+    const channel = await channelOf(host)
+    /* A chooser between actions belongs to no action and is dropped. */
+    host.fire("Page.fileChooserOpened", { frameId: "F0", mode: "selectSingle" })
+    channel.beginFileChooserWindow()
+    expect(channel.consumeFileChooser()).toBe(false)
+    /* One opened inside the window is charged to the action. */
+    channel.beginFileChooserWindow()
+    host.fire("Page.fileChooserOpened", { frameId: "F0", mode: "selectSingle" })
+    expect(channel.consumeFileChooser()).toBe(true)
+  })
 })

--- a/src/background/agent/agent-browser-adapters.ts
+++ b/src/background/agent/agent-browser-adapters.ts
@@ -220,6 +220,7 @@ export const createAgentBrowserAdapters = (input: {
     | "dispatchNativeInput"
     | "settleNativeInput"
     | "viewportCentre"
+    | "fileChooserOpened"
   > = {
     async nativeControl(effect) {
       const channel = nativeChannel(effect)
@@ -265,6 +266,9 @@ export const createAgentBrowserAdapters = (input: {
     },
     async viewportCentre(effect) {
       return nativeChannel(effect)?.viewportCentre()
+    },
+    async fileChooserOpened(effect) {
+      return nativeChannel(effect)?.consumeFileChooser() ?? false
     }
   }
 

--- a/src/background/agent/agent-browser-adapters.ts
+++ b/src/background/agent/agent-browser-adapters.ts
@@ -228,6 +228,12 @@ export const createAgentBrowserAdapters = (input: {
       if (!channel) {
         return { cdpControl, attached: false, frameMapped: false, platform }
       }
+      /**
+       * The facts are read once, immediately before the action acts, so this
+       * is where its file-chooser window opens: a chooser the page raised
+       * before now belongs to no action of this run and is discarded.
+       */
+      channel.beginFileChooserWindow()
       const frame = targetFrame(effect)
       const frames = frame.frameId === 0 ? [] : await listFrames(frame.tabId)
       const offset = await channel.frameOffset(frame.frameId, frames)

--- a/src/background/agent/agent-browser-session-manager.ts
+++ b/src/background/agent/agent-browser-session-manager.ts
@@ -154,10 +154,17 @@ export interface AgentNativeInputChannel {
     scale: number
   }): Promise<AgentRawCapture | undefined>
   /**
-   * Whether the page asked the browser for a file chooser since the last time
-   * this was asked. The dialog itself was held back — the run cannot answer
-   * it and the user must — so the answer is charged to whichever action asks
-   * first, and cleared by the asking.
+   * Opens the file-chooser window for one action. Every chooser the page
+   * raises before this is discarded, so a dialog opened between actions — or
+   * during a `select` or `check` that never reads it — cannot be charged to a
+   * later, unrelated action. Called once immediately before the action acts.
+   */
+  beginFileChooserWindow(): void
+  /**
+   * Whether the page asked the browser for a file chooser since
+   * `beginFileChooserWindow`. The dialog itself was held back — the run cannot
+   * answer it and the user must — so the step that opened it is left for the
+   * user. Reading clears the window.
    */
   consumeFileChooser(): boolean
 }
@@ -1054,6 +1061,10 @@ export const createAgentBrowserSessionManager = (input?: {
       })
       if (!isScreenshot(shot)) return undefined
       return { data: shot.data, mimeType: "image/jpeg", layout }
+    },
+    beginFileChooserWindow() {
+      if (attachments.get(attachment.runId) !== attachment) return
+      attachment.fileChoosers = 0
     },
     consumeFileChooser() {
       if (attachments.get(attachment.runId) !== attachment) return false

--- a/src/background/agent/agent-browser-session-manager.ts
+++ b/src/background/agent/agent-browser-session-manager.ts
@@ -153,6 +153,13 @@ export interface AgentNativeInputChannel {
     rect: { x: number; y: number; width: number; height: number }
     scale: number
   }): Promise<AgentRawCapture | undefined>
+  /**
+   * Whether the page asked the browser for a file chooser since the last time
+   * this was asked. The dialog itself was held back — the run cannot answer
+   * it and the user must — so the answer is charged to whichever action asks
+   * first, and cleared by the asking.
+   */
+  consumeFileChooser(): boolean
 }
 
 export interface AgentBrowserSessionManager {
@@ -198,7 +205,25 @@ interface Attachment {
   frames: Map<string, AgentCdpFrame>
   /** Sessions whose `DOM` domain has been enabled for box-model reads. */
   domEnabled: Set<string>
+  /**
+   * An HTML5 drag the browser started from a held pointer move, intercepted
+   * so it can be driven by protocol: the drag data travels with every later
+   * move and the drop. `intercepting` is set while the browser is being asked
+   * whether a held move starts one; `waiter` receives the answer.
+   */
+  drag?: { data: unknown }
+  intercepting: boolean
+  dragWaiter?: (data: unknown) => void
+  /** File choosers the page opened and the debugger held back, not yet charged. */
+  fileChoosers: number
 }
+
+/**
+ * How long a held pointer move is given to turn into an HTML5 drag before the
+ * move is taken as a plain pointer move. The browser answers within the same
+ * input task when it does start one; the wait is for the event to arrive.
+ */
+const DRAG_INTERCEPT_WAIT_MS = 150
 
 /** CDP `Input` mouse button and event names for the planner's steps. */
 const MOUSE_EVENT_TYPES = {
@@ -501,6 +526,16 @@ export const createAgentBrowserSessionManager = (input?: {
         waitForDebuggerOnStart: false,
         flatten: true
       })
+      /**
+       * A file chooser the page opens while the run drives the tab is held
+       * back and reported rather than shown: the run cannot choose a file and
+       * a dialog left open would block the page under it. Detaching the
+       * debugger — which every takeover does — lets the user's own click open
+       * the chooser normally.
+       */
+      await send(attachment.target, "Page.setInterceptFileChooserDialog", {
+        enabled: true
+      }).catch(() => undefined)
       await readFrameTree(attachment, {})
       if (attachments.get(attachment.runId) === attachment) {
         attachment.tracking = "tracking"
@@ -631,7 +666,20 @@ export const createAgentBrowserSessionManager = (input?: {
 
   const onDebuggerEvent: DebuggerEventListener = (source, method, params) => {
     const attachment = attachmentFor(source)
-    if (!attachment || attachment.tracking !== "tracking") return
+    if (!attachment) return
+    if (method === "Input.dragIntercepted") {
+      const data = (params as { data?: unknown } | undefined)?.data
+      if (attachment.intercepting && data !== undefined) {
+        attachment.drag = { data }
+        attachment.dragWaiter?.(data)
+      }
+      return
+    }
+    if (method === "Page.fileChooserOpened") {
+      attachment.fileChoosers += 1
+      return
+    }
+    if (attachment.tracking !== "tracking") return
     frameEventHandlers[method]?.(
       attachment,
       source,
@@ -810,11 +858,115 @@ export const createAgentBrowserSessionManager = (input?: {
     return undefined
   }
 
+  const heldMouse = (
+    type: "mouseMoved" | "mouseReleased",
+    x: number,
+    y: number
+  ) =>
+    ({
+      type,
+      x,
+      y,
+      button: "left",
+      buttons: type === "mouseMoved" ? 1 : 0,
+      clickCount: 1,
+      modifiers: 0
+    }) as const
+
+  /**
+   * The first held move asks the browser whether it starts an HTML5 drag:
+   * interception is switched on around the move, and an `Input.dragIntercepted`
+   * arriving within the wait means the page's `dragstart` ran and the browser
+   * now expects the drag to be driven by protocol. Without one, the move was a
+   * plain pointer move — what a pointer-based library reads — and later moves
+   * stay plain.
+   */
+  const dragMove = async (
+    attachment: Attachment,
+    step: Extract<AgentNativeInputStep, { kind: "drag" }>
+  ): Promise<void> => {
+    if (attachment.drag) {
+      await send(attachment.target, "Input.dispatchDragEvent", {
+        type: "dragOver",
+        x: step.x,
+        y: step.y,
+        data: attachment.drag.data
+      })
+      return
+    }
+    if (attachment.intercepting) {
+      await send(
+        attachment.target,
+        "Input.dispatchMouseEvent",
+        heldMouse("mouseMoved", step.x, step.y)
+      )
+      return
+    }
+    attachment.intercepting = true
+    const intercepted = new Promise<unknown | undefined>((resolve) => {
+      attachment.dragWaiter = resolve
+      setTimeout(() => resolve(undefined), DRAG_INTERCEPT_WAIT_MS)
+    })
+    try {
+      await send(attachment.target, "Input.setInterceptDrags", {
+        enabled: true
+      })
+      await send(
+        attachment.target,
+        "Input.dispatchMouseEvent",
+        heldMouse("mouseMoved", step.x, step.y)
+      )
+      const data = await intercepted
+      await send(attachment.target, "Input.setInterceptDrags", {
+        enabled: false
+      }).catch(() => undefined)
+      if (data !== undefined) {
+        attachment.drag = { data }
+        await send(attachment.target, "Input.dispatchDragEvent", {
+          type: "dragEnter",
+          x: step.x,
+          y: step.y,
+          data
+        })
+      }
+    } finally {
+      attachment.dragWaiter = undefined
+    }
+  }
+
+  /** A drop releases into the drag if one started, else the button; a cancel never drops. */
+  const dragEnd = async (
+    attachment: Attachment,
+    step: Extract<AgentNativeInputStep, { kind: "drag" }>
+  ): Promise<void> => {
+    const drag = attachment.drag
+    attachment.drag = undefined
+    attachment.intercepting = false
+    if (drag) {
+      await send(attachment.target, "Input.dispatchDragEvent", {
+        type: step.type === "drop" ? "drop" : "dragCancel",
+        x: step.x,
+        y: step.y,
+        data: drag.data
+      })
+      return
+    }
+    await send(
+      attachment.target,
+      "Input.dispatchMouseEvent",
+      heldMouse("mouseReleased", step.x, step.y)
+    )
+  }
+
   const dispatchStep = async (
     attachment: Attachment,
     step: AgentNativeInputStep
   ): Promise<void> => {
     switch (step.kind) {
+      case "drag":
+        if (step.type === "move") await dragMove(attachment, step)
+        else await dragEnd(attachment, step)
+        return
       case "mouse":
         await send(attachment.target, "Input.dispatchMouseEvent", {
           type: MOUSE_EVENT_TYPES[step.type],
@@ -902,6 +1054,12 @@ export const createAgentBrowserSessionManager = (input?: {
       })
       if (!isScreenshot(shot)) return undefined
       return { data: shot.data, mimeType: "image/jpeg", layout }
+    },
+    consumeFileChooser() {
+      if (attachments.get(attachment.runId) !== attachment) return false
+      const opened = attachment.fileChoosers > 0
+      attachment.fileChoosers = 0
+      return opened
     }
   })
 
@@ -937,7 +1095,9 @@ export const createAgentBrowserSessionManager = (input?: {
         ready: Promise.resolve(),
         tracking: "pending",
         frames: new Map(),
-        domEnabled: new Set()
+        domEnabled: new Set(),
+        intercepting: false,
+        fileChoosers: 0
       }
       attachment.rawAttach = cdp
         ? callDebugger(

--- a/src/features/agent/lib/__tests__/presentation.test.ts
+++ b/src/features/agent/lib/__tests__/presentation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { AGENT_PAGE_TEXT_LIMIT, agentPlainText } from "../presentation"
+import {
+  AGENT_PAGE_TEXT_LIMIT,
+  agentPlainText,
+  toAgentWorkLog
+} from "../presentation"
 
 describe("Agent presentation", () => {
   it("flattens page-controlled multiline text and applies its cap", () => {
@@ -13,5 +17,32 @@ describe("Agent presentation", () => {
 
   it("removes control characters", () => {
     expect(agentPlainText("safe\u0000\u0007 label", 100)).toBe("safe label")
+  })
+
+  it("labels editing and drag steps without echoing what was typed", () => {
+    const ground = { snapshotId: "s", generation: 1, ref: "e1" }
+    const log = toAgentWorkLog([
+      {
+        runId: "run-1",
+        stepId: "s1",
+        sequence: 1,
+        status: "executed",
+        at: 1,
+        command: { type: "replace_text", find: "secret", text: "x", ...ground }
+      },
+      {
+        runId: "run-1",
+        stepId: "s2",
+        sequence: 2,
+        status: "executed",
+        at: 2,
+        command: { type: "drag", to: "e2", ...ground }
+      }
+    ])
+    expect(log.map((item) => item.label)).toEqual([
+      "Edit text in field",
+      "Drag control to a drop target"
+    ])
+    expect(JSON.stringify(log)).not.toContain("secret")
   })
 })

--- a/src/features/agent/lib/presentation.ts
+++ b/src/features/agent/lib/presentation.ts
@@ -37,6 +37,10 @@ const commandLabel = (command?: AgentCommand): string => {
       return `Press ${agentPlainText(command.key, AGENT_PAGE_TEXT_LIMIT)}`
     case "type":
       return "Type in field"
+    case "replace_text":
+      return "Edit text in field"
+    case "drag":
+      return "Drag control to a drop target"
     case "select":
       return "Select option"
     case "check":

--- a/src/lib/browser-agent/__tests__/editing-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/editing-actions.test.ts
@@ -29,6 +29,7 @@ import {
   type AgentEffectResolverAdapter,
   resolveDomMutationAgentEffect
 } from "../resolved-effect"
+import { installAgentExecCommandStub } from "./execcommand-stub"
 
 /**
  * Editors, in-place edits, drags and file choosers through the resolver,
@@ -42,6 +43,7 @@ beforeEach(() => {
   document.title = "Board"
   document.body.replaceChildren()
   history.replaceState({}, "", "/board")
+  installAgentExecCommandStub(document)
   vi.spyOn(Element.prototype, "getClientRects").mockReturnValue([
     {
       bottom: 20,
@@ -544,9 +546,11 @@ describe("editing verification", () => {
       elements: [item("e2", "Task B"), column("e3", "Done")],
       visibleText: "Task B Done"
     })
+    /* A vanished source is never confirmed: an unrelated rerender looks the
+     * same, so the drop is left for the user to review. */
     expect(await verify(drag, gone, before)).toMatchObject({
-      outcome: "confirmed",
-      evidence: { summary: expect.stringContaining("no longer on the page") }
+      outcome: "ambiguous",
+      evidence: { summary: expect.stringContaining("unconfirmed") }
     })
   })
 

--- a/src/lib/browser-agent/__tests__/editing-actions.test.ts
+++ b/src/lib/browser-agent/__tests__/editing-actions.test.ts
@@ -1,0 +1,609 @@
+import {
+  type AgentCancellationSignal,
+  AgentGroundingError,
+  type AgentVerificationInput,
+  type AuthorizedAgentEffect,
+  evaluateAgentPolicy
+} from "@ollama-client/agent-runtime"
+import type { AgentElement, AgentObservation } from "@ollama-client/contracts"
+import {
+  type AgentCommand,
+  AgentCommandSchema,
+  type AgentSnapshotIdentity
+} from "@ollama-client/contracts"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  type AgentCommandExecutorAdapter,
+  executeAgentDomMutationInDocument,
+  executeDomMutationAgentEffect
+} from "../command-executor"
+import { agentEditorText } from "../editor-page"
+import {
+  type AgentEffectVerifierAdapter,
+  verifyDomMutationAgentEffect
+} from "../effect-verifier"
+import { createAgentElementReferenceStore } from "../element-references"
+import { buildAgentElementObservation } from "../observation-builder"
+import {
+  type AgentEffectResolverAdapter,
+  resolveDomMutationAgentEffect
+} from "../resolved-effect"
+
+/**
+ * Editors, in-place edits, drags and file choosers through the resolver,
+ * the DOM backend and the verifier — what each is grounded in, what the page
+ * receives, and what counts as the effect having happened.
+ */
+
+const signal: AgentCancellationSignal = { aborted: false }
+
+beforeEach(() => {
+  document.title = "Board"
+  document.body.replaceChildren()
+  history.replaceState({}, "", "/board")
+  vi.spyOn(Element.prototype, "getClientRects").mockReturnValue([
+    {
+      bottom: 20,
+      height: 20,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100
+    } as DOMRect
+  ] as unknown as DOMRectList)
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+    bottom: 20,
+    height: 20,
+    left: 0,
+    right: 100,
+    top: 0,
+    width: 100
+  } as DOMRect)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+const element = (overrides: Partial<AgentElement> = {}): AgentElement => ({
+  ref: "e1",
+  frameId: 0,
+  tag: "div",
+  type: "contenteditable",
+  value: "Hello world",
+  visible: true,
+  enabled: true,
+  editable: true,
+  sensitive: false,
+  multiline: true,
+  ...overrides
+})
+
+const observation = (
+  overrides: Partial<AgentObservation> = {}
+): AgentObservation => ({
+  snapshotId: "snapshot-1",
+  generation: 1,
+  tabId: 7,
+  frameId: 0,
+  documentId: "document-1",
+  url: new URL("/board", location.href).href,
+  origin: location.origin,
+  title: "Board",
+  frames: [
+    {
+      frameId: 0,
+      documentId: "document-1",
+      origin: location.origin,
+      url: new URL("/board", location.href).href,
+      access: "ok",
+      snapshotId: "snapshot-1",
+      generation: 1
+    }
+  ],
+  elements: [element()],
+  visibleText: "Hello world",
+  scroll: {
+    x: 0,
+    y: 0,
+    viewportWidth: 100,
+    viewportHeight: 100,
+    documentWidth: 100,
+    documentHeight: 100
+  },
+  dialogs: [],
+  capturedAt: 1,
+  ...overrides
+})
+
+const command = (input: Record<string, unknown>): AgentCommand =>
+  AgentCommandSchema.parse({
+    ...input,
+    snapshotId: "snapshot-1",
+    generation: 1
+  })
+
+const resolverAdapter = (): AgentEffectResolverAdapter => ({
+  getTab: async (tabId) => ({ id: tabId, url: observation().url }),
+  classifyAccess: async () => "ok",
+  resolveHistoryDestination: async () => undefined
+})
+
+const resolve = (action: AgentCommand, before = observation()) =>
+  resolveDomMutationAgentEffect({
+    command: action,
+    observation: before,
+    adapter: resolverAdapter()
+  })
+
+const authorize = async (
+  action: AgentCommand,
+  before = observation()
+): Promise<AuthorizedAgentEffect> => ({
+  ...(await resolve(action, before)),
+  authorization: {
+    type: "approval",
+    risk: "high",
+    approvalId: "a1",
+    authorizedAt: 2
+  }
+})
+
+const verifierAdapter = (
+  after: AgentObservation
+): AgentEffectVerifierAdapter => ({
+  observe: async () => after,
+  getActiveTabId: async () => 7,
+  getTab: async () => ({ url: after.url }),
+  classifyAccess: async () => "ok",
+  now: () => 10
+})
+
+const verify = async (
+  action: AgentCommand,
+  after: AgentObservation,
+  before = observation(),
+  receipt: AgentVerificationInput["receipt"] = { executedAt: 5 }
+) =>
+  verifyDomMutationAgentEffect({
+    verification: {
+      effect: await authorize(action, before),
+      receipt,
+      before,
+      allowedOrigins: [location.origin]
+    },
+    adapter: verifierAdapter(after),
+    signal
+  })
+
+const item = (ref: string, name: string): AgentElement =>
+  element({
+    ref,
+    tag: "li",
+    type: undefined,
+    value: undefined,
+    editable: false,
+    multiline: undefined,
+    draggable: true,
+    name,
+    verificationId: `v-${ref}`
+  })
+
+const column = (ref: string, name: string): AgentElement =>
+  element({
+    ref,
+    tag: "ul",
+    role: "list",
+    type: undefined,
+    value: undefined,
+    editable: false,
+    multiline: undefined,
+    name,
+    verificationId: `v-${ref}`
+  })
+
+describe("editing resolution", () => {
+  it("resolves the value an in-place edit leaves behind", async () => {
+    const resolved = await resolve(
+      command({ type: "replace_text", ref: "e1", find: "world", text: "there" })
+    )
+    expect(resolved.target.expectedValue).toBe("Hello there")
+    expect(resolved.semanticEffects).toEqual(["form_mutation"])
+  })
+
+  it("refuses an edit the observed value does not ground", async () => {
+    await expect(
+      resolve(
+        command({ type: "replace_text", ref: "e1", find: "gone", text: "x" })
+      )
+    ).rejects.toBeInstanceOf(AgentGroundingError)
+  })
+
+  it("resolves a drag onto its destination and reads the destination's label for destructive intent", async () => {
+    const before = observation({
+      elements: [
+        item("e1", "Task A"),
+        column("e2", "Done"),
+        column("e3", "Delete")
+      ]
+    })
+    const moved = await resolve(
+      command({ type: "drag", ref: "e1", to: "e2" }),
+      before
+    )
+    expect(moved.semanticEffects).toEqual(["drag"])
+    expect(moved.target.drop).toEqual({
+      ref: "e2",
+      verificationId: "v-e2",
+      frameId: 0,
+      tag: "ul",
+      role: "list",
+      accessibleName: "Done"
+    })
+    const binned = await resolve(
+      command({ type: "drag", ref: "e1", to: "e3" }),
+      before
+    )
+    expect(binned.semanticEffects).toEqual(["drag", "destructive"])
+  })
+
+  it("turns a click on a file input into a file-upload takeover", async () => {
+    const before = observation({
+      elements: [
+        element({
+          ref: "e1",
+          tag: "input",
+          type: "file",
+          sensitive: true,
+          value: undefined,
+          multiline: undefined,
+          editable: true
+        })
+      ]
+    })
+    const resolved = await resolve(
+      command({ type: "click", ref: "e1" }),
+      before
+    )
+    expect(resolved.semanticEffects).toContain("file_selection")
+    const decision = evaluateAgentPolicy({
+      runId: "run-1",
+      stepId: "step-1",
+      effect: resolved,
+      allowedOrigins: [location.origin],
+      scopedTabIds: [7],
+      now: 3
+    })
+    expect(decision.type).toBe("takeover_required")
+    if (decision.type === "takeover_required") {
+      expect(decision.request.reason).toBe("file_upload")
+    }
+  })
+})
+
+describe("editing on the DOM backend", () => {
+  const liveEffect = async (
+    action: AgentCommand,
+    targets: Element[]
+  ): Promise<{
+    effect: AuthorizedAgentEffect & { frame: AgentSnapshotIdentity }
+    references: ReturnType<typeof createAgentElementReferenceStore>
+  }> => {
+    const references = createAgentElementReferenceStore({
+      documentId: "document-1",
+      frameId: 0
+    })
+    const snapshot = references.beginSnapshot({
+      minimumGeneration: 1,
+      createSnapshotId: () => "snapshot-1"
+    })
+    const elements = targets.map((target) =>
+      buildAgentElementObservation(
+        target,
+        snapshot.reference(target),
+        0,
+        snapshot.verificationId(target)
+      )
+    )
+    const effect = await authorize(action, observation({ elements }))
+    return {
+      effect: {
+        ...effect,
+        frame: effect.target.frame ?? effect.snapshotIdentity
+      },
+      references
+    }
+  }
+
+  const editor = (html: string) => {
+    const host = document.createElement("div")
+    host.setAttribute("contenteditable", "true")
+    host.setAttribute("aria-multiline", "true")
+    host.innerHTML = html
+    document.body.append(host)
+    return host
+  }
+
+  it("appends, replaces and edits an editing host through its editing pipeline", async () => {
+    const host = editor("<p>Hello world</p>")
+    const inputs: string[] = []
+    host.addEventListener("input", (event) =>
+      inputs.push((event as InputEvent).inputType)
+    )
+    const typed = await liveEffect(
+      command({ type: "type", ref: "e1", text: "\nSecond" }),
+      [host]
+    )
+    executeAgentDomMutationInDocument({
+      effect: typed.effect,
+      document,
+      references: typed.references,
+      signal
+    })
+    expect(agentEditorText(host)).toBe("Hello world\nSecond")
+
+    const edited = await liveEffect(
+      command({
+        type: "replace_text",
+        ref: "e1",
+        find: "world",
+        text: "there"
+      }),
+      [host]
+    )
+    executeAgentDomMutationInDocument({
+      effect: edited.effect,
+      document,
+      references: edited.references,
+      signal
+    })
+    expect(agentEditorText(host)).toBe("Hello there\nSecond")
+
+    const cleared = await liveEffect(
+      command({ type: "clear_and_type", ref: "e1", text: "Fresh" }),
+      [host]
+    )
+    executeAgentDomMutationInDocument({
+      effect: cleared.effect,
+      document,
+      references: cleared.references,
+      signal
+    })
+    expect(agentEditorText(host)).toBe("Fresh")
+    expect(inputs).toEqual(["insertText", "insertText", "insertText"])
+  })
+
+  it("edits a text control in place and dispatches input", async () => {
+    const input = document.createElement("input")
+    input.value = "Hello world"
+    document.body.append(input)
+    const seen = vi.fn()
+    input.addEventListener("input", seen)
+    const { effect, references } = await liveEffect(
+      command({
+        type: "replace_text",
+        ref: "e1",
+        find: "world",
+        text: "there"
+      }),
+      [input]
+    )
+    executeAgentDomMutationInDocument({ effect, document, references, signal })
+    expect(input.value).toBe("Hello there")
+    expect(seen).toHaveBeenCalledTimes(1)
+  })
+
+  it("drags a board item onto a column with the page's own drop handlers", async () => {
+    document.body.innerHTML =
+      '<ul id="todo" role="list" aria-label="Todo"><li id="a" draggable="true">Task A</li></ul><ul id="done" role="list" aria-label="Done"></ul>'
+    const li = document.getElementById("a") as HTMLElement
+    const done = document.getElementById("done") as HTMLElement
+    li.addEventListener("dragstart", (event) =>
+      (event as DragEvent).dataTransfer?.setData("text/plain", "a")
+    )
+    done.addEventListener("dragover", (event) => event.preventDefault())
+    done.addEventListener("drop", (event) => {
+      const id = (event as DragEvent).dataTransfer?.getData("text/plain")
+      if (id) done.append(document.getElementById(id) as Element)
+    })
+    const { effect, references } = await liveEffect(
+      command({ type: "drag", ref: "e1", to: "e2" }),
+      [li, done]
+    )
+    const adapter: AgentCommandExecutorAdapter = {
+      getTab: async (tabId) => ({ id: tabId, url: observation().url }),
+      getFrame: async () => ({
+        documentId: "document-1",
+        url: observation().url
+      }),
+      classifyAccess: async () => "ok",
+      scroll: vi.fn(),
+      mutate: async () => {
+        executeAgentDomMutationInDocument({
+          effect,
+          document,
+          references,
+          signal
+        })
+        return undefined
+      },
+      activateTab: vi.fn(),
+      goHistory: vi.fn(),
+      resolveHistoryDestination: async () => undefined,
+      wait: vi.fn(),
+      navigate: vi.fn(),
+      createTab: vi.fn(),
+      now: () => 10
+    }
+    const receipt = await executeDomMutationAgentEffect({
+      effect,
+      adapter,
+      signal
+    })
+    expect(receipt.backend).toBe("dom")
+    expect(done.contains(li)).toBe(true)
+  })
+
+  it("marks the receipt when the action opened a file chooser the debugger held back", async () => {
+    const button = document.createElement("button")
+    button.textContent = "Upload"
+    document.body.append(button)
+    const { effect, references } = await liveEffect(
+      command({ type: "click", ref: "e1" }),
+      [button]
+    )
+    const adapter: AgentCommandExecutorAdapter = {
+      getTab: async (tabId) => ({ id: tabId, url: observation().url }),
+      getFrame: async () => ({
+        documentId: "document-1",
+        url: observation().url
+      }),
+      classifyAccess: async () => "ok",
+      scroll: vi.fn(),
+      mutate: async () => {
+        executeAgentDomMutationInDocument({
+          effect,
+          document,
+          references,
+          signal
+        })
+        return undefined
+      },
+      fileChooserOpened: async () => true,
+      activateTab: vi.fn(),
+      goHistory: vi.fn(),
+      resolveHistoryDestination: async () => undefined,
+      wait: vi.fn(),
+      navigate: vi.fn(),
+      createTab: vi.fn(),
+      now: () => 10
+    }
+    const receipt = await executeDomMutationAgentEffect({
+      effect,
+      adapter,
+      signal
+    })
+    expect(receipt.fileChooser).toBe(true)
+  })
+})
+
+describe("editing verification", () => {
+  it("compares an editor's value in its normalized form", async () => {
+    const after = observation({
+      elements: [element({ value: "Hello  there" })]
+    })
+    const result = await verify(
+      command({
+        type: "replace_text",
+        ref: "e1",
+        find: "world",
+        text: "there"
+      }),
+      after
+    )
+    expect(result.outcome).toBe("confirmed")
+  })
+
+  it("confirms a drag by the arrangement it leaves, not by the page having changed", async () => {
+    const before = observation({
+      elements: [
+        item("e1", "Task A"),
+        item("e2", "Task B"),
+        column("e3", "Done")
+      ],
+      visibleText: "Task A Task B Done"
+    })
+    const drag = command({ type: "drag", ref: "e1", to: "e3" })
+    const moved = observation({
+      elements: [
+        item("e2", "Task B"),
+        column("e3", "Done"),
+        item("e1", "Task A")
+      ],
+      visibleText: "Task B Done Task A"
+    })
+    expect(await verify(drag, moved, before)).toMatchObject({
+      outcome: "confirmed",
+      evidence: {
+        kind: "arrangement",
+        summary: expect.stringContaining("past")
+      }
+    })
+    expect(await verify(drag, before, before)).toMatchObject({
+      outcome: "negative",
+      evidence: { summary: "Arrangement did not change" }
+    })
+    const restyled = observation({
+      ...before,
+      visibleText: "Task A Task B Done!"
+    })
+    expect(await verify(drag, restyled, before)).toMatchObject({
+      outcome: "ambiguous",
+      evidence: { summary: expect.stringContaining("did not visibly move") }
+    })
+    const gone = observation({
+      elements: [item("e2", "Task B"), column("e3", "Done")],
+      visibleText: "Task B Done"
+    })
+    expect(await verify(drag, gone, before)).toMatchObject({
+      outcome: "confirmed",
+      evidence: { summary: expect.stringContaining("no longer on the page") }
+    })
+  })
+
+  it("confirms a drag that moved the item among different neighbours within one region", async () => {
+    const before = observation({
+      elements: [
+        item("e1", "Task A"),
+        item("e2", "Task B"),
+        item("e3", "Task C")
+      ],
+      visibleText: "A B C"
+    })
+    const after = observation({
+      elements: [
+        item("e2", "Task B"),
+        item("e1", "Task A"),
+        item("e3", "Task C")
+      ],
+      visibleText: "B A C"
+    })
+    expect(
+      await verify(
+        command({ type: "drag", ref: "e1", to: "e2" }),
+        after,
+        before
+      )
+    ).toMatchObject({ outcome: "confirmed" })
+  })
+
+  it("leaves a step that opened a file chooser to the user", async () => {
+    const before = observation({
+      elements: [
+        element({
+          tag: "button",
+          type: undefined,
+          value: undefined,
+          editable: false,
+          multiline: undefined,
+          name: "Upload"
+        })
+      ],
+      visibleText: "Upload"
+    })
+    const result = await verify(
+      command({ type: "click", ref: "e1" }),
+      before,
+      before,
+      {
+        executedAt: 5,
+        backend: "cdp",
+        inputDelivery: "delivered",
+        fileChooser: true
+      }
+    )
+    expect(result).toMatchObject({
+      outcome: "ambiguous",
+      evidence: { kind: "file_chooser" }
+    })
+  })
+})

--- a/src/lib/browser-agent/__tests__/editor-page.test.ts
+++ b/src/lib/browser-agent/__tests__/editor-page.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeAgentEditorText,
   replaceAgentTextOnce
 } from "../editor-text"
+import { installAgentExecCommandStub } from "./execcommand-stub"
 
 /**
  * The page's half of editing, driven against a document rather than a mock:
@@ -23,6 +24,7 @@ import {
 
 beforeEach(() => {
   document.body.replaceChildren()
+  installAgentExecCommandStub(document)
 })
 
 afterEach(() => vi.restoreAllMocks())

--- a/src/lib/browser-agent/__tests__/editor-page.test.ts
+++ b/src/lib/browser-agent/__tests__/editor-page.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { executeAgentSyntheticDrag } from "../drag-page"
+import {
+  agentEditorText,
+  insertAgentEditableText,
+  isAgentEditingHost,
+  locateAgentEditorRange,
+  placeAgentEditableCaret,
+  selectAgentEditableText
+} from "../editor-page"
+import {
+  countAgentTextOccurrences,
+  normalizeAgentEditorText,
+  replaceAgentTextOnce
+} from "../editor-text"
+
+/**
+ * The page's half of editing, driven against a document rather than a mock:
+ * the editor's flattened text, the range under a run of it, and the fallback
+ * insertion a runtime without `execCommand` takes.
+ */
+
+beforeEach(() => {
+  document.body.replaceChildren()
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+const host = (html: string, attributes: Record<string, string> = {}) => {
+  const editor = document.createElement("div")
+  editor.setAttribute("contenteditable", "true")
+  for (const [name, value] of Object.entries(attributes)) {
+    editor.setAttribute(name, value)
+  }
+  editor.innerHTML = html
+  document.body.append(editor)
+  return editor
+}
+
+describe("editor text normalization", () => {
+  it("keeps paragraph breaks as single line breaks and drops blank lines and stray spaces", () => {
+    expect(normalizeAgentEditorText("  Hello   world \n\n\n Second  ")).toBe(
+      "Hello world\nSecond"
+    )
+    expect(normalizeAgentEditorText("\n\n")).toBe("")
+  })
+
+  it("counts exact, non-overlapping occurrences and replaces only a single one", () => {
+    expect(countAgentTextOccurrences("aaa", "aa")).toBe(1)
+    expect(countAgentTextOccurrences("a b a", "a")).toBe(2)
+    expect(countAgentTextOccurrences("abc", "")).toBe(0)
+    expect(replaceAgentTextOnce("Hello world", "world", "there")).toBe(
+      "Hello there"
+    )
+    expect(replaceAgentTextOnce("a a", "a", "b")).toBeUndefined()
+    expect(replaceAgentTextOnce("abc", "x", "b")).toBeUndefined()
+  })
+})
+
+describe("editing hosts", () => {
+  it("recognizes a host by its own attribute, however true is spelled, and never its children", () => {
+    const editor = host("<p>One</p>", { contenteditable: "" })
+    expect(isAgentEditingHost(editor)).toBe(true)
+    const paragraph = editor.querySelector("p") as Element
+    expect(isAgentEditingHost(paragraph)).toBe(false)
+    editor.setAttribute("contenteditable", "plaintext-only")
+    expect(isAgentEditingHost(editor)).toBe(true)
+    editor.setAttribute("contenteditable", "FALSE")
+    expect(isAgentEditingHost(editor)).toBe(false)
+  })
+
+  it("flattens blocks and line breaks into lines, skipping scripts and trailing break placeholders", () => {
+    const editor = host(
+      "<p>Hello <b>big</b> world</p><p><br></p><ul><li>one</li><li>two</li></ul><div>a<br>b</div><script>x()</script>"
+    )
+    expect(agentEditorText(editor)).toBe("Hello big world\none\ntwo\na\nb")
+  })
+
+  it("locates a unique run across text nodes and refuses an ambiguous or absent one", () => {
+    const editor = host("<p>Hello <b>wor</b>ld</p><p>again</p>")
+    const range = locateAgentEditorRange(editor, "world")
+    expect(range?.toString()).toBe("world")
+    expect(locateAgentEditorRange(editor, "again again")).toBeUndefined()
+    const repeated = host("<p>go</p><p>go</p>")
+    expect(locateAgentEditorRange(repeated, "go")).toBeUndefined()
+  })
+
+  it("matches a run the model read with a line break where the document has a paragraph break", () => {
+    const editor = host("<p>first line</p><p>second line</p>")
+    expect(
+      locateAgentEditorRange(editor, "line\nsecond")?.toString()
+    ).toContain("line")
+  })
+})
+
+describe("editable selection and insertion", () => {
+  it("selects a unique run in a text control and refuses a repeated one", () => {
+    const input = document.createElement("input")
+    input.value = "Hello world"
+    document.body.append(input)
+    expect(selectAgentEditableText(input, "world")).toBe(true)
+    expect(input.selectionStart).toBe(6)
+    expect(input.selectionEnd).toBe(11)
+    input.value = "go go"
+    expect(selectAgentEditableText(input, "go")).toBe(false)
+  })
+
+  it("places the caret at the end or over everything in a text control", () => {
+    const area = document.createElement("textarea")
+    area.value = "abc"
+    document.body.append(area)
+    placeAgentEditableCaret(area, "end")
+    expect([area.selectionStart, area.selectionEnd]).toEqual([3, 3])
+    placeAgentEditableCaret(area, "all")
+    expect([area.selectionStart, area.selectionEnd]).toEqual([0, 3])
+  })
+
+  it("inserts over the selection of a text control and tells the page through an input event", () => {
+    const input = document.createElement("input")
+    input.value = "Hello world"
+    document.body.append(input)
+    const seen: string[] = []
+    input.addEventListener("input", (event) =>
+      seen.push((event as InputEvent).inputType ?? "input")
+    )
+    selectAgentEditableText(input, "world")
+    insertAgentEditableText(input, "there")
+    expect(input.value).toBe("Hello there")
+    expect(seen).toEqual(["insertText"])
+  })
+
+  it("replaces the selected run inside an editing host with a line break per newline, announcing beforeinput and input", () => {
+    const editor = host("<p>Hello world</p>")
+    const seen: string[] = []
+    editor.addEventListener("beforeinput", (event) =>
+      seen.push(`before:${(event as InputEvent).inputType}`)
+    )
+    editor.addEventListener("input", (event) =>
+      seen.push(`input:${(event as InputEvent).inputType}`)
+    )
+    expect(selectAgentEditableText(editor, "world")).toBe(true)
+    insertAgentEditableText(editor, "there\nfriend")
+    expect(agentEditorText(editor)).toBe("Hello there\nfriend")
+    expect(editor.querySelectorAll("br")).toHaveLength(1)
+    expect(seen).toEqual(["before:insertText", "input:insertText"])
+  })
+
+  it("leaves the document to an editor that cancels beforeinput", () => {
+    const editor = host("<p>Hello world</p>")
+    editor.addEventListener("beforeinput", (event) => event.preventDefault())
+    selectAgentEditableText(editor, "world")
+    insertAgentEditableText(editor, "there")
+    expect(agentEditorText(editor)).toBe("Hello world")
+  })
+
+  it("appends at the end and replaces everything through the caret placement", () => {
+    const editor = host("<p>Hello</p>")
+    placeAgentEditableCaret(editor, "end")
+    insertAgentEditableText(editor, " there")
+    expect(agentEditorText(editor)).toBe("Hello there")
+    placeAgentEditableCaret(editor, "all")
+    insertAgentEditableText(editor, "Fresh")
+    expect(agentEditorText(editor)).toBe("Fresh")
+    placeAgentEditableCaret(editor, "all")
+    insertAgentEditableText(editor, "")
+    expect(agentEditorText(editor)).toBe("")
+  })
+})
+
+describe("synthetic drag", () => {
+  const board = () => {
+    document.body.innerHTML = `
+      <ul id="todo" role="list"><li id="a" draggable="true">Task A</li></ul>
+      <ul id="done" role="list"></ul>`
+    const item = document.getElementById("a") as HTMLElement
+    const done = document.getElementById("done") as HTMLElement
+    return { item, done }
+  }
+
+  it("carries one DataTransfer from dragstart to drop and drops only where dragover was accepted", () => {
+    const { item, done } = board()
+    const events: string[] = []
+    item.addEventListener("dragstart", (event) => {
+      events.push("dragstart")
+      ;(event as DragEvent).dataTransfer?.setData("text/plain", "a")
+    })
+    item.addEventListener("dragend", () => events.push("dragend"))
+    done.addEventListener("dragover", (event) => {
+      events.push("dragover")
+      event.preventDefault()
+    })
+    done.addEventListener("drop", (event) => {
+      events.push(
+        `drop:${(event as DragEvent).dataTransfer?.getData("text/plain")}`
+      )
+      done.append(item)
+    })
+    const outcome = executeAgentSyntheticDrag({
+      source: item,
+      destination: done,
+      from: { x: 5, y: 5 },
+      to: { x: 50, y: 50 }
+    })
+    expect(outcome.dropped).toBe(true)
+    expect(events).toEqual(["dragstart", "dragover", "drop:a", "dragend"])
+    expect(done.contains(item)).toBe(true)
+  })
+
+  it("sends the pointer sequence for a non-draggable source and no HTML5 events", () => {
+    const { item, done } = board()
+    item.removeAttribute("draggable")
+    const events: string[] = []
+    for (const type of ["pointerdown", "mousedown", "dragstart"]) {
+      item.addEventListener(type, () => events.push(type))
+    }
+    for (const type of ["pointermove", "pointerup", "mouseup", "drop"]) {
+      done.addEventListener(type, () => events.push(type))
+    }
+    const outcome = executeAgentSyntheticDrag({
+      source: item,
+      destination: done,
+      from: { x: 5, y: 5 },
+      to: { x: 50, y: 50 }
+    })
+    expect(outcome.dropped).toBe(false)
+    expect(events).toEqual([
+      "pointerdown",
+      "mousedown",
+      "pointermove",
+      "pointerup",
+      "mouseup"
+    ])
+  })
+
+  it("does not drop on a destination that leaves dragover uncancelled", () => {
+    const { item, done } = board()
+    const dropped = vi.fn()
+    done.addEventListener("drop", dropped)
+    const left = vi.fn()
+    done.addEventListener("dragleave", left)
+    expect(
+      executeAgentSyntheticDrag({
+        source: item,
+        destination: done,
+        from: { x: 5, y: 5 },
+        to: { x: 50, y: 50 }
+      }).dropped
+    ).toBe(false)
+    expect(dropped).not.toHaveBeenCalled()
+    expect(left).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/browser-agent/__tests__/execcommand-stub.ts
+++ b/src/lib/browser-agent/__tests__/execcommand-stub.ts
@@ -1,0 +1,77 @@
+/**
+ * A test stand-in for the browser's `document.execCommand`, which happy-dom
+ * does not implement.
+ *
+ * Production edits an editing host only through `execCommand`, never by
+ * writing its DOM, so a real browser (Chrome via the debugger, Firefox via
+ * `execCommand`) owns the mutation. This reproduces what that command does to
+ * a `contenteditable` — delete the selection, insert the text with a `<br>`
+ * per newline, collapse the caret, and fire `beforeinput`/`input` — so a unit
+ * test can drive the same code path a browser would. A cancelled `beforeinput`
+ * leaves the DOM untouched, as the platform does.
+ */
+export const installAgentExecCommandStub = (doc: Document): void => {
+  const view = doc.defaultView as
+    | (Window & typeof globalThis)
+    | null
+    | undefined
+  const fire = (
+    target: Element,
+    type: "beforeinput" | "input",
+    inputType: string,
+    data: string | null
+  ): boolean => {
+    const Ctor = view?.InputEvent ?? globalThis.InputEvent
+    const event =
+      typeof Ctor === "function"
+        ? new Ctor(type, {
+            bubbles: true,
+            cancelable: type === "beforeinput",
+            composed: true,
+            inputType,
+            data
+          })
+        : new Event(type, { bubbles: true, cancelable: type === "beforeinput" })
+    return target.dispatchEvent(event)
+  }
+  ;(
+    doc as Document & {
+      execCommand?: (command: string, ui?: boolean, value?: string) => boolean
+    }
+  ).execCommand = (command, _ui, value) => {
+    const insert = command === "insertText"
+    const text = insert ? (value ?? "") : ""
+    const selection = view?.getSelection?.()
+    if (!selection || selection.rangeCount === 0) return false
+    const range = selection.getRangeAt(0)
+    const start = range.startContainer
+    const anchor =
+      start.nodeType === 1
+        ? (start as Element)
+        : (start.parentElement ?? doc.body)
+    const inputType =
+      insert && text.length > 0 ? "insertText" : "deleteContentBackward"
+    if (!fire(anchor, "beforeinput", inputType, insert ? text : null)) {
+      return true
+    }
+    range.deleteContents()
+    if (insert && text.length > 0) {
+      const fragment = doc.createDocumentFragment()
+      text.split(/\r\n|\r|\n/).forEach((line, index) => {
+        if (index > 0) fragment.append(doc.createElement("br"))
+        if (line.length > 0) fragment.append(doc.createTextNode(line))
+      })
+      const last = fragment.lastChild
+      range.insertNode(fragment)
+      if (last) {
+        const caret = doc.createRange()
+        caret.setStartAfter(last)
+        caret.collapse(true)
+        selection.removeAllRanges()
+        selection.addRange(caret)
+      }
+    }
+    fire(anchor, "input", inputType, insert ? text : null)
+    return true
+  }
+}

--- a/src/lib/browser-agent/__tests__/native-input-editing.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input-editing.test.ts
@@ -1,0 +1,454 @@
+import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
+import type { AgentCommand } from "@ollama-client/contracts"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentDomMutationInstruction } from "../control-port"
+import { createAgentElementReferenceStore } from "../element-references"
+import {
+  type AgentInputTrace,
+  AgentNativeInputCancelledError,
+  type AgentNativeInputStep,
+  assessAgentInputDelivery,
+  chooseAgentInputBackend,
+  planAgentNativeInput,
+  runAgentNativeInputPlan
+} from "../native-input"
+import {
+  createAgentInputWatch,
+  prepareAgentNativeInputInDocument
+} from "../native-input-page"
+import {
+  buildAgentElementObservation,
+  buildAgentObservation
+} from "../observation-builder"
+
+/**
+ * Editing and dragging on the native backend: the plans, the release a
+ * cancelled drag owes, the delivery matching a drag's end allows, and the
+ * page-side preparation that places a selection or finds a drop point.
+ */
+
+const grounded = { snapshotId: "snapshot-1", generation: 1 }
+const command = (partial: Record<string, unknown>) =>
+  ({ ...grounded, ref: "e1", ...partial }) as AgentCommand
+
+const plan = (
+  partial: Record<string, unknown>,
+  overrides: Partial<Parameters<typeof planAgentNativeInput>[0]> = {}
+) =>
+  planAgentNativeInput({
+    command: command(partial),
+    point: { x: 10, y: 20 },
+    frameOffset: { x: 100, y: 200 },
+    focused: false,
+    platform: "other",
+    ...overrides
+  })
+
+const kinds = (steps: readonly AgentNativeInputStep[]) =>
+  steps.map((step) =>
+    step.kind === "mouse"
+      ? step.type
+      : step.kind === "key"
+        ? `${step.type}:${step.key}`
+        : step.kind === "insertText"
+          ? `insert:${step.text}`
+          : step.kind === "drag"
+            ? `drag:${step.type}@${step.x},${step.y}`
+            : "wheel"
+  )
+
+describe("native editing plans", () => {
+  it("types a replacement over the selection the page placed, without a click", () => {
+    const built = plan({ type: "replace_text", find: "old", text: "new" })
+    expect(kinds(built.steps)).toEqual([
+      "keyDown:n",
+      "keyUp:n",
+      "keyDown:e",
+      "keyUp:e",
+      "keyDown:w",
+      "keyUp:w"
+    ])
+  })
+
+  it("deletes the selection with Backspace when the replacement is empty", () => {
+    const built = plan({ type: "replace_text", find: "old", text: "" })
+    expect(kinds(built.steps)).toEqual(["keyDown:Backspace", "keyUp:Backspace"])
+  })
+
+  it("presses on the source, moves in held steps and drops at the destination in root coordinates", () => {
+    const built = plan(
+      { type: "drag", to: "e2" },
+      { dropPoint: { x: 70, y: 80 } }
+    )
+    expect(kinds(built.steps)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "drag:move@122,232",
+      "drag:move@140,250",
+      "drag:move@170,280",
+      "drag:drop@170,280"
+    ])
+    expect(built.expected).toEqual([
+      { type: "mousemove", x: 10, y: 20 },
+      { type: "mousedown", x: 10, y: 20 },
+      {
+        type: "mouseup",
+        alternatives: ["drop"],
+        x: 70,
+        y: 80,
+        anyTarget: true
+      }
+    ])
+  })
+
+  it("refuses to plan a drag with no drop point", () => {
+    expect(() => plan({ type: "drag", to: "e2" })).toThrow(/drop point/)
+  })
+
+  it("chooses the native backend for edits and drags when the debugger holds the frame", () => {
+    for (const type of ["replace_text", "drag"]) {
+      expect(
+        chooseAgentInputBackend({
+          effect: {
+            command: command({ type, to: "e2", find: "a", text: "b" }),
+            target: { sensitive: false, maySubmit: false }
+          },
+          cdpControl: true,
+          attached: true,
+          frameMapped: true
+        })
+      ).toEqual({ backend: "cdp", reason: "native" })
+    }
+  })
+})
+
+describe("cancelled drags", () => {
+  it("cancels the drag rather than dropping when the run stops mid-gesture", async () => {
+    const built = plan(
+      { type: "drag", to: "e2" },
+      { dropPoint: { x: 70, y: 80 } }
+    )
+    const sent: AgentNativeInputStep[] = []
+    let aborted = false
+    const dispatcher = {
+      async dispatch(step: AgentNativeInputStep) {
+        sent.push(step)
+        if (step.kind === "drag" && step.x === 140) aborted = true
+      }
+    }
+    await expect(
+      runAgentNativeInputPlan(built, dispatcher, {
+        get aborted() {
+          return aborted
+        }
+      })
+    ).rejects.toBeInstanceOf(AgentNativeInputCancelledError)
+    expect(kinds(sent)).toEqual([
+      "mouseMoved",
+      "mousePressed",
+      "drag:move@122,232",
+      "drag:move@140,250",
+      "drag:cancel@140,250"
+    ])
+  })
+})
+
+describe("drag delivery", () => {
+  const dragPlan = plan(
+    { type: "drag", to: "e2" },
+    { dropPoint: { x: 70, y: 80 } }
+  )
+  const trace = (events: AgentInputTrace["events"]): AgentInputTrace => ({
+    events
+  })
+
+  it("accepts a drop on the destination as the end of the plan", () => {
+    expect(
+      assessAgentInputDelivery(
+        dragPlan,
+        trace([
+          { type: "mousemove", x: 10, y: 20, onTarget: true },
+          { type: "mousedown", x: 10, y: 20, onTarget: true },
+          { type: "mousemove", x: 40, y: 50, onTarget: false },
+          { type: "drop", x: 70, y: 80, onTarget: false }
+        ])
+      )
+    ).toBe("delivered")
+  })
+
+  it("accepts a mouseup wherever the pointer is for a pointer-based drag", () => {
+    expect(
+      assessAgentInputDelivery(
+        dragPlan,
+        trace([
+          { type: "mousemove", x: 10, y: 20, onTarget: true },
+          { type: "mousedown", x: 10, y: 20, onTarget: true },
+          { type: "mouseup", x: 70, y: 80, onTarget: true }
+        ])
+      )
+    ).toBe("delivered")
+  })
+
+  it("still reports a press that landed off the source as misdirected", () => {
+    expect(
+      assessAgentInputDelivery(
+        dragPlan,
+        trace([
+          { type: "mousemove", x: 10, y: 20, onTarget: true },
+          { type: "mousedown", x: 10, y: 20, onTarget: false },
+          { type: "drop", x: 70, y: 80, onTarget: false }
+        ])
+      )
+    ).toBe("misdirected")
+  })
+
+  it("treats a drop the plan did not send as interference", () => {
+    expect(
+      assessAgentInputDelivery(plan({ type: "click" }), {
+        events: [
+          { type: "mousemove", x: 10, y: 20, onTarget: true },
+          { type: "mousedown", x: 10, y: 20, onTarget: true },
+          { type: "mouseup", x: 10, y: 20, onTarget: true },
+          { type: "drop", x: 30, y: 30, onTarget: false }
+        ]
+      })
+    ).toBe("interference")
+  })
+})
+
+describe("page-side editing preparation", () => {
+  const identity = {
+    snapshotId: "snapshot-1",
+    generation: 1,
+    tabId: 7,
+    frameId: 0,
+    documentId: "document-1"
+  }
+
+  const rect = (top: number, left: number, size = 20) =>
+    ({
+      top,
+      left,
+      bottom: top + size,
+      right: left + size,
+      width: size,
+      height: size
+    }) as DOMRect
+
+  beforeEach(() => {
+    document.body.replaceChildren()
+    vi.spyOn(Element.prototype, "getClientRects").mockReturnValue([
+      rect(10, 10)
+    ] as unknown as DOMRectList)
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+      rect(10, 10)
+    )
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  const snapshotOf = () => {
+    const references = createAgentElementReferenceStore({
+      documentId: identity.documentId,
+      frameId: 0
+    })
+    const snapshot = references.beginSnapshot({
+      minimumGeneration: 0,
+      createSnapshotId: () => identity.snapshotId
+    })
+    return { references, snapshot }
+  }
+
+  it("selects the run to replace, focuses the editor and reports it focused", () => {
+    const editor = document.createElement("div")
+    editor.setAttribute("contenteditable", "true")
+    editor.innerHTML = "<p>Hello world</p>"
+    document.body.append(editor)
+    document.elementFromPoint = () => editor
+    const { references, snapshot } = snapshotOf()
+    const ref = snapshot.reference(editor)
+    const element = buildAgentElementObservation(editor, ref, 0)
+    const instruction: AgentDomMutationInstruction = {
+      command: {
+        ...grounded,
+        type: "replace_text",
+        ref,
+        find: "world",
+        text: "x"
+      },
+      target: {
+        ref,
+        frameId: 0,
+        tag: "div",
+        inputType: "contenteditable",
+        observedValue: element.value,
+        expectedValue: "Hello x",
+        sensitive: false,
+        maySubmit: false
+      },
+      snapshotIdentity: identity,
+      frame: identity
+    }
+    const watch = createAgentInputWatch(document, { trusted: () => true })
+    const prepared = prepareAgentNativeInputInDocument({
+      effect: instruction,
+      references,
+      watch
+    })
+    expect(prepared.focused).toBe(true)
+    expect(prepared.dropPoint).toBeUndefined()
+    expect(window.getSelection()?.toString()).toBe("world")
+    editor.innerHTML = "<p>world world</p>"
+    expect(() =>
+      prepareAgentNativeInputInDocument({
+        effect: instruction,
+        references,
+        watch
+      })
+    ).toThrow(AgentEffectNotAppliedError)
+  })
+
+  it("returns the destination's own point for a drag and refuses a destination that changed", () => {
+    document.body.innerHTML =
+      '<ul role="list" aria-label="Todo"><li id="a" draggable="true">Task A</li></ul><ul id="done" role="list" aria-label="Done"></ul>'
+    const item = document.getElementById("a") as HTMLElement
+    const done = document.getElementById("done") as HTMLElement
+    item.getClientRects = () => [rect(10, 10)] as unknown as DOMRectList
+    done.getClientRects = () => [rect(50, 50)] as unknown as DOMRectList
+    document.elementFromPoint = ((x: number) =>
+      x < 40 ? item : done) as Document["elementFromPoint"]
+    const { references, snapshot } = snapshotOf()
+    const ref = snapshot.reference(item)
+    const to = snapshot.reference(done)
+    const source = buildAgentElementObservation(item, ref, 0)
+    const destination = buildAgentElementObservation(done, to, 0)
+    const instruction: AgentDomMutationInstruction = {
+      command: { ...grounded, type: "drag", ref, to },
+      target: {
+        ref,
+        frameId: 0,
+        tag: "li",
+        accessibleName: source.name,
+        observedValue: source.value,
+        drop: {
+          ref: to,
+          frameId: 0,
+          tag: "ul",
+          role: "list",
+          accessibleName: destination.name
+        },
+        sensitive: false,
+        maySubmit: false
+      },
+      snapshotIdentity: identity,
+      frame: identity
+    }
+    const watch = createAgentInputWatch(document, { trusted: () => true })
+    const prepared = prepareAgentNativeInputInDocument({
+      effect: instruction,
+      references,
+      watch
+    })
+    expect(prepared.point).toEqual({ x: 20, y: 20 })
+    expect(prepared.dropPoint).toEqual({ x: 60, y: 60 })
+    done.setAttribute("aria-label", "Archive")
+    expect(() =>
+      prepareAgentNativeInputInDocument({
+        effect: instruction,
+        references,
+        watch
+      })
+    ).toThrow(AgentEffectNotAppliedError)
+  })
+
+  it("observes an editing host as a typed, valued, multiline control named by its placeholder, and marks draggable items", () => {
+    document.body.innerHTML =
+      '<div id="doc" contenteditable="true" role="textbox" aria-multiline="true" aria-placeholder="Write something"><p>Hello</p><p>World</p></div>' +
+      '<div id="line" contenteditable="true" role="textbox">One line</div>' +
+      '<div id="free" contenteditable="plaintext-only">Free</div>' +
+      '<li id="card" draggable="true">Card</li>' +
+      '<div contenteditable="false" role="button">Toolbar</div>' +
+      '<div id="sortable" role="button" aria-roledescription="sortable">Row</div>'
+    history.replaceState({}, "", "/editor")
+    const observation = buildAgentObservation({
+      document,
+      tabId: 7,
+      documentId: "document-1",
+      minimumGeneration: 0,
+      references: createAgentElementReferenceStore({
+        documentId: "document-1",
+        frameId: 0
+      }),
+      createSnapshotId: () => "snapshot-1",
+      capturedAt: 1
+    })
+    const byTag = observation.elements.map(
+      ({ tag, type, value, name, multiline, draggable, editable }) => ({
+        tag,
+        type,
+        value,
+        name,
+        multiline,
+        draggable,
+        editable
+      })
+    )
+    expect(byTag).toEqual([
+      {
+        tag: "div",
+        type: "contenteditable",
+        value: "Hello\nWorld",
+        name: "Write something",
+        multiline: true,
+        draggable: undefined,
+        editable: true
+      },
+      {
+        tag: "div",
+        type: "contenteditable",
+        value: "One line",
+        name: undefined,
+        multiline: undefined,
+        draggable: undefined,
+        editable: true
+      },
+      {
+        tag: "div",
+        type: "contenteditable",
+        value: "Free",
+        name: undefined,
+        multiline: true,
+        draggable: undefined,
+        editable: true
+      },
+      {
+        tag: "li",
+        type: undefined,
+        value: undefined,
+        name: "Card",
+        multiline: undefined,
+        draggable: true,
+        editable: false
+      },
+      {
+        tag: "div",
+        type: undefined,
+        value: undefined,
+        name: "Toolbar",
+        multiline: undefined,
+        draggable: undefined,
+        editable: false
+      },
+      {
+        tag: "div",
+        type: undefined,
+        value: undefined,
+        name: "Row",
+        multiline: undefined,
+        draggable: true,
+        editable: false
+      }
+    ])
+  })
+})

--- a/src/lib/browser-agent/__tests__/native-input.test.ts
+++ b/src/lib/browser-agent/__tests__/native-input.test.ts
@@ -131,13 +131,20 @@ describe("native input planning", () => {
     expect(kinds(other.steps)[0]).toBe("keyDown:Control")
   })
 
-  it("types a newline as Enter and expects each key the page should see", () => {
+  it("inserts a newline as text and never presses Enter for it", () => {
     const built = plan({ type: "type", text: "a\nb" }, { focused: true })
-    expect(kinds(built.steps)).toContain("keyDown:Enter")
+    expect(kinds(built.steps)).toEqual([
+      "keyDown:End",
+      "keyUp:End",
+      "keyDown:a",
+      "keyUp:a",
+      "insert:\n",
+      "keyDown:b",
+      "keyUp:b"
+    ])
     expect(built.expected.filter((event) => event.type === "keydown")).toEqual([
       { type: "keydown", key: "End" },
       { type: "keydown", key: "a" },
-      { type: "keydown", key: "Enter" },
       { type: "keydown", key: "b" }
     ])
   })

--- a/src/lib/browser-agent/command-executor.ts
+++ b/src/lib/browser-agent/command-executor.ts
@@ -190,14 +190,21 @@ const executeEditorTextMutation = (
   effect: AgentDomMutationInstruction,
   host: Element
 ): void => {
+  const apply = (text: string): void => {
+    if (!insertAgentEditableText(host, text)) {
+      throw new AgentEffectNotAppliedError(
+        "Agent cannot edit this host through the browser's editing pipeline"
+      )
+    }
+  }
   switch (effect.command.type) {
     case "type":
       placeAgentEditableCaret(host, "end")
-      insertAgentEditableText(host, effect.command.text)
+      apply(effect.command.text)
       return
     case "clear_and_type":
       placeAgentEditableCaret(host, "all")
-      insertAgentEditableText(host, effect.command.text)
+      apply(effect.command.text)
       return
     case "replace_text":
       if (!selectAgentEditableText(host, effect.command.find)) {
@@ -205,7 +212,7 @@ const executeEditorTextMutation = (
           "Agent text to replace is no longer unique in the target"
         )
       }
-      insertAgentEditableText(host, effect.command.text)
+      apply(effect.command.text)
       return
     default:
       throw new Error("Invalid Agent editor text effect")

--- a/src/lib/browser-agent/command-executor.ts
+++ b/src/lib/browser-agent/command-executor.ts
@@ -10,6 +10,13 @@ import {
 } from "@ollama-client/contracts"
 
 import type { TabAccess } from "@/lib/browser-tab-access"
+import { executeAgentSyntheticDrag } from "./drag-page"
+import {
+  insertAgentEditableText,
+  isAgentEditingHost,
+  placeAgentEditableCaret,
+  selectAgentEditableText
+} from "./editor-page"
 import type { AgentElementReferenceStore } from "./element-references"
 import {
   type AgentInputBackendChoice,
@@ -172,10 +179,47 @@ const assertUnchangedMutationTarget = (
     )
 }
 
+/**
+ * Text into an editing host goes through the browser's editing pipeline —
+ * caret placed, then `insertText` — never through `textContent`: a rich-text
+ * editor rebuilds its DOM from its own model on the next keystroke and would
+ * discard anything written behind its back. The resolved value is what the
+ * verifier compares afterwards; it is not assigned.
+ */
+const executeEditorTextMutation = (
+  effect: AgentDomMutationInstruction,
+  host: Element
+): void => {
+  switch (effect.command.type) {
+    case "type":
+      placeAgentEditableCaret(host, "end")
+      insertAgentEditableText(host, effect.command.text)
+      return
+    case "clear_and_type":
+      placeAgentEditableCaret(host, "all")
+      insertAgentEditableText(host, effect.command.text)
+      return
+    case "replace_text":
+      if (!selectAgentEditableText(host, effect.command.find)) {
+        throw new AgentEffectNotAppliedError(
+          "Agent text to replace is no longer unique in the target"
+        )
+      }
+      insertAgentEditableText(host, effect.command.text)
+      return
+    default:
+      throw new Error("Invalid Agent editor text effect")
+  }
+}
+
 const executeTextMutation = (
   effect: AgentDomMutationInstruction,
   element: Element
 ): void => {
+  if (isAgentEditingHost(element)) {
+    executeEditorTextMutation(effect, element)
+    return
+  }
   if (
     !(element instanceof HTMLInputElement) &&
     !(element instanceof HTMLTextAreaElement)
@@ -184,6 +228,18 @@ const executeTextMutation = (
   }
   if (effect.target.expectedValue === undefined) {
     throw new Error("Agent text effect has no resolved value")
+  }
+  /**
+   * A replacement is grounded in the live value too: the run it names has to
+   * still be there once, or the resolved value describes a field that moved.
+   */
+  if (
+    effect.command.type === "replace_text" &&
+    !selectAgentEditableText(element, effect.command.find)
+  ) {
+    throw new AgentEffectNotAppliedError(
+      "Agent text to replace is no longer unique in the target"
+    )
   }
   setNativeValue(element, effect.target.expectedValue)
   dispatchFormEvents(element, false)
@@ -443,6 +499,47 @@ export const resolveAgentMutationTarget = (
   return element
 }
 
+/**
+ * The live destination of a drag, or a typed refusal. Checked like the source
+ * — same snapshot, same element, same observed facts — because a drop is an
+ * effect on the destination, and a destination that changed since approval is
+ * a drop nobody approved.
+ */
+export const resolveAgentDropTarget = (
+  effect: AgentDomMutationInstruction,
+  references: AgentElementReferenceStore
+): Element => {
+  const drop = effect.target.drop
+  if (!drop) throw new Error("Agent drag has no drop target")
+  const element = references.resolve(drop.ref, effect.frame)
+  if (!element?.isConnected) {
+    throw new AgentEffectNotAppliedError("Agent drop target is stale")
+  }
+  const current = buildAgentElementObservation(
+    element,
+    drop.ref,
+    effect.frame.frameId
+  )
+  const unchanged =
+    current.visible &&
+    current.tag === drop.tag &&
+    sameOptional(current.role, drop.role) &&
+    sameOptional(current.name, drop.accessibleName) &&
+    (drop.verificationId === undefined ||
+      references.verificationIdOf(element) === drop.verificationId)
+  if (!unchanged) {
+    throw new AgentEffectNotAppliedError(
+      "Agent drop target changed after approval"
+    )
+  }
+  return element
+}
+
+const centreOf = (element: Element): { x: number; y: number } => {
+  const rect = element.getBoundingClientRect()
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+}
+
 const pointerEventInit = (element: Element): MouseEventInit => {
   const rect = element.getBoundingClientRect()
   return {
@@ -544,8 +641,19 @@ export const executeAgentDomMutationInDocument = (input: {
       break
     case "type":
     case "clear_and_type":
+    case "replace_text":
       executeTextMutation(input.effect, element)
       break
+    case "drag": {
+      const destination = resolveAgentDropTarget(input.effect, input.references)
+      executeAgentSyntheticDrag({
+        source: element,
+        destination,
+        from: centreOf(element),
+        to: centreOf(destination)
+      })
+      break
+    }
     case "select":
       executeSelectionMutation(input.effect, element)
       break
@@ -580,6 +688,8 @@ export interface AgentNativeControlFacts {
 export interface AgentNativeInputPreparation {
   point: AgentInputPoint
   focused: boolean
+  /** Where a drag is released, for a `drag` alone. */
+  dropPoint?: AgentInputPoint
 }
 
 export interface AgentCommandExecutorAdapter {
@@ -625,6 +735,12 @@ export interface AgentCommandExecutorAdapter {
   viewportCentre?(
     effect: AuthorizedAgentEffect
   ): Promise<AgentInputPoint | undefined>
+  /**
+   * Whether the page asked for a file chooser since the action began. The
+   * debugger holds such a chooser back; asked once after the action and
+   * cleared by the asking, so it is charged to the step that caused it.
+   */
+  fileChooserOpened?(effect: AuthorizedAgentEffect): Promise<boolean>
   activateTab(tabId: number): Promise<void>
   goHistory(tabId: number, direction: "back" | "forward"): Promise<void>
   resolveHistoryDestination(
@@ -799,6 +915,7 @@ const executeNative = async (
     point: prepared.point,
     frameOffset: facts.frameOffset,
     focused: prepared.focused,
+    ...(prepared.dropPoint ? { dropPoint: prepared.dropPoint } : {}),
     platform: facts.platform
   })
   try {
@@ -835,8 +952,22 @@ const executeNative = async (
   return {
     ...receipt(adapter, effect.command.type),
     backend: "cdp",
-    inputDelivery: settled ? assessAgentInputDelivery(plan, trace) : "unknown"
+    inputDelivery: settled ? assessAgentInputDelivery(plan, trace) : "unknown",
+    ...(await fileChooserFlag(effect, adapter))
   }
+}
+
+/**
+ * A file chooser the action opened, on either backend: a DOM click on an
+ * upload button reaches the same `input.click()` a native one does, and the
+ * attached debugger holds the chooser back either way.
+ */
+const fileChooserFlag = async (
+  effect: AuthorizedAgentEffect,
+  adapter: AgentCommandExecutorAdapter
+): Promise<Pick<AgentExecutionReceipt, "fileChooser">> => {
+  const opened = await adapter.fileChooserOpened?.(effect)
+  return opened ? { fileChooser: true } : {}
 }
 
 /** The DOM backend, recorded as such so the verifier expects no native record. */
@@ -849,7 +980,8 @@ const executeSynthetic = async (
   return {
     ...receipt(adapter, effect.command.type),
     backend: "dom",
-    ...(submissionUrl ? { submissionUrl } : {})
+    ...(submissionUrl ? { submissionUrl } : {}),
+    ...(await fileChooserFlag(effect, adapter))
   }
 }
 
@@ -1093,6 +1225,14 @@ export const DOM_MUTATION_AGENT_EXECUTORS = {
     return executeElementAction(effect, adapter, signal)
   },
   async clear_and_type(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    return executeElementAction(effect, adapter, signal)
+  },
+  async replace_text(effect, adapter, signal) {
+    await assertSource(effect, adapter, true)
+    return executeElementAction(effect, adapter, signal)
+  },
+  async drag(effect, adapter, signal) {
     await assertSource(effect, adapter, true)
     return executeElementAction(effect, adapter, signal)
   },

--- a/src/lib/browser-agent/control-port.ts
+++ b/src/lib/browser-agent/control-port.ts
@@ -160,6 +160,18 @@ const AgentDomMutationTargetSchema = z
     submitter: z.boolean().optional(),
     expectedValue: z.string().max(500).optional(),
     expectedChecked: z.boolean().optional(),
+    /** Where a drag is released; the page rechecks it like the source. */
+    drop: z
+      .object({
+        ref: z.string().min(1),
+        verificationId: z.string().min(1).max(128).optional(),
+        frameId: z.number().int().nonnegative(),
+        tag: z.string().min(1),
+        role: z.string().min(1).optional(),
+        accessibleName: z.string().max(500).optional()
+      })
+      .strict()
+      .optional(),
     sensitive: z.boolean(),
     maySubmit: z.boolean()
   })
@@ -174,6 +186,8 @@ const AgentDomMutationCommandSchema = AgentCommandSchema.refine(
       "hover",
       "type",
       "clear_and_type",
+      "replace_text",
+      "drag",
       "select",
       "check",
       "uncheck",
@@ -253,6 +267,16 @@ export const AgentDomMutationInstructionSchema = z
         code: "custom",
         path: ["point"],
         message: "A visual point is measured in the root frame only"
+      })
+    }
+    if (
+      instruction.target.drop &&
+      instruction.target.drop.frameId !== instruction.target.frameId
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["target", "drop", "frameId"],
+        message: "A drag stays within the frame it starts in"
       })
     }
   })
@@ -389,7 +413,9 @@ export const AgentPrepareNativeInputResponseSchema = z
     sequence: z.number().int().positive(),
     documentId: z.string().min(1),
     point: AgentInputPointSchema.optional(),
-    focused: z.boolean().optional()
+    focused: z.boolean().optional(),
+    /** Where a drag is released, in the same frame's viewport pixels. */
+    dropPoint: AgentInputPointSchema.optional()
   })
   .strict()
 export type AgentPrepareNativeInputResponse = z.infer<
@@ -399,6 +425,7 @@ export type AgentPrepareNativeInputResponse = z.infer<
 export interface AgentNativeInputPreparedResult {
   point: { x: number; y: number }
   focused: boolean
+  dropPoint?: { x: number; y: number }
 }
 
 export const AgentSettleNativeInputRequestSchema = z
@@ -426,7 +453,8 @@ const AgentRecordedInputEventSchema = z
       "mouseup",
       "keydown",
       "keyup",
-      "wheel"
+      "wheel",
+      "drop"
     ]),
     x: z.number().finite().optional(),
     y: z.number().finite().optional(),
@@ -838,7 +866,11 @@ export const validateAgentPrepareNativeInputResponse = (
   if (!response.point || response.focused === undefined) {
     throw new Error("Agent native input preparation is incomplete")
   }
-  return { point: response.point, focused: response.focused }
+  return {
+    point: response.point,
+    focused: response.focused,
+    ...(response.dropPoint ? { dropPoint: response.dropPoint } : {})
+  }
 }
 
 export const validateAgentSettleNativeInputResponse = (
@@ -1255,13 +1287,17 @@ const controlFailureReason = (
 /** Only a typed, pre-effect rejection may authorize re-observation instead of uncertainty. */
 const runContentPreparation = (
   prepare: () => AgentNativeInputPreparedResult
-): Pick<AgentPrepareNativeInputResponse, "type" | "point" | "focused"> => {
+): Pick<
+  AgentPrepareNativeInputResponse,
+  "type" | "point" | "focused" | "dropPoint"
+> => {
   try {
     const prepared = prepare()
     return {
       type: "agent_native_input_prepared",
       point: prepared.point,
-      focused: prepared.focused
+      focused: prepared.focused,
+      ...(prepared.dropPoint ? { dropPoint: prepared.dropPoint } : {})
     }
   } catch (error) {
     if (error instanceof AgentEffectNotAppliedError)

--- a/src/lib/browser-agent/drag-page.ts
+++ b/src/lib/browser-agent/drag-page.ts
@@ -1,0 +1,212 @@
+/**
+ * A drag without a debugger: the synthetic event sequence the DOM backend
+ * sends when no native pointer is available.
+ *
+ * Two families of drag-and-drop exist and a page may use either. Pointer-based
+ * libraries read `pointerdown`/`pointermove`/`pointerup` (and their mouse
+ * twins) and move the element themselves; HTML5 drag-and-drop starts with a
+ * `dragstart` the browser fires on a `draggable` element and ends with a
+ * `drop` on whichever element cancelled `dragover`. Both sequences are sent,
+ * in the order a real gesture would produce them, and the same `DataTransfer`
+ * travels from `dragstart` to `drop` so what the source wrote the target can
+ * read. A page can tell these events from a user's; the receipt says so.
+ */
+
+export interface AgentSyntheticDragInput {
+  source: Element
+  destination: Element
+  /** Where the gesture starts, in this frame's viewport CSS pixels. */
+  from: { x: number; y: number }
+  /** Where it ends. */
+  to: { x: number; y: number }
+}
+
+type PointerCtor = new (type: string, init: MouseEventInit) => MouseEvent
+
+const pointerInit = (
+  view: Window | null | undefined,
+  point: { x: number; y: number },
+  buttons: number
+): MouseEventInit => ({
+  bubbles: true,
+  cancelable: true,
+  composed: true,
+  clientX: point.x,
+  clientY: point.y,
+  button: 0,
+  buttons,
+  view: view ?? undefined
+})
+
+const dispatchPointer = (
+  target: Element,
+  types: readonly string[],
+  init: MouseEventInit
+): void => {
+  const view = target.ownerDocument.defaultView
+  const Pointer = (view?.PointerEvent ?? globalThis.PointerEvent) as
+    | PointerCtor
+    | undefined
+  for (const type of types) {
+    const usesPointer = type.startsWith("pointer")
+    const Ctor = usesPointer && Pointer ? Pointer : MouseEvent
+    target.dispatchEvent(
+      new Ctor(type, {
+        ...init,
+        ...(usesPointer ? { pointerId: 1, isPrimary: true } : {})
+      } as MouseEventInit)
+    )
+  }
+}
+
+/**
+ * The store a `dragstart` handler writes and a `drop` handler reads. The
+ * platform's own `DataTransfer` is used where it can be constructed; the
+ * shim carries the same read/write surface for a runtime without one.
+ */
+const createDataTransfer = (view: Window | null | undefined): DataTransfer => {
+  const Ctor =
+    (view as (Window & typeof globalThis) | null | undefined)?.DataTransfer ??
+    globalThis.DataTransfer
+  if (typeof Ctor === "function") {
+    try {
+      return new Ctor()
+    } catch {
+      /* A runtime that declares the constructor but refuses it gets the shim. */
+    }
+  }
+  const data = new Map<string, string>()
+  const shim = {
+    dropEffect: "none",
+    effectAllowed: "all",
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    get types() {
+      return [...data.keys()]
+    },
+    setData(format: string, value: string) {
+      data.set(format.toLowerCase(), value)
+    },
+    getData(format: string) {
+      return data.get(format.toLowerCase()) ?? ""
+    },
+    clearData(format?: string) {
+      if (format === undefined) data.clear()
+      else data.delete(format.toLowerCase())
+    },
+    setDragImage() {
+      /* Nothing is painted for a synthetic drag. */
+    }
+  }
+  return shim as unknown as DataTransfer
+}
+
+const dragEvent = (
+  view: Window | null | undefined,
+  type: string,
+  init: MouseEventInit,
+  dataTransfer: DataTransfer
+): Event => {
+  const Ctor = ((view as (Window & typeof globalThis) | null | undefined)
+    ?.DragEvent ?? globalThis.DragEvent) as
+    | (new (
+        type: string,
+        init: DragEventInit
+      ) => DragEvent)
+    | undefined
+  const event =
+    typeof Ctor === "function"
+      ? new Ctor(type, { ...init, dataTransfer })
+      : new MouseEvent(type, init)
+  /**
+   * The constructor's own `dataTransfer` is defined only where the runtime
+   * implements it; the store is forced on regardless, so the one object
+   * travels from `dragstart` to `drop` even where the DragEvent init drops it.
+   */
+  if ((event as DragEvent).dataTransfer !== dataTransfer) {
+    Object.defineProperty(event, "dataTransfer", {
+      configurable: true,
+      value: dataTransfer
+    })
+  }
+  return event
+}
+
+const isDraggable = (element: Element): boolean => {
+  const declared = element.getAttribute("draggable")
+  if (declared !== null) return declared.toLowerCase() === "true"
+  return (element as Partial<HTMLElement>).draggable === true
+}
+
+export interface AgentSyntheticDragOutcome {
+  /** Whether the page accepted an HTML5 drop on the destination. */
+  dropped: boolean
+}
+
+/**
+ * Sends the gesture. The pointer sequence always goes out — it is what a
+ * pointer-based library reads and does no harm to an HTML5 page. The HTML5
+ * sequence goes out only for a draggable source whose `dragstart` was not
+ * cancelled, and `drop` only when the destination cancelled `dragover`, which
+ * is the page's way of saying it accepts the drop. `dragend` closes either
+ * way, so the source never stays in a dragging state.
+ */
+export const executeAgentSyntheticDrag = (
+  input: AgentSyntheticDragInput
+): AgentSyntheticDragOutcome => {
+  const { source, destination, from, to } = input
+  const view = source.ownerDocument.defaultView
+  const midpoint = { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 }
+
+  dispatchPointer(
+    source,
+    ["pointerdown", "mousedown"],
+    pointerInit(view, from, 1)
+  )
+  dispatchPointer(
+    source,
+    ["pointermove", "mousemove"],
+    pointerInit(view, midpoint, 1)
+  )
+
+  let dropped = false
+  if (isDraggable(source)) {
+    const dataTransfer = createDataTransfer(view)
+    const started = source.dispatchEvent(
+      dragEvent(view, "dragstart", pointerInit(view, from, 1), dataTransfer)
+    )
+    if (started) {
+      destination.dispatchEvent(
+        dragEvent(view, "dragenter", pointerInit(view, to, 1), dataTransfer)
+      )
+      const accepts = !destination.dispatchEvent(
+        dragEvent(view, "dragover", pointerInit(view, to, 1), dataTransfer)
+      )
+      if (accepts) {
+        destination.dispatchEvent(
+          dragEvent(view, "drop", pointerInit(view, to, 1), dataTransfer)
+        )
+        dropped = true
+      } else {
+        destination.dispatchEvent(
+          dragEvent(view, "dragleave", pointerInit(view, to, 1), dataTransfer)
+        )
+      }
+      source.dispatchEvent(
+        dragEvent(view, "dragend", pointerInit(view, to, 0), dataTransfer)
+      )
+    }
+  }
+
+  dispatchPointer(
+    destination,
+    ["pointermove", "mousemove"],
+    pointerInit(view, to, 1)
+  )
+  dispatchPointer(
+    destination,
+    ["pointerup", "mouseup"],
+    pointerInit(view, to, 0)
+  )
+  return { dropped }
+}

--- a/src/lib/browser-agent/editor-page.ts
+++ b/src/lib/browser-agent/editor-page.ts
@@ -1,0 +1,352 @@
+import { normalizeAgentEditorText } from "./editor-text"
+
+/**
+ * The page's half of editing: what an editing host says, where a run of its
+ * text sits, and how a selection is placed and typed over.
+ *
+ * Everything here drives the browser's own editing pipeline — a selection the
+ * editor sees as the user's, `insertText` the editor receives as `beforeinput`
+ * and `input` — because a rich-text editor keeps its document in its own
+ * model and rebuilds the DOM from it. Writing into the DOM behind its back is
+ * how the text appears once and vanishes on the next keystroke.
+ */
+
+/** Elements whose start is a line of its own in an editor's flattened text. */
+const LINE_BREAKING_TAGS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "br",
+  "dd",
+  "details",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "ul"
+])
+
+/** Content an editor's text never includes, whatever the markup holds. */
+const UNREAD_TAGS = new Set(["noscript", "script", "style", "template"])
+
+/**
+ * An element that is itself the root of editable content: the attribute is
+ * on it and does not say `false`. Read from the attribute rather than
+ * `isContentEditable`, which is also true for every descendant of a host and
+ * would make each paragraph of a document its own editor.
+ */
+export const isAgentEditingHost = (element: Element): boolean => {
+  const declared = element.getAttribute("contenteditable")
+  if (declared === null) return false
+  return declared.trim().toLowerCase() !== "false"
+}
+
+interface TextSegment {
+  node: Text
+  /** Where this node's text starts in the raw string. */
+  start: number
+}
+
+/**
+ * The host's text as one raw string — text nodes concatenated, a line break at
+ * the start of every block — with the text nodes that produced it. Open shadow
+ * roots are walked at their host; closed ones stay unread.
+ */
+const readEditorText = (
+  host: Element
+): { raw: string; segments: TextSegment[] } => {
+  const segments: TextSegment[] = []
+  let raw = ""
+  const stack: Node[] = []
+  const push = (parent: Node) => {
+    const shadow = (parent as Element).shadowRoot
+    const children = shadow ? shadow.childNodes : parent.childNodes
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index])
+    }
+  }
+  push(host)
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node) continue
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? ""
+      if (text.length > 0) {
+        segments.push({ node: node as Text, start: raw.length })
+        raw += text
+      }
+      continue
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) continue
+    const tag = (node as Element).tagName.toLowerCase()
+    if (UNREAD_TAGS.has(tag)) continue
+    if (LINE_BREAKING_TAGS.has(tag)) raw += "\n"
+    push(node)
+  }
+  return { raw, segments }
+}
+
+/** What an editing host says, in the shared normalized form. */
+export const agentEditorText = (host: Element): string =>
+  normalizeAgentEditorText(readEditorText(host).raw)
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+/**
+ * A pattern matching `find` wherever the normalized text would contain it:
+ * the tokens in order with any whitespace run between them, since the raw
+ * text may hold a paragraph break or a non-breaking space where the model saw
+ * one space or one line break.
+ */
+const findPattern = (find: string): RegExp | undefined => {
+  const tokens = find.split(/\s+/).filter((token) => token.length > 0)
+  if (tokens.length === 0) return undefined
+  return new RegExp(tokens.map(escapeRegExp).join("\\s+"), "g")
+}
+
+const positionAt = (
+  segments: readonly TextSegment[],
+  offset: number,
+  endInclusive: boolean
+): { node: Text; offset: number } | undefined => {
+  for (const segment of segments) {
+    const length = segment.node.textContent?.length ?? 0
+    const end = segment.start + length
+    if (offset < end || (endInclusive && offset === end)) {
+      return { node: segment.node, offset: offset - segment.start }
+    }
+  }
+  return undefined
+}
+
+/**
+ * The DOM range holding the single occurrence of `find` in the host, or
+ * nothing when it occurs no times or more than once. Uniqueness is decided
+ * here against the live document, not only against the observation the model
+ * read, so an edit whose target grew ambiguous since is refused rather than
+ * applied to the first match.
+ */
+export const locateAgentEditorRange = (
+  host: Element,
+  find: string
+): Range | undefined => {
+  const pattern = findPattern(find)
+  if (!pattern) return undefined
+  const { raw, segments } = readEditorText(host)
+  const matches = [...raw.matchAll(pattern)]
+  if (matches.length !== 1 || matches[0].index === undefined) return undefined
+  const start = positionAt(segments, matches[0].index, false)
+  const end = positionAt(
+    segments,
+    matches[0].index + matches[0][0].length,
+    true
+  )
+  if (!start || !end) return undefined
+  const range = host.ownerDocument.createRange()
+  range.setStart(start.node, start.offset)
+  range.setEnd(end.node, end.offset)
+  return range
+}
+
+const isTextControl = (
+  element: Element
+): element is HTMLInputElement | HTMLTextAreaElement =>
+  element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+
+const selectRange = (host: Element, range: Range): boolean => {
+  const selection = host.ownerDocument.defaultView?.getSelection?.()
+  if (!selection) return false
+  selection.removeAllRanges()
+  selection.addRange(range)
+  return true
+}
+
+/**
+ * Places the selection over the single occurrence of `find` in an editable
+ * control and focuses it, so what is typed next replaces exactly that run.
+ * False means the occurrence is not single any more and nothing was placed.
+ */
+export const selectAgentEditableText = (
+  element: Element,
+  find: string
+): boolean => {
+  if (isTextControl(element)) {
+    const value = element.value
+    const first = value.indexOf(find)
+    if (first < 0 || value.indexOf(find, first + find.length) >= 0) {
+      return false
+    }
+    element.focus()
+    element.setSelectionRange(first, first + find.length)
+    return true
+  }
+  const range = locateAgentEditorRange(element, find)
+  if (!range) return false
+  ;(element as HTMLElement).focus?.()
+  return selectRange(element, range)
+}
+
+/**
+ * Focuses an editable control with its caret at the end of its content, or
+ * with everything selected, which is where appended and replacing text go.
+ */
+export const placeAgentEditableCaret = (
+  element: Element,
+  where: "end" | "all"
+): boolean => {
+  if (isTextControl(element)) {
+    element.focus()
+    const length = element.value.length
+    element.setSelectionRange(where === "all" ? 0 : length, length)
+    return true
+  }
+  ;(element as HTMLElement).focus?.()
+  const range = element.ownerDocument.createRange()
+  range.selectNodeContents(element)
+  if (where === "end") range.collapse(false)
+  return selectRange(element, range)
+}
+
+const inputEvent = (
+  view: Window | null | undefined,
+  type: "beforeinput" | "input",
+  inputType: string,
+  data: string | null
+): Event => {
+  const Ctor =
+    (view as (Window & typeof globalThis) | null | undefined)?.InputEvent ??
+    globalThis.InputEvent
+  if (typeof Ctor === "function") {
+    return new Ctor(type, {
+      bubbles: true,
+      cancelable: type === "beforeinput",
+      composed: true,
+      inputType,
+      data
+    })
+  }
+  return new Event(type, { bubbles: true, composed: true })
+}
+
+/**
+ * The fallback for a runtime without `execCommand`: the selection's contents
+ * are replaced in the DOM directly, with a line break element per newline,
+ * and the editor is told through the same `beforeinput`/`input` pair the
+ * browser would have sent. A `beforeinput` the editor cancels is honoured —
+ * the editor has said it will apply the edit to its own model itself.
+ */
+const insertIntoHostDirectly = (host: Element, text: string): void => {
+  const doc = host.ownerDocument
+  const selection = doc.defaultView?.getSelection?.()
+  const range =
+    selection && selection.rangeCount > 0
+      ? selection.getRangeAt(0)
+      : (() => {
+          const whole = doc.createRange()
+          whole.selectNodeContents(host)
+          whole.collapse(false)
+          return whole
+        })()
+  const inputType = text.length > 0 ? "insertText" : "deleteContentBackward"
+  const before = inputEvent(
+    doc.defaultView,
+    "beforeinput",
+    inputType,
+    text.length > 0 ? text : null
+  )
+  if (!host.dispatchEvent(before)) return
+  range.deleteContents()
+  const lines = text.split(/\r\n|\r|\n/)
+  const fragment = doc.createDocumentFragment()
+  lines.forEach((line, index) => {
+    if (index > 0) fragment.append(doc.createElement("br"))
+    if (line.length > 0) fragment.append(doc.createTextNode(line))
+  })
+  const last = fragment.lastChild
+  range.insertNode(fragment)
+  if (last && selection) {
+    const caret = doc.createRange()
+    caret.setStartAfter(last)
+    caret.collapse(true)
+    selection.removeAllRanges()
+    selection.addRange(caret)
+  }
+  host.dispatchEvent(
+    inputEvent(
+      doc.defaultView,
+      "input",
+      inputType,
+      text.length > 0 ? text : null
+    )
+  )
+}
+
+/**
+ * Types `text` over the current selection of a focused editable control the
+ * way the browser's editing pipeline does — `execCommand("insertText")`, or
+ * `delete` for an empty replacement — so the editor receives `beforeinput`,
+ * mutates its own model and re-renders. Only a runtime without `execCommand`
+ * takes the direct path.
+ */
+export const insertAgentEditableText = (
+  element: Element,
+  text: string
+): void => {
+  const doc = element.ownerDocument
+  const execCommand = (
+    doc as Document & {
+      execCommand?: (command: string, ui?: boolean, value?: string) => boolean
+    }
+  ).execCommand
+  if (typeof execCommand === "function") {
+    const applied =
+      text.length > 0
+        ? execCommand.call(doc, "insertText", false, text)
+        : execCommand.call(doc, "delete", false)
+    if (applied) return
+  }
+  if (isTextControl(element)) {
+    const start = element.selectionStart ?? element.value.length
+    const end = element.selectionEnd ?? start
+    element.setRangeText(text, start, end, "end")
+    element.dispatchEvent(
+      inputEvent(
+        doc.defaultView,
+        "input",
+        text.length > 0 ? "insertText" : "deleteContentBackward",
+        text.length > 0 ? text : null
+      )
+    )
+    return
+  }
+  insertIntoHostDirectly(element, text)
+}

--- a/src/lib/browser-agent/editor-page.ts
+++ b/src/lib/browser-agent/editor-page.ts
@@ -258,82 +258,21 @@ const inputEvent = (
 }
 
 /**
- * The fallback for a runtime without `execCommand`: the selection's contents
- * are replaced in the DOM directly, with a line break element per newline,
- * and the editor is told through the same `beforeinput`/`input` pair the
- * browser would have sent. A `beforeinput` the editor cancels is honoured —
- * the editor has said it will apply the edit to its own model itself.
- */
-const insertIntoHostDirectly = (host: Element, text: string): void => {
-  const doc = host.ownerDocument
-  const selection = doc.defaultView?.getSelection?.()
-  const range =
-    selection && selection.rangeCount > 0
-      ? selection.getRangeAt(0)
-      : (() => {
-          const whole = doc.createRange()
-          whole.selectNodeContents(host)
-          whole.collapse(false)
-          return whole
-        })()
-  const inputType = text.length > 0 ? "insertText" : "deleteContentBackward"
-  const before = inputEvent(
-    doc.defaultView,
-    "beforeinput",
-    inputType,
-    text.length > 0 ? text : null
-  )
-  if (!host.dispatchEvent(before)) return
-  range.deleteContents()
-  const lines = text.split(/\r\n|\r|\n/)
-  const fragment = doc.createDocumentFragment()
-  lines.forEach((line, index) => {
-    if (index > 0) fragment.append(doc.createElement("br"))
-    if (line.length > 0) fragment.append(doc.createTextNode(line))
-  })
-  const last = fragment.lastChild
-  range.insertNode(fragment)
-  if (last && selection) {
-    const caret = doc.createRange()
-    caret.setStartAfter(last)
-    caret.collapse(true)
-    selection.removeAllRanges()
-    selection.addRange(caret)
-  }
-  host.dispatchEvent(
-    inputEvent(
-      doc.defaultView,
-      "input",
-      inputType,
-      text.length > 0 ? text : null
-    )
-  )
-}
-
-/**
  * Types `text` over the current selection of a focused editable control the
- * way the browser's editing pipeline does — `execCommand("insertText")`, or
- * `delete` for an empty replacement — so the editor receives `beforeinput`,
- * mutates its own model and re-renders. Only a runtime without `execCommand`
- * takes the direct path.
+ * way the browser's editing pipeline does — a form control through
+ * `setRangeText`, an editing host through `execCommand("insertText")` (or
+ * `delete` for an empty replacement) — so the editor receives `beforeinput`,
+ * mutates its own model and re-renders. The host is never written directly:
+ * a controlled editor rebuilds its DOM from its own model, so a node inserted
+ * behind its back would vanish on the next render. `false` means the host
+ * could not be edited through the pipeline (a runtime with no `execCommand`),
+ * and the caller reports an unapplied effect rather than corrupting the page.
  */
 export const insertAgentEditableText = (
   element: Element,
   text: string
-): void => {
+): boolean => {
   const doc = element.ownerDocument
-  const execCommand = (
-    doc as Document & {
-      execCommand?: (command: string, ui?: boolean, value?: string) => boolean
-    }
-  ).execCommand
-  if (typeof execCommand === "function") {
-    const applied =
-      text.length > 0
-        ? execCommand.call(doc, "insertText", false, text)
-        : execCommand.call(doc, "delete", false)
-    if (applied) return
-  }
   if (isTextControl(element)) {
     const start = element.selectionStart ?? element.value.length
     const end = element.selectionEnd ?? start
@@ -346,7 +285,15 @@ export const insertAgentEditableText = (
         text.length > 0 ? text : null
       )
     )
-    return
+    return true
   }
-  insertIntoHostDirectly(element, text)
+  const execCommand = (
+    doc as Document & {
+      execCommand?: (command: string, ui?: boolean, value?: string) => boolean
+    }
+  ).execCommand
+  if (typeof execCommand !== "function") return false
+  return text.length > 0
+    ? execCommand.call(doc, "insertText", false, text)
+    : execCommand.call(doc, "delete", false)
 }

--- a/src/lib/browser-agent/editor-text.ts
+++ b/src/lib/browser-agent/editor-text.ts
@@ -1,0 +1,55 @@
+/**
+ * The one reading of an editor's text that every side agrees on.
+ *
+ * A rich-text editor's document is markup: paragraphs, soft breaks, trailing
+ * `<br>` placeholders, non-breaking spaces where a user typed two. The page
+ * reports it as text, the resolver computes what the text should become, and
+ * the verifier compares the two — so all three have to flatten the markup the
+ * same way, or a paragraph the editor rendered as `<p>` on one read and
+ * `<div>` on the next reads as a change nobody made. No DOM here: this is the
+ * string rule, and the page-side walk that produces the raw text is separate.
+ */
+
+/**
+ * Lines are trimmed and their inner whitespace collapsed, and empty lines are
+ * dropped. Paragraph structure survives as single line breaks; the exact
+ * number of blank lines between paragraphs does not, because editors disagree
+ * about it and the model cannot see the difference either.
+ */
+export const normalizeAgentEditorText = (text: string): string =>
+  text
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.replaceAll(/\s+/g, " ").trim())
+    .filter((line) => line.length > 0)
+    .join("\n")
+
+/** How many times `find` occurs in `text`, non-overlapping, exactly. */
+export const countAgentTextOccurrences = (
+  text: string,
+  find: string
+): number => {
+  if (!find) return 0
+  let count = 0
+  let from = 0
+  for (;;) {
+    const index = text.indexOf(find, from)
+    if (index < 0) return count
+    count += 1
+    from = index + find.length
+  }
+}
+
+/**
+ * The value after replacing the single occurrence of `find`, or nothing when
+ * the occurrence is not single. Callers decide whether "nothing" is a refusal
+ * or a stale target; this only answers whether the edit is well defined.
+ */
+export const replaceAgentTextOnce = (
+  value: string,
+  find: string,
+  text: string
+): string | undefined => {
+  if (countAgentTextOccurrences(value, find) !== 1) return undefined
+  const index = value.indexOf(find)
+  return `${value.slice(0, index)}${text}${value.slice(index + find.length)}`
+}

--- a/src/lib/browser-agent/effect-verifier.ts
+++ b/src/lib/browser-agent/effect-verifier.ts
@@ -6,6 +6,7 @@ import type {
 import type { AgentObservation } from "@ollama-client/contracts"
 
 import type { TabAccess } from "@/lib/browser-tab-access"
+import { normalizeAgentEditorText } from "./editor-text"
 import type {
   DomMutationAgentAction,
   NavigationAgentAction,
@@ -543,11 +544,50 @@ const deliveryProblem = (
   }
 }
 
+/**
+ * A file chooser the page opened is a step the run cannot finish: the
+ * debugger held the dialog back, nothing was chosen, and only the user can
+ * choose. The step is left unresolved for them rather than judged from a page
+ * that is waiting for a file.
+ */
+const fileChooserProblem = (
+  input: AgentVerificationInput,
+  now: number
+): AgentVerificationResult | undefined =>
+  input.receipt.fileChooser
+    ? result(
+        "ambiguous",
+        "file_chooser",
+        "The page asked for a file; choose it yourself, then continue",
+        now
+      )
+    : undefined
+
 const withDelivery =
   (kind: string, verifier: Verifier): Verifier =>
   async (input, adapter, signal) =>
+    fileChooserProblem(input, adapter.now()) ??
     deliveryProblem(input, kind, adapter.now()) ??
     verifier(input, adapter, signal)
+
+/**
+ * Field values compare exactly, except an editor's: its value is its markup
+ * flattened, and the editor may render the same text as `<p>` on one read and
+ * `<div><br></div>` on the next. Both sides go through the one normalization
+ * the page used, so a paragraph break is a paragraph break however it is
+ * spelled.
+ */
+const sameFieldValue = (
+  target: AgentVerificationInput["effect"]["target"],
+  actual: string,
+  expected: string | undefined
+): boolean => {
+  if (expected === undefined) return false
+  if (target.inputType?.toLowerCase() !== "contenteditable") {
+    return actual === expected
+  }
+  return normalizeAgentEditorText(actual) === normalizeAgentEditorText(expected)
+}
 
 const verifyValueMutation: Verifier = async (input, adapter, signal) => {
   const after = await observeAfter(input, adapter, signal)
@@ -570,7 +610,13 @@ const verifyValueMutation: Verifier = async (input, adapter, signal) => {
       adapter.now()
     )
   }
-  if (target.element.value === input.effect.target.expectedValue) {
+  if (
+    sameFieldValue(
+      input.effect.target,
+      target.element.value,
+      input.effect.target.expectedValue
+    )
+  ) {
     return result(
       "confirmed",
       "field",
@@ -832,6 +878,150 @@ const verifyKey: Verifier = async (input, adapter, signal) => {
   )
 }
 
+type ObservedElement = AgentObservation["elements"][number]
+
+const sameSemantics = (
+  first: Pick<ObservedElement, "tag" | "role" | "name" | "type">,
+  second: Pick<ObservedElement, "tag" | "role" | "name" | "type">
+): boolean =>
+  first.tag === second.tag &&
+  first.role === second.role &&
+  first.name === second.name &&
+  first.type === second.type
+
+/**
+ * The one element in an observation matching the drop target's facts, in the
+ * drag's own frame. Ambiguity is reported as absence: a destination the
+ * observation cannot single out cannot anchor an arrangement claim.
+ */
+const dropTargetIn = (
+  input: AgentVerificationInput,
+  observation: AgentObservation
+): ObservedElement | undefined => {
+  const drop = input.effect.target.drop
+  if (!drop) return undefined
+  const matches = observation.elements.filter(
+    (element) =>
+      element.frameId === drop.frameId &&
+      (drop.verificationId === undefined ||
+        element.verificationId === drop.verificationId) &&
+      element.tag === drop.tag &&
+      element.role === drop.role &&
+      element.name === drop.accessibleName
+  )
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+/** The neighbours an element has in document order, by what they are. */
+const neighboursOf = (
+  observation: AgentObservation,
+  element: ObservedElement
+): { before?: ObservedElement; after?: ObservedElement } => {
+  const peers = observation.elements.filter(
+    (candidate) => candidate.frameId === element.frameId
+  )
+  const index = peers.indexOf(element)
+  return { before: peers[index - 1], after: peers[index + 1] }
+}
+
+const sameNeighbour = (
+  first: ObservedElement | undefined,
+  second: ObservedElement | undefined
+): boolean =>
+  first === undefined || second === undefined
+    ? first === second
+    : sameSemantics(first, second)
+
+/**
+ * A drag is verified by the arrangement it leaves, never by the page merely
+ * having changed. The dragged element is found again by what it is; it has
+ * moved when its order relative to the destination flipped, when it sits in
+ * a different region, or when the controls beside it are no longer the ones
+ * that were beside it. A destination that swallowed it — a trash target —
+ * shows as the element gone from a page that changed. An identical page is a
+ * negative; a page that changed without the element visibly moving is left
+ * uncertain, because a pointer drag that landed somewhere else has changed
+ * something the run did not intend.
+ */
+const verifyDrag: Verifier = async (input, adapter, signal) => {
+  const after = await observeAfter(input, adapter, signal)
+  const changed = pageEvidence(after) !== pageEvidence(input.before)
+  const source = mutationTargetAfter(input, after)
+  if (source.type === "missing" && changed) {
+    return result(
+      "confirmed",
+      "arrangement",
+      "Dragged element is no longer on the page",
+      adapter.now()
+    )
+  }
+  if (source.type !== "one") {
+    return result(
+      "ambiguous",
+      "arrangement",
+      "Dragged element is no longer identifiable",
+      adapter.now()
+    )
+  }
+  const sourceBefore = input.before.elements.find(
+    (element) => element.ref === input.effect.target.ref
+  )
+  const destinationBefore = dropTargetIn(input, input.before)
+  const destinationAfter = dropTargetIn(input, after)
+  if (sourceBefore && destinationBefore && destinationAfter) {
+    const wasBefore =
+      input.before.elements.indexOf(sourceBefore) <
+      input.before.elements.indexOf(destinationBefore)
+    const isBefore =
+      after.elements.indexOf(source.element) <
+      after.elements.indexOf(destinationAfter)
+    if (wasBefore !== isBefore) {
+      return result(
+        "confirmed",
+        "arrangement",
+        "Dragged element moved past its destination",
+        adapter.now()
+      )
+    }
+  }
+  if (sourceBefore && sourceBefore.group !== source.element.group) {
+    return result(
+      "confirmed",
+      "arrangement",
+      "Dragged element moved into another region",
+      adapter.now()
+    )
+  }
+  if (sourceBefore) {
+    const before = neighboursOf(input.before, sourceBefore)
+    const now = neighboursOf(after, source.element)
+    if (
+      !sameNeighbour(before.before, now.before) ||
+      !sameNeighbour(before.after, now.after)
+    ) {
+      return result(
+        "confirmed",
+        "arrangement",
+        "Dragged element sits among different controls",
+        adapter.now()
+      )
+    }
+  }
+  return changed
+    ? result(
+        "ambiguous",
+        "arrangement",
+        "Page changed but the dragged element did not visibly move",
+        adapter.now()
+      )
+    : result(
+        "negative",
+        "arrangement",
+        "Arrangement did not change",
+        adapter.now()
+      )
+}
+
 export const DOM_MUTATION_AGENT_VERIFIERS = {
   click: withDelivery("activation", verifyActivation),
   click_point: withDelivery("activation", verifyActivation),
@@ -839,6 +1029,8 @@ export const DOM_MUTATION_AGENT_VERIFIERS = {
   hover: withDelivery("hover", verifyHover),
   type: withDelivery("field", verifyValueMutation),
   clear_and_type: withDelivery("field", verifyValueMutation),
+  replace_text: withDelivery("field", verifyValueMutation),
+  drag: withDelivery("arrangement", verifyDrag),
   select: verifyValueMutation,
   check: verifyCheckedMutation,
   uncheck: verifyCheckedMutation,

--- a/src/lib/browser-agent/effect-verifier.ts
+++ b/src/lib/browser-agent/effect-verifier.ts
@@ -937,29 +937,25 @@ const sameNeighbour = (
  * having changed. The dragged element is found again by what it is; it has
  * moved when its order relative to the destination flipped, when it sits in
  * a different region, or when the controls beside it are no longer the ones
- * that were beside it. A destination that swallowed it — a trash target —
- * shows as the element gone from a page that changed. An identical page is a
- * negative; a page that changed without the element visibly moving is left
- * uncertain, because a pointer drag that landed somewhere else has changed
- * something the run did not intend.
+ * that were beside it. A source that is simply gone is never confirmed: a
+ * rerender that hides it, a timer, or a misdirected drag looks identical to a
+ * drop a trash target swallowed, and confirming a disappearance would credit
+ * an effect that may never have reached the destination. An identical page is
+ * a negative; a page that changed without the element visibly moving to its
+ * destination is left uncertain, because a pointer drag that landed somewhere
+ * else has changed something the run did not intend.
  */
 const verifyDrag: Verifier = async (input, adapter, signal) => {
   const after = await observeAfter(input, adapter, signal)
   const changed = pageEvidence(after) !== pageEvidence(input.before)
   const source = mutationTargetAfter(input, after)
-  if (source.type === "missing" && changed) {
-    return result(
-      "confirmed",
-      "arrangement",
-      "Dragged element is no longer on the page",
-      adapter.now()
-    )
-  }
   if (source.type !== "one") {
     return result(
       "ambiguous",
       "arrangement",
-      "Dragged element is no longer identifiable",
+      source.type === "missing"
+        ? "Dragged element is gone; its move to the destination is unconfirmed"
+        : "Dragged element is no longer identifiable",
       adapter.now()
     )
   }

--- a/src/lib/browser-agent/native-input-page.ts
+++ b/src/lib/browser-agent/native-input-page.ts
@@ -1,7 +1,11 @@
 import { AgentEffectNotAppliedError } from "@ollama-client/agent-runtime"
 
-import { resolveAgentMutationTarget } from "./command-executor"
+import {
+  resolveAgentDropTarget,
+  resolveAgentMutationTarget
+} from "./command-executor"
 import type { AgentDomMutationInstruction } from "./control-port"
+import { selectAgentEditableText } from "./editor-page"
 import type { AgentElementReferenceStore } from "./element-references"
 import type {
   AgentInputPoint,
@@ -25,6 +29,8 @@ export interface AgentNativeInputPreparation {
   point: AgentInputPoint
   /** Whether the target already holds focus. */
   focused: boolean
+  /** Where a drag is released, for a `drag` alone. */
+  dropPoint?: AgentInputPoint
 }
 
 const RECORDED_EVENT_TYPES: readonly AgentRecordedInputEventType[] = [
@@ -33,7 +39,8 @@ const RECORDED_EVENT_TYPES: readonly AgentRecordedInputEventType[] = [
   "mouseup",
   "keydown",
   "keyup",
-  "wheel"
+  "wheel",
+  "drop"
 ]
 
 const isRecordedType = (type: string): type is AgentRecordedInputEventType =>
@@ -164,6 +171,78 @@ const fullyInViewport = (element: Element): boolean => {
   )
 }
 
+const centreOf = (element: Element): AgentInputPoint => {
+  const rect = element.getBoundingClientRect()
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+}
+
+/**
+ * An in-place edit sends no pointer: the selection is placed over the text
+ * to replace and the control focused, here, in the same pass that checked
+ * the target, and what the debugger then types replaces exactly that run. A
+ * run that is no longer there once is a target that changed since approval.
+ */
+const prepareReplacement = (
+  effect: AgentDomMutationInstruction,
+  element: Element,
+  watch: AgentInputWatch
+): AgentNativeInputPreparation => {
+  if (effect.command.type !== "replace_text") {
+    throw new Error("Invalid Agent replacement effect")
+  }
+  if (!selectAgentEditableText(element, effect.command.find)) {
+    throw new AgentEffectNotAppliedError(
+      "Agent text to replace is no longer unique in the target"
+    )
+  }
+  watch.arm(element)
+  return {
+    point: findAgentReachablePoint(element) ?? centreOf(element),
+    focused: true
+  }
+}
+
+/**
+ * A drag needs both ends on screen at once, so the source is brought into
+ * view and the destination has to be visible already — scrolling the
+ * destination in could scroll the source out, and a pointer cannot drag what
+ * it cannot press. The destination is rechecked against what was approved and
+ * its own reachable point taken from the same hit test the source's is.
+ */
+const prepareDrag = (
+  effect: AgentDomMutationInstruction,
+  element: Element,
+  references: AgentElementReferenceStore,
+  watch: AgentInputWatch
+): AgentNativeInputPreparation => {
+  const destination = resolveAgentDropTarget(effect, references)
+  if (!fullyInViewport(element)) {
+    element.scrollIntoView({
+      block: "center",
+      inline: "center",
+      behavior: "instant"
+    })
+  }
+  const point = findAgentReachablePoint(element)
+  if (!point) {
+    throw new AgentEffectNotAppliedError(
+      "Agent drag source is covered by another element"
+    )
+  }
+  const dropPoint = findAgentReachablePoint(destination)
+  if (!dropPoint) {
+    throw new AgentEffectNotAppliedError(
+      "Agent drop destination is not reachable on screen"
+    )
+  }
+  watch.arm(element)
+  return {
+    point,
+    focused: element === element.ownerDocument.activeElement,
+    dropPoint
+  }
+}
+
 /**
  * Rechecks the approved target and picks the point a native pointer goes to.
  *
@@ -180,6 +259,12 @@ export const prepareAgentNativeInputInDocument = (input: {
   watch: AgentInputWatch
 }): AgentNativeInputPreparation => {
   const element = resolveAgentMutationTarget(input.effect, input.references)
+  if (input.effect.command.type === "replace_text") {
+    return prepareReplacement(input.effect, element, input.watch)
+  }
+  if (input.effect.command.type === "drag") {
+    return prepareDrag(input.effect, element, input.references, input.watch)
+  }
   /**
    * A named point is used as named, never re-sampled: the run approved a
    * click there. It has to still land on the control, though — scrolling is

--- a/src/lib/browser-agent/native-input.ts
+++ b/src/lib/browser-agent/native-input.ts
@@ -27,6 +27,8 @@ export const NATIVE_INPUT_AGENT_ACTIONS = [
   "hover",
   "type",
   "clear_and_type",
+  "replace_text",
+  "drag",
   "press_key"
 ] as const
 export type NativeInputAgentAction = (typeof NATIVE_INPUT_AGENT_ACTIONS)[number]
@@ -173,25 +175,46 @@ export type AgentNativeInputStep =
       deltaX: number
       deltaY: number
     }
+  /**
+   * The pointer moving with its button held, and the release that ends it.
+   * Spoken as drag steps rather than mouse steps because the browser may turn
+   * the first held move into an HTML5 drag, after which the page receives
+   * drag events instead of mouse events; the channel that dispatches them
+   * decides which, and a `cancel` releases without dropping.
+   */
+  | { kind: "drag"; type: "move" | "drop" | "cancel"; x: number; y: number }
+
+export type AgentRecordedInputEventType =
+  | "mousemove"
+  | "mousedown"
+  | "mouseup"
+  | "keydown"
+  | "keyup"
+  | "wheel"
+  | "drop"
 
 /**
  * One DOM event the page is expected to report if the plan arrived. Pointer
  * coordinates are in the target frame's own viewport; keys carry their `key`.
+ * `alternatives` name other event types that satisfy the same expectation —
+ * a drag ends in `mouseup` or, once the browser made it an HTML5 drag, in
+ * `drop`. `anyTarget` waives the target check for an event that lands where
+ * the pointer is rather than on the resolved element: the release of a drag
+ * lands on the destination, or on the dragged element itself.
  */
 export interface AgentExpectedInputEvent {
-  type: "mousemove" | "mousedown" | "mouseup" | "keydown" | "keyup" | "wheel"
+  type: AgentRecordedInputEventType
+  alternatives?: readonly AgentRecordedInputEventType[]
   x?: number
   y?: number
   key?: string
+  anyTarget?: boolean
 }
 
 export interface AgentNativeInputPlan {
   steps: readonly AgentNativeInputStep[]
   expected: readonly AgentExpectedInputEvent[]
 }
-
-const modifierMask = (modifiers: readonly AgentKeyModifier[]): number =>
-  modifiers.reduce((mask, modifier) => mask | MODIFIER_BITS[modifier], 0)
 
 const primaryModifier = (platform: AgentInputPlatform): AgentKeyModifier =>
   platform === "mac" ? "Meta" : "Control"
@@ -277,6 +300,14 @@ const pushCombination = (
   }
 }
 
+/**
+ * Typed text, one key per character the table can press and inserted text for
+ * the rest. A line break is inserted, never pressed: an inserted newline
+ * starts a paragraph in an editor and a line in a textarea through the
+ * browser's own editing pipeline, without the `keydown` an Enter would send
+ * — and Enter is what a chat composer sends its message on. Completion is
+ * pressed on purpose, through `press_key`, or not at all.
+ */
 const pushText = (builder: PlanBuilder, text: string): void => {
   let pending = ""
   const flush = () => {
@@ -284,13 +315,8 @@ const pushText = (builder: PlanBuilder, text: string): void => {
     pending = ""
   }
   for (const character of text) {
-    if (character === "\n" || character === "\r") {
-      flush()
-      pushCombination(builder, [], NAMED_KEY_DEFINITIONS.Enter)
-      continue
-    }
     const definition = agentNativeKeyDefinition(character)
-    if (!definition || !definition.text) {
+    if (!definition?.text) {
       pending += character
       continue
     }
@@ -322,7 +348,69 @@ export interface AgentNativeInputPlanInput {
   frameOffset: AgentInputPoint
   /** Whether the target already holds focus, so typing needs no click first. */
   focused: boolean
+  /** Where a drag is released, in the frame's viewport; required for `drag`. */
+  dropPoint?: AgentInputPoint
   platform: AgentInputPlatform
+}
+
+/**
+ * How far the pointer first travels with the button held before heading for
+ * the destination. Pointer-based drag libraries start a drag only past an
+ * activation distance, and the browser starts an HTML5 drag only once the
+ * pointer has moved; a straight jump to the destination would skip both.
+ */
+const DRAG_ACTIVATION_PX = 12
+
+/**
+ * The sequence of a drag: press on the source, move a little, move to the
+ * destination, release there. Every move carries the held button. The
+ * expectation is the press on the source and a release at the destination —
+ * as `mouseup` for a pointer drag or `drop` for an HTML5 one — on whatever
+ * element is under the pointer then, since the dragged element itself often
+ * is. The moves in between are not expected: the browser synthesizes its own.
+ */
+const dragTo = (
+  builder: PlanBuilder,
+  root: AgentInputPoint,
+  local: AgentInputPoint,
+  destination: AgentInputPoint,
+  frameOffset: AgentInputPoint
+): void => {
+  pushMouse(builder, "mouseMoved", root, local, 0)
+  pushMouse(builder, "mousePressed", root, local, 1)
+  const direction = {
+    x: destination.x >= local.x ? 1 : -1,
+    y: destination.y >= local.y ? 1 : -1
+  }
+  const activation = {
+    x: local.x + direction.x * DRAG_ACTIVATION_PX,
+    y: local.y + direction.y * DRAG_ACTIVATION_PX
+  }
+  const midpoint = {
+    x: (local.x + destination.x) / 2,
+    y: (local.y + destination.y) / 2
+  }
+  for (const stop of [activation, midpoint, destination]) {
+    builder.steps.push({
+      kind: "drag",
+      type: "move",
+      x: stop.x + frameOffset.x,
+      y: stop.y + frameOffset.y
+    })
+  }
+  builder.steps.push({
+    kind: "drag",
+    type: "drop",
+    x: destination.x + frameOffset.x,
+    y: destination.y + frameOffset.y
+  })
+  builder.expected.push({
+    type: "mouseup",
+    alternatives: ["drop"],
+    x: destination.x,
+    y: destination.y,
+    anyTarget: true
+  })
 }
 
 /**
@@ -370,6 +458,20 @@ export const planAgentNativeInput = (
       pushText(builder, input.command.text)
       break
     }
+    /**
+     * The page placed the selection over the text to replace during
+     * preparation and focused the control without a click — a click would
+     * move the caret. What follows is typed over the selection: the
+     * replacement as text, or a Backspace when there is none.
+     */
+    case "replace_text":
+      if (input.command.text.length > 0) pushText(builder, input.command.text)
+      else pushCombination(builder, [], NAMED_KEY_DEFINITIONS.Backspace)
+      break
+    case "drag":
+      if (!input.dropPoint) throw new Error("Agent drag has no drop point")
+      dragTo(builder, root, input.point, input.dropPoint, input.frameOffset)
+      break
     case "press_key": {
       const combination = parseAgentKeyCombination(input.command.key)
       if (!combination) throw new Error("Agent key combination is invalid")
@@ -463,12 +565,26 @@ export class AgentNativeInputFailedError extends Error {
 
 interface HeldInput {
   button?: { x: number; y: number; clickCount: number }
+  /** Set once the held button has moved, so its release is a drag cancel. */
+  dragging?: boolean
   keys: Map<string, Extract<AgentNativeInputStep, { kind: "key" }>>
 }
 
+/**
+ * A held button is released where it is; a button that has been dragging is
+ * released through a drag cancel, so an HTML5 drag the browser started ends
+ * without a drop rather than dropping wherever the pointer happened to be.
+ */
 const releaseSteps = (held: HeldInput): AgentNativeInputStep[] => {
   const steps: AgentNativeInputStep[] = []
-  if (held.button) {
+  if (held.button && held.dragging) {
+    steps.push({
+      kind: "drag",
+      type: "cancel",
+      x: held.button.x,
+      y: held.button.y
+    })
+  } else if (held.button) {
     steps.push({
       kind: "mouse",
       type: "mouseReleased",
@@ -497,8 +613,20 @@ const track = (held: HeldInput, step: AgentNativeInputStep): void => {
   if (step.kind === "mouse") {
     if (step.type === "mousePressed") {
       held.button = { x: step.x, y: step.y, clickCount: step.clickCount }
+      held.dragging = false
     } else if (step.type === "mouseReleased") {
       held.button = undefined
+      held.dragging = false
+    }
+    return
+  }
+  if (step.kind === "drag") {
+    if (step.type === "move" && held.button) {
+      held.button = { ...held.button, x: step.x, y: step.y }
+      held.dragging = true
+    } else if (step.type !== "move") {
+      held.button = undefined
+      held.dragging = false
     }
     return
   }
@@ -551,8 +679,6 @@ export const runAgentNativeInputPlan = async (
   return { dispatched }
 }
 
-export type AgentRecordedInputEventType = AgentExpectedInputEvent["type"]
-
 /** One trusted input event the page recorded while a plan was in flight. */
 export interface AgentRecordedInputEvent {
   type: AgentRecordedInputEventType
@@ -575,7 +701,8 @@ const INTERFERENCE_TYPES = new Set([
   "mouseup",
   "keydown",
   "keyup",
-  "wheel"
+  "wheel",
+  "drop"
 ])
 
 const POINTER_TOLERANCE_PX = 1.5
@@ -584,7 +711,12 @@ const matchesExpected = (
   expected: AgentExpectedInputEvent,
   recorded: AgentRecordedInputEvent
 ): boolean => {
-  if (expected.type !== recorded.type) return false
+  if (
+    expected.type !== recorded.type &&
+    !expected.alternatives?.includes(recorded.type)
+  ) {
+    return false
+  }
   if (expected.key !== undefined) return expected.key === recorded.key
   if (expected.x === undefined || expected.y === undefined) return true
   return (
@@ -612,11 +744,11 @@ export const assessAgentInputDelivery = (
   if (!trace || trace.overflow) return "unknown"
   let next = 0
   let interference = false
-  const matched: AgentRecordedInputEvent[] = []
+  const matched: { event: AgentRecordedInputEvent; anyTarget: boolean }[] = []
   for (const recorded of trace.events) {
     const expected = plan.expected[next]
     if (expected && matchesExpected(expected, recorded)) {
-      matched.push(recorded)
+      matched.push({ event: recorded, anyTarget: expected.anyTarget === true })
       next += 1
       continue
     }
@@ -632,7 +764,10 @@ export const assessAgentInputDelivery = (
    * control, after Enter it may be a dialog. Only the press has to have reached
    * the resolved target for the plan to count as delivered there.
    */
-  return matched.every((event) => event.type === "keyup" || event.onTarget)
+  return matched.every(
+    ({ event, anyTarget }) =>
+      anyTarget || event.type === "keyup" || event.onTarget
+  )
     ? "delivered"
     : "misdirected"
 }

--- a/src/lib/browser-agent/observation-builder.ts
+++ b/src/lib/browser-agent/observation-builder.ts
@@ -5,6 +5,7 @@ import {
   MAX_AGENT_DESTINATION_URL_CHARS
 } from "@ollama-client/contracts"
 
+import { agentEditorText, isAgentEditingHost } from "./editor-page"
 import type { AgentElementReferenceStore } from "./element-references"
 
 export const AGENT_OBSERVATION_LIMITS = {
@@ -55,7 +56,14 @@ const INTERACTIVE_SELECTOR = [
   "select",
   "textarea",
   "[role]",
-  "[contenteditable='true']"
+  /**
+   * Every editing host, however it spells `true` — the bare attribute and
+   * `plaintext-only` included — except one that says `false`, which is how an
+   * editor marks a toolbar inside its own document as not editable.
+   */
+  "[contenteditable]:not([contenteditable='false'])",
+  /** A board item or a sortable row is a control a pointer picks up. */
+  "[draggable='true']"
 ].join(",")
 
 const truncate = (value: string, limit: number): string =>
@@ -602,7 +610,12 @@ export const isSensitiveAgentElement = (element: Element): boolean => {
   )
 }
 
+/**
+ * An editing host's value is its text, read the one way every side reads it
+ * (`agentEditorText`). A form control's is its `value` property.
+ */
 const elementValue = (element: Element): string | undefined => {
+  if (isAgentEditingHost(element)) return agentEditorText(element)
   if (!("value" in element)) return undefined
   return String((element as HTMLInputElement).value ?? "")
 }
@@ -617,10 +630,44 @@ const elementValue = (element: Element): string | undefined => {
  * through a check that answers for a non-HTML element too.
  */
 const elementType = (element: Element): string | undefined => {
+  /**
+   * An editing host has no `type` property; it reports one so the model and
+   * the affordance rules can tell an editor from the `<div>` it is built on.
+   */
+  if (isAgentEditingHost(element)) return "contenteditable"
   const declared = (element as Partial<HTMLInputElement>).type
   return typeof declared === "string" && declared.length > 0
     ? declared
     : undefined
+}
+
+/**
+ * Whether a control's value may hold line breaks. A textarea's always may.
+ * An editing host is read from its ARIA: `aria-multiline="true"` says so, a
+ * `textbox` without it is single-line by the role's definition, and a host
+ * with no role is a document rather than a field, so Enter starts a paragraph.
+ * Whether Enter also *sends* — a chat composer's habit — is a page handler
+ * this cannot see, which is why typed text never presses Enter at all.
+ */
+const isMultiline = (element: Element): boolean => {
+  if (element instanceof HTMLTextAreaElement) return true
+  if (!isAgentEditingHost(element)) return false
+  const declared = element.getAttribute("aria-multiline")?.toLowerCase()
+  if (declared === "true") return true
+  if (declared === "false") return false
+  return element.getAttribute("role")?.toLowerCase() !== "textbox"
+}
+
+/**
+ * Whether the page marks the element as something a pointer picks up. The
+ * `draggable` attribute is the HTML5 mark; an ARIA role description saying
+ * sortable or draggable is how pointer-based libraries label their items.
+ */
+const isMarkedDraggable = (element: Element): boolean => {
+  if (element.getAttribute("draggable")?.toLowerCase() === "true") return true
+  if (element.hasAttribute("aria-grabbed")) return true
+  const description = element.getAttribute("aria-roledescription") ?? ""
+  return /\b(?:sortable|draggable|drag)/i.test(description)
 }
 
 const isEnabled = (element: Element): boolean => {
@@ -969,6 +1016,18 @@ const accessibleName = (
       .join(" ")
     if (label) return label
   }
+  /**
+   * An editor's text is its value, not its name: a document named by its own
+   * first paragraph would rename itself on every edit and could never be
+   * told from the text it holds. Only a placeholder names it.
+   */
+  if (isAgentEditingHost(element)) {
+    const placeholder =
+      element.getAttribute("aria-placeholder") ??
+      element.getAttribute("data-placeholder") ??
+      element.getAttribute("placeholder")
+    return placeholder || undefined
+  }
   const text = collectVisibleText(
     element,
     AGENT_OBSERVATION_LIMITS.elementNameChars,
@@ -1079,6 +1138,8 @@ const buildElementObservation = (
     enabled: isEnabled(element),
     editable: isEditable(element),
     sensitive,
+    ...(isMultiline(element) ? { multiline: true } : {}),
+    ...(isMarkedDraggable(element) ? { draggable: true } : {}),
     ...(group ? { group } : {})
   }
 }

--- a/src/lib/browser-agent/resolved-effect.ts
+++ b/src/lib/browser-agent/resolved-effect.ts
@@ -1,5 +1,6 @@
 import {
   type AgentDestination,
+  type AgentDropTarget,
   AgentGroundingError,
   type AgentResolutionContext,
   type AgentSemanticEffect,
@@ -20,6 +21,7 @@ import {
 
 import type { TabAccess } from "@/lib/browser-tab-access"
 import type { AgentHitTestResult } from "./control-port"
+import { replaceAgentTextOnce } from "./editor-text"
 import {
   agentFramePage,
   agentFrameSnapshotIdentity,
@@ -431,6 +433,8 @@ export const DOM_MUTATION_AGENT_ACTIONS = [
   "hover",
   "type",
   "clear_and_type",
+  "replace_text",
+  "drag",
   "select",
   "check",
   "uncheck",
@@ -438,6 +442,9 @@ export const DOM_MUTATION_AGENT_ACTIONS = [
 ] as const
 
 export type DomMutationAgentAction = (typeof DOM_MUTATION_AGENT_ACTIONS)[number]
+
+/** The most a field may hold for its value to remain verifiable. */
+const MAX_VERIFIABLE_VALUE_CHARS = 500
 
 const DESTRUCTIVE_LABELS = [
   /\b(?:delete|remove|erase|destroy|discard)\b/i,
@@ -571,7 +578,70 @@ const clickSemantics = (
   if (element.tag === "input" && element.type?.toLowerCase() === "reset") {
     return { effects: ["form_mutation"] }
   }
+  /** A file input's click is a request for the user's files, nothing else. */
+  if (element.tag === "input" && element.type?.toLowerCase() === "file") {
+    return { effects: ["file_selection"] }
+  }
   return { effects: ["activation"] }
+}
+
+/**
+ * The value an edit should leave behind, or a refusal when the observation
+ * cannot say. A value at the observation's cap may have been cut, so nothing
+ * computed from it is a fact about the field; a result past the cap could not
+ * be read back either way.
+ */
+const expectedTextValue = (
+  element: AgentElement,
+  compute: (current: string) => string | undefined
+): string => {
+  const current = element.value ?? ""
+  if (current.length >= MAX_VERIFIABLE_VALUE_CHARS) {
+    throw new Error("Agent text target exceeds the verifiable value limit")
+  }
+  const next = compute(current)
+  if (next === undefined) {
+    throw new AgentGroundingError({
+      refusal: { reason: "text_not_found", ref: element.ref, tag: element.tag }
+    })
+  }
+  if (next.length > MAX_VERIFIABLE_VALUE_CHARS) {
+    throw new Error("Agent text result exceeds the verifiable value limit")
+  }
+  return next
+}
+
+/**
+ * The destination of a drag, grounded through the same classifier that
+ * accepted the command, then carried in the terms its recheck compares. A
+ * drop is an effect on the destination as much as on the source, so its
+ * facts are part of what the user approves.
+ */
+const dropTargetOf = (
+  command: Extract<AgentCommand, { type: "drag" }>,
+  observation: AgentObservation
+): { element: AgentElement; drop: AgentDropTarget } => {
+  const element = observation.elements.find(
+    (candidate) => candidate.ref === command.to
+  )
+  if (!element) {
+    throw new AgentGroundingError({
+      refusal: { reason: "unknown_destination", ref: command.to }
+    })
+  }
+  return {
+    element,
+    drop: {
+      ref: element.ref,
+      ...(element.verificationId
+        ? { verificationId: element.verificationId }
+        : {}),
+      frameId: element.frameId,
+      tag: element.tag,
+      ...(element.role ? { role: element.role } : {}),
+      ...(element.name ? { accessibleName: element.name } : {})
+    }
+  }
 }
 
 /**
@@ -692,6 +762,7 @@ export const resolveDomMutationAgentEffect = async (input: {
   const effects: AgentSemanticEffect[] = []
   let destination: AgentDestination | undefined
   let expected: { value?: string; checked?: boolean } | undefined
+  let drop: { element: AgentElement; drop: AgentDropTarget } | undefined
 
   switch (command.type) {
     case "click":
@@ -710,13 +781,12 @@ export const resolveDomMutationAgentEffect = async (input: {
       break
     case "type": {
       if (!element.sensitive) {
-        const current = element.value ?? ""
-        if (current.length + command.text.length > 500) {
-          throw new Error(
-            "Agent text result exceeds the verifiable value limit"
+        expected = {
+          value: expectedTextValue(
+            element,
+            (current) => `${current}${command.text}`
           )
         }
-        expected = { value: `${current}${command.text}` }
       }
       effects.push("form_mutation")
       break
@@ -724,6 +794,26 @@ export const resolveDomMutationAgentEffect = async (input: {
     case "clear_and_type":
       if (!element.sensitive) expected = { value: command.text }
       effects.push("form_mutation")
+      break
+    case "replace_text":
+      if (!element.sensitive) {
+        expected = {
+          value: expectedTextValue(element, (current) =>
+            replaceAgentTextOnce(current, command.find, command.text)
+          )
+        }
+      }
+      effects.push("form_mutation")
+      break
+    /**
+     * A drop lands on the destination, so its label is read for destructive
+     * intent too: dragging an item onto "Trash" deletes it as surely as a
+     * button would.
+     */
+    case "drag":
+      drop = dropTargetOf(command, observation)
+      effects.push("drag")
+      if (isDestructiveLabel(drop.element.name)) effects.push("destructive")
       break
     case "select":
       expected = { value: command.value }
@@ -760,7 +850,8 @@ export const resolveDomMutationAgentEffect = async (input: {
     command,
     target: {
       ...targetFromElement(element, observation, expected),
-      ...(point ? { point } : {})
+      ...(point ? { point } : {}),
+      ...(drop ? { drop: drop.drop } : {})
     },
     ...(destination ? { destination } : {}),
     semanticEffects: [...new Set(effects)],

--- a/tools/checks/check-bundle-size.ts
+++ b/tools/checks/check-bundle-size.ts
@@ -236,8 +236,14 @@ const budgets: Budget[] = [
      * and geometry, the OffscreenCanvas editor, the debugger capture, hit-test
      * and rect messages, and the vision variant of the decision tool — took it
      * to 248,454. Firefox carries no Agent code and is unchanged.
+     *
+     * Editors and drag interactions — the editing-host reader and its
+     * selection/insertion helpers, the shared text normalization, the
+     * synthetic and debugger-driven drag with its HTML5 interception, the
+     * arrangement verifier, and the file-chooser hold-back — took it to
+     * 251,314. Firefox carries no Agent code and is unchanged.
      */
-    max: isFirefox ? 210_000 : 249_000
+    max: isFirefox ? 210_000 : 252_000
   }
 ]
 


### PR DESCRIPTION
Implements PR 7 of the agent readiness plan: editors and drag interactions.

## Behavior
- **replace_text** edits one exact run of a field in place. contenteditable hosts are observed as `contenteditable`-typed controls whose value is their flattened text; editing drives the browser's editing pipeline (caret/selection, execCommand/insertText) so rich-text editors keep the change. Values compare in one shared normalized form.
- Typed text inserts a newline as a line break only in multiline fields; Enter stays a deliberate press_key.
- **drag** grounds a source and destination in one frame, driven natively with HTML5-drag interception (synthetic pointer+HTML5 fallback off the debugger); a stopped drag cancels, never drops.
- Drag verification confirms a changed arrangement (past destination, into another region, among different neighbours, or off the page), not a mere page change.
- A file input click raises a file_upload takeover; the debugger holds the chooser back.

## Validation
- 4432 unit tests pass (6 new files).
- 20/20 agent e2e scenarios pass, including edit-and-save a document and move a board item, each verifying resulting state.
- typecheck, lint, format, both bundle budgets, resource generation pass.

## Limitations
- Drag verification is structural, not pixel-exact.
- draggable is an advisory hint.
- Firefox has no chooser interception, but policy still routes file inputs to takeover.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The latest changes address the earlier review feedback while completing rich-text editing, native drag interactions, and file-upload takeover handling.
- Removes direct contenteditable DOM mutation and fails safely when the browser editing pipeline is unavailable.
- Makes drag verification treat a disappeared source as ambiguous rather than confirming an unrelated change.
- Introduces action-scoped file-chooser accounting to prevent stale events from reaching later actions.
- Strengthens the Chromium editor scenario with an editor-owned model that rerenders on input.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest changes resolve the previously reported failures without introducing an established new defect.

The drag verifier no longer confirms source disappearance, chooser accounting now resets at the action boundary, contenteditable execution no longer writes editor DOM directly, and the Chromium fixture now rerenders from an editor-owned model. All four previous threads were manually resolved without explanatory replies and therefore do not remain outstanding.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/browser-agent/editor-page.ts | Removes the direct-DOM editor fallback and requires contenteditable changes to succeed through the browser editing pipeline. |
| src/lib/browser-agent/effect-verifier.ts | Prevents a vanished drag source from being treated as proof that the approved destination received the item. |
| src/background/agent/agent-browser-session-manager.ts | Adds action-scoped file-chooser accounting to discard chooser events raised before an action begins. |
| src/background/agent/agent-browser-adapters.ts | Opens the chooser-attribution window immediately before native action preparation. |
| e2e/chromium/critical/__tests__/agent-editing.spec.ts | Reworks the rich-text fixture around an editor-owned model that rerenders synchronously from input events. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[Agent command] --> A{Action}
  A -->|replace_text| E[Ground exact editor text]
  E --> P[Browser editing pipeline]
  P --> V[Verify normalized field value]
  A -->|drag| G[Ground source and destination]
  G --> N[Native pointer or HTML5 drag]
  N --> R[Verify changed arrangement]
  A -->|file input click| C[Intercept file chooser]
  C --> T[Request user takeover]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): tighten drag verification, s..."](https://github.com/shishir435/ollama-client/commit/d39e13d0787eaf7757c54f51f9a22f0f5758446b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62573730)</sub>

<!-- /greptile_comment -->