### PR TITLE
fix(agent): evidence the benchmark scenarios and stop them breaking unseen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,16 @@ jobs:
       - name: Verify isolated service-worker turn recovery
         run: E2E_HEADFUL=1 xvfb-run --auto-servernum pnpm verify:sw-turn-recovery
 
+      - name: Verify isolated service-worker Agent recovery
+        run: E2E_HEADFUL=1 xvfb-run --auto-servernum pnpm verify:sw-agent-recovery
+
+      # Not a threshold gate — it records what happened. It is run here because
+      # it still asserts, and an ungated project is one nothing tells you about:
+      # the completion-evidence rule broke two of its three scenarios and only
+      # a manual run found out.
+      - name: Record the agent benchmark on the fixture model
+        run: pnpm e2e:chromium:agent-benchmark
+
       # Traces, videos, and the HTML report are only worth minutes and storage
       # when something failed.
       - name: Upload failure artifacts

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -71,7 +71,7 @@ const record = (
 
 const clickContinue = (observation: AgentFixtureObservation) =>
   observation.text.includes("Status: Active")
-    ? { type: "complete", summary: "Active" }
+    ? { type: "complete", summary: "Active", evidence: "Status: Active" }
     : {
         type: "click",
         ref: agentFixtureElement(
@@ -128,7 +128,7 @@ runAgentScenario({
     )
     return field && !field.value
       ? { type: "clear_and_type", ref: field.ref, text: "Alice" }
-      : { type: "complete", summary: "Filled." }
+      : { type: "complete", summary: "Filled.", evidence: "Alice" }
   },
   verify: (outcome) => {
     record("form-preparation", "benchmark form-preparation", startedAt, outcome)


### PR DESCRIPTION
Found while starting PR 11. Small and worth landing ahead of it.

The completion-evidence rule from #383 broke two of the three benchmark scenarios — both change the page, so both now owe a citation and neither had one. `release/0.14.0` has been failing that project since it merged.

Nothing reported it: the benchmark project is not in the `@critical` gate, and a manual run is what found it. That is the second time an ungated path hid my own breakage, so CI runs it now — not as a threshold gate, which it deliberately is not, but because it still asserts, and a project that asserts and is never run is one nothing tells you about. It takes eleven seconds.

The Agent worker-recovery runner joins the same job while I am there; it had only been wired into `e2e:release:run`, where the turn runner it mirrors was already in the PR gate.

Verified: `pnpm e2e:chromium:agent-benchmark` 3/3, lint, typecheck, tooling-workflow tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs two agent benchmark scenarios for the completion-evidence requirement and adds previously ungated benchmark and worker-recovery coverage to CI.
- Adds grounded evidence for the status-change and form-preparation benchmark completions.
- Runs isolated service-worker Agent recovery in the pull-request E2E job.
- Runs the fixture-model agent benchmark so its assertions cannot regress unnoticed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the benchmark evidence is correctly grounded and the added CI commands have the required environment and artifacts.

No actionable failures remain: the evidence values represent observable post-mutation state, and the new CI steps invoke existing isolated runners under compatible job setup.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the Agent worker-recovery runner and fixture-model benchmark to the existing Chromium E2E job with the required setup already available. |
| e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts | Supplies post-action evidence that conforms to the runtime’s completion-grounding rules for both affected scenarios. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): evidence the benchmark scena..."](https://github.com/shishir435/ollama-client/commit/a401d1d181ce140526c87cbe29d66b894b314a1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62771581)</sub>

<!-- /greptile_comment -->