### PR TITLE
feat(olc): proxy reliability for unresumed decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,10 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
   and a parked call is a promise something awaits. `ChatRoutes.inspect()`
   reports what is still held so a test can tell the two apart, and shutdown
   disposes the turns it fails rather than leaving them to a timer nobody will
-  see.
+  see. It settles the union of parked turns, resume holds and whatever the
+  call registry still names — a resuming turn is deliberately taken *out* of
+  the parked map while its deadlines are suspended, so walking that map alone
+  left a live session whose calls had no timer left to settle them.
 - **A tool result belongs to one turn, or to none.** The parked-call registry is process-wide, so a follow-up releases only the calls the turn it resumes actually owns. A follow-up whose results name no live turn is refused with `400 StaleToolResults`; starting a fresh turn instead drops the result the client just produced and lets the model redo the work behind its back. The correlation is resolved twice — once to answer fast, once inside the queue slot — because a request can wait there for as long as another turn may run, and **both** of the turn's deadlines — the turn-level one and the shorter per-call one in the registry — are suspended for as long as its own resume is waiting. They ask the same question, so a fix that suspends one and not the other only moves which timer loses the result.
 - **One turn at a time is an invariant, not a hint.** A request past its deadline is cancelled through an `AbortSignal` and the queue keeps holding the slot: a task still running has not left the single-flight boundary, whatever its caller was told. If it will not stop, the queue refuses requests with `503` and names it rather than starting a second turn beside it.
 - **A browser origin is refused unless it is allowed.** The proxy listens on loopback and runs an agent, so a wildcard `Access-Control-Allow-Origin` would let any page spend a turn — a missing response header does not stop a simple request. `ALLOWED_ORIGINS` defaults to the extension schemes; a request with no `Origin` is not a page and is left alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,24 @@ In agent mode it serves a local agent runtime over `/v1/chat/completions`, so th
 - **Generated images are bytes, not links.** `/v1/images/generations` accepts the OpenAI-compatible `b64_json` shape and returns only validated base64 from the selected backend. A missing runtime image operation is `501`, never a text fallback disguised as image generation.
 - **Tool calls round-trip through the wire format.** The runtime does not forward a caller's tool definitions to its model, so the proxy registers them, parks a call mid-turn, emits it as an OpenAI `tool_calls` delta with `finish_reason: "tool_calls"`, and resumes the same turn when the next request carries matching `tool_call_id`s. The extension's native tool loop drives it unchanged, and its approval and permission gates still apply because the tools still execute in the extension.
 - Inside the proxy, `src/core/` is runtime-agnostic and every runtime detail sits behind the `AgentBackend` port (`src/backends/types.ts`), with OpenCode as the first adapter. A new runtime is an adapter plus a registry entry, never a change in `core/`.
+- **A decision is isolated; the session behind it is not free.** Every chat
+  request that carries no trailing tool results starts a new backend turn, so
+  the extension's agent — which sends one full conversation per step and never
+  returns a tool result for the decision it parsed — gets an isolated session
+  per decision. Nothing in the wire says a client will not resume, and it must
+  not be inferred: a client may legitimately start fresh work while still
+  computing a result for a turn it left parked, so discarding on that basis
+  throws away work it is about to hand back. What is not defensible is
+  unbounded, so `MAX_PARKED_TURNS` caps how many turns may sit parked and a
+  fresh request discards the oldest above it, never one with a resume hold.
+  Before that, only each turn's own ten-minute TTL ended one, and a
+  twenty-five-step run held twenty-five live sessions at once.
+- **Every terminal path settles the session and the slot.** A response that
+  stopped is not a session that ended: a parked turn is a live runtime session
+  and a parked call is a promise something awaits. `ChatRoutes.inspect()`
+  reports what is still held so a test can tell the two apart, and shutdown
+  disposes the turns it fails rather than leaving them to a timer nobody will
+  see.
 - **A tool result belongs to one turn, or to none.** The parked-call registry is process-wide, so a follow-up releases only the calls the turn it resumes actually owns. A follow-up whose results name no live turn is refused with `400 StaleToolResults`; starting a fresh turn instead drops the result the client just produced and lets the model redo the work behind its back. The correlation is resolved twice — once to answer fast, once inside the queue slot — because a request can wait there for as long as another turn may run, and **both** of the turn's deadlines — the turn-level one and the shorter per-call one in the registry — are suspended for as long as its own resume is waiting. They ask the same question, so a fix that suspends one and not the other only moves which timer loses the result.
 - **One turn at a time is an invariant, not a hint.** A request past its deadline is cancelled through an `AbortSignal` and the queue keeps holding the slot: a task still running has not left the single-flight boundary, whatever its caller was told. If it will not stop, the queue refuses requests with `503` and names it rather than starting a second turn beside it.
 - **A browser origin is refused unless it is allowed.** The proxy listens on loopback and runs an agent, so a wildcard `Access-Control-Allow-Origin` would let any page spend a turn — a missing response header does not stop a simple request. `ALLOWED_ORIGINS` defaults to the extension schemes; a request with no `Origin` is not a page and is left alone.

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -328,10 +328,29 @@ readiness reporting. Ollama itself is installed separately.
 | `BRIDGE_ENABLED` | `--no-bridge` to disable | `OLC_BRIDGE_ENABLED` | `true` |
 | `DEBUG` | `--debug` | `OLC_DEBUG` | `false` |
 | `REQUEST_TIMEOUT_MS` | — | `OLC_REQUEST_TIMEOUT_MS` | `300000` |
