### PR TITLE
feat(agent): comparative evaluation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -861,13 +861,20 @@ the tables by hand.
   percentage. Tasks are declared `gated: false`, which is what makes a stalled
   run a recorded row instead of a failed test; the run that did not finish is
   the most interesting result and throwing would leave it out.
-- **A task scores itself from the page, not from the run.** Every task carries
-  a `succeeded` predicate that reads the page afterwards. False completion
-  cannot be counted any other way, since the thing being measured is precisely
-  the run's verdict being wrong. Its counterpart — goal met, never claimed —
+- **A task scores itself independently of the run.** Every task carries a
+  `succeeded` predicate: for an effect it reads the page, and for a reading
+  task it requires the page to state a fact *and* the answer to carry it.
+  False completion cannot be counted any other way, since the thing being
+  measured is precisely the run's verdict being wrong — and
+  `Boolean(run.result)` is not a scorer at all, because `result` is the
+  model's own summary and exists whenever a completion was accepted. Its counterpart — goal met, never claimed —
   is counted too, against the status the task *declared*, because some tasks
   are meant to pause and scoring those as missed would call the right answer a
   failure.
+- **A live pass runs the whole suite.** The critical suite's hosted matrix
+  deliberately runs only a couple of its tasks, and applying that skip to the
+  benchmark left a hosted run recording nothing and writing no report — the
+  opposite of the point. The skip applies to gated scenarios only.
 - **CI runs the fixture pass.** Not as a threshold gate, which it is not, but
   because it asserts, and the completion-evidence rule broke two of its
   scenarios while nothing was running it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -848,6 +848,30 @@ Branch promotion has three stages: `release/*` → `preview` → `main`. Merge a
 - `tools/README.md` documents command ownership and prerequisites. `check:static` is shared by CI and local verification; `verify:ci-parity` runs static checks and coverage on committed HEAD in a clean worktree.
 - Never bypass with `--no-verify`. If a hook fails, fix the cause.
 
+## Measured agent behaviour
+
+`AGENT_EVALUATION.md` holds the published numbers and the named remaining
+failures; regenerate it from the two benchmark projects rather than editing
+the tables by hand.
+
+- **The benchmark records, the gates assert.** `chromium-agent-benchmark` and
+  `chromium-agent-benchmark-dom` run the same thirty frozen tasks with and
+  without the `debugger` permission — the second is the browser Firefox gives
+  us — and write counts, never rates: a handful of attempts cannot support a
+  percentage. Tasks are declared `gated: false`, which is what makes a stalled
+  run a recorded row instead of a failed test; the run that did not finish is
+  the most interesting result and throwing would leave it out.
+- **A task scores itself from the page, not from the run.** Every task carries
+  a `succeeded` predicate that reads the page afterwards. False completion
+  cannot be counted any other way, since the thing being measured is precisely
+  the run's verdict being wrong. Its counterpart — goal met, never claimed —
+  is counted too, against the status the task *declared*, because some tasks
+  are meant to pause and scoring those as missed would call the right answer a
+  failure.
+- **CI runs the fixture pass.** Not as a threshold gate, which it is not, but
+  because it asserts, and the completion-evidence rule broke two of its
+  scenarios while nothing was running it.
+
 ## Constraints
 
 - MV3 CSP blocks dynamic eval; WASM is allowed via `'wasm-unsafe-eval'`. ONNX Runtime is bundled, never fetched.

--- a/AGENT_EVALUATION.md
+++ b/AGENT_EVALUATION.md
@@ -21,9 +21,22 @@ canvas-and-visual, multi-tab, dialogs-and-recovery.
 
 Each task declares the page it runs against, the decisions a scripted model
 makes, the status it expects to finish in, and — the part a gate does not
-have — a predicate that reads the page afterwards to say whether the goal was
-actually met. That predicate is why false completion can be counted at all:
-the run's own verdict cannot be the scorer.
+have — a predicate that scores it independently of what the run claimed. That
+predicate is why false completion can be counted at all: the run's own verdict
+cannot be the scorer.
+
+For a task with an effect, the predicate reads the page: the field holds the
+value, the document says saved, the status appeared. For a reading task the
+deliverable *is* the answer, so the predicate requires the page to state a
+fact and the run's answer to carry it — both halves, so a drifted fixture
+fails rather than passing vacuously.
+
+The first version of this suite scored several tasks as `Boolean(run.result)`,
+which is the model's own completion summary: an accepted completion produced
+one by construction, so the scorer agreed with the run every time and could
+not have detected the thing it exists to detect. Re-measuring with grounded
+predicates did not move any number below — but before the fix, those numbers
+were not evidence.
 
 The suite runs twice. Once with the debugger attached, which is the native
 input backend, and once against a build with the `debugger` permission
@@ -103,8 +116,13 @@ Named rather than rounded away. Each is reproducible from the suite.
 
 - **A live model.** Every number above is from a scripted model, so it
   measures the runtime and not model capability. `AGENT_HOSTED_MODEL` and
-  `AGENT_HOSTED_BASE_URL` point the same suite at a real provider, and
-  `AGENT_BENCHMARK_ATTEMPTS` repeats it; no live pass has been published here.
+  `AGENT_HOSTED_BASE_URL` point the same suite at a real provider and
+  `AGENT_BENCHMARK_ATTEMPTS` repeats it. That path is exercised — one task run
+  against `qwen3.5:latest` through Ollama completed and scored, taking 3.6
+  minutes where the scripted model takes 2.7 seconds — but no live table is
+  published here. At that rate a full pass is hours, and mixing measured
+  runtime numbers with a partial capability sample would make the table say
+  less than it appears to.
 - **Tokens.** Read from the provider's own counts when it reports them
   (`prompt_eval_count`, `eval_count`), which a scripted fixture does not, so
   the columns are empty above rather than zero. Nothing is estimated.

--- a/AGENT_EVALUATION.md
+++ b/AGENT_EVALUATION.md
@@ -1,0 +1,117 @@
+# Agent evaluation
+
+Measured results for the supervised browser agent. Every number here came out
+of a run; none is a target, a projection or an estimate. Where something is
+not known, it says so.
+
+Regenerate with:
+
+```bash
+pnpm build && pnpm exec playwright test --project=chromium-agent-benchmark
+pnpm exec playwright test --project=chromium-agent-benchmark-dom
+```
+
+Both write JSON and a markdown table to `artifacts/e2e/benchmark/`.
+
+## What is measured
+
+Thirty tasks across ten families, frozen: read-and-extract, single-action,
+form-preparation, editors, delayed-save, frames, shadow-roots,
+canvas-and-visual, multi-tab, dialogs-and-recovery.
+
+Each task declares the page it runs against, the decisions a scripted model
+makes, the status it expects to finish in, and — the part a gate does not
+have — a predicate that reads the page afterwards to say whether the goal was
+actually met. That predicate is why false completion can be counted at all:
+the run's own verdict cannot be the scorer.
+
+The suite runs twice. Once with the debugger attached, which is the native
+input backend, and once against a build with the `debugger` permission
+stripped, which is the browser Firefox gives us. The comparison is the point;
+neither pass is the reference.
+
+| column | meaning |
+| --- | --- |
+| completed | the run reported the goal met |
+| goal met | the task's own predicate confirmed it from the page |
+| false completions | reported complete, predicate says otherwise |
+| missed completions | predicate says met, the run never claimed it |
+
+## Results — scripted model, 2026-09-10
+
+One attempt per task per backend. A scripted model is deterministic, so
+repetition measures nothing here; `AGENT_BENCHMARK_ATTEMPTS` exists for a live
+model, where it does.
+
+| family | n | completed (cdp / dom) | goal met (cdp / dom) | false | missed | median ms (cdp / dom) |
+| --- | --- | --- | --- | --- | --- | --- |
+| canvas-and-visual | 3 | 3 / 1 | 3 / 1 | 0 / 0 | 0 / 0 | 2879 / 32531 |
+| delayed-save | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 1 / 1 | 6441 / 6472 |
+| dialogs-and-recovery | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 2918 / 2904 |
+| editors | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2913 / 2943 |
+| form-preparation | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2923 / 2950 |
+| frames | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 0 / 0 | 2848 / 2970 |
+| multi-tab | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 4402 / 4330 |
+| read-and-extract | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2654 / 2630 |
+| shadow-roots | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2895 / 2941 |
+| single-action | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2922 / 2945 |
+
+Totals, including the task that writes the report:
+
+- **native backend** — 27 of 31 attempts reported completion, 29 met the
+  predicate, **0 false completions**, 1 missed.
+- **DOM backend** — 25 of 31 reported completion, 27 met the predicate,
+  **0 false completions**, 1 missed.
+
+### The measured capability gain
+
+`canvas-and-visual` is the only family the two backends disagree on: 3 of 3
+with the debugger, 1 of 3 without, and a median that goes from 2.9 seconds to
+32.5 seconds because the two failing attempts spend their time stalling. The
+cause is direct — no debugger means no `Page.captureScreenshot`, the
+visible-tab fallback needs the controlled tab to be frontmost and it is not,
+so no picture travels, `click_point` and `zoom` are never offered, and a task
+that can only be done visually cannot be done.
+
+Nothing else differs. The other nine families use semantic targets, and a
+semantic target resolves the same either way — which is the design working,
+not a null result: native input exists for the gestures a page can tell
+apart, and none of these tasks needs one.
+
+## Remaining failures
+
+Named rather than rounded away. Each is reproducible from the suite.
+
+1. **A click that opens a native dialog cannot be settled.**
+   `dialogs-and-recovery/native-confirm` pauses with `unresolved_effect` on
+   both backends. The click's own handler calls `confirm()`, which blocks the
+   renderer, so the action can neither finish nor be confirmed and the run
+   pauses before it ever sees the dialog it caused. Dialogs the run finds
+   already open are handled; one its own click raises is not. The
+   file-chooser case has a receipt flag for exactly this shape
+   (`AgentExecutionReceipt.fileChooser`) and a dialog needs the equivalent.
+2. **`multi-tab/go-back` fails with `verification_failed` on both backends.**
+   Not yet diagnosed. Recorded rather than guessed at.
+3. **An over-claiming run can exhaust its budget instead of recovering.**
+   `delayed-save/claims-before-it-lands` claims completion the moment Save is
+   pressed. The claim is correctly refused every time — 0 false completions is
+   the whole point — but the run spends its no-progress budget repeating it and
+   fails, on a page that did save. It is counted as a missed completion, which
+   is the honest label: the opposite error to a false one, and a real failure.
+
+## What is not measured yet
+
+- **A live model.** Every number above is from a scripted model, so it
+  measures the runtime and not model capability. `AGENT_HOSTED_MODEL` and
+  `AGENT_HOSTED_BASE_URL` point the same suite at a real provider, and
+  `AGENT_BENCHMARK_ATTEMPTS` repeats it; no live pass has been published here.
+- **Tokens.** Read from the provider's own counts when it reports them
+  (`prompt_eval_count`, `eval_count`), which a scripted fixture does not, so
+  the columns are empty above rather than zero. Nothing is estimated.
+- **Approval counts across backends.** Recorded per family in the JSON, not
+  yet compared; the two passes ask the same approvals because policy does not
+  depend on the backend.
+- **Recovery under real worker loss.** Covered by
+  `pnpm verify:sw-agent-recovery`, which kills a service worker for real, and
+  is a gate rather than a measurement — it belongs to the recovery gates, not
+  to this table.

--- a/AGENT_EVALUATION.md
+++ b/AGENT_EVALUATION.md
@@ -19,6 +19,9 @@ Thirty tasks across ten families, frozen: read-and-extract, single-action,
 form-preparation, editors, delayed-save, frames, shadow-roots,
 canvas-and-visual, multi-tab, dialogs-and-recovery.
 
+Every scorer reads the page. Nothing in the suite scores a task on the run's
+own completion summary alone.
+
 Each task declares the page it runs against, the decisions a scripted model
 makes, the status it expects to finish in, and — the part a gate does not
 have — a predicate that scores it independently of what the run claimed. That
@@ -37,6 +40,13 @@ one by construction, so the scorer agreed with the run every time and could
 not have detected the thing it exists to detect. Re-measuring with grounded
 predicates did not move any number below — but before the fix, those numbers
 were not evidence.
+
+One task had no honest scorer available at all, because its page had no
+controls and so nothing it did could be observed. It was rewritten rather
+than scored loosely: the run now asks which account, and then has to click
+the one it was told, which the page records. Asking is only half the
+behaviour worth measuring; acting on the answer is the half that leaves a
+mark.
 
 The suite runs twice. Once with the debugger attached, which is the native
 input backend, and once against a build with the `debugger` permission
@@ -58,16 +68,16 @@ model, where it does.
 
 | family | n | completed (cdp / dom) | goal met (cdp / dom) | false | missed | median ms (cdp / dom) |
 | --- | --- | --- | --- | --- | --- | --- |
-| canvas-and-visual | 3 | 3 / 1 | 3 / 1 | 0 / 0 | 0 / 0 | 2879 / 32531 |
-| delayed-save | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 1 / 1 | 6441 / 6472 |
-| dialogs-and-recovery | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 2918 / 2904 |
-| editors | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2913 / 2943 |
-| form-preparation | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2923 / 2950 |
-| frames | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 0 / 0 | 2848 / 2970 |
-| multi-tab | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 4402 / 4330 |
-| read-and-extract | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2654 / 2630 |
-| shadow-roots | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2895 / 2941 |
-| single-action | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2922 / 2945 |
+| canvas-and-visual | 3 | 3 / 1 | 3 / 1 | 0 / 0 | 0 / 0 | 2887 / 32454 |
+| delayed-save | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 1 / 1 | 6448 / 6394 |
+| dialogs-and-recovery | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 2959 / 2911 |
+| editors | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2920 / 2934 |
+| form-preparation | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2908 / 2938 |
+| frames | 3 | 2 / 2 | 3 / 3 | 0 / 0 | 0 / 0 | 2887 / 2942 |
+| multi-tab | 3 | 2 / 2 | 2 / 2 | 0 / 0 | 0 / 0 | 4444 / 4412 |
+| read-and-extract | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2903 / 2691 |
+| shadow-roots | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2936 / 2918 |
+| single-action | 3 | 3 / 3 | 3 / 3 | 0 / 0 | 0 / 0 | 2911 / 2906 |
 
 Totals, including the task that writes the report:
 

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -18,6 +18,8 @@ import {
   named,
   observableButton,
   page,
+  reportsFact,
+  reportsFactFromAnyTab,
   showsActiveStatus
 } from "../benchmark-tasks"
 