+| `MAX_PARKED_TURNS` | — | `OLC_MAX_PARKED_TURNS` | `4` |
 
-`REQUEST_TIMEOUT_MS`, `BRIDGE_CALL_TIMEOUT_MS`, `BRIDGE_BATCH_MS` and
-`SUSPENDED_TURN_TTL_MS` follow the same precedence with `OLC_`-prefixed
-environment variables.
+`REQUEST_TIMEOUT_MS`, `BRIDGE_CALL_TIMEOUT_MS`, `BRIDGE_BATCH_MS`,
+`SUSPENDED_TURN_TTL_MS` and `MAX_PARKED_TURNS` follow the same precedence with
+`OLC_`-prefixed environment variables.
+
+#### Parked turns
+
+A request whose tools the runtime calls is answered with a `tool_calls` delta
+and left parked: the backend session stays alive waiting for the result, and
+whichever later request carries it resumes that same turn.
+
+A client is not obliged to come back. The browser agent, for one, sends a full
+conversation per step and treats the tool call it gets as the step's answer —
+each decision is an isolated session it never resumes. Nothing in the wire
+says so in advance, and it must not be guessed at: a client may legitimately
+start fresh work while still computing a result for a turn it left parked.
+
+So the number of parked turns is bounded instead. `MAX_PARKED_TURNS` (default
+`4`) is how many may sit parked at once; admitting a fresh turn discards the
+oldest above that, never one whose resume request already exists. Each turn
+still carries its own `SUSPENDED_TURN_TTL_MS` deadline. Raise the cap for a
+client that genuinely interleaves several tool-calling turns.
 
 #### Who may call it
 

--- a/packages/olc/README.md
+++ b/packages/olc/README.md
@@ -350,7 +350,9 @@ So the number of parked turns is bounded instead. `MAX_PARKED_TURNS` (default
 `4`) is how many may sit parked at once; admitting a fresh turn discards the
 oldest above that, never one whose resume request already exists. Each turn
 still carries its own `SUSPENDED_TURN_TTL_MS` deadline. Raise the cap for a
-client that genuinely interleaves several tool-calling turns.
+client that genuinely interleaves several tool-calling turns; it is clamped to
+at least one, because parking is how a tool call reaches the client and zero
+would disable client tool calling rather than bound it.
 
 #### Who may call it
 

--- a/packages/olc/src/__tests__/config.test.ts
+++ b/packages/olc/src/__tests__/config.test.ts
@@ -21,6 +21,15 @@ describe("resolveConfig", () => {
     expect(resolveConfig().PORT).toBe(8084)
   })
 
+  it("bounds parked turns, overridably", () => {
+    // The default is what stops a client whose every request is one
+    // unresumed decision from holding a backend session per step.
+    expect(resolveConfig().MAX_PARKED_TURNS).toBe(4)
+    process.env.OLC_MAX_PARKED_TURNS = "2"
+    expect(resolveConfig().MAX_PARKED_TURNS).toBe(2)
+    expect(resolveConfig({ MAX_PARKED_TURNS: 6 }).MAX_PARKED_TURNS).toBe(6)
+  })
+
   it("still reads the legacy OPENCODE_PROXY_ environment names", () => {
     process.env.OPENCODE_PROXY_PORT = "9200"
     expect(resolveConfig().PORT).toBe(9200)

--- a/packages/olc/src/__tests__/config.test.ts
+++ b/packages/olc/src/__tests__/config.test.ts
@@ -30,6 +30,16 @@ describe("resolveConfig", () => {
     expect(resolveConfig({ MAX_PARKED_TURNS: 6 }).MAX_PARKED_TURNS).toBe(6)
   })
 
+  it("never lets the parked-turn cap reach zero", () => {
+    // Parking is how a tool call reaches the client, so zero would disable
+    // client tool calling rather than bound it — and the sweep runs before
+    // the turn it makes room for parks, so it could not deliver zero anyway.
+    expect(resolveConfig({ MAX_PARKED_TURNS: 0 }).MAX_PARKED_TURNS).toBe(1)
+    // A negative is not a smaller cap, it is invalid input, so the shared
+    // number reader passes it over and the default stands.
+    expect(resolveConfig({ MAX_PARKED_TURNS: -3 }).MAX_PARKED_TURNS).toBe(4)
+  })
+
   it("still reads the legacy OPENCODE_PROXY_ environment names", () => {
     process.env.OPENCODE_PROXY_PORT = "9200"
     expect(resolveConfig().PORT).toBe(9200)

--- a/packages/olc/src/config.ts
+++ b/packages/olc/src/config.ts
@@ -199,11 +199,21 @@ export const resolveConfig = (
       fileOptions.BRIDGE_BATCH_MS,
       DEFAULTS.BRIDGE_BATCH_MS
     ),
-    MAX_PARKED_TURNS: numberOption(
-      options.MAX_PARKED_TURNS,
-      env.OLC_MAX_PARKED_TURNS,
-      fileOptions.MAX_PARKED_TURNS,
-      DEFAULTS.MAX_PARKED_TURNS
+    /**
+     * At least one. A cap of zero cannot mean "park nothing": parking is how
+     * a tool call reaches the client at all, so zero would disable client
+     * tool calling rather than bound it — and the pre-admission sweep could
+     * not deliver it anyway, since the turn it makes room for parks
+     * afterwards. One means only the turn in flight may be parked.
+     */
+    MAX_PARKED_TURNS: Math.max(
+      1,
+      numberOption(
+        options.MAX_PARKED_TURNS,
+        env.OLC_MAX_PARKED_TURNS,
+        fileOptions.MAX_PARKED_TURNS,
+        DEFAULTS.MAX_PARKED_TURNS
+      )
     ),
     SUSPENDED_TURN_TTL_MS: numberOption(
       options.SUSPENDED_TURN_TTL_MS,

--- a/packages/olc/src/config.ts
+++ b/packages/olc/src/config.ts
@@ -40,7 +40,16 @@ export const DEFAULTS = {
   BRIDGE_PATH: "/bridge/call",
   BRIDGE_CALL_TIMEOUT_MS: 300_000,
   BRIDGE_BATCH_MS: 150,
-  SUSPENDED_TURN_TTL_MS: 600_000
+  SUSPENDED_TURN_TTL_MS: 600_000,
+  /**
+   * A parked turn is a live backend session, and its own TTL is ten minutes —
+   * fine for one turn a client abandoned, wrong for a client whose every
+   * request is a single decision it never resumes. Four leaves room for a
+   * client that legitimately interleaves a fresh turn with one it is still
+   * computing a tool result for, and stops a long run holding a session per
+   * step.
+   */
+  MAX_PARKED_TURNS: 4
 } as const
 
 /** Options as they arrive from a config file or the command line. */
@@ -189,6 +198,12 @@ export const resolveConfig = (
       env.OLC_BRIDGE_BATCH_MS,
       fileOptions.BRIDGE_BATCH_MS,
       DEFAULTS.BRIDGE_BATCH_MS
+    ),
+    MAX_PARKED_TURNS: numberOption(
+      options.MAX_PARKED_TURNS,
+      env.OLC_MAX_PARKED_TURNS,
+      fileOptions.MAX_PARKED_TURNS,
+      DEFAULTS.MAX_PARKED_TURNS
     ),
     SUSPENDED_TURN_TTL_MS: numberOption(
       options.SUSPENDED_TURN_TTL_MS,

--- a/packages/olc/src/core/__tests__/chat-route.test.ts
+++ b/packages/olc/src/core/__tests__/chat-route.test.ts
@@ -62,12 +62,14 @@ const createFakeBackend = (
     abort: number
     ensureReady: number
     reasoningEfforts: Array<ReasoningEffort | undefined>
+    startedMessages: unknown[][]
   } = {
     startTurn: 0,
     dispose: 0,
     abort: 0,
     ensureReady: 0,
-    reasoningEfforts: []
+    reasoningEfforts: [],
+    startedMessages: [] as unknown[][]
   }
   let nextId = 0
 
@@ -207,6 +209,7 @@ const createFakeBackend = (
     startTurn: async (input) => {
       calls.startTurn += 1
       calls.reasoningEfforts.push(input.reasoningEffort)
+      calls.startedMessages.push(input.messages as unknown[])
       nextId += 1
       const turn = new FakeTurn(
         `turn_${nextId}`,
@@ -225,12 +228,15 @@ const createFakeBackend = (
 interface Harness {
   url: string
   server: Server
+  routes: ReturnType<typeof registerChatRoutes>
   calls: {
     startTurn: number
     dispose: number
     abort: number
     ensureReady: number
     reasoningEfforts: Array<ReasoningEffort | undefined>
+    /** The messages each turn was started with, in order. */
+    startedMessages: unknown[][]
   }
   pending: PendingToolCalls
 }
@@ -265,7 +271,7 @@ const startHarness = async (
   router.get("/health", (_request, response) =>
     sendJson(response, 200, { status: "ok" })
   )
-  registerChatRoutes(router, {
+  const routes = registerChatRoutes(router, {
     backend,
     config,
     log: () => {},
@@ -280,7 +286,7 @@ const startHarness = async (
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
   const { port } = server.address() as AddressInfo
 
-  return { url: `http://127.0.0.1:${port}`, server, calls, pending }
+  return { url: `http://127.0.0.1:${port}`, server, calls, pending, routes }
 }
 
 interface StreamedTurn {
@@ -905,5 +911,234 @@ describe("chat completions", () => {
       { Authorization: "Bearer secret" }
     )
     expect(accepted.finishReason).toBe("stop")
+  })
+})
+
+/**
+ * A browser-agent run, as the proxy sees it.
+ *
+ * Every step is one request that declares a decision tool, gets the call back
+ * as a `tool_calls` delta, and never returns a result: the extension parses
+ * the decision and starts the next step as a fresh conversation. Nothing in
+ * the wire says so, which is why the proxy cannot conclude the client has
+ * moved on — it can only refuse to hold an unbounded number of the sessions
+ * such a run leaves behind.
+ */
+const oneShotDecision = (harness: Harness, step: number) =>
+  streamTurn(harness.url, {
+    model: "fake/model-a",
+    stream: true,
+    messages: [
+      { role: "system", content: "decide one action" },
+      { role: "user", content: `step ${step}` }
+    ],
+    tools: [{ type: "function", function: { name: "list_tabs" } }]
+  })
+
+describe("a client that never resumes its turns", () => {
+  it("does not accumulate a parked session per decision", async () => {
+    harness = await startHarness({ mode: "tool" })
+
+    for (let step = 1; step <= 12; step += 1) {
+      const decision = await oneShotDecision(harness, step)
+      expect(decision.finishReason).toBe("tool_calls")
+      expect(decision.toolCalls).toHaveLength(1)
+    }
+
+    // Bounded by the cap rather than growing with the run: twelve steps used
+    // to leave twelve live backend sessions parked for ten minutes each.
+    const held = harness.routes.inspect()
+    expect(held.parkedTurns).toBeLessThanOrEqual(
+      resolveConfig({}).MAX_PARKED_TURNS
+    )
+    expect(held.pendingCalls).toBe(held.parkedTurns)
+  })
+
+  it("keeps answering after a long run rather than blocking on what it left", async () => {
+    harness = await startHarness({ mode: "tool" })
+    for (let step = 1; step <= 12; step += 1) {
+      await oneShotDecision(harness, step)
+    }
+    // The queue slot is released when a turn suspends, so the run's own steps
+    // never queued behind each other; this asserts the twelfth answers as the
+    // first did rather than waiting behind eleven parked sessions.
+    const last = await oneShotDecision(harness, 13)
+    expect(last.status).toBe(200)
+    expect(last.finishReason).toBe("tool_calls")
+  })
+
+  it("discards the oldest parked turn first", async () => {
+    harness = await startHarness({ mode: "tool" }, { MAX_PARKED_TURNS: 2 })
+    const first = await oneShotDecision(harness, 1)
+    const second = await oneShotDecision(harness, 2)
+    await oneShotDecision(harness, 3)
+
+    // The oldest is gone, so its result is refused rather than joined to
+    // whatever turn happens to be live now.
+    const stale = await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [
+        { role: "user", content: "step 1" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: first.toolCalls[0]?.id,
+              type: "function",
+              function: first.toolCalls[0]?.function
+            }
+          ]
+        },
+        {
+          role: "tool",
+          tool_call_id: first.toolCalls[0]?.id,
+          content: "two tabs"
+        }
+      ],
+      tools: [{ type: "function", function: { name: "list_tabs" } }]
+    })
+    expect(stale.status).toBe(400)
+    expect(stale.content).toContain("StaleToolResults")
+    expect(second.toolCalls[0]?.id).toBeDefined()
+  })
+
+  it("leaves nothing held once the proxy shuts down", async () => {
+    harness = await startHarness({ mode: "tool" })
+    await oneShotDecision(harness, 1)
+    await oneShotDecision(harness, 2)
+    expect(harness.routes.inspect().parkedTurns).toBeGreaterThan(0)
+
+    await harness.routes.shutdown()
+
+    // Both the parked turn and its call settle, and the backend is told to
+    // drop the session rather than being left to a timer nobody will see.
+    expect(harness.routes.inspect()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+    expect(harness.calls.dispose).toBeGreaterThanOrEqual(2)
+  })
+})
+
+/**
+ * Every way a turn can end has to leave the proxy holding nothing.
+ *
+ * A response that stopped is not a session that settled: a backend turn is a
+ * live session and a parked call is a promise something is awaiting, and a
+ * test that asserted only the response body could not tell one from the
+ * other. `inspect` is what makes the difference visible.
+ */
+describe("terminal paths settle the session and the slot", () => {
+  const held = () => harness?.routes.inspect()
+
+  it("settles a plain answer", async () => {
+    harness = await startHarness({ mode: "answer", answer: "all good" })
+    const turn = await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: askedForTabs
+    })
+    expect(turn.finishReason).toBe("stop")
+    expect(held()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+    expect(harness.calls.dispose).toBe(1)
+  })
+
+  it("settles a turn the backend failed", async () => {
+    harness = await startHarness({ mode: "fail" })
+    const turn = await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: askedForTabs
+    })
+    expect(turn.error ?? turn.status).toBeTruthy()
+    expect(held()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+  })
+
+  it("settles a model the catalog does not have", async () => {
+    harness = await startHarness({ mode: "answer" })
+    const turn = await streamTurn(harness.url, {
+      model: "fake/not-a-model",
+      stream: true,
+      messages: askedForTabs
+    })
+    expect(turn.status).toBe(400)
+    // Refused before a session was ever started, so nothing to settle.
+    expect(harness.calls.startTurn).toBe(0)
+    expect(held()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+  })
+
+  it("settles a resumed turn once its result is delivered", async () => {
+    harness = await startHarness({ mode: "tool" })
+    const first = await oneShotDecision(harness, 1)
+    const call = first.toolCalls[0]
+    expect(held()).toMatchObject({ parkedTurns: 1, pendingCalls: 1 })
+
+    const resumed = await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [
+        { role: "user", content: "step 1" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: call?.id, type: "function", function: call?.function }
+          ]
+        },
+        { role: "tool", tool_call_id: call?.id, content: "two tabs" }
+      ],
+      tools: [{ type: "function", function: { name: "list_tabs" } }]
+    })
+    expect(resumed.finishReason).toBe("stop")
+    expect(held()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+  })
+})
+
+describe("images the client attached", () => {
+  it("reaches the backend as a part, not flattened into the text", async () => {
+    /**
+     * An `image_url` part carries no `text`, so a message flattened to a
+     * string drops it and leaves the model answering about a picture it never
+     * saw. Asserted here, through the route, and not only over the wire
+     * helper: this is the path a vision agent decision actually takes.
+     */
+    harness = await startHarness({ mode: "answer", answer: "a cat" })
+    const dataUrl = "data:image/png;base64,AAAA"
+    await streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "what is in this picture?" },
+            { type: "image_url", image_url: { url: dataUrl } }
+          ]
+        }
+      ]
+    })
+
+    const started = JSON.stringify(harness.calls.startedMessages.at(-1))
+    expect(started).toContain("what is in this picture?")
+    expect(started).toContain(dataUrl)
   })
 })

--- a/packages/olc/src/core/__tests__/chat-route.test.ts
+++ b/packages/olc/src/core/__tests__/chat-route.test.ts
@@ -1004,6 +1004,58 @@ describe("a client that never resumes its turns", () => {
     expect(second.toolCalls[0]?.id).toBeDefined()
   })
 
+  it("settles a turn whose resume is still queued when the proxy shuts down", async () => {
+    /**
+     * A resuming turn is taken out of the parked map — a request carrying its
+     * results already exists, so its deadlines are suspended — which meant a
+     * shutdown that walked that map alone left the session, the hold and the
+     * suspended calls behind. The calls were the worst of it: their timers
+     * were cleared on the way in, so nothing was ever going to settle them.
+     */
+    harness = await startHarness({ mode: "tool" })
+    const first = await oneShotDecision(harness, 1)
+    const call = first.toolCalls[0]
+
+    // Occupy the single-flight slot so the resume below waits behind it, which
+    // is the window the hold exists for.
+    const slow = streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [{ role: "user", content: SLOW_TURN_MARKER }]
+    })
+    const resumed = streamTurn(harness.url, {
+      model: "fake/model-a",
+      stream: true,
+      messages: [
+        { role: "user", content: "step 1" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: call?.id, type: "function", function: call?.function }
+          ]
+        },
+        { role: "tool", tool_call_id: call?.id, content: "two tabs" }
+      ],
+      tools: [{ type: "function", function: { name: "list_tabs" } }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    expect(harness.routes.inspect()).toMatchObject({
+      parkedTurns: 0,
+      resumeHolds: 1,
+      pendingCalls: 1
+    })
+
+    await harness.routes.shutdown()
+    expect(harness.routes.inspect()).toEqual({
+      parkedTurns: 0,
+      pendingCalls: 0,
+      resumeHolds: 0
+    })
+    await slow
+    await resumed
+  })
+
   it("leaves nothing held once the proxy shuts down", async () => {
     harness = await startHarness({ mode: "tool" })
     await oneShotDecision(harness, 1)

--- a/packages/olc/src/core/chat-route.ts
+++ b/packages/olc/src/core/chat-route.ts
@@ -432,6 +432,50 @@ export const registerChatRoutes = (
   }
 
   /**
+   * Bound how many turns may sit parked on a client tool result.
+   *
+   * A parked turn is a live backend session, and only its own ten-minute TTL
+   * used to end one. That is fine for a turn a client abandoned once, and
+   * wrong for a client whose every request is a single decision it never
+   * resumes: a browser-agent run left one session parked per step, all of
+   * them at once, and the runtime's own session bookkeeping pays for that.
+   *
+   * A bound rather than a guess. "This request carries no tool results, so
+   * the client has moved on" is not true — a client may legitimately start a
+   * fresh turn while still computing the result for one it left parked, and
+   * discarding on that basis throws away work it is about to hand back.
+   * What can be said without guessing is that unbounded is wrong, so the
+   * oldest parked turns above the cap are discarded when a fresh one is
+   * admitted, oldest first.
+   *
+   * A turn with an outstanding resume hold is never reaped: a request
+   * carrying its results already exists and may be queued behind this one.
+   */
+  const reapExcessParkedTurns = async (requestId: string): Promise<number> => {
+    const reapable = [...parkedTurns.keys()].filter(
+      (turnId) => !resumeHolds.has(turnId)
+    )
+    /** Room for the turn about to be admitted, so the steady state is the cap. */
+    const excess = reapable.length - Math.max(0, config.MAX_PARKED_TURNS - 1)
+    if (excess <= 0) return 0
+    for (const turnId of reapable.slice(0, excess)) {
+      clearParked(turnId)
+      pending.failTurn(
+        turnId,
+        "The proxy discarded this parked turn to stay within its parked-turn limit"
+      )
+      const turn = backend.findTurn(turnId)
+      if (turn) await discardTurn(turn, { abort: true })
+    }
+    log("Discarded parked turns above the limit", {
+      requestId,
+      discarded: excess,
+      limit: config.MAX_PARKED_TURNS
+    })
+    return excess
+  }
+
+  /**
    * Which live turn, if any, a request's trailing tool results continue.
    *
    * Resolved twice per request: once to answer the client quickly, and again inside
@@ -830,6 +874,16 @@ export const registerChatRoutes = (
           sendStaleToolResults(response, requestId, toolResults)
           return Promise.resolve()
         }
+        if (!current.resumeTurn) {
+          return reapExcessParkedTurns(requestId).then(() =>
+            runChatRequest({
+              body,
+              response,
+              requestId,
+              signal
+            })
+          )
+        }
         return runChatRequest({
           body,
           response,
@@ -872,10 +926,22 @@ export const registerChatRoutes = (
   })
 
   return {
+    /**
+     * What the route is still holding. Every terminal path is supposed to
+     * leave both at zero, and a test that asserts the response alone cannot
+     * tell a settled turn from one that merely stopped answering.
+     */
+    inspect: () => ({
+      parkedTurns: parkedTurns.size,
+      pendingCalls: pending.size,
+      resumeHolds: resumeHolds.size
+    }),
     shutdown: async () => {
-      for (const turnId of parkedTurns.keys()) {
+      for (const turnId of [...parkedTurns.keys()]) {
         pending.failTurn(turnId, "The proxy is shutting down")
         clearParked(turnId)
+        const turn = backend.findTurn(turnId)
+        if (turn) await discardTurn(turn, { abort: true })
       }
     }
   }

--- a/packages/olc/src/core/chat-route.ts
+++ b/packages/olc/src/core/chat-route.ts
@@ -936,10 +936,28 @@ export const registerChatRoutes = (
       pendingCalls: pending.size,
       resumeHolds: resumeHolds.size
     }),
+    /**
+     * Settle everything still held, not just what is parked.
+     *
+     * `holdTurn` takes a resuming turn out of `parkedTurns` — its deadline is
+     * suspended because a request carrying its results already exists — so a
+     * shutdown that walked that map alone left a live session, its suspended
+     * calls and its hold behind. The calls are the worst of the three: their
+     * timers were cleared on the way in, so nothing was ever going to settle
+     * them and whatever the backend awaited would hang for the life of the
+     * process. The registry is asked as well, for a call parked against a
+     * turn that is neither parked nor held.
+     */
     shutdown: async () => {
-      for (const turnId of [...parkedTurns.keys()]) {
-        pending.failTurn(turnId, "The proxy is shutting down")
+      const held = new Set([
+        ...parkedTurns.keys(),
+        ...resumeHolds.keys(),
+        ...pending.turnIds()
+      ])
+      for (const turnId of held) {
         clearParked(turnId)
+        resumeHolds.delete(turnId)
+        pending.failTurn(turnId, "The proxy is shutting down")
         const turn = backend.findTurn(turnId)
         if (turn) await discardTurn(turn, { abort: true })
       }

--- a/packages/olc/src/core/pending-tool-calls.ts
+++ b/packages/olc/src/core/pending-tool-calls.ts
@@ -101,6 +101,11 @@ export class PendingToolCalls {
     return claimed.sort((left, right) => left.createdAt - right.createdAt)
   }
 
+  /** Every turn with a call still parked. */
+  turnIds(): string[] {
+    return [...new Set([...this.calls.values()].map((call) => call.turnId))]
+  }
+
   hasPending(turnId: string): boolean {
     for (const call of this.calls.values()) {
       if (call.turnId === turnId) return true

--- a/packages/olc/src/types.ts
+++ b/packages/olc/src/types.ts
@@ -99,6 +99,8 @@ export interface ProxyConfig {
   BRIDGE_CALL_TIMEOUT_MS: number
   BRIDGE_BATCH_MS: number
   SUSPENDED_TURN_TTL_MS: number
+  /** How many turns may sit parked on a client tool result at once. */
+  MAX_PARKED_TURNS: number
   DEBUG: boolean
 }
 


### PR DESCRIPTION
PR 10 of the 0.14.0 agent plan.

**The leak.** Every chat request without trailing tool results starts a backend turn, and a turn whose tools the runtime calls is parked waiting for the result. The browser agent sends a full conversation per step and treats the tool call it gets back as that step's answer — so it never resumes. Only each turn's own `SUSPENDED_TURN_TTL_MS` (ten minutes) ended one, which meant a twenty-five-step run held twenty-five live runtime sessions at once.

**Why it is a bound and not a rule.** My first fix concluded that a request carrying no tool results meant the client had moved on, and discarded its parked turns. Two existing tests say otherwise, correctly: a client may legitimately start a fresh turn while still computing the result for one it left parked, and there is nothing in the wire that distinguishes that from abandonment. So the number is bounded instead — `MAX_PARKED_TURNS` (default 4), oldest discarded first when a fresh turn is admitted, never one whose resume request already exists. Raise it for a client that genuinely interleaves.

**Terminal paths.** `ChatRoutes.inspect()` reports the parked turns, pending calls and resume holds still held, because a response that stopped is not a session that ended — a test asserting only the body cannot tell them apart. Covered: plain answer, backend failure, unknown model, resumed turn, shutdown. Shutdown now disposes the turns it fails rather than leaving them to a timer nobody will see.

**Also verified rather than assumed:** the decision tool round trip over 13 consecutive one-shot steps; an `image_url` part reaching the backend through the route (not just the wire helper) so a vision decision cannot be silently flattened to text; the `MAX_PARKED_TURNS` precedence chain.

**Scope I did not claim.** "Context limits" amounts to the catalog publishing `context_length` for the client to size against, plus an over-long prompt surfacing as an error — both already covered; there is no proxy-side truncation to test. Cancellation keeps its existing queue and client-gone coverage. The pass criterion names OpenCode and Codex specifically, and this is verified against the fake backend that exists to exercise the core; a measured run through both real runtimes belongs to PR 11's evaluation.

`typecheck`, `lint:check`, `test:run` (4570, 352 in olc) pass.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds abandoned tool-calling sessions while preserving legitimate interleaved resumes, adds explicit terminal-state inspection, and makes shutdown settle every held turn and pending call.

- Adds configurable `MAX_PARKED_TURNS` handling with oldest-first eviction.
- Covers unresumed decision loops, queued resumes during shutdown, terminal cleanup, configuration precedence, and image-part preservation.
- Documents parked-turn lifecycle and configuration behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the prior zero-cap behavior is corrected and shutdown now settles resume-held turns as required.

No actionable new failure remains. The zero-cap previous finding is fully fixed by enforcing a minimum of one, and the shutdown implementation now covers parked turns, resume holds, and pending-call owners. The earlier shutdown thread was manually resolved without explanation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/olc/src/core/chat-route.ts | Adds serialized parked-turn eviction, route-state inspection, and comprehensive shutdown cleanup across parked, resume-held, and pending-call-owned turns. |
| packages/olc/src/core/pending-tool-calls.ts | Exposes unique pending-call turn IDs so shutdown can settle turns absent from the parked map. |
| packages/olc/src/config.ts | Adds the parked-turn cap and clamps it to the documented minimum of one. |
| packages/olc/src/core/__tests__/chat-route.test.ts | Adds coverage for bounded unresumed decisions, eviction order, shutdown lifecycle, terminal cleanup, and multimodal message forwarding. |
| packages/olc/src/__tests__/config.test.ts | Verifies cap defaults, precedence, negative-input fallback, and zero-value clamping. |
| packages/olc/README.md | Documents parked-turn semantics, limits, precedence, and the minimum supported cap. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Chat completion request] --> B{Trailing tool results?}
  B -->|Yes, live owner| C[Hold parked turn]
  C --> D[Enter single-flight queue]
  D --> E[Re-resolve owning turn]
  E --> F[Resume backend turn]
  F --> G{Calls another tool?}
  G -->|Yes| H[Park turn and release queue]
  G -->|No| I[Dispose completed turn]
  B -->|No| J[Enter single-flight queue]
  J --> K[Reap oldest excess parked turns]
  K --> L[Start fresh backend turn]
  L --> G
  M[Shutdown] --> N[Union parked turns, resume holds, and pending-call owners]
  N --> O[Fail calls, abort, and dispose turns]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(olc): settle resume-held turns at sh..."](https://github.com/shishir435/ollama-client/commit/049ba79c19935de80a4dd65d9b73d336a9d8b27a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62759499)</sub>

<!-- /greptile_comment -->