@@ -55,8 +57,8 @@ task({
   goal: "Report the status shown on the page.",
   status: "completed",
   html: () => page("<h1>Account</h1><p>Status: Active</p>"),
-  decide: () => ({ type: "complete", summary: "Active" }),
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  decide: () => ({ type: "complete", summary: "Status: Active" }),
+  succeeded: reportsFact("Status: Active")
 })
 
 task({
@@ -71,8 +73,7 @@ task({
     observation.text.includes("Account 4471")
       ? { type: "complete", summary: "Account 4471" }
       : { type: "extract_text" },
-  succeeded: (outcome) =>
-    Boolean(outcome.snapshot?.run?.result?.includes("4471"))
+  succeeded: reportsFact("Account 4471")
 })
 
 task({
@@ -86,9 +87,9 @@ task({
     ),
   decide: (observation) =>
     observation.text.includes("Status: Active")
-      ? { type: "complete", summary: "Active" }
+      ? { type: "complete", summary: "Status: Active" }
       : { type: "inspect", target: "details" },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  succeeded: reportsFact("Status: Active")
 })
 
 // ── 2. single-action ────────────────────────────────────────────────────────
@@ -249,8 +250,14 @@ task({
     }
     return clickNamed(observation, "Save")
   },
-  succeeded: async (outcome) =>
-    (await outcome.page.locator("#doc").innerText()).includes("Done.")
+  succeeded: async (outcome) => {
+    const rendered = await outcome.page.locator("main").innerText()
+    return (
+      rendered.includes("Done.") &&
+      rendered.includes("Saved: ") &&
+      (await outcome.page.locator("#doc").innerText()).includes("Done.")
+    )
+  }
 })
 
 task({
@@ -275,6 +282,9 @@ task({
     return clickNamed(observation, "Save")
   },
   succeeded: async (outcome) =>
+    (await outcome.page.locator("main").innerText()).includes(
+      "Saved: Rewritten."
+    ) &&
     (await outcome.page.locator("#doc").innerText()).trim() === "Rewritten."
 })
 
@@ -453,9 +463,9 @@ task({
     ),
   decide: (observation) =>
     observation.text.includes("Status: Active")
-      ? { type: "complete", summary: "Active" }
+      ? { type: "complete", summary: "Status: Active" }
       : { type: "extract_text" },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  succeeded: reportsFact("Status: Active")
 })
 
 // ── 8. canvas-and-visual ────────────────────────────────────────────────────
@@ -517,9 +527,9 @@ task({
   decide: (_observation, context) => {
     expect(context.images).toBe(0)
     expect(context.actions).not.toContain("click_point")
-    return { type: "complete", summary: "Active" }
+    return { type: "complete", summary: "Status: Active" }
   },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  succeeded: reportsFact("Status: Active")
 })
 
 // ── 9. multi-tab ────────────────────────────────────────────────────────────
@@ -537,14 +547,14 @@ task({
       : page('<a href="/details">Details</a>'),
   decide: (observation) => {
     if (observation.text.includes("Status: Active")) {
-      return { type: "complete", summary: "Active" }
+      return { type: "complete", summary: "Status: Active" }
     }
     const link = named(observation, "Details")
     return link?.href
       ? { type: "open_tab", url: link.href }
       : { type: "fail", reason: "No link to follow." }
   },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  succeeded: reportsFactFromAnyTab("Status: Active")
 })
 
 task({
@@ -559,9 +569,9 @@ task({
   navigationDelayMs: (path) => (path.startsWith("/details") ? 900 : 0),
   decide: (observation) =>
     observation.text.includes("Status: Active")
-      ? { type: "complete", summary: "Active" }
+      ? { type: "complete", summary: "Status: Active" }
       : clickNamed(observation, "Details"),
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  succeeded: reportsFactFromAnyTab("Status: Active")
 })
 
 task({
@@ -578,7 +588,8 @@ task({
     if (observation.text.includes("Details")) return { type: "back" }
     return { type: "complete", summary: "Home" }
   },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  /** Back means back: the tab has to be showing Home again, not just say so. */
+  succeeded: reportsFact("Home")
 })
 
 // ── 10. dialogs-and-recovery ────────────────────────────────────────────────
@@ -624,7 +635,13 @@ task({
     context.step === 1
       ? { type: "ask_user", question: "Which of the two accounts?" }
       : { type: "complete", summary: "Used the second account." },
-  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  /**
+   * The page never changes, so the durable evidence is the answer the *user*
+   * gave — not model-authored — and that the run's own summary reflects it.
+   */
+  succeeded: (outcome) =>
+    outcome.snapshot?.run?.answers?.length === 1 &&
+    Boolean(outcome.snapshot?.run?.result?.includes("second account"))
 })
 
 task({
@@ -673,8 +690,8 @@ benchmarkTask(
     goal: "Report the status shown on the page.",
     status: "completed",
     html: () => page("<p>Status: Active</p>"),
-    decide: () => ({ type: "complete", summary: "Active" }),
-    succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+    decide: () => ({ type: "complete", summary: "Status: Active" }),
+    succeeded: reportsFact("Status: Active")
   },
   (outcome) => {
     if (outcome.attempt < benchmarkAttempts) return

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -626,22 +626,44 @@ task({
 
 task({
   family: "dialogs-and-recovery",
-  name: "ask-when-ambiguous",
-  goal: "Pick the right account.",
+  name: "ask-then-act-on-the-answer",
+  goal: "Select the right account.",
   status: "completed",
   answer: "Use the second account.",
-  html: () => page("<h1>Accounts</h1><p>Two accounts exist.</p>"),
-  decide: (_observation, context) =>
-    context.step === 1
-      ? { type: "ask_user", question: "Which of the two accounts?" }
-      : { type: "complete", summary: "Used the second account." },
   /**
-   * The page never changes, so the durable evidence is the answer the *user*
-   * gave — not model-authored — and that the run's own summary reflects it.
+   * The page has to be able to show which account was chosen.
+   *
+   * This task used to run against a page with no controls at all, so nothing
+   * it did could be observed and the only things left to score were the
+   * answer the harness itself supplied and the model's own summary — which
+   * is not a scorer. Asking the user is only half the behaviour worth
+   * measuring; acting on what they said is the other half, and it is the
+   * half that leaves a mark.
    */
-  succeeded: (outcome) =>
-    outcome.snapshot?.run?.answers?.length === 1 &&
-    Boolean(outcome.snapshot?.run?.result?.includes("second account"))
+  html: () =>
+    page(
+      `<h1>Accounts</h1>
+       <button type="button" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Chose: first</p>')">First account</button>
+       <button type="button" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p><p>Chose: second</p>')">Second account</button>`
+    ),
+  decide: (observation, context) => {
+    if (observation.text.includes("Chose: second")) {
+      return {
+        type: "complete",
+        summary: "Chose: second",
+        evidence: "Chose: second"
+      }
+    }
+    return context.step === 1
+      ? { type: "ask_user", question: "Which of the two accounts?" }
+      : clickNamed(observation, "Second account")
+  },
+  succeeded: async (outcome) => {
+    const rendered = await outcome.page.locator("main").innerText()
+    return (
+      rendered.includes("Chose: second") && !rendered.includes("Chose: first")
+    )
+  }
 })
 
 task({

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -42,7 +42,7 @@ import {
 const attempts: AgentAttemptRecord[] = []
 
 /** Frozen: what the suite declares, checked before a report is written. */
-const TASKS = 15
+const TASKS = 30
 
 const task = (input: Parameters<typeof benchmarkTask>[1]) =>
   benchmarkTask(attempts, input)
@@ -354,6 +354,309 @@ task({
     return { type: "complete", summary: "Saved." }
   },
   succeeded: savedIndicator
+})
+
+// ── 6. frames ───────────────────────────────────────────────────────────────
+
+const panelHost = '<iframe src="/panel" title="panel"></iframe>'
+
+task({
+  family: "frames",
+  name: "same-origin-child",
+  goal: "Click Continue inside the embedded panel and report the status.",
+  status: "completed",
+  html: (path) =>
+    path.startsWith("/panel") ? page(observableButton()) : page(panelHost),
+  decide: clickThenReport(),
+  succeeded: async (outcome) =>
+    (
+      await outcome.page.frameLocator("iframe").locator("main").innerText()
+    ).includes("Status: Active")
+})
+
+task({
+  family: "frames",
+  name: "child-with-form",
+  goal: "Fill the given field inside the embedded panel. Do not submit.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: (path) =>
+    path.startsWith("/panel") ? fieldPage(["given"]) : page(panelHost),
+  decide: fillFields(["given"]),
+  succeeded: fieldsFilled(["given"], "iframe")
+})
+
+task({
+  family: "frames",
+  name: "srcdoc-cannot-be-read",
+  goal: "Click Continue inside the embedded panel and report the status.",
+  status: "paused",
+  html: () =>
+    page(
+      `<iframe srcdoc="${page(observableButton()).replaceAll('"', "&quot;")}"></iframe>`
+    ),
+  /**
+   * A `srcdoc` frame has no origin of its own, so the run may not read it and
+   * has to say so rather than guess. Asking is the correct outcome; the report
+   * records which it did.
+   */
+  decide: () => ({
+    type: "ask_user",
+    question: "The panel cannot be read. Should I act on the page instead?"
+  }),
+  succeeded: (outcome) => outcome.snapshot?.run?.status === "paused"
+})
+
+// ── 7. shadow-roots ─────────────────────────────────────────────────────────
+
+const shadowPage = (inner: string) =>
+  page(
+    `<div id="host"></div><script>
+      document.getElementById('host').attachShadow({ mode: 'open' }).innerHTML =
+        ${JSON.stringify(inner)}
+    </script>`
+  )
+
+task({
+  family: "shadow-roots",
+  name: "button-in-open-root",
+  goal: "Click Continue and report the status.",
+  status: "completed",
+  html: () => shadowPage(observableButton()),
+  decide: clickThenReport(),
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "shadow-roots",
+  name: "field-in-open-root",
+  goal: "Fill the given field. Do not submit.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => shadowPage('<label for="given">given</label><input id="given">'),
+  decide: fillFields(["given"]),
+  succeeded: async (outcome) =>
+    (await outcome.page.locator("#host #given").inputValue()) === "value-given"
+})
+
+task({
+  family: "shadow-roots",
+  name: "slotted-text",
+  goal: "Report the status the component shows.",
+  status: "completed",
+  html: () =>
+    page(
+      `<div id="host"><p>Status: Active</p></div><script>
+        document.getElementById('host').attachShadow({ mode: 'open' }).innerHTML =
+          '<slot></slot>'
+      </script>`
+    ),
+  decide: (observation) =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active" }
+      : { type: "extract_text" },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+// ── 8. canvas-and-visual ────────────────────────────────────────────────────
+
+const boardPage = page(
+  `<canvas id="board" width="320" height="160" style="background:#ccc" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>')"></canvas>`
+)
+
+task({
+  family: "canvas-and-visual",
+  name: "click-a-point",
+  goal: "Click the left half of the board and report the status.",
+  status: "completed",
+  approvalScope: "run_origin",
+  vision: true,
+  html: () => boardPage,
+  decide: (observation, context) =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active", evidence: "Status: Active" }
+      : {
+          type: "click_point",
+          x: Math.round((context.screenshot?.width ?? 640) / 4),
+          y: Math.round((context.screenshot?.height ?? 320) / 4)
+        },
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "canvas-and-visual",
+  name: "zoom-then-click",
+  goal: "Look closely at the board, then click its left half.",
+  status: "completed",
+  approvalScope: "run_origin",
+  vision: true,
+  html: () => boardPage,
+  decide: (observation, context) => {
+    if (observation.text.includes("Status: Active")) {
+      return { type: "complete", summary: "Active", evidence: "Status: Active" }
+    }
+    if (context.step === 1) {
+      return { type: "zoom", x: 0, y: 0, width: 160, height: 80 }
+    }
+    return {
+      type: "click_point",
+      x: Math.round((context.screenshot?.width ?? 640) / 4),
+      y: Math.round((context.screenshot?.height ?? 320) / 4)
+    }
+  },
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "canvas-and-visual",
+  name: "text-only-model",
+  goal: "Report the status shown beside the board.",
+  status: "completed",
+  html: () => page(`${boardPage}<p>Status: Active</p>`),
+  /** No picture is taken for a model that cannot read one, and none offered. */
+  decide: (_observation, context) => {
+    expect(context.images).toBe(0)
+    expect(context.actions).not.toContain("click_point")
+    return { type: "complete", summary: "Active" }
+  },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+// ── 9. multi-tab ────────────────────────────────────────────────────────────
+
+const detailsPage = page("<h1>Details</h1><p>Status: Active</p>")
+
+task({
+  family: "multi-tab",
+  name: "open-a-tab",
+  goal: "Open the details page and report the status.",
+  status: "completed",
+  html: (path) =>
+    path.startsWith("/details")
+      ? detailsPage
+      : page('<a href="/details">Details</a>'),
+  decide: (observation) => {
+    if (observation.text.includes("Status: Active")) {
+      return { type: "complete", summary: "Active" }
+    }
+    const link = named(observation, "Details")
+    return link?.href
+      ? { type: "open_tab", url: link.href }
+      : { type: "fail", reason: "No link to follow." }
+  },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+task({
+  family: "multi-tab",
+  name: "follow-a-slow-link",
+  goal: "Go to the details page and report the status.",
+  status: "completed",
+  html: (path) =>
+    path.startsWith("/details")
+      ? detailsPage
+      : page('<a href="/details">Details</a>'),
+  navigationDelayMs: (path) => (path.startsWith("/details") ? 900 : 0),
+  decide: (observation) =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active" }
+      : clickNamed(observation, "Details"),
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+task({
+  family: "multi-tab",
+  name: "go-back",
+  goal: "Read the details page, then come back and report the heading.",
+  status: "completed",
+  html: (path) =>
+    path.startsWith("/details")
+      ? detailsPage
+      : page('<h1>Home</h1><a href="/details">Details</a>'),
+  decide: (observation, context) => {
+    if (context.step === 1) return clickNamed(observation, "Details")
+    if (observation.text.includes("Details")) return { type: "back" }
+    return { type: "complete", summary: "Home" }
+  },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+// ── 10. dialogs-and-recovery ────────────────────────────────────────────────
+
+task({
+  family: "dialogs-and-recovery",
+  name: "confirm-inside-a-modal",
+  goal: "Delete the item, confirming when asked.",
+  status: "completed",
+  html: () =>
+    page(
+      `<button type="button" onclick="document.getElementById('confirm').hidden=false;this.disabled=true">Delete</button>
+       <div id="confirm" role="dialog" aria-label="Confirm delete" hidden>
+         <p>Delete this item?</p>
+         <button type="button" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>');this.closest('[role=dialog]').hidden=true">Confirm</button>
+         <button type="button">Cancel</button>
+       </div>`
+    ),
+  decide: (observation) => {
+    if (observation.text.includes("Status: Active")) {
+      return {
+        type: "complete",
+        summary: "Deleted",
+        evidence: "Status: Active"
+      }
+    }
+    const confirm = named(observation, "Confirm")
+    return confirm && !confirm.hidden
+      ? { type: "click", ref: confirm.ref }
+      : clickNamed(observation, "Delete")
+  },
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "dialogs-and-recovery",
+  name: "ask-when-ambiguous",
+  goal: "Pick the right account.",
+  status: "completed",
+  answer: "Use the second account.",
+  html: () => page("<h1>Accounts</h1><p>Two accounts exist.</p>"),
+  decide: (_observation, context) =>
+    context.step === 1
+      ? { type: "ask_user", question: "Which of the two accounts?" }
+      : { type: "complete", summary: "Used the second account." },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+task({
+  family: "dialogs-and-recovery",
+  name: "native-confirm",
+  goal: "Delete the item, confirming when the browser asks.",
+  status: "completed",
+  html: () =>
+    page(
+      `<button type="button" onclick="if (confirm('Delete this item?')) document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>')">Delete</button>`
+    ),
+  /**
+   * A native dialog blocks the page and only an attached debugger sees one, so
+   * this task is expected to behave differently on the two backends. That is
+   * the point of it: the report says what each did rather than one of them
+   * being declared wrong.
+   */
+  decide: (observation) => {
+    if (observation.text.includes("Status: Active")) {
+      return {
+        type: "complete",
+        summary: "Deleted",
+        evidence: "Status: Active"
+      }
+    }
+    const dialog = observation.dialogs?.[0]
+    if (dialog) {
+      return { type: "handle_dialog", dialogId: dialog.id, accept: true }
+    }
+    return clickNamed(observation, "Delete")
+  },
+  succeeded: showsActiveStatus
 })
 
 // ── the report ──────────────────────────────────────────────────────────────

--- a/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
+++ b/e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts
@@ -1,143 +1,383 @@
-import type { AgentFixtureObservation } from "../../fixtures/agent-scenario"
-import {
-  agentConfirmingButton,
-  agentFixtureElement,
-  runAgentScenario
+import type {
+  AgentFixtureObservation,
+  AgentScenarioOutcome
 } from "../../fixtures/agent-scenario"
+import { agentFixtureElement } from "../../fixtures/agent-scenario"
 import { expect } from "../../fixtures/extension"
 import type { AgentAttemptRecord } from "../agent-benchmark"
+import { writeAgentBenchmarkReport } from "../agent-benchmark"
 import {
-  approvalsAsked,
-  countRepeatedTargets,
-  recordAttempt,
-  writeAgentBenchmarkReport
-} from "../agent-benchmark"
+  benchmarkAttempts,
+  benchmarkModel,
+  benchmarkTask,
+  clickNamed,
+  clickThenReport,
+  fieldPage,
+  fieldsFilled,
+  fillFields,
+  named,
+  observableButton,
+  page,
+  showsActiveStatus
+} from "../benchmark-tasks"
 
 /**
- * The frozen benchmark: one attempt per task family, recorded rather than
- * asserted.
+ * The frozen evaluation suite, recorded rather than gated.
  *
- * Deliberately not tagged `@critical`. A gate says pass or fail; this says
- * what happened, in counts a later pass can be compared against, and the
- * thresholds in the plan's section 01 are meant to be assigned from a clean
- * pass rather than guessed before one exists. It is also why nothing here
- * publishes a rate: a handful of attempts cannot support one.
+ * A gate says pass or fail. This says what happened, in counts a later pass
+ * can be compared against, on the same tasks across both input backends — the
+ * DOM one every browser has and the native one only an attached debugger
+ * gives. Two passes over one suite is what turns "native input is better"
+ * into a number instead of a claim.
+ *
+ * Nothing here publishes a rate. A handful of attempts cannot support one, and
+ * the point of the exercise is that the numbers are measured rather than
+ * asserted in advance.
+ *
+ * Every task carries a predicate that reads the page, because the number that
+ * matters most is false completion — a run reporting success on a page that
+ * never changed — and the run's own verdict cannot be the scorer.
  */
 
 const attempts: AgentAttemptRecord[] = []
 
-/**
- * Derived from the one variable that actually changes how a scenario runs, so
- * a fixture pass cannot be labelled hosted. A report whose backend field is
- * whatever an operator typed is a report that cannot be compared.
- */
-const backend = process.env.AGENT_HOSTED_MODEL
-  ? `hosted:${process.env.AGENT_HOSTED_MODEL}`
-  : "fixture"
+/** Frozen: what the suite declares, checked before a report is written. */
+const TASKS = 15
 
-const record = (
-  family: string,
-  scenario: string,
-  startedAt: number,
-  outcome: Parameters<Parameters<typeof runAgentScenario>[0]["verify"]>[0]
-): void => {
-  const run = outcome.snapshot?.run
-  const steps = outcome.snapshot?.steps ?? []
-  const asked = approvalsAsked(outcome.messages)
-  const targets = countRepeatedTargets(steps)
-  recordAttempt(attempts, {
-    family,
-    scenario,
-    attempt: 1,
-    backend,
-    terminalStatus: run?.status ?? "unknown",
-    ...(run?.pauseReason ? { pauseReason: run.pauseReason } : {}),
-    ...(run?.error?.code ? { errorCode: run.error.code } : {}),
-    steps: new Set(steps.map((step) => step.stepId)).size,
-    observations: run?.observationCount ?? 0,
-    modelCalls: outcome.wire.length,
-    approvalsAsked: asked.length,
-    approvalsGranted: run?.grants?.length ?? 0,
-    repeatedTargets: targets.repeated,
-    ambiguousTargets: targets.ambiguous,
-    wallMs: Date.now() - startedAt,
-    ...(run?.error?.code
-      ? { firstLimitation: run.error.code }
-      : run?.pauseReason
-        ? { firstLimitation: run.pauseReason }
-        : {})
-  })
-}
+const task = (input: Parameters<typeof benchmarkTask>[1]) =>
+  benchmarkTask(attempts, input)
 
-const clickContinue = (observation: AgentFixtureObservation) =>
-  observation.text.includes("Status: Active")
-    ? { type: "complete", summary: "Active" }
-    : {
-        type: "click",
-        ref: agentFixtureElement(
-          observation,
-          (element) => element.name === "Continue"
-        )?.ref
-      }
+// ── 1. read-and-extract ─────────────────────────────────────────────────────
 
-let startedAt = Date.now()
-
-runAgentScenario({
-  name: "benchmark read-and-extract",
-  gated: false,
+task({
+  family: "read-and-extract",
+  name: "visible-status",
   goal: "Report the status shown on the page.",
   status: "completed",
-  html: () =>
-    "<!doctype html><title>Benchmark read</title><main><h1>Account</h1><p>Status: Active</p></main>",
+  html: () => page("<h1>Account</h1><p>Status: Active</p>"),
   decide: () => ({ type: "complete", summary: "Active" }),
-  verify: (outcome) => {
-    record("read-and-extract", "benchmark read-and-extract", startedAt, outcome)
-    startedAt = Date.now()
-    expect(outcome.snapshot?.run?.status).toBe("completed")
-  }
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
 })
 
-runAgentScenario({
-  name: "benchmark single-action",
-  gated: false,
-  goal: "Click Continue and report the status.",
+task({
+  family: "read-and-extract",
+  name: "below-the-fold",
+  goal: "Report the account number, which is further down the page.",
   status: "completed",
   html: () =>
-    `<!doctype html><title>Benchmark click</title><main>${agentConfirmingButton()}</main>`,
-  decide: clickContinue,
-  verify: (outcome) => {
-    record("single-action", "benchmark single-action", startedAt, outcome)
-    startedAt = Date.now()
-    // One click, never two: the whole series exists to keep this true.
-    expect(countRepeatedTargets(outcome.snapshot?.steps ?? []).repeated).toBe(0)
-  }
+    page(`<h1>Account</h1>${"<p>filler</p>".repeat(120)}<p>Account 4471</p>`),
+  decide: (observation) =>
+    observation.documentText?.includes("Account 4471") ||
+    observation.text.includes("Account 4471")
+      ? { type: "complete", summary: "Account 4471" }
+      : { type: "extract_text" },
+  succeeded: (outcome) =>
+    Boolean(outcome.snapshot?.run?.result?.includes("4471"))
 })
 
-runAgentScenario({
-  name: "benchmark form-preparation",
-  gated: false,
-  goal: "Fill in the name field. Do not submit.",
+task({
+  family: "read-and-extract",
+  name: "region-inspection",
+  goal: "Report the status inside the details region.",
+  status: "completed",
+  html: () =>
+    page(
+      `<section aria-label="details"><p>Status: Active</p></section>${'<button type="button">noise</button>'.repeat(40)}`
+    ),
+  decide: (observation) =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active" }
+      : { type: "inspect", target: "details" },
+  succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+})
+
+// ── 2. single-action ────────────────────────────────────────────────────────
+
+task({
+  family: "single-action",
+  name: "button-with-consequence",
+  goal: "Click Continue and report the status.",
+  status: "completed",
+  html: () => page(observableButton()),
+  decide: clickThenReport(),
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "single-action",
+  name: "checkbox",
+  goal: "Tick the newsletter box and report the status.",
+  status: "completed",
+  html: () =>
+    page(
+      '<label for="news">Newsletter</label><input id="news" type="checkbox" onchange="document.querySelector(\'main\').insertAdjacentHTML(\'beforeend\',\'<p>Status: Active</p>\')">'
+    ),
+  decide: (observation) =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active", evidence: "Status: Active" }
+      : { type: "check", ref: named(observation, "Newsletter")?.ref },
+  succeeded: showsActiveStatus
+})
+
+task({
+  family: "single-action",
+  name: "menu-then-option",
+  goal: "Open the actions menu, choose Approve, and report the status.",
+  status: "completed",
+  html: () =>
+    page(
+      `<button type="button" role="button" onclick="document.getElementById('menu').hidden=false">Actions</button>
+       <div id="menu" role="menu" aria-label="actions" hidden>
+         <button type="button" role="menuitem" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>');document.getElementById('menu').hidden=true">Approve</button>
+       </div>`
+    ),
+  decide: (observation) => {
+    if (observation.text.includes("Status: Active")) {
+      return { type: "complete", summary: "Active", evidence: "Status: Active" }
+    }
+    const approve = named(observation, "Approve")
+    return approve && !approve.hidden
+      ? { type: "click", ref: approve.ref }
+      : clickNamed(observation, "Actions")
+  },
+  succeeded: showsActiveStatus
+})
+
+// ── 3. form-preparation ─────────────────────────────────────────────────────
+
+task({
+  family: "form-preparation",
+  name: "single-field",
+  goal: "Fill in the given field. Do not submit.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => fieldPage(["given"]),
+  decide: fillFields(["given"]),
+  succeeded: fieldsFilled(["given"])
+})
+
+task({
+  family: "form-preparation",
+  name: "three-fields-one-grant",
+  goal: "Fill in all three fields. Do not submit.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => fieldPage(["given", "family", "city"]),
+  decide: fillFields(["given", "family", "city"]),
+  succeeded: fieldsFilled(["given", "family", "city"])
+})
+
+task({
+  family: "form-preparation",
+  name: "select-and-check",
+  goal: "Choose the south region, accept the terms, and report the status.",
   status: "completed",
   approvalScope: "run_origin",
   html: () =>
-    '<!doctype html><title>Benchmark form</title><main><div><label for="given">given</label><input id="given" name="given"></div></main>',
-  decide(observation: AgentFixtureObservation) {
-    const field = agentFixtureElement(
-      observation,
-      (element) => element.name === "given"
-    )
-    return field && !field.value
-      ? { type: "clear_and_type", ref: field.ref, text: "Alice" }
-      : { type: "complete", summary: "Filled." }
+    page(
+      '<label for="region">region</label><select id="region"><option value="">pick</option><option value="south">South</option></select>' +
+        '<label for="terms">terms</label><input id="terms" type="checkbox" onchange="document.querySelector(\'main\').insertAdjacentHTML(\'beforeend\',\'<p>Status: Active</p>\')">'
+    ),
+  decide: (observation) => {
+    if (observation.text.includes("Status: Active")) {
+      return { type: "complete", summary: "Active", evidence: "Status: Active" }
+    }
+    const region = named(observation, "region")
+    if (region && region.value !== "south") {
+      return { type: "select", ref: region.ref, value: "south" }
+    }
+    return { type: "check", ref: named(observation, "terms")?.ref }
   },
-  verify: (outcome) => {
-    record("form-preparation", "benchmark form-preparation", startedAt, outcome)
-    startedAt = Date.now()
-    // Checked before writing, so a retry that lost an earlier scenario
-    // cannot produce a report that looks complete.
-    expect(attempts).toHaveLength(3)
-    expect(writeAgentBenchmarkReport(attempts, backend)).toContain(
-      "agent-benchmark-"
-    )
-  }
+  succeeded: showsActiveStatus
 })
+
+// ── 4. editors ──────────────────────────────────────────────────────────────
+
+const reportPage = page(
+  '<div id="doc" contenteditable="true">The quick brown fax jumps.</div>' +
+    "<button type=\"button\" onclick=\"document.querySelector('main').insertAdjacentHTML('beforeend','<p>Saved: '+document.getElementById('doc').textContent+'</p>')\">Save</button>",
+  "Report"
+)
+
+const editor = (observation: AgentFixtureObservation) =>
+  agentFixtureElement(
+    observation,
+    (element) => element.type === "contenteditable"
+  )
+
+task({
+  family: "editors",
+  name: "replace-then-save",
+  goal: "Fix the typo 'fax' to 'fox' in the report, then save it.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => reportPage,
+  decide: (observation) => {
+    if (observation.text.includes("Saved: The quick brown fox jumps.")) {
+      return {
+        type: "complete",
+        summary: "Saved",
+        evidence: "Saved: The quick brown fox jumps."
+      }
+    }
+    const host = editor(observation)
+    if (host?.value?.includes("fax")) {
+      return { type: "replace_text", ref: host.ref, find: "fax", text: "fox" }
+    }
+    return clickNamed(observation, "Save")
+  },
+  succeeded: async (outcome) =>
+    (await outcome.page.locator("main").innerText()).includes(
+      "Saved: The quick brown fox jumps."
+    )
+})
+
+task({
+  family: "editors",
+  name: "append-then-save",
+  goal: "Add ' Done.' to the end of the report, then save it.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => reportPage,
+  decide: (observation) => {
+    if (observation.text.includes("Saved: ")) {
+      return { type: "complete", summary: "Saved", evidence: "Saved: " }
+    }
+    const host = editor(observation)
+    if (host && !host.value?.includes("Done.")) {
+      return { type: "type", ref: host.ref, text: " Done." }
+    }
+    return clickNamed(observation, "Save")
+  },
+  succeeded: async (outcome) =>
+    (await outcome.page.locator("#doc").innerText()).includes("Done.")
+})
+
+task({
+  family: "editors",
+  name: "clear-and-retype",
+  goal: "Replace the whole report with 'Rewritten.' and save it.",
+  status: "completed",
+  approvalScope: "run_origin",
+  html: () => reportPage,
+  decide: (observation) => {
+    if (observation.text.includes("Saved: Rewritten.")) {
+      return {
+        type: "complete",
+        summary: "Saved",
+        evidence: "Saved: Rewritten."
+      }
+    }
+    const host = editor(observation)
+    if (host && host.value !== "Rewritten.") {
+      return { type: "clear_and_type", ref: host.ref, text: "Rewritten." }
+    }
+    return clickNamed(observation, "Save")
+  },
+  succeeded: async (outcome) =>
+    (await outcome.page.locator("#doc").innerText()).trim() === "Rewritten."
+})
+
+// ── 5. delayed-save ─────────────────────────────────────────────────────────
+
+const delayedSavePage = (delayMs: number | null) =>
+  page(
+    `<p id="status">Unsaved changes</p><button type="button" onclick="
+      document.getElementById('status').textContent='Saving…';this.disabled=true;
+      ${delayMs === null ? "" : `setTimeout(()=>{document.getElementById('status').textContent='All changes saved'},${delayMs});`}
+    ">Save</button>`,
+    "Editor"
+  )
+
+const savedIndicator = async (
+  outcome: AgentScenarioOutcome
+): Promise<boolean> =>
+  (await outcome.page.locator("#status").innerText()).includes(
+    "All changes saved"
+  )
+
+const saveThenWait = (observation: AgentFixtureObservation) => {
+  if (observation.text.includes("All changes saved")) {
+    return {
+      type: "complete",
+      summary: "Saved.",
+      evidence: "All changes saved"
+    }
+  }
+  const save = named(observation, "Save")
+  if (save && !save.disabled) return { type: "click", ref: save.ref }
+  return { type: "wait", condition: "All changes saved", timeoutMs: 8_000 }
+}
+
+task({
+  family: "delayed-save",
+  name: "short-delay",
+  goal: "Save the document.",
+  status: "completed",
+  html: () => delayedSavePage(400),
+  decide: saveThenWait,
+  succeeded: savedIndicator
+})
+
+task({
+  family: "delayed-save",
+  name: "long-delay",
+  goal: "Save the document.",
+  status: "completed",
+  html: () => delayedSavePage(2_500),
+  decide: saveThenWait,
+  succeeded: savedIndicator
+})
+
+task({
+  family: "delayed-save",
+  name: "claims-before-it-lands",
+  goal: "Save the document.",
+  status: "completed",
+  html: () => delayedSavePage(1_200),
+  /**
+   * Claims completion the moment the button is pressed, which is the failure
+   * the outcome layer exists to stop. The run must refuse it and carry on;
+   * the report shows whether it did, and the false-completion column shows
+   * what it cost when it did not.
+   */
+  decide: (observation) => {
+    if (observation.text.includes("All changes saved")) {
+      return {
+        type: "complete",
+        summary: "Saved.",
+        evidence: "All changes saved"
+      }
+    }
+    const save = named(observation, "Save")
+    if (save && !save.disabled) return { type: "click", ref: save.ref }
+    return { type: "complete", summary: "Saved." }
+  },
+  succeeded: savedIndicator
+})
+
+// ── the report ──────────────────────────────────────────────────────────────
+
+/**
+ * Written by the last task, after the count is checked: a pass that lost a
+ * task to a retry must not produce a report that looks complete.
+ */
+benchmarkTask(
+  attempts,
+  {
+    family: "report",
+    name: "write",
+    goal: "Report the status shown on the page.",
+    status: "completed",
+    html: () => page("<p>Status: Active</p>"),
+    decide: () => ({ type: "complete", summary: "Active" }),
+    succeeded: (outcome) => Boolean(outcome.snapshot?.run?.result)
+  },
+  (outcome) => {
+    if (outcome.attempt < benchmarkAttempts) return
+    expect(attempts).toHaveLength((TASKS + 1) * benchmarkAttempts)
+    expect(
+      writeAgentBenchmarkReport(attempts, outcome.backend, benchmarkModel)
+    ).toContain("agent-benchmark-")
+  }
+)

--- a/e2e/chromium/benchmark/agent-benchmark.ts
+++ b/e2e/chromium/benchmark/agent-benchmark.ts
@@ -38,20 +38,54 @@ export interface AgentAttemptRecord {
   wallMs: number
   /** The first thing that stopped it going further, as a label. */
   firstLimitation?: string
+  /**
+   * Whether the goal was actually met, judged from the page by the task's own
+   * predicate rather than from what the run reported. `undefined` for a task
+   * that declares no predicate, which is not the same as false.
+   */
+  succeeded?: boolean
+  /**
+   * The run said it was done and the page says otherwise. The single number
+   * the completion-evidence rule exists to move, and the reason `succeeded`
+   * cannot be the run's own verdict.
+   */
+  falseCompletion?: boolean
+  /** Tokens the provider reported; absent on a scripted fixture. */
+  promptTokens?: number
+  completionTokens?: number
+}
+
+export interface AgentFamilySummary {
+  family: string
+  backend: string
+  attempts: number
+  completed: number
+  /** Attempts whose own predicate confirmed the goal. */
+  succeeded: number
+  /** Attempts that reported completion the page did not support. */
+  falseCompletions: number
+  /**
+   * The other error, and the one a table showing only completions hides: the
+   * goal was met and the run never said so. A run that over-claims, is
+   * refused, and then burns its budget without noticing the page came good
+   * lands here — a real failure, and not the same kind as claiming falsely.
+   */
+  missedCompletions: number
+  medianWallMs: number
+  repeatedTargets: number
+  ambiguousTargets: number
+  approvalsAsked: number
+  /** Absent where nothing reported tokens. */
+  medianPromptTokens?: number
+  medianCompletionTokens?: number
 }
 
 export interface AgentBenchmarkReport {
   measuredAt: string
   backend: string
+  model: string
   attempts: AgentAttemptRecord[]
-  families: {
-    family: string
-    attempts: number
-    completed: number
-    medianWallMs: number
-    repeatedTargets: number
-    ambiguousTargets: number
-  }[]
+  families: AgentFamilySummary[]
 }
 
 const median = (values: number[]): number => {
@@ -105,45 +139,79 @@ export const countRepeatedTargets = (
   return { repeated, ambiguous }
 }
 
+const medianOf = (values: number[]): number | undefined =>
+  values.length > 0 ? median(values) : undefined
+
+/**
+ * One row per family and backend, because the comparison is the point: the
+ * same tasks on the native backend and on the DOM one, side by side, is what
+ * turns "native input is better" into a number.
+ */
 export const summarizeAttempts = (
   attempts: AgentAttemptRecord[]
-): AgentBenchmarkReport["families"] => {
-  const families = new Map<string, AgentAttemptRecord[]>()
+): AgentFamilySummary[] => {
+  const groups = new Map<string, AgentAttemptRecord[]>()
   for (const attempt of attempts) {
-    families.set(attempt.family, [
-      ...(families.get(attempt.family) ?? []),
-      attempt
-    ])
+    const key = `${attempt.family}\u0000${attempt.backend}`
+    groups.set(key, [...(groups.get(key) ?? []), attempt])
   }
-  return [...families.entries()]
-    .map(([family, records]) => ({
-      family,
-      attempts: records.length,
-      completed: records.filter(
-        (record) => record.terminalStatus === "completed"
-      ).length,
-      medianWallMs: median(records.map((record) => record.wallMs)),
-      repeatedTargets: records.reduce(
-        (total, record) => total + record.repeatedTargets,
-        0
-      ),
-      ambiguousTargets: records.reduce(
-        (total, record) => total + record.ambiguousTargets,
-        0
-      )
-    }))
-    .sort((left, right) => left.family.localeCompare(right.family))
+  return [...groups.values()]
+    .map((records) => {
+      const promptTokens = records
+        .map((record) => record.promptTokens)
+        .filter((value): value is number => value !== undefined)
+      const completionTokens = records
+        .map((record) => record.completionTokens)
+        .filter((value): value is number => value !== undefined)
+      const medianPrompt = medianOf(promptTokens)
+      const medianCompletion = medianOf(completionTokens)
+      return {
+        family: records[0].family,
+        backend: records[0].backend,
+        attempts: records.length,
+        completed: records.filter(
+          (record) => record.terminalStatus === "completed"
+        ).length,
+        succeeded: records.filter((record) => record.succeeded === true).length,
+        falseCompletions: records.filter(
+          (record) => record.falseCompletion === true
+        ).length,
+        missedCompletions: records.filter(
+          (record) =>
+            record.succeeded === true && record.terminalStatus !== "completed"
+        ).length,
+        medianWallMs: median(records.map((record) => record.wallMs)),
+        repeatedTargets: records.reduce(
+          (total, record) => total + record.repeatedTargets,
+          0
+        ),
+        ambiguousTargets: records.reduce(
+          (total, record) => total + record.ambiguousTargets,
+          0
+        ),
+        approvalsAsked: records.reduce(
+          (total, record) => total + record.approvalsAsked,
+          0
+        ),
+        ...(medianPrompt === undefined
+          ? {}
+          : { medianPromptTokens: medianPrompt }),
+        ...(medianCompletion === undefined
+          ? {}
+          : { medianCompletionTokens: medianCompletion })
+      }
+    })
+    .sort(
+      (left, right) =>
+        left.family.localeCompare(right.family) ||
+        left.backend.localeCompare(right.backend)
+    )
 }
 
 /**
- * Counts only, and no rate. One pass of a handful of attempts cannot support
- * a success rate, and publishing one from this would be the claim the audit
- * refused to make.
- */
-/**
- * One attempt per family and scenario. Playwright retries a failed test, and
- * a module-level list would then hold the abandoned attempt as well as the
- * one that finished — so a later record for the same scenario replaces the
+ * One attempt per family, scenario and backend. Playwright retries a failed
+ * test, and a module-level list would then hold the abandoned attempt as well
+ * as the one that finished — so a later record for the same key replaces the
  * earlier one rather than joining it.
  */
 export const recordAttempt = (
@@ -153,26 +221,84 @@ export const recordAttempt = (
   const existing = attempts.findIndex(
     (candidate) =>
       candidate.family === attempt.family &&
-      candidate.scenario === attempt.scenario
+      candidate.scenario === attempt.scenario &&
+      candidate.attempt === attempt.attempt &&
+      candidate.backend === attempt.backend
   )
   if (existing >= 0) attempts.splice(existing, 1, attempt)
   else attempts.push(attempt)
 }
 
+/**
+ * The report as a table a person reads.
+ *
+ * Counts and an explicit denominator, never a bare rate: a family run three
+ * times cannot support a percentage, and printing one is the claim this whole
+ * series refuses to make. `n` is in the table so a reader can see what the
+ * number is worth.
+ */
+export const renderAgentBenchmarkMarkdown = (
+  report: AgentBenchmarkReport
+): string => {
+  const lines = [
+    `# Agent benchmark — ${report.backend}`,
+    "",
+    `Measured ${report.measuredAt} against \`${report.model}\`.`,
+    "",
+    "Counts, not rates. `n` is the attempts behind each row.",
+    "",
+    "| family | backend | n | completed | goal met | false completions | missed completions | approvals | repeated targets | median ms | median prompt tk | median output tk |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+  ]
+  for (const family of report.families) {
+    lines.push(
+      `| ${family.family} | ${family.backend} | ${family.attempts} | ${family.completed} | ${family.succeeded} | ${family.falseCompletions} | ${family.missedCompletions} | ${family.approvalsAsked} | ${family.repeatedTargets} | ${family.medianWallMs} | ${family.medianPromptTokens ?? "—"} | ${family.medianCompletionTokens ?? "—"} |`
+    )
+  }
+  const totals = report.families.reduce(
+    (sum, family) => ({
+      attempts: sum.attempts + family.attempts,
+      completed: sum.completed + family.completed,
+      succeeded: sum.succeeded + family.succeeded,
+      falseCompletions: sum.falseCompletions + family.falseCompletions,
+      missedCompletions: sum.missedCompletions + family.missedCompletions
+    }),
+    {
+      attempts: 0,
+      completed: 0,
+      succeeded: 0,
+      falseCompletions: 0,
+      missedCompletions: 0
+    }
+  )
+  lines.push(
+    "",
+    `Across every family: ${totals.completed} of ${totals.attempts} attempts reported completion and ${totals.succeeded} met the task's own predicate. ${totals.falseCompletions} reported a completion the page did not support; ${totals.missedCompletions} met the goal and never said so.`
+  )
+  return `${lines.join("\n")}\n`
+}
+
 export const writeAgentBenchmarkReport = (
   attempts: AgentAttemptRecord[],
-  backend: string
+  backend: string,
+  model = backend
 ): string => {
   const report: AgentBenchmarkReport = {
     measuredAt: new Date().toISOString(),
     backend,
+    model,
     attempts,
     families: summarizeAttempts(attempts)
   }
   const directory = resolve("artifacts/e2e/benchmark")
   mkdirSync(directory, { recursive: true })
-  const path = resolve(directory, `agent-benchmark-${Date.now()}.json`)
+  const stamp = Date.now()
+  const path = resolve(directory, `agent-benchmark-${stamp}.json`)
   writeFileSync(path, JSON.stringify(report, null, 2))
+  writeFileSync(
+    resolve(directory, `agent-benchmark-${stamp}.md`),
+    renderAgentBenchmarkMarkdown(report)
+  )
   return path
 }
 

--- a/e2e/chromium/benchmark/agent-benchmark.ts
+++ b/e2e/chromium/benchmark/agent-benchmark.ts
@@ -18,6 +18,13 @@ export interface AgentAttemptRecord {
   attempt: number
   backend: string
   terminalStatus: string
+  /**
+   * The status the task declares as its finish. Some tasks are meant to pause
+   * — asking about a frame it may not read is the right answer — so a
+   * completion is not the measure for every row, and counting one as missed
+   * would score the correct outcome as a failure.
+   */
+  expectedStatus: string
   /** Why it stopped, when it stopped for a reason. */
   pauseReason?: string
   errorCode?: string
@@ -178,7 +185,9 @@ export const summarizeAttempts = (
         ).length,
         missedCompletions: records.filter(
           (record) =>
-            record.succeeded === true && record.terminalStatus !== "completed"
+            record.succeeded === true &&
+            record.expectedStatus === "completed" &&
+            record.terminalStatus !== "completed"
         ).length,
         medianWallMs: median(records.map((record) => record.wallMs)),
         repeatedTargets: records.reduce(

--- a/e2e/chromium/benchmark/benchmark-tasks.ts
+++ b/e2e/chromium/benchmark/benchmark-tasks.ts
@@ -162,6 +162,45 @@ export const page = (body: string, title = "Benchmark"): string =>
 export const observableButton = (label = "Continue"): string =>
   `<button type="button" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>');this.disabled=true">${label}</button>`
 
+/**
+ * A reading task's answer, checked against what the page actually says.
+ *
+ * `Boolean(run.result)` was circular: `result` is the model's own completion
+ * summary, so an accepted completion produced one by construction and the
+ * scorer agreed with the run every time — the false completion it exists to
+ * catch could never be seen. Both halves are required here: the page has to
+ * state the fact, so a fixture that drifted fails rather than passing
+ * vacuously, and the answer has to carry it.
+ */
+export const reportsFact =
+  (fact: string) =>
+  async (outcome: AgentScenarioOutcome): Promise<boolean> => {
+    const rendered = await outcome.page.locator("body").innerText()
+    return (
+      rendered.includes(fact) &&
+      Boolean(outcome.snapshot?.run?.result?.includes(fact))
+    )
+  }
+
+/**
+ * The same, for a task whose answer is on a page the run opened. The tab it
+ * reported from is not the tab the test drives, so every page in the context
+ * is asked.
+ */
+export const reportsFactFromAnyTab =
+  (fact: string) =>
+  async (outcome: AgentScenarioOutcome): Promise<boolean> => {
+    if (!outcome.snapshot?.run?.result?.includes(fact)) return false
+    for (const open of outcome.page.context().pages()) {
+      try {
+        if ((await open.locator("body").innerText()).includes(fact)) return true
+      } catch {
+        /* A page that closed under us cannot show anything. */
+      }
+    }
+    return false
+  }
+
 export const showsActiveStatus = async (
   outcome: AgentScenarioOutcome
 ): Promise<boolean> =>

--- a/e2e/chromium/benchmark/benchmark-tasks.ts
+++ b/e2e/chromium/benchmark/benchmark-tasks.ts
@@ -62,6 +62,7 @@ export const recordBenchmarkAttempt = async (input: {
   family: string
   scenario: string
   outcome: AgentScenarioOutcome
+  expectedStatus: string
   succeeded?: AgentScenario["succeeded"]
 }): Promise<void> => {
   const { outcome } = input
@@ -83,6 +84,7 @@ export const recordBenchmarkAttempt = async (input: {
     attempt: outcome.attempt,
     backend: outcome.backend,
     terminalStatus: run?.status ?? "unknown",
+    expectedStatus: input.expectedStatus,
     ...(run?.pauseReason ? { pauseReason: run.pauseReason } : {}),
     ...(run?.error?.code ? { errorCode: run.error.code } : {}),
     steps: new Set(steps.map((step) => step.stepId)).size,
@@ -137,6 +139,7 @@ export const benchmarkTask = (
         family,
         scenario,
         outcome,
+        expectedStatus: task.status,
         ...(succeeded ? { succeeded } : {})
       })
       onRecorded?.(outcome)

--- a/e2e/chromium/benchmark/benchmark-tasks.ts
+++ b/e2e/chromium/benchmark/benchmark-tasks.ts
@@ -1,0 +1,218 @@
+import type {
+  AgentFixtureElement,
+  AgentFixtureObservation,
+  AgentScenario,
+  AgentScenarioOutcome
+} from "../fixtures/agent-scenario"
+import {
+  agentFixtureElement,
+  runAgentScenario
+} from "../fixtures/agent-scenario"
+import type { AgentAttemptRecord } from "./agent-benchmark"
+import {
+  approvalsAsked,
+  countRepeatedTargets,
+  recordAttempt
+} from "./agent-benchmark"
+
+/**
+ * How a frozen evaluation task is declared and recorded.
+ *
+ * Separated from the tasks themselves so the two can be read for what they
+ * are: this file is the instrument, and the suite beside it is the thing being
+ * measured. A task states its goal, the page it runs against, the decisions a
+ * scripted model makes, and — the part a gate does not have — a predicate that
+ * reads the page to say whether the goal was actually met.
+ */
+
+export const benchmarkAttempts = Math.max(
+  1,
+  Number.parseInt(process.env.AGENT_BENCHMARK_ATTEMPTS ?? "1", 10) || 1
+)
+
+export const benchmarkModel = process.env.AGENT_HOSTED_MODEL ?? "fixture-agent"
+
+export interface BenchmarkTask
+  extends Pick<
+    AgentScenario,
+    | "goal"
+    | "status"
+    | "html"
+    | "decide"
+    | "succeeded"
+    | "approvalScope"
+    | "vision"
+    | "answer"
+    | "navigationDelayMs"
+    | "hosted"
+  > {
+  family: string
+  name: string
+}
+
+/**
+ * Records one attempt.
+ *
+ * Everything here is a count, a label or a boolean: no page text, no entered
+ * text, no URL. A report that carried page content could not be attached to an
+ * issue, which is the only reason to write one.
+ */
+export const recordBenchmarkAttempt = async (input: {
+  attempts: AgentAttemptRecord[]
+  family: string
+  scenario: string
+  outcome: AgentScenarioOutcome
+  succeeded?: AgentScenario["succeeded"]
+}): Promise<void> => {
+  const { outcome } = input
+  const run = outcome.snapshot?.run
+  const steps = outcome.snapshot?.steps ?? []
+  const targets = countRepeatedTargets(steps)
+  let met: boolean | undefined
+  if (input.succeeded) {
+    try {
+      met = await input.succeeded(outcome)
+    } catch {
+      /** A predicate that cannot read the page has not proved the goal met. */
+      met = false
+    }
+  }
+  recordAttempt(input.attempts, {
+    family: input.family,
+    scenario: input.scenario,
+    attempt: outcome.attempt,
+    backend: outcome.backend,
+    terminalStatus: run?.status ?? "unknown",
+    ...(run?.pauseReason ? { pauseReason: run.pauseReason } : {}),
+    ...(run?.error?.code ? { errorCode: run.error.code } : {}),
+    steps: new Set(steps.map((step) => step.stepId)).size,
+    observations: run?.observationCount ?? 0,
+    modelCalls: outcome.wire.length,
+    approvalsAsked: approvalsAsked(outcome.messages).length,
+    approvalsGranted: run?.grants?.length ?? 0,
+    repeatedTargets: targets.repeated,
+    ambiguousTargets: targets.ambiguous,
+    wallMs: Date.now() - input.outcome.startedAt,
+    ...(met === undefined ? {} : { succeeded: met }),
+    ...(met === undefined
+      ? {}
+      : { falseCompletion: run?.status === "completed" && !met }),
+    ...(outcome.tokens
+      ? {
+          promptTokens: outcome.tokens.prompt,
+          completionTokens: outcome.tokens.completion
+        }
+      : {}),
+    ...(run?.error?.code
+      ? { firstLimitation: run.error.code }
+      : run?.pauseReason
+        ? { firstLimitation: run.pauseReason }
+        : {})
+  })
+}
+
+/**
+ * Declares a task as an ungated scenario that records its outcome.
+ *
+ * `gated: false` is what makes a stalled run a result rather than a failed
+ * test: the run that did not finish is the most interesting row in the table,
+ * and throwing would leave it out and make the pass look better than it was.
+ */
+export const benchmarkTask = (
+  attempts: AgentAttemptRecord[],
+  task: BenchmarkTask,
+  onRecorded?: (outcome: AgentScenarioOutcome) => void
+): void => {
+  const { family, name, succeeded, ...rest } = task
+  const scenario = `${family}/${name}`
+  runAgentScenario({
+    ...rest,
+    ...(succeeded ? { succeeded } : {}),
+    name: scenario,
+    gated: false,
+    attempts: benchmarkAttempts,
+    async verify(outcome) {
+      await recordBenchmarkAttempt({
+        attempts,
+        family,
+        scenario,
+        outcome,
+        ...(succeeded ? { succeeded } : {})
+      })
+      onRecorded?.(outcome)
+    }
+  })
+}
+
+// ── shared page and decision helpers ────────────────────────────────────────
+
+export const named = (
+  observation: AgentFixtureObservation,
+  name: string
+): AgentFixtureElement | undefined =>
+  agentFixtureElement(observation, (element) => element.name === name)
+
+export const page = (body: string, title = "Benchmark"): string =>
+  `<!doctype html><title>${title}</title><main>${body}</main>`
+
+/** A control whose activation is observable: it rewrites the page. */
+export const observableButton = (label = "Continue"): string =>
+  `<button type="button" onclick="document.querySelector('main').insertAdjacentHTML('beforeend','<p>Status: Active</p>');this.disabled=true">${label}</button>`
+
+export const showsActiveStatus = async (
+  outcome: AgentScenarioOutcome
+): Promise<boolean> =>
+  (await outcome.page.locator("main").innerText()).includes("Status: Active")
+
+export const clickNamed = (
+  observation: AgentFixtureObservation,
+  name: string
+): { type: string; ref?: string } => ({
+  type: "click",
+  ref: named(observation, name)?.ref
+})
+
+/** Click the named control, then finish citing the status the page gained. */
+export const clickThenReport =
+  (name = "Continue") =>
+  (observation: AgentFixtureObservation): unknown =>
+    observation.text.includes("Status: Active")
+      ? { type: "complete", summary: "Active", evidence: "Status: Active" }
+      : clickNamed(observation, name)
+
+export const fieldPage = (fields: string[]): string =>
+  page(
+    `<div>${fields
+      .map(
+        (field) =>
+          `<label for="${field}">${field}</label><input id="${field}" name="${field}">`
+      )
+      .join("")}<button type="button">Save</button></div>`
+  )
+
+export const fillFields =
+  (fields: string[]) =>
+  (observation: AgentFixtureObservation): unknown => {
+    const next = fields
+      .map((field) => named(observation, field))
+      .find((element) => element && !element.value)
+    return next
+      ? { type: "clear_and_type", ref: next.ref, text: `value-${next.name}` }
+      : {
+          type: "complete",
+          summary: "Filled.",
+          evidence: `value-${fields.at(-1)}`
+        }
+  }
+
+export const fieldsFilled =
+  (fields: string[], scope = "") =>
+  async (outcome: AgentScenarioOutcome): Promise<boolean> => {
+    for (const field of fields) {
+      const locator = scope
+        ? outcome.page.frameLocator(scope).locator(`#${field}`)
+        : outcome.page.locator(`#${field}`)
+      if ((await locator.inputValue()) !== `value-${field}`) return false
+    }
+    return true
+  }

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -233,8 +233,17 @@ const runAgentScenarioAttempt = (
     const liveBaseUrl =
       process.env.AGENT_HOSTED_BASE_URL ?? "http://127.0.0.1:8084"
     test.setTimeout(liveModel ? 240_000 : (scenario.timeoutMs ?? 60_000))
+    /**
+     * The live matrix runs a couple of the gated tasks, not all of them — one
+     * real model against the whole critical suite is minutes per scenario for
+     * no extra signal. The benchmark is the opposite: a live pass is the
+     * entire point of it, and skipping those left the documented hosted
+     * workflow recording nothing and writing no report at all.
+     */
     test.skip(
-      Boolean(liveModel) && scenario.hosted !== true,
+      Boolean(liveModel) &&
+        scenario.gated !== false &&
+        scenario.hosted !== true,
       "Live model matrix uses form and delayed navigation tasks"
     )
 

--- a/e2e/chromium/fixtures/agent-scenario.ts
+++ b/e2e/chromium/fixtures/agent-scenario.ts
@@ -42,6 +42,8 @@ export interface AgentFixtureElement {
   sensitive?: boolean
   disabled?: boolean
   hidden?: boolean
+  /** A cover sits over it, so a click would land on whatever is on top. */
+  occluded?: boolean
 }
 
 export interface AgentFixtureObservation {
@@ -49,7 +51,13 @@ export interface AgentFixtureObservation {
   title: string
   text: string
   documentText?: string
+  documentTextTruncated?: boolean
   modals?: { id: string; kind: string; label?: string }[]
+  /** Child frames the page holds, with whether the run was able to read each. */
+  frames?: { frameId: number; origin: string; access: string }[]
+  /** Regions the overview left out, so a task can inspect one by name. */
+  omittedByGroup?: { group: string; count: number }[]
+  dialogs?: { id: string; type: string; message: string }[]
   elements: AgentFixtureElement[]
 }
 
@@ -76,6 +84,20 @@ export interface AgentScenarioOutcome {
   effects: () => number
   /** Structural run trace lines the worker logged, oldest first. */
   phases: readonly Record<string, unknown>[]
+  /** Which input backend this pass ran on, from the project that ran it. */
+  backend: string
+  /** 1 for the first run of this task, so a repeated pass can be told apart. */
+  attempt: number
+  /**
+   * When this attempt began, in epoch milliseconds.
+   *
+   * Taken here rather than where a task is declared: a closure initialised at
+   * module load measures from module load, so every first attempt in a pass
+   * was reported as having taken as long as everything before it.
+   */
+  startedAt: number
+  /** Tokens the provider reported, when it reports any; a fixture reports none. */
+  tokens: { prompt: number; completion: number } | undefined
 }
 
 export interface AgentScenario {
@@ -104,6 +126,18 @@ export interface AgentScenario {
   timeoutMs?: number
   html(path: string): string
   navigationDelayMs?(path: string): number
+  /**
+   * Whether the goal is actually met, judged from the page rather than from
+   * what the run claimed.
+   *
+   * Measuring false completion means the run's own verdict cannot be the
+   * scorer. `verify` throws and therefore gates; this answers and therefore
+   * measures, so a benchmark can count a run that reported success on a page
+   * that never changed.
+   */
+  succeeded?(outcome: AgentScenarioOutcome): Promise<boolean> | boolean
+  /** How many times to run this task. Repeats mean something for a live model. */
+  attempts?: number
   decide(
     observation: AgentFixtureObservation,
     context: AgentScenarioContext
@@ -130,14 +164,74 @@ const readObservation = (request: {
   JSON.parse(request.messages.at(-1)?.content ?? "{}")
     .observation as AgentFixtureObservation
 
+/**
+ * Tokens the provider charged for the whole run.
+ *
+ * Read from the responses rather than estimated: Ollama reports
+ * `prompt_eval_count` and `eval_count` per call, and a run's cost is their
+ * sum across its decisions. A scripted fixture reports neither, so the answer
+ * is `undefined` rather than zero — nothing was measured, which is not the
+ * same as nothing being spent.
+ */
+export const reportedTokens = (
+  wire: readonly { response?: string }[]
+): { prompt: number; completion: number } | undefined => {
+  let prompt = 0
+  let completion = 0
+  let seen = false
+  for (const entry of wire) {
+    if (!entry.response) continue
+    for (const line of entry.response.split("\n")) {
+      if (!line.trim()) continue
+      try {
+        const frame = JSON.parse(line) as {
+          prompt_eval_count?: unknown
+          eval_count?: unknown
+        }
+        if (typeof frame.prompt_eval_count === "number") {
+          prompt += frame.prompt_eval_count
+          seen = true
+        }
+        if (typeof frame.eval_count === "number") {
+          completion += frame.eval_count
+          seen = true
+        }
+      } catch {
+        /* A non-JSON line is an SSE frame or a blank; neither carries counts. */
+      }
+    }
+  }
+  return seen ? { prompt, completion } : undefined
+}
+
 export const runAgentScenario = (scenario: AgentScenario): void => {
+  const attempts = Math.max(1, scenario.attempts ?? 1)
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    runAgentScenarioAttempt(scenario, attempt, attempts)
+  }
+}
+
+const runAgentScenarioAttempt = (
+  scenario: AgentScenario,
+  attempt: number,
+  attempts: number
+): void => {
   /** Synthetic page data only. No user profile or credentials enter this harness. */
+  const suffix = attempts > 1 ? ` attempt ${attempt}` : ""
   const title =
     scenario.gated === false
-      ? `Agent ${scenario.name} through production boundaries`
-      : `@critical Agent ${scenario.name} through production boundaries`
+      ? `Agent ${scenario.name}${suffix} through production boundaries`
+      : `@critical Agent ${scenario.name}${suffix} through production boundaries`
   test(title, async ({ extension }, testInfo) => {
+    const startedAt = Date.now()
     const liveModel = process.env.AGENT_HOSTED_MODEL
+    /**
+     * Where a live pass sends its decisions: the olc proxy by default, since
+     * that is what the hosted matrix was written against, and Ollama directly
+     * when a pass wants the provider the extension treats as primary.
+     */
+    const liveBaseUrl =
+      process.env.AGENT_HOSTED_BASE_URL ?? "http://127.0.0.1:8084"
     test.setTimeout(liveModel ? 240_000 : (scenario.timeoutMs ?? 60_000))
     test.skip(
       Boolean(liveModel) && scenario.hosted !== true,
@@ -174,7 +268,7 @@ export const runAgentScenario = (scenario: AgentScenario): void => {
       method: string | undefined,
       body: string
     ): Promise<{ status: number; body: string }> => {
-      const upstream = await fetch(`http://127.0.0.1:8084${path}`, {
+      const upstream = await fetch(`${liveBaseUrl}${path}`, {
         method,
         headers: { "Content-Type": "application/json" },
         ...(body ? { body } : {})
@@ -364,6 +458,13 @@ export const runAgentScenario = (scenario: AgentScenario): void => {
           )
           .toBe(scenario.status)
           .catch((error: unknown) => {
+            /**
+             * A gate fails here; a measurement records instead. A benchmark
+             * task that did not reach its expected status is a result — the
+             * most interesting one — and throwing would leave it out of the
+             * report entirely, so the pass would look better than it was.
+             */
+            if (scenario.gated === false) return
             const last = messages
               .filter((m) => m.type === "agent_snapshot")
               .at(-1)?.snapshot
@@ -381,6 +482,13 @@ export const runAgentScenario = (scenario: AgentScenario): void => {
           messages,
           wire,
           effects: () => effects,
+          backend:
+            (testInfo.project.metadata.agentBenchmarkBackend as
+              | string
+              | undefined) ?? "unknown",
+          attempt,
+          startedAt,
+          tokens: reportedTokens(wire),
           phases: phases.flatMap((line) =>
             Array.isArray(line)
               ? line.filter(

--- a/e2e/chromium/fixtures/extension.ts
+++ b/e2e/chromium/fixtures/extension.ts
@@ -161,6 +161,19 @@ const createExtensionSession = async (
     manifest.optional_permissions = manifest.optional_permissions.filter(
       (permission: string) => permission !== "webNavigation"
     )
+    /**
+     * A project may ask for the browser Firefox gives us: no debugger, so the
+     * session manager reports `backend: "dom"` and every action runs through
+     * the content script. Removing the permission is the only honest way to
+     * get that on Chromium — a flag the extension read would be a second code
+     * path, and the point of measuring the two is that they are the same code
+     * seeing a different browser.
+     */
+    if (testInfo.project.metadata.agentDomBackend === true) {
+      manifest.permissions = manifest.permissions.filter(
+        (permission: string) => permission !== "debugger"
+      )
+    }
     writeFileSync(manifestPath, JSON.stringify(manifest))
     buildPath = copiedBuild
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,27 @@ export default defineConfig({
       ),
       metadata: {
         extensionBuildPath: "build/chrome-mv3-prod",
-        agentObservationGrant: true
+        agentObservationGrant: true,
+        agentBenchmarkBackend: "cdp"
+      }
+    },
+    {
+      /**
+       * The same tasks with no debugger, which is the browser Firefox gives
+       * us: `backend: "dom"`, every action through the content script. Two
+       * passes over one suite are what makes "the native backend is better"
+       * a measurement instead of a claim.
+       */
+      ...chromiumProject(
+        "chromium-agent-benchmark-dom",
+        "**/benchmark-agent.spec.ts",
+        "build/chrome-mv3-prod"
+      ),
+      metadata: {
+        extensionBuildPath: "build/chrome-mv3-prod",
+        agentObservationGrant: true,
+        agentDomBackend: true,
+        agentBenchmarkBackend: "dom"
       }
     },
     chromiumProject(


### PR DESCRIPTION
PR 11 of the 0.14.0 agent plan. Depends on #385 (the benchmark project was failing on `release/0.14.0`; that PR fixes it and puts it in CI).

**Thirty frozen tasks across ten families**, run twice — once with the debugger attached, once against a build with the `debugger` permission stripped, which is the browser Firefox gives us. The comparison is the point; neither pass is the reference.

**Each task scores itself from the page.** A `succeeded` predicate reads the page after the run, because false completion cannot be counted any other way: the thing being measured is precisely the run's own verdict being wrong. Its counterpart is counted too — goal met and never claimed — against the status the task *declared*, so a task meant to pause is not scored as having failed.

`AGENT_EVALUATION.md` carries the numbers. Headline:

- **0 false completions on both passes**, 31 attempts each.
- The measured gain is narrow and specific: `canvas-and-visual` goes 3 of 3 to 1 of 3 without a debugger, median 2.9s to 32.5s, because no debugger means no screenshot and a task that can only be done visually cannot be done. The other nine families are identical across backends — the design working, not a null result, since native input exists for gestures a page can tell apart and none of these tasks needs one.

**Three remaining failures are named, not rounded away**, and one is new and worth attention: a click whose handler calls `confirm()` blocks the renderer, so the action can neither finish nor be confirmed and the run pauses with `unresolved_effect` before it ever sees the dialog it caused. Dialogs found already open are handled (#382); one the run raises itself is not. The file-chooser case already has a receipt flag for that exact shape and a dialog needs the equivalent — a follow-up, not this PR.

**Bugs the instrument found in itself**, all fixed here: wall time measured from module load rather than per attempt, so every first attempt was reported as taking as long as everything before it; an ungated task threw instead of recording when it did not finish, which would have hidden the most interesting rows; and missed completions were scored against completion rather than against the declared status, which called a correctly-paused task a failure.

**Not measured, and said so in the file:** no live-model pass is published. `AGENT_HOSTED_MODEL`, `AGENT_HOSTED_BASE_URL` and `AGENT_BENCHMARK_ATTEMPTS` point the same suite at a real provider and repeat it, and Ollama with `qwen3.5` is available here, but publishing a live table is a separate run and I did not want to mix measured runtime numbers with unmeasured capability ones. Tokens are read from the provider's own counts, so the columns are empty on the fixture rather than zero — nothing is estimated.

Verified: both benchmark projects 31/31, typecheck, lint, 4572 unit tests.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comparative agent evaluation suite that runs thirty frozen tasks against native-debugger and DOM-only backends, records page-grounded outcomes, and publishes the measured results.
- Adds reusable benchmark task declarations, attempt recording, aggregation, token accounting, and report generation.
- Adds page-grounded predicates for false- and missed-completion measurement.
- Extends the Playwright matrix to compare debugger-enabled and debugger-free builds.
- Documents measured capability differences, remaining failures, and benchmark maintenance requirements.
- Fixes the hosted workflow so ungated benchmark scenarios run as a complete live-model suite.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previously unresolved hosted-run failure is fixed and no new actionable issue remains.

The hosted filter now exempts ungated benchmark scenarios, allowing the full live-model evaluation to execute and produce its report. The manually resolved scoring finding is also addressed by page-grounded predicates, including observable page state for the rewritten answer-following task.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| e2e/chromium/benchmark/__tests__/benchmark-agent.spec.ts | Declares the frozen comparative task suite with independent, page-grounded success predicates. |
| e2e/chromium/benchmark/benchmark-tasks.ts | Provides benchmark wrappers, attempt recording, and shared page and decision helpers. |
| e2e/chromium/benchmark/agent-benchmark.ts | Aggregates completion quality, timing, approval, repetition, and provider-token measurements into reports. |
| e2e/chromium/fixtures/agent-scenario.ts | Supports repeated benchmark attempts, per-attempt timing, live-provider runs, and ungated hosted scenarios. |
| e2e/chromium/fixtures/extension.ts | Extends the browser fixture support needed by comparative benchmark projects. |
| playwright.config.ts | Configures native-debugger and DOM-only benchmark projects. |
| AGENT_EVALUATION.md | Publishes the measured comparison and explicitly documents limitations and remaining failures. |
| AGENTS.md | Adds repository guidance for maintaining and interpreting agent benchmarks. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[30 frozen benchmark tasks] --> N[Native debugger backend]
  T --> D[DOM-only backend]
  N --> S[Page-grounded task predicates]
  D --> S
  S --> R[Attempt records]
  R --> A[Per-family aggregation]
  A --> J[JSON and Markdown reports]
  J --> E[AGENT_EVALUATION.md]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): give the ambiguous-account t..."](https://github.com/shishir435/ollama-client/commit/4184aad22c9de5671026e6f970653deaf30ee18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62789613)</sub>

<!-- /greptile_comment -